### PR TITLE
Fix series tab ignoring sort dropdown selection

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -173,7 +173,7 @@ function App() {
             </details>
             {isLoading && <p>Loading...</p>}
             {error && <p className="error">{error.message}</p>}
-            <BookList books={catalog} onEdit={handleEdit} libraryView={libraryView} onLibraryViewChange={handleLibraryViewChange} />
+            <BookList books={catalog} onEdit={handleEdit} libraryView={libraryView} onLibraryViewChange={handleLibraryViewChange} sortBy={sortBy} sortOrder={sortOrder} />
           </>
         );
     }

--- a/frontend/src/components/BookList.jsx
+++ b/frontend/src/components/BookList.jsx
@@ -643,7 +643,7 @@ function StandaloneTagAction({ book, seriesOptions }) {
 
 const TAB_PAGE_SIZE = 30;
 
-function BookList({ books = [], onEdit, libraryView: libraryViewProp, onLibraryViewChange }) {
+function BookList({ books = [], onEdit, libraryView: libraryViewProp, onLibraryViewChange, sortBy = "title", sortOrder = "asc" }) {
   const sentinelRef = useRef(null);
   const [internalView, setInternalView] = useState("series");
   const libraryView = libraryViewProp ?? internalView;
@@ -686,7 +686,25 @@ function BookList({ books = [], onEdit, libraryView: libraryViewProp, onLibraryV
       seriesBooks.sort(compareSeriesBooks);
     }
 
-    const sorted = Object.keys(sMap).sort();
+    const dir = sortOrder === "desc" ? -1 : 1;
+    const sorted = Object.keys(sMap).sort((a, b) => {
+      const booksA = sMap[a];
+      const booksB = sMap[b];
+      if (sortBy === "author") {
+        return dir * (booksA[0].author || "").localeCompare(booksB[0].author || "");
+      }
+      if (sortBy === "word_count") {
+        const wcA = booksA.reduce((sum, bk) => sum + (bk.current_word_count || 0), 0);
+        const wcB = booksB.reduce((sum, bk) => sum + (bk.current_word_count || 0), 0);
+        return dir * (wcA - wcB);
+      }
+      if (sortBy === "updated_at") {
+        const latestA = Math.max(...booksA.map((bk) => new Date(bk.updated_at || 0).getTime()));
+        const latestB = Math.max(...booksB.map((bk) => new Date(bk.updated_at || 0).getTime()));
+        return dir * (latestA - latestB);
+      }
+      return dir * a.localeCompare(b);
+    });
     return {
       seriesMap: sMap,
       sortedSeries: sorted,
@@ -694,7 +712,7 @@ function BookList({ books = [], onEdit, libraryView: libraryViewProp, onLibraryV
       webBooks: web,
       counts: { series: sorted.length, standalone: standalone.length, web: web.length },
     };
-  }, [books]);
+  }, [books, sortBy, sortOrder]);
 
   const tabItems =
     libraryView === "series" ? sortedSeries :


### PR DESCRIPTION
## Summary
- The series tab always sorted series alphabetically, ignoring the sort dropdown (title, author, word count, last updated)
- Pass `sortBy`/`sortOrder` props from `App.jsx` to `BookList` and use them to sort series by the selected criteria
- Series sort by: name (title), first book's author, total word count, or most recently updated book

## Test plan
- [ ] Switch to the series tab and change the sort dropdown — verify series reorder accordingly
- [ ] Toggle ascending/descending — verify order reverses
- [ ] Confirm infinite scroll still works after sorting
- [ ] All 28 frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)