### PR TITLE
Add docker-compose with persistent Postgres and Unraid docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,6 @@ cython_debug/
 # Node build artifacts
 frontend/node_modules/
 frontend/dist/
+
+# Docker Compose persistent data
+pgdata/

--- a/README.md
+++ b/README.md
@@ -67,3 +67,21 @@ Story Manager is a self-hosted digital library and reader for your personal coll
     * Start the frontend development server from the `frontend` directory.
 
 ---
+
+## 🐋 Deploy with Docker Compose
+
+A `docker-compose.yml` file is provided for running Story Manager with Docker. It exposes the web UI on port **7890** and the API on **8000**. PostgreSQL data is stored on the host in the `pgdata/` folder so it survives container restarts.
+
+```bash
+docker compose up -d
+```
+
+### Using on Unraid
+
+1. Copy the repository (or just `docker-compose.yml`) to your Unraid server.
+2. Create a directory for persistent data, e.g. `/mnt/user/appdata/story-manager/pgdata`.
+3. Edit the `pgdata` volume path in `docker-compose.yml` to point to that directory.
+4. From the directory containing `docker-compose.yml`, run `docker compose up -d` using the Docker Compose plugin or the Docker Compose Manager.
+5. Visit `http://<UNRAID_HOST>:7890` in your browser to use the Story Manager UI.
+
+---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+services:
+  story-manager:
+    build: .
+    ports:
+      - "7890:5173"  # UI
+      - "8000:8000"  # API
+    volumes:
+      - ./pgdata:/tmp/pgdata
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- Add docker-compose setup exposing UI on 7890 and persisting PostgreSQL data
- Document Docker Compose usage and Unraid deployment instructions
- Ignore pgdata directory used for persistent database storage

## Testing
- `python3.12 -m flake8 backend`
- `npm --prefix frontend run lint`
- `PYTHONPATH=. python3.12 -m pytest backend/tests`
- `npm --prefix frontend test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68ad3d841820832da34d783c3dd67d0d