### PR TITLE
ci: push PR images for preview deployments

### DIFF
--- a/.github/workflows/preview-image.yml
+++ b/.github/workflows/preview-image.yml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
 
@@ -39,3 +40,21 @@ jobs:
 
       - name: Push image
         run: docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.tag }}
+
+      - name: Comment image
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        env:
+          TAG: ${{ steps.meta.outputs.tag }}
+        with:
+          script: |
+            const tag = process.env.TAG;
+            const image = `${process.env.REGISTRY}/${process.env.IMAGE_NAME}:${tag}`;
+            const url = `https://${process.env.REGISTRY}/${process.env.IMAGE_NAME}:${tag}`;
+            const body = `Preview image available: \`${image}\`\n\n[View image in registry](${url})`;
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body
+            });

--- a/.github/workflows/preview-image.yml
+++ b/.github/workflows/preview-image.yml
@@ -1,0 +1,41 @@
+name: preview-image
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Log in to registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.REGISTRY_USERNAME || github.actor }}
+          password: ${{ secrets.REGISTRY_PASSWORD || secrets.GITHUB_TOKEN }}
+
+      - name: Set image tag
+        id: meta
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "tag=pr-${{ github.event.number }}" >> $GITHUB_OUTPUT
+          else
+            echo "tag=${{ github.sha }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build image
+        run: docker build -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.tag }} .
+
+      - name: Push image
+        run: docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.tag }}


### PR DESCRIPTION
## Summary
- add workflow to build and push container images on push and pull_request events
- authenticate to registry using GITHUB_TOKEN or custom secrets
- tag images with PR number or commit SHA and push for preview deployments

## Testing
- `PYENV_VERSION=3.13.3 make test`

------
https://chatgpt.com/codex/tasks/task_e_68abf019b6c8832db63d02284996924e