### PR TITLE
ci: add Docker image publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,15 +8,20 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     env:
-      IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/story-manager
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
     steps:
     - uses: actions/checkout@v3
-    - name: Log in to Docker Hub
+    - name: Log in to GitHub Container Registry
       uses: docker/login-action@v3
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build and push
       uses: docker/build-push-action@v5
       with:
@@ -24,5 +29,5 @@ jobs:
         file: Dockerfile
         push: true
         tags: |
-          ${{ env.IMAGE_NAME }}:${{ github.ref_name }}
-          ${{ env.IMAGE_NAME }}:latest
+          ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+          ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,28 @@
+name: Docker publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/story-manager
+    steps:
+    - uses: actions/checkout@v3
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Build and push
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: Dockerfile
+        push: true
+        tags: |
+          ${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+          ${{ env.IMAGE_NAME }}:latest


### PR DESCRIPTION
## Summary
- publish Docker images to Docker Hub when tags like `v*` are pushed
- build from repository Dockerfile and push tagged images

## Testing
- `python3 -m pytest backend/tests`
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68abf0191c80832d9378e0799a5df15d