### PR TITLE
Fix cleaning update tracking and polish library UI

### DIFF
--- a/backend/app/epub_editor.py
+++ b/backend/app/epub_editor.py
@@ -276,6 +276,11 @@ async def apply_book_cleaning(book, db, force: bool = False, cleaning_configs: l
             chapter_selectors,
         )
         if word_count is None:
+            if force:
+                await crud.touch_book_content(db, book)
+                await db.commit()
+                await db.refresh(book)
+                return True
             return False
         book.current_word_count = word_count
         await crud.touch_book_content(db, book)

--- a/backend/app/routers/books.py
+++ b/backend/app/routers/books.py
@@ -313,6 +313,21 @@ async def get_book_chapters(book_id: int, db: AsyncSession = Depends(get_db)):
     return epub_editor.get_chapters(str(epub_path))
 
 
+@router.get("/api/books/{book_id}/cleaned-chapters", response_model=List[Dict[str, Any]])
+async def get_book_cleaned_chapters(book_id: int, db: AsyncSession = Depends(get_db)):
+    db_book = await crud.get_book(db, book_id=book_id)
+    if db_book is None:
+        raise HTTPException(status_code=404, detail="Book not found")
+    if not db_book.current_path:
+        raise HTTPException(status_code=404, detail="Cleaned EPUB file not found")
+
+    epub_path = LIBRARY_PATH.parent / db_book.current_path
+    if not epub_path.exists():
+        raise HTTPException(status_code=404, detail="Cleaned EPUB file not found")
+
+    return epub_editor.get_chapters(str(epub_path))
+
+
 @router.get("/api/books/{book_id}/download")
 async def download_book(book_id: int, db: AsyncSession = Depends(get_db)):
     db_book = await crud.get_book(db, book_id=book_id)

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -60,31 +60,43 @@
   font-size: 0.9rem;
   font-weight: 500;
   color: var(--text-muted);
-  padding: 0.6rem 0;
+  padding: 0.55rem 0.85rem;
   list-style: none;
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: 0.5rem;
   user-select: none;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  transition: background-color 0.15s, border-color 0.15s, color 0.15s;
 }
 
 .add-book-summary::-webkit-details-marker {
   display: none;
 }
 
-.add-book-summary::before {
-  content: "▸";
+.add-book-summary::after {
+  content: "";
   display: inline-block;
+  width: 0.45em;
+  height: 0.45em;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: rotate(-45deg);
   transition: transform 0.15s;
-  font-size: 0.75rem;
+  margin-top: 0.1em;
 }
 
-.add-book-details[open] > .add-book-summary::before {
-  transform: rotate(90deg);
+.add-book-details[open] > .add-book-summary::after {
+  transform: rotate(45deg);
+  margin-top: -0.1em;
 }
 
 .add-book-summary:hover {
   color: var(--text);
+  border-color: var(--accent);
+  background: var(--surface-2);
 }
 
 /* ─── Buttons ────────────────────────────────────────────── */
@@ -151,9 +163,60 @@
   align-items: center;
 }
 
-.search-controls input {
+.search-input-wrap {
+  position: relative;
   flex: 1;
-  min-width: 180px;
+  min-width: 200px;
+  display: flex;
+  align-items: center;
+}
+
+.search-icon {
+  position: absolute;
+  left: 0.65rem;
+  color: var(--text-muted);
+  pointer-events: none;
+  flex-shrink: 0;
+}
+
+.search-input-wrap input {
+  width: 100%;
+  padding-left: 2rem;
+  padding-right: 2rem;
+}
+
+.search-clear {
+  position: absolute;
+  right: 0.25rem;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 1.1rem;
+  padding: 0.2em 0.45em;
+  line-height: 1;
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+}
+.search-clear:hover:not(:disabled) {
+  color: var(--text);
+  background: var(--surface-3);
+}
+
+.sort-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  flex-shrink: 0;
+}
+
+.sort-controls select {
+  width: auto;
+}
+
+.sort-order-btn {
+  padding: 0.45em 0.6em;
+  font-size: 1rem;
+  line-height: 1;
 }
 
 /* ─── Add Book ───────────────────────────────────────────── */
@@ -165,25 +228,36 @@
   margin-bottom: 1.5rem;
 }
 
-.add-book-container h2 {
-  margin-bottom: 1rem;
-  font-size: 1rem;
+.add-book-columns {
+  display: flex;
+  gap: 1rem;
+  align-items: stretch;
+}
+
+.add-book-divider {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
   color: var(--text-muted);
-  font-weight: 500;
+  font-size: 0.8rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
 
 .drop-zone {
+  flex: 1;
   border: 2px dashed var(--border-strong);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius);
   padding: 1.25rem;
   text-align: center;
   cursor: pointer;
-  margin-bottom: 0.75rem;
   color: var(--text-muted);
   transition: border-color 0.15s, background-color 0.15s;
   font-size: 0.875rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 5rem;
 }
 .drop-zone:hover,
 .drop-zone.dragging {
@@ -191,14 +265,29 @@
   background-color: rgba(98, 114, 234, 0.06);
   color: var(--text);
 }
-.drop-zone p {
-  margin: 0;
+.drop-zone--has-files {
+  align-items: flex-start;
+  justify-content: flex-start;
+}
+.drop-zone-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+}
+.drop-zone-empty svg {
+  opacity: 0.5;
+}
+.drop-zone:hover .drop-zone-empty svg,
+.drop-zone.dragging .drop-zone-empty svg {
+  opacity: 0.85;
 }
 .file-list {
   list-style: none;
   padding: 0;
   margin: 0;
   text-align: left;
+  width: 100%;
 }
 .file-list li {
   display: flex;
@@ -213,6 +302,7 @@
   font-size: 0.75rem;
   justify-content: center;
   padding-top: 0.35rem;
+  cursor: pointer;
 }
 .remove-btn {
   background: none;
@@ -226,6 +316,14 @@
 .remove-btn:hover {
   color: var(--text);
 }
+
+.url-section {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  justify-content: center;
+}
 .url-row {
   display: flex;
   gap: 0.35rem;
@@ -237,20 +335,25 @@
 .add-url-btn {
   align-self: flex-start;
   background: none;
-  border: 1px dashed var(--border-strong);
-  border-radius: var(--radius-sm);
+  border: none;
   color: var(--text-muted);
   cursor: pointer;
   font-size: 0.8rem;
-  padding: 0.25rem 0.6rem;
-  margin-top: 0.25rem;
+  padding: 0.15rem 0;
 }
 .add-url-btn:hover {
   color: var(--text);
-  border-color: var(--accent);
 }
+
+.add-book-submit {
+  margin-top: 1rem;
+  width: 100%;
+}
+
 .add-results {
-  margin-top: 0.75rem;
+  margin-top: 1rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--border);
   font-size: 0.875rem;
 }
 .add-results .summary {
@@ -285,16 +388,23 @@
   color: var(--text-muted);
 }
 
-.form-group {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-  margin-bottom: 0.75rem;
-}
-
-.form-group label {
-  font-size: 0.8rem;
-  color: var(--text-muted);
+@media (max-width: 600px) {
+  .add-book-columns {
+    flex-direction: column;
+  }
+  .add-book-divider {
+    justify-content: center;
+    padding: 0;
+  }
+  .add-book-divider::before,
+  .add-book-divider::after {
+    content: "";
+    flex: 1;
+    height: 1px;
+    background: var(--border);
+  }
+  .add-book-divider::before { margin-right: 0.75rem; }
+  .add-book-divider::after { margin-left: 0.75rem; }
 }
 
 /* ─── Book Grid & Cards ──────────────────────────────────── */
@@ -1353,6 +1463,11 @@
   border-bottom: none;
   padding-bottom: 0;
   flex: 1;
+}
+.chapter-preview-mode-select {
+  font-size: 0.8rem;
+  padding: 0.15em 0.4em;
+  border-radius: 4px;
 }
 .chapter-count {
   font-size: 0.8rem;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -128,25 +128,36 @@ function App() {
         return (
           <>
             <div className="search-controls">
-              <input
-                type="text"
-                placeholder="Search by title, author, series, or tag"
-                value={q}
-                onChange={(e) => setQ(e.target.value)}
-              />
-              <button onClick={handleClearSearch}>Clear</button>
-              <select
-                value={sortBy}
-                onChange={(e) => handleSortByChange(e.target.value)}
-              >
-                <option value="title">Title</option>
-                <option value="author">Author</option>
-                <option value="word_count">Word Count</option>
-                <option value="updated_at">Last Updated</option>
-              </select>
-              <button onClick={handleToggleSortOrder}>
-                {sortOrder === "asc" ? "↑" : "↓"}
-              </button>
+              <div className="search-input-wrap">
+                <svg className="search-icon" viewBox="0 0 20 20" fill="currentColor" width="16" height="16">
+                  <path fillRule="evenodd" d="M9 3.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM2 9a7 7 0 1112.45 4.38l3.09 3.08a.75.75 0 11-1.06 1.06l-3.09-3.08A7 7 0 012 9z" clipRule="evenodd" />
+                </svg>
+                <input
+                  type="text"
+                  placeholder="Search by title, author, series, or tag"
+                  value={q}
+                  onChange={(e) => setQ(e.target.value)}
+                />
+                {q && (
+                  <button className="search-clear" onClick={handleClearSearch} aria-label="Clear search">
+                    ×
+                  </button>
+                )}
+              </div>
+              <div className="sort-controls">
+                <select
+                  value={sortBy}
+                  onChange={(e) => handleSortByChange(e.target.value)}
+                >
+                  <option value="title">Title</option>
+                  <option value="author">Author</option>
+                  <option value="word_count">Word Count</option>
+                  <option value="updated_at">Last Updated</option>
+                </select>
+                <button className="sort-order-btn" onClick={handleToggleSortOrder} aria-label="Toggle sort order">
+                  {sortOrder === "asc" ? "↑" : "↓"}
+                </button>
+              </div>
             </div>
             <details className="add-book-details" open={addBookOpen}>
               <summary

--- a/frontend/src/api/books.js
+++ b/frontend/src/api/books.js
@@ -100,6 +100,10 @@ export function getBookChapters(bookId) {
   return getJson(`/api/books/${bookId}/chapters`, "Failed to fetch chapters");
 }
 
+export function getBookCleanedChapters(bookId) {
+  return getJson(`/api/books/${bookId}/cleaned-chapters`, "Failed to fetch cleaned chapters");
+}
+
 export function getMatchedConfigs(bookId) {
   return getJson(`/api/books/${bookId}/matched-config`, "Failed to fetch matched config");
 }

--- a/frontend/src/components/AddBook.jsx
+++ b/frontend/src/components/AddBook.jsx
@@ -149,65 +149,73 @@ function AddBook() {
 
   return (
     <div className="add-book-container">
-      <h2>Add Books</h2>
       <form onSubmit={handleSubmit}>
-        <div
-          id="drop-zone"
-          className={`drop-zone ${dragging ? "dragging" : ""}`}
-          onDragOver={handleDragOver}
-          onDragLeave={handleDragLeave}
-          onDrop={handleDrop}
-          onClick={() => fileInputRef.current.click()}
-        >
-          {files.length > 0 ? (
-            <ul className="file-list" onClick={(e) => e.stopPropagation()}>
-              {files.map((f, i) => (
-                <li key={i}>
-                  <span>{f.name}</span>
-                  <button type="button" className="remove-btn" onClick={() => removeFile(i)}>
+        <div className="add-book-columns">
+          <div
+            className={`drop-zone ${dragging ? "dragging" : ""} ${files.length > 0 ? "drop-zone--has-files" : ""}`}
+            onDragOver={handleDragOver}
+            onDragLeave={handleDragLeave}
+            onDrop={handleDrop}
+            onClick={() => fileInputRef.current.click()}
+          >
+            {files.length > 0 ? (
+              <ul className="file-list" onClick={(e) => e.stopPropagation()}>
+                {files.map((f, i) => (
+                  <li key={i}>
+                    <span>{f.name}</span>
+                    <button type="button" className="remove-btn" onClick={() => removeFile(i)}>
+                      ×
+                    </button>
+                  </li>
+                ))}
+                <li className="add-more-hint">+ more files</li>
+              </ul>
+            ) : (
+              <div className="drop-zone-empty">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" width="28" height="28">
+                  <path d="M12 16V6m0 0l-4 4m4-4l4 4" strokeLinecap="round" strokeLinejoin="round"/>
+                  <path d="M20 16.7V19a2 2 0 01-2 2H6a2 2 0 01-2-2v-2.3" strokeLinecap="round" strokeLinejoin="round"/>
+                </svg>
+                <span>Drop EPUBs or ZIPs here, or click to browse</span>
+              </div>
+            )}
+            <input
+              type="file"
+              accept=".epub,.zip"
+              multiple
+              onChange={handleFileChange}
+              ref={fileInputRef}
+              style={{ display: "none" }}
+            />
+          </div>
+
+          <div className="add-book-divider">
+            <span>or</span>
+          </div>
+
+          <div className="url-section">
+            {urls.map((url, i) => (
+              <div key={i} className="url-row">
+                <input
+                  type="text"
+                  placeholder="Paste a web novel URL"
+                  value={url}
+                  onChange={(e) => handleUrlChange(i, e.target.value)}
+                />
+                {urls.length > 1 && (
+                  <button type="button" className="remove-btn" onClick={() => removeUrlField(i)}>
                     ×
                   </button>
-                </li>
-              ))}
-              <li className="add-more-hint">Click or drop to add more EPUBs or ZIPs</li>
-            </ul>
-          ) : (
-            <p>Drag & drop EPUB or ZIP files here, or click to select</p>
-          )}
-          <input
-            id="file-upload"
-            type="file"
-            accept=".epub,.zip"
-            multiple
-            onChange={handleFileChange}
-            ref={fileInputRef}
-            style={{ display: "none" }}
-          />
+                )}
+              </div>
+            ))}
+            <button type="button" className="add-url-btn" onClick={addUrlField}>
+              + Add another URL
+            </button>
+          </div>
         </div>
 
-        <div className="form-group">
-          <label>Or add by URL:</label>
-          {urls.map((url, i) => (
-            <div key={i} className="url-row">
-              <input
-                type="text"
-                placeholder="Enter URL"
-                value={url}
-                onChange={(e) => handleUrlChange(i, e.target.value)}
-              />
-              {urls.length > 1 && (
-                <button type="button" className="remove-btn" onClick={() => removeUrlField(i)}>
-                  ×
-                </button>
-              )}
-            </div>
-          ))}
-          <button type="button" className="add-url-btn" onClick={addUrlField}>
-            + Add URL
-          </button>
-        </div>
-
-        <button type="submit" disabled={pending || total === 0}>
+        <button className="btn-primary add-book-submit" type="submit" disabled={pending || total === 0}>
           {pending ? "Adding..." : total > 1 ? `Add ${total} Books` : "Add Book"}
         </button>
       </form>

--- a/frontend/src/components/AddBook.jsx
+++ b/frontend/src/components/AddBook.jsx
@@ -152,6 +152,7 @@ function AddBook() {
       <form onSubmit={handleSubmit}>
         <div className="add-book-columns">
           <div
+            id="drop-zone"
             className={`drop-zone ${dragging ? "dragging" : ""} ${files.length > 0 ? "drop-zone--has-files" : ""}`}
             onDragOver={handleDragOver}
             onDragLeave={handleDragLeave}
@@ -180,6 +181,7 @@ function AddBook() {
               </div>
             )}
             <input
+              id="file-upload"
               type="file"
               accept=".epub,.zip"
               multiple

--- a/frontend/src/components/BookSettings.jsx
+++ b/frontend/src/components/BookSettings.jsx
@@ -6,6 +6,7 @@ import {
   detachBookSource,
   getApiCoverUrl,
   getBookChapters,
+  getBookCleanedChapters,
   getMatchedConfigs,
   previewCleaning,
   processBook,
@@ -21,6 +22,11 @@ import { getSeries } from "../api/series";
 const fetchChapters = async ({ queryKey }) => {
   const [_key, bookId] = queryKey;
   return getBookChapters(bookId);
+};
+
+const fetchCleanedChapters = async ({ queryKey }) => {
+  const [_key, bookId] = queryKey;
+  return getBookCleanedChapters(bookId);
 };
 
 const fetchMatchedConfig = async ({ queryKey }) => {
@@ -127,6 +133,7 @@ function BookSettings({ book, onBack }) {
   const [previewedChapter, setPreviewedChapter] = useState(null);
   const [chapterSearch, setChapterSearch] = useState("");
   const [chaptersExpanded, setChaptersExpanded] = useState(false);
+  const [chapterPreviewMode, setChapterPreviewMode] = useState("original");
   const [identifiersExpanded, setIdentifiersExpanded] = useState(false);
 
   useEffect(() => {
@@ -149,6 +156,7 @@ function BookSettings({ book, onBack }) {
     setPreviewResult(null);
     setChapterSearch("");
     setChaptersExpanded(false);
+    setChapterPreviewMode("original");
     setIdentifiersExpanded(false);
   }, [book]);
 
@@ -159,6 +167,12 @@ function BookSettings({ book, onBack }) {
   const { data: chapters = [], isLoading: chaptersLoading } = useQuery({
     queryKey: ["chapters", book.id],
     queryFn: fetchChapters,
+  });
+
+  const { data: cleanedChapters = [], isLoading: cleanedChaptersLoading } = useQuery({
+    queryKey: ["cleaned-chapters", book.id],
+    queryFn: fetchCleanedChapters,
+    enabled: chapterPreviewMode === "cleaned",
   });
 
   const { data: matchedConfigs = [] } = useQuery({
@@ -184,7 +198,7 @@ function BookSettings({ book, onBack }) {
     mutationFn: () => processBook(book.id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["book-catalog"] });
-      onBack();
+      queryClient.invalidateQueries({ queryKey: ["cleaned-chapters", book.id] });
     },
   });
 
@@ -347,11 +361,14 @@ function BookSettings({ book, onBack }) {
   const canDetachWebMarker =
     book.source_type === "web" && book.immutable_path && book.current_path;
 
+  const activeChapters = chapterPreviewMode === "cleaned" ? cleanedChapters : chapters;
+  const activeChaptersLoading = chapterPreviewMode === "cleaned" ? cleanedChaptersLoading : chaptersLoading;
+
   const filteredChapters = useMemo(() => {
-    if (!chapterSearch.trim()) return chapters;
+    if (!chapterSearch.trim()) return activeChapters;
     const q = chapterSearch.toLowerCase();
-    return chapters.filter((ch) => ch.title.toLowerCase().includes(q));
-  }, [chapters, chapterSearch]);
+    return activeChapters.filter((ch) => ch.title.toLowerCase().includes(q));
+  }, [activeChapters, chapterSearch]);
 
   return (
     <div className="book-settings">
@@ -711,22 +728,34 @@ function BookSettings({ book, onBack }) {
         <div className="chapter-section-header">
           <h3>
             Chapters
-            {chapters.length > 0 && (
-              <span className="chapter-count"> ({chapters.length})</span>
+            {activeChapters.length > 0 && (
+              <span className="chapter-count"> ({activeChapters.length})</span>
             )}
           </h3>
-          <button
-            className="btn-text"
-            onClick={() => setChaptersExpanded((e) => !e)}
-            disabled={chaptersLoading}
-          >
-            {chaptersExpanded ? "▲ Collapse" : "▼ Expand"}
-          </button>
+          <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+            {chaptersExpanded && (
+              <select
+                value={chapterPreviewMode}
+                onChange={(e) => setChapterPreviewMode(e.target.value)}
+                className="chapter-preview-mode-select"
+              >
+                <option value="original">Original</option>
+                <option value="cleaned">Cleaned</option>
+              </select>
+            )}
+            <button
+              className="btn-text"
+              onClick={() => setChaptersExpanded((e) => !e)}
+              disabled={activeChaptersLoading}
+            >
+              {chaptersExpanded ? "▲ Collapse" : "▼ Expand"}
+            </button>
+          </div>
         </div>
 
-        {chaptersLoading && <p className="hint" style={{ marginTop: "0.5rem" }}>Loading chapters…</p>}
+        {activeChaptersLoading && <p className="hint" style={{ marginTop: "0.5rem" }}>Loading chapters…</p>}
 
-        {chaptersExpanded && !chaptersLoading && (
+        {chaptersExpanded && !activeChaptersLoading && (
           <>
             {chapters.length > 10 && (
               <input
@@ -743,7 +772,7 @@ function BookSettings({ book, onBack }) {
                   <li className="chapter-no-results">No chapters match your search.</li>
                 ) : (
                   filteredChapters.map((chapter) => {
-                    const isRemoved = removedChapters.includes(chapter.filename);
+                    const isRemoved = chapterPreviewMode === "original" && removedChapters.includes(chapter.filename);
                     const isPreviewed = previewedChapter === chapter.filename;
                     return (
                       <li
@@ -751,14 +780,18 @@ function BookSettings({ book, onBack }) {
                         className={isRemoved ? "removed" : ""}
                       >
                         <div className="chapter-row">
-                          <label>
-                            <input
-                              type="checkbox"
-                              checked={!isRemoved}
-                              onChange={() => toggleChapter(chapter.filename)}
-                            />
-                            {chapter.title}
-                          </label>
+                          {chapterPreviewMode === "original" ? (
+                            <label>
+                              <input
+                                type="checkbox"
+                                checked={!isRemoved}
+                                onChange={() => toggleChapter(chapter.filename)}
+                              />
+                              {chapter.title}
+                            </label>
+                          ) : (
+                            <span>{chapter.title}</span>
+                          )}
                           <button
                             className="btn-text chapter-preview-toggle"
                             onClick={() => toggleChapterPreview(chapter.filename)}

--- a/frontend/tests-e2e/EpubEditor.spec.js
+++ b/frontend/tests-e2e/EpubEditor.spec.js
@@ -87,7 +87,9 @@ test("EpubEditor interactions", async ({ page }) => {
   // Click Save & Re-process
   await page.getByRole("button", { name: /save & rebuild epub/i }).click();
 
-  // We should be back on the book list
+  // Wait for rebuild to finish, then go back to the book list
+  await expect(page.getByRole("button", { name: /save & rebuild epub/i })).toBeEnabled();
+  await page.getByRole("button", { name: /back/i }).click();
   await expect(page.getByText("Story Manager")).toBeVisible();
   await page.getByRole("tab", { name: /standalone/i }).click();
 


### PR DESCRIPTION
## Summary
- **Fix book cleaning not bumping content version**: The `force` parameter in `apply_book_cleaning` was dead code — reprocess-all and Save & Rebuild now properly call `touch_book_content` so the reader API's `/reader/updates?since=...` endpoint picks up cleaned books
- **Add cleaned chapter preview**: New `GET /api/books/{id}/cleaned-chapters` endpoint and an Original/Cleaned toggle in the chapter preview UI so you can verify cleaning results directly
- **Save & Rebuild stays on page**: No longer navigates away, refreshes cleaned chapters instead so you can immediately check the output
- **Library page UI polish**: Search bar with magnifying glass icon and inline clear button, grouped sort controls, button-style Add Books collapsible with chevron, side-by-side file drop zone and URL input layout

## Test plan
- [ ] Add a cleaning config, run reprocess-all, verify books show as updated in `/reader/updates?since=...`
- [ ] Open book settings, expand chapters, toggle to "Cleaned" to verify cleaned content displays correctly
- [ ] Click "Save & Rebuild EPUB" and confirm it stays on the page
- [ ] Verify the search bar, sort controls, and Add Books section look correct on the library page
- [ ] Test Add Books section on narrow viewport to confirm responsive stacking

🤖 Generated with [Claude Code](https://claude.com/claude-code)