### PR TITLE
Allow GitHub Actions to push lint fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
@@ -53,6 +55,8 @@ jobs:
 
   lint-ui:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     defaults:
       run:
         working-directory: frontend


### PR DESCRIPTION
## Summary
- allow workflow jobs to write back to repo so git-auto-commit action can push formatting fixes

## Testing
- `PYTHONPATH=. pytest backend/tests`
- `(cd frontend && npm ci && npm test -- --run)`

------
https://chatgpt.com/codex/tasks/task_e_68afd2c4e3a0832dac8de349fe092baa