### PR TITLE
Persist update schedule progress

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -1,28 +1,41 @@
 from typing import List, Optional
+from datetime import datetime
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 from . import models, schemas
 
-async def get_book_by_source_url(db: AsyncSession, source_url: str) -> Optional[models.Book]:
+
+async def get_book_by_source_url(
+    db: AsyncSession, source_url: str
+) -> Optional[models.Book]:
     """
     Retrieve a single book from the database by its source URL.
     """
-    result = await db.execute(select(models.Book).filter(models.Book.source_url == source_url))
+    result = await db.execute(
+        select(models.Book).filter(models.Book.source_url == source_url)
+    )
     return result.scalars().first()
+
 
 async def get_web_books(db: AsyncSession) -> List[models.Book]:
     """
     Retrieve all web books from the database.
     """
-    result = await db.execute(select(models.Book).filter(models.Book.source_type == models.SourceType.web))
+    result = await db.execute(
+        select(models.Book).filter(models.Book.source_type == models.SourceType.web)
+    )
     return result.scalars().all()
 
-async def get_books(db: AsyncSession, skip: int = 0, limit: int = 100) -> List[models.Book]:
+
+async def get_books(
+    db: AsyncSession, skip: int = 0, limit: int = 100
+) -> List[models.Book]:
     """
     Retrieve a list of books from the database.
     """
     result = await db.execute(select(models.Book).offset(skip).limit(limit))
     return result.scalars().all()
+
 
 async def create_book(db: AsyncSession, book: schemas.BookCreate) -> models.Book:
     """
@@ -38,6 +51,7 @@ async def create_book(db: AsyncSession, book: schemas.BookCreate) -> models.Book
     await db.refresh(db_book)
     return db_book
 
+
 async def get_book(db: AsyncSession, book_id: int) -> Optional[models.Book]:
     """
     Retrieve a single book from the database by its ID.
@@ -45,7 +59,10 @@ async def get_book(db: AsyncSession, book_id: int) -> Optional[models.Book]:
     result = await db.execute(select(models.Book).filter(models.Book.id == book_id))
     return result.scalars().first()
 
-async def update_book(db: AsyncSession, book: models.Book, update_data: schemas.BookUpdate) -> models.Book:
+
+async def update_book(
+    db: AsyncSession, book: models.Book, update_data: schemas.BookUpdate
+) -> models.Book:
     """
     Update a book record in the database.
     """
@@ -56,7 +73,10 @@ async def update_book(db: AsyncSession, book: models.Book, update_data: schemas.
     await db.refresh(book)
     return book
 
-async def get_books_by_author(db: AsyncSession, author: str, skip: int = 0, limit: int = 100) -> List[models.Book]:
+
+async def get_books_by_author(
+    db: AsyncSession, author: str, skip: int = 0, limit: int = 100
+) -> List[models.Book]:
     """
     Retrieve books from the database by author.
     """
@@ -68,7 +88,10 @@ async def get_books_by_author(db: AsyncSession, author: str, skip: int = 0, limi
     )
     return result.scalars().all()
 
-async def create_book_log(db: AsyncSession, log: schemas.BookLogCreate) -> models.BookLog:
+
+async def create_book_log(
+    db: AsyncSession, log: schemas.BookLogCreate
+) -> models.BookLog:
     """
     Create a new book log entry in the database.
     """
@@ -78,7 +101,52 @@ async def create_book_log(db: AsyncSession, log: schemas.BookLogCreate) -> model
     await db.refresh(db_log)
     return db_log
 
-async def get_books_by_series(db: AsyncSession, series: str, skip: int = 0, limit: int = 100) -> List[models.Book]:
+
+async def get_latest_book_log(
+    db: AsyncSession, book_id: int
+) -> Optional[models.BookLog]:
+    result = await db.execute(
+        select(models.BookLog)
+        .filter(models.BookLog.book_id == book_id)
+        .order_by(models.BookLog.timestamp.desc())
+        .limit(1)
+    )
+    return result.scalars().first()
+
+
+async def get_active_update_task(db: AsyncSession) -> Optional[models.UpdateTask]:
+    result = await db.execute(
+        select(models.UpdateTask).filter(models.UpdateTask.status == "running")
+    )
+    return result.scalars().first()
+
+
+async def create_update_task(db: AsyncSession, total_books: int) -> models.UpdateTask:
+    task = models.UpdateTask(
+        total_books=total_books, completed_books=0, status="running"
+    )
+    db.add(task)
+    await db.commit()
+    await db.refresh(task)
+    return task
+
+
+async def increment_update_task(db: AsyncSession, task: models.UpdateTask) -> None:
+    task.completed_books += 1
+    await db.commit()
+    await db.refresh(task)
+
+
+async def complete_update_task(db: AsyncSession, task: models.UpdateTask) -> None:
+    task.status = "completed"
+    task.completed_at = datetime.utcnow()
+    await db.commit()
+    await db.refresh(task)
+
+
+async def get_books_by_series(
+    db: AsyncSession, series: str, skip: int = 0, limit: int = 100
+) -> List[models.Book]:
     """
     Retrieve books from the database by series.
     """

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -3,9 +3,11 @@ from sqlalchemy.sql import func
 from .database import Base
 import enum
 
+
 class SourceType(enum.Enum):
     web = "web"
     epub = "epub"
+
 
 class Book(Base):
     __tablename__ = "books"
@@ -24,6 +26,7 @@ class Book(Base):
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
 
+
 class BookLog(Base):
     __tablename__ = "book_logs"
 
@@ -34,3 +37,14 @@ class BookLog(Base):
     new_chapter_count = Column(Integer, nullable=True)
     words_added = Column(Integer, nullable=True)
     timestamp = Column(DateTime(timezone=True), server_default=func.now())
+
+
+class UpdateTask(Base):
+    __tablename__ = "update_tasks"
+
+    id = Column(Integer, primary_key=True, index=True)
+    total_books = Column(Integer, nullable=False)
+    completed_books = Column(Integer, nullable=False, default=0)
+    status = Column(String, nullable=False, default="running")
+    started_at = Column(DateTime(timezone=True), server_default=func.now())
+    completed_at = Column(DateTime(timezone=True), nullable=True)


### PR DESCRIPTION
## Summary
- add `UpdateTask` model to store scheduled update progress
- track and skip books already updated in a task via book logs
- log checked books and update task completion counts

## Testing
- `PYENV_VERSION=3.11.12 flake8 backend/app/models.py backend/app/crud.py backend/app/main.py` *(fails: line too long)*
- `PYENV_VERSION=3.11.12 PYTHONPATH=/workspace/story-manager pytest backend/tests`


------
https://chatgpt.com/codex/tasks/task_e_68a95592d0ac832d8dda9b865ed18352