### PR TITLE
[codex] Add configurable daily scheduler time

### DIFF
--- a/backend/alembic/versions/0014_add_scheduler_settings.py
+++ b/backend/alembic/versions/0014_add_scheduler_settings.py
@@ -1,0 +1,35 @@
+"""Add scheduler settings for configurable daily web novel runs.
+
+Revision ID: 0014
+Revises: 0013
+Create Date: 2026-04-15 00:00:00
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0014"
+down_revision = "0013"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    if not sa.inspect(conn).has_table("scheduler_settings"):
+        op.create_table(
+            "scheduler_settings",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("web_novel_schedule_hour", sa.Integer(), nullable=True),
+            sa.Column("web_novel_schedule_minute", sa.Integer(), nullable=True),
+            sa.Column("web_novel_schedule_timezone", sa.String(), nullable=True),
+        )
+
+
+def downgrade():
+    conn = op.get_bind()
+
+    if sa.inspect(conn).has_table("scheduler_settings"):
+        op.drop_table("scheduler_settings")

--- a/backend/app/crud/__init__.py
+++ b/backend/app/crud/__init__.py
@@ -46,6 +46,7 @@ from .logs import (  # noqa: F401
     get_latest_update_task,
     get_update_tasks,
     increment_update_task,
+    interrupt_update_task,
     reset_stuck_update_tasks,
 )
 from .cleaning import (  # noqa: F401
@@ -67,6 +68,10 @@ from .reader import (  # noqa: F401
     get_reader_standalone_books,
     get_reader_updates,
     search_reader_books,
+)
+from .scheduler_settings import (  # noqa: F401
+    get_scheduler_settings,
+    upsert_scheduler_settings,
 )
 from .api_keys import (  # noqa: F401
     create_api_key,

--- a/backend/app/crud/logs.py
+++ b/backend/app/crud/logs.py
@@ -68,12 +68,19 @@ async def fail_update_task(db: AsyncSession, task: models.UpdateTask) -> None:
     await db.refresh(task)
 
 
+async def interrupt_update_task(db: AsyncSession, task: models.UpdateTask) -> None:
+    task.status = "interrupted"
+    task.completed_at = datetime.now(timezone.utc)
+    await db.commit()
+    await db.refresh(task)
+
+
 async def reset_stuck_update_tasks(db: AsyncSession) -> None:
-    """Mark any tasks left in 'running' state (e.g. from a crashed run) as 'failed'."""
+    """Mark any tasks left in 'running' state (e.g. from a crashed run) as 'interrupted'."""
     result = await db.execute(select(models.UpdateTask).filter(models.UpdateTask.status == "running"))
     stuck = result.scalars().all()
     for task in stuck:
-        task.status = "failed"
+        task.status = "interrupted"
         task.completed_at = datetime.now(timezone.utc)
     if stuck:
         await db.commit()

--- a/backend/app/crud/scheduler_settings.py
+++ b/backend/app/crud/scheduler_settings.py
@@ -1,0 +1,38 @@
+"""Scheduler settings CRUD operations."""
+
+from typing import Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from .. import models
+
+
+async def get_scheduler_settings(db: AsyncSession) -> Optional[models.SchedulerSettings]:
+    result = await db.execute(select(models.SchedulerSettings).order_by(models.SchedulerSettings.id.asc()).limit(1))
+    return result.scalars().first()
+
+
+async def upsert_scheduler_settings(
+    db: AsyncSession,
+    *,
+    web_novel_schedule_hour: int,
+    web_novel_schedule_minute: int,
+    web_novel_schedule_timezone: str,
+) -> models.SchedulerSettings:
+    settings = await get_scheduler_settings(db)
+    if settings is None:
+        settings = models.SchedulerSettings(
+            web_novel_schedule_hour=web_novel_schedule_hour,
+            web_novel_schedule_minute=web_novel_schedule_minute,
+            web_novel_schedule_timezone=web_novel_schedule_timezone,
+        )
+        db.add(settings)
+    else:
+        settings.web_novel_schedule_hour = web_novel_schedule_hour
+        settings.web_novel_schedule_minute = web_novel_schedule_minute
+        settings.web_novel_schedule_timezone = web_novel_schedule_timezone
+
+    await db.commit()
+    await db.refresh(settings)
+    return settings

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -137,6 +137,15 @@ class CleaningConfig(Base):
     content_selectors = Column(JSON, nullable=True)
 
 
+class SchedulerSettings(Base):
+    __tablename__ = "scheduler_settings"
+
+    id = Column(Integer, primary_key=True, index=True)
+    web_novel_schedule_hour = Column(Integer, nullable=True)
+    web_novel_schedule_minute = Column(Integer, nullable=True)
+    web_novel_schedule_timezone = Column(String, nullable=True)
+
+
 class ApiKey(Base):
     __tablename__ = "api_keys"
 

--- a/backend/app/routers/cleaning.py
+++ b/backend/app/routers/cleaning.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import logging
-import re
 from typing import List
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status

--- a/backend/app/routers/scheduler.py
+++ b/backend/app/routers/scheduler.py
@@ -15,6 +15,27 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+def _build_scheduler_job_status(
+    latest_task: Optional[schemas.UpdateTask],
+    schedule_settings,
+    job,
+) -> schemas.SchedulerJobStatus:
+    next_run_at = job.next_run_time if job is not None else None
+    return schemas.SchedulerJobStatus(
+        job_id=update_scheduler.WEB_NOVEL_UPDATE_JOB_ID,
+        schedule=update_scheduler.get_schedule_label(schedule_settings),
+        schedule_mode=update_scheduler.get_schedule_mode(schedule_settings),
+        schedule_time_local=update_scheduler.get_schedule_time_local(schedule_settings),
+        schedule_timezone=update_scheduler.get_schedule_timezone(schedule_settings),
+        next_run_at=next_run_at,
+        scheduler_running=update_scheduler.is_scheduler_running(),
+        run_in_progress=update_scheduler.is_update_running(),
+        last_run_started_at=latest_task.started_at if latest_task is not None else None,
+        last_run_completed_at=latest_task.completed_at if latest_task is not None else None,
+        last_run_status=latest_task.status if latest_task is not None else None,
+    )
+
+
 @router.get("/api/scheduler/status", response_model=Optional[schemas.UpdateTask])
 async def get_scheduler_status(db: AsyncSession = Depends(get_db)):
     return await crud.get_latest_update_task(db)
@@ -23,18 +44,24 @@ async def get_scheduler_status(db: AsyncSession = Depends(get_db)):
 @router.get("/api/scheduler/job", response_model=schemas.SchedulerJobStatus)
 async def get_scheduler_job_status(db: AsyncSession = Depends(get_db)):
     latest_task = await crud.get_latest_update_task(db)
+    schedule_settings = await crud.get_scheduler_settings(db)
     job = update_scheduler.get_scheduled_job()
-    next_run_at = job.next_run_time if job is not None else None
-    return schemas.SchedulerJobStatus(
-        job_id=update_scheduler.WEB_NOVEL_UPDATE_JOB_ID,
-        schedule=update_scheduler.get_schedule_label(),
-        next_run_at=next_run_at,
-        scheduler_running=update_scheduler.is_scheduler_running(),
-        run_in_progress=update_scheduler.is_update_running(),
-        last_run_started_at=latest_task.started_at if latest_task is not None else None,
-        last_run_completed_at=latest_task.completed_at if latest_task is not None else None,
-        last_run_status=latest_task.status if latest_task is not None else None,
+    return _build_scheduler_job_status(latest_task, schedule_settings, job)
+
+
+@router.put("/api/scheduler/config", response_model=schemas.SchedulerJobStatus)
+async def update_scheduler_config(config: schemas.SchedulerConfigUpdate, db: AsyncSession = Depends(get_db)):
+    hour_text, minute_text = config.time_local.split(":")
+    schedule_settings = await crud.upsert_scheduler_settings(
+        db,
+        web_novel_schedule_hour=int(hour_text),
+        web_novel_schedule_minute=int(minute_text),
+        web_novel_schedule_timezone=config.timezone,
     )
+    await update_scheduler.schedule_next_web_novel_update()
+    latest_task = await crud.get_latest_update_task(db)
+    job = update_scheduler.get_scheduled_job()
+    return _build_scheduler_job_status(latest_task, schedule_settings, job)
 
 
 @router.post("/api/scheduler/trigger", status_code=202)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,6 +1,7 @@
-from pydantic import BaseModel, ConfigDict, Field, HttpUrl
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl, field_validator
 from datetime import datetime
 from typing import Optional, List
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from .models import SourceType
 
 
@@ -132,12 +133,39 @@ class UpdateTask(BaseModel):
 class SchedulerJobStatus(BaseModel):
     job_id: str
     schedule: str
+    schedule_mode: str = "interval"
+    schedule_time_local: Optional[str] = None
+    schedule_timezone: Optional[str] = None
     next_run_at: Optional[datetime] = None
     scheduler_running: bool
     run_in_progress: bool
     last_run_started_at: Optional[datetime] = None
     last_run_completed_at: Optional[datetime] = None
     last_run_status: Optional[str] = None
+
+
+class SchedulerConfigUpdate(BaseModel):
+    time_local: str = Field(pattern=r"^\d{2}:\d{2}$")
+    timezone: str = Field(min_length=1, max_length=100)
+
+    @field_validator("time_local")
+    @classmethod
+    def validate_time_local(cls, value: str) -> str:
+        hour_text, minute_text = value.split(":")
+        hour = int(hour_text)
+        minute = int(minute_text)
+        if hour < 0 or hour > 23 or minute < 0 or minute > 59:
+            raise ValueError("time_local must be a valid 24-hour time")
+        return value
+
+    @field_validator("timezone")
+    @classmethod
+    def validate_timezone(cls, value: str) -> str:
+        try:
+            ZoneInfo(value)
+        except ZoneInfoNotFoundError as exc:
+            raise ValueError("timezone must be a valid IANA timezone") from exc
+        return value
 
 
 class BookLogWithTitle(BookLog):

--- a/backend/app/services/update_scheduler.py
+++ b/backend/app/services/update_scheduler.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 from datetime import datetime, timedelta, timezone
 from typing import Optional
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
@@ -41,10 +42,6 @@ def is_scheduler_running() -> bool:
     return _scheduler.running
 
 
-def get_schedule_label() -> str:
-    return f"Every {WEB_NOVEL_UPDATE_INTERVAL_HOURS} hours"
-
-
 def get_metadata_schedule_label() -> str:
     return f"Check for stale metadata every {METADATA_STALE_SCAN_INTERVAL_HOURS} hours"
 
@@ -69,6 +66,54 @@ def _as_utc(dt: Optional[datetime]) -> Optional[datetime]:
     return dt.astimezone(timezone.utc)
 
 
+def has_daily_schedule(settings: Optional[models.SchedulerSettings]) -> bool:
+    return bool(
+        settings is not None
+        and settings.web_novel_schedule_hour is not None
+        and settings.web_novel_schedule_minute is not None
+        and settings.web_novel_schedule_timezone
+    )
+
+
+def get_schedule_mode(settings: Optional[models.SchedulerSettings]) -> str:
+    return "daily_time" if has_daily_schedule(settings) else "interval"
+
+
+def get_schedule_time_local(settings: Optional[models.SchedulerSettings]) -> Optional[str]:
+    if not has_daily_schedule(settings):
+        return None
+    return f"{settings.web_novel_schedule_hour:02d}:{settings.web_novel_schedule_minute:02d}"
+
+
+def get_schedule_timezone(settings: Optional[models.SchedulerSettings]) -> Optional[str]:
+    if not has_daily_schedule(settings):
+        return None
+    return settings.web_novel_schedule_timezone
+
+
+def _format_hour_minute(hour: int, minute: int) -> str:
+    suffix = "AM" if hour < 12 else "PM"
+    hour_12 = hour % 12 or 12
+    return f"{hour_12}:{minute:02d} {suffix}"
+
+
+def get_schedule_label(settings: Optional[models.SchedulerSettings] = None) -> str:
+    if has_daily_schedule(settings):
+        return (
+            f"Daily at {_format_hour_minute(settings.web_novel_schedule_hour, settings.web_novel_schedule_minute)} "
+            f"({settings.web_novel_schedule_timezone})"
+        )
+    return f"Every {WEB_NOVEL_UPDATE_INTERVAL_HOURS} hours"
+
+
+def _get_zoneinfo(timezone_name: str) -> ZoneInfo:
+    try:
+        return ZoneInfo(timezone_name)
+    except ZoneInfoNotFoundError:
+        logger.warning("Unknown scheduler timezone %s; falling back to UTC.", timezone_name)
+        return ZoneInfo("UTC")
+
+
 def get_last_run_anchor(task: Optional[models.UpdateTask]) -> Optional[datetime]:
     if task is None:
         return None
@@ -89,11 +134,45 @@ def calculate_next_run_time(last_run_at: Optional[datetime], now: Optional[datet
     return next_run_at
 
 
+def calculate_next_daily_run_time(
+    hour: int,
+    minute: int,
+    timezone_name: str,
+    now: Optional[datetime] = None,
+) -> datetime:
+    now_utc = _as_utc(now) or datetime.now(timezone.utc)
+    schedule_tz = _get_zoneinfo(timezone_name)
+    now_local = now_utc.astimezone(schedule_tz)
+    next_local = now_local.replace(hour=hour, minute=minute, second=0, microsecond=0)
+    if next_local <= now_local:
+        next_local += timedelta(days=1)
+    return next_local.astimezone(timezone.utc)
+
+
+def get_next_run_time_for_task(
+    task: Optional[models.UpdateTask],
+    schedule_settings: Optional[models.SchedulerSettings] = None,
+    now: Optional[datetime] = None,
+) -> datetime:
+    now_utc = _as_utc(now) or datetime.now(timezone.utc)
+    if task is not None and task.status == "interrupted" and task.completed_books < task.total_books:
+        return now_utc + OVERDUE_RUN_DELAY
+    if has_daily_schedule(schedule_settings):
+        return calculate_next_daily_run_time(
+            schedule_settings.web_novel_schedule_hour,
+            schedule_settings.web_novel_schedule_minute,
+            schedule_settings.web_novel_schedule_timezone,
+            now=now_utc,
+        )
+    return calculate_next_run_time(get_last_run_anchor(task), now=now_utc)
+
+
 async def schedule_next_web_novel_update() -> datetime:
     async with SessionLocal() as db:
         latest_task = await crud.get_latest_update_task(db)
+        schedule_settings = await crud.get_scheduler_settings(db)
 
-    next_run_at = calculate_next_run_time(get_last_run_anchor(latest_task))
+    next_run_at = get_next_run_time_for_task(latest_task, schedule_settings=schedule_settings)
     _scheduler.add_job(
         run_web_novel_update,
         "date",

--- a/backend/app/services/web_novel.py
+++ b/backend/app/services/web_novel.py
@@ -250,6 +250,7 @@ async def update_web_novels() -> None:
     db = SessionLocal()
     task = None
     failed = False
+    had_book_failures = False
     try:
         books = await crud.get_web_books(db)
         task = await crud.get_active_update_task(db)
@@ -260,16 +261,18 @@ async def update_web_novels() -> None:
         logger.info(f"Update task {task.id} processing {task.completed_books}/{task.total_books} books.")
 
         for book in books:
-            if not book.immutable_path or not book.current_path:
-                logger.warning("Skipping %s (id=%s): missing epub paths.", book.title, book.id)
-                await crud.increment_update_task(db, task)
-                continue
-            latest_log = await crud.get_latest_book_log(db, book.id)
-            if latest_log and latest_log.timestamp >= task.started_at:
-                logger.info(f"Skipping {book.title}, already processed in this task.")
-                continue
-            logger.info(f"Checking {book.title} for updates.")
+            old_chapter_count: Optional[int] = None
             try:
+                if not book.immutable_path or not book.current_path:
+                    logger.warning("Skipping %s (id=%s): missing epub paths.", book.title, book.id)
+                    continue
+
+                latest_log = await crud.get_latest_book_log(db, book.id)
+                if latest_log and latest_log.timestamp >= task.started_at:
+                    logger.info(f"Skipping {book.title}, already processed in this task.")
+                    continue
+
+                logger.info(f"Checking {book.title} for updates.")
                 immutable_path = LIBRARY_PATH.parent / book.immutable_path
                 current_path = LIBRARY_PATH.parent / book.current_path
 
@@ -286,7 +289,6 @@ async def update_web_novels() -> None:
                         words_added=0,
                     )
                     await crud.create_book_log(db, log_entry)
-                    await crud.increment_update_task(db, task)
                     continue
 
                 new_epub_path, _ = result
@@ -320,15 +322,27 @@ async def update_web_novels() -> None:
                     )
                 await crud.create_book_log(db, log_entry)
                 await epub_editor.apply_book_cleaning(book, db)
-                await crud.increment_update_task(db, task)
             except Exception as e:
+                had_book_failures = True
                 logger.error(f"Failed to update {book.title}: {e}\n{traceback.format_exc()}")
+                await crud.create_book_log(
+                    db,
+                    schemas.BookLogCreate(
+                        book_id=book.id,
+                        entry_type="error",
+                        previous_chapter_count=old_chapter_count,
+                        new_chapter_count=old_chapter_count,
+                        words_added=0,
+                    ),
+                )
+            finally:
+                await crud.increment_update_task(db, task)
     except Exception as e:
         logger.error(f"Scheduler run failed: {e}\n{traceback.format_exc()}")
         failed = True
     finally:
         if task is not None:
-            if failed:
+            if failed or had_book_failures:
                 await crud.fail_update_task(db, task)
             else:
                 await crud.complete_update_task(db, task)

--- a/backend/tests/test_crud_modules.py
+++ b/backend/tests/test_crud_modules.py
@@ -172,7 +172,29 @@ class TestLogsCrud:
         assert task.status == "running"
         await crud.reset_stuck_update_tasks(db)
         await db.refresh(task)
-        assert task.status == "failed"
+        assert task.status == "interrupted"
+
+    @pytest.mark.asyncio
+    async def test_upsert_scheduler_settings(self, db):
+        settings = await crud.upsert_scheduler_settings(
+            db,
+            web_novel_schedule_hour=6,
+            web_novel_schedule_minute=30,
+            web_novel_schedule_timezone="America/New_York",
+        )
+        assert settings.id is not None
+        assert settings.web_novel_schedule_hour == 6
+
+        updated = await crud.upsert_scheduler_settings(
+            db,
+            web_novel_schedule_hour=7,
+            web_novel_schedule_minute=45,
+            web_novel_schedule_timezone="UTC",
+        )
+        assert updated.id == settings.id
+        assert updated.web_novel_schedule_hour == 7
+        assert updated.web_novel_schedule_minute == 45
+        assert updated.web_novel_schedule_timezone == "UTC"
 
 
 class TestCleaningCrud:

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -2,6 +2,7 @@ import pytest
 import pytest_asyncio
 import zipfile
 from datetime import datetime, timedelta, timezone
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
 from sqlalchemy.pool import StaticPool
@@ -9,7 +10,7 @@ from pathlib import Path
 
 from ebooklib import epub
 from backend.app.main import app
-from backend.app.services import update_scheduler
+from backend.app.services import update_scheduler, web_novel
 from backend.app.services.series import SeriesBook, detect_series_from_books, detect_series_from_titles
 from backend.app.database import Base, get_db
 from backend.app import crud, epub_editor, models, schemas
@@ -1798,6 +1799,17 @@ def test_get_last_run_anchor_prefers_start_for_failed_tasks():
     assert anchor == task.started_at
 
 
+def test_get_next_run_time_for_interrupted_task_runs_soon():
+    now = datetime(2026, 3, 19, 10, 0, tzinfo=timezone.utc)
+    task = models.UpdateTask(status="interrupted", total_books=30, completed_books=14)
+    task.started_at = now - timedelta(minutes=15)
+    task.completed_at = now - timedelta(seconds=5)
+
+    next_run = update_scheduler.get_next_run_time_for_task(task, now=now)
+
+    assert next_run == now + update_scheduler.OVERDUE_RUN_DELAY
+
+
 @pytest.mark.asyncio
 async def test_scheduler_job_status(db_session, mocker):
     """
@@ -1823,9 +1835,96 @@ async def test_scheduler_job_status(db_session, mocker):
     assert data["next_run_at"] == "2026-03-20T14:30:00Z"
     assert data["scheduler_running"] is True
     assert data["run_in_progress"] is False
+    assert data["schedule_mode"] == "interval"
+    assert data["schedule_time_local"] is None
+    assert data["schedule_timezone"] is None
     assert data["last_run_status"] == "completed"
     assert data["last_run_started_at"] is not None
     assert data["last_run_completed_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_update_scheduler_config_persists_daily_time_and_reschedules(db_session, mocker):
+    class DummyJob:
+        next_run_time = datetime(2026, 3, 20, 10, 30, tzinfo=timezone.utc)
+
+    schedule_mock = mocker.patch(
+        "backend.app.routers.scheduler.update_scheduler.schedule_next_web_novel_update",
+        return_value=DummyJob.next_run_time,
+    )
+    mocker.patch("backend.app.routers.scheduler.update_scheduler.get_scheduled_job", return_value=DummyJob())
+    mocker.patch("backend.app.routers.scheduler.update_scheduler.is_scheduler_running", return_value=True)
+    mocker.patch("backend.app.routers.scheduler.update_scheduler.is_update_running", return_value=False)
+
+    response = client.put(
+        "/api/scheduler/config",
+        json={"time_local": "06:30", "timezone": "America/New_York"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["schedule"] == "Daily at 6:30 AM (America/New_York)"
+    assert data["schedule_mode"] == "daily_time"
+    assert data["schedule_time_local"] == "06:30"
+    assert data["schedule_timezone"] == "America/New_York"
+    assert data["next_run_at"] == "2026-03-20T10:30:00Z"
+    schedule_mock.assert_awaited_once()
+
+    async with AsyncTestingSessionLocal() as session:
+        settings = await crud.get_scheduler_settings(session)
+        assert settings is not None
+        assert settings.web_novel_schedule_hour == 6
+        assert settings.web_novel_schedule_minute == 30
+        assert settings.web_novel_schedule_timezone == "America/New_York"
+
+
+@pytest.mark.asyncio
+async def test_update_web_novels_counts_and_logs_book_failures(db_session, mocker):
+    async with AsyncTestingSessionLocal() as session:
+        await crud.create_book(
+            session,
+            schemas.BookCreate(
+                title="Broken Book A",
+                author="Author",
+                immutable_path="broken_a.epub",
+                current_path="broken_a_current.epub",
+                source_type=models.SourceType.web,
+                source_url="https://example.com/broken-a",
+            ),
+        )
+        await crud.create_book(
+            session,
+            schemas.BookCreate(
+                title="Broken Book B",
+                author="Author",
+                immutable_path="broken_b.epub",
+                current_path="broken_b_current.epub",
+                source_type=models.SourceType.web,
+                source_url="https://example.com/broken-b",
+            ),
+        )
+
+    mocker.patch("backend.app.services.web_novel.get_epub_word_and_chapter_count", return_value=(1000, 10))
+    mocker.patch(
+        "backend.app.services.web_novel.download_web_novel",
+        side_effect=HTTPException(status_code=500, detail="boom"),
+    )
+    mocker.patch("backend.app.services.web_novel.SessionLocal", AsyncTestingSessionLocal)
+
+    await web_novel.update_web_novels()
+
+    async with AsyncTestingSessionLocal() as session:
+        task = await crud.get_latest_update_task(session)
+        assert task is not None
+        assert task.total_books == 2
+        assert task.completed_books == 2
+        assert task.status == "failed"
+
+        logs = await crud.get_book_logs_for_task(session, task.id)
+        _, rows = logs
+        assert rows is not None
+        assert len(rows) == 2
+        assert {row[0].entry_type for row in rows} == {"error"}
 
 
 @pytest.mark.asyncio
@@ -2423,7 +2522,7 @@ async def test_scheduler_history_task_logs(db_session):
         )
         await crud.complete_update_task(session, task)
 
-    response = client.get(f"/api/scheduler/history/{task.id}/logs")
+        response = client.get(f"/api/scheduler/history/{task.id}/logs")
     assert response.status_code == 200
     data = response.json()
     assert len(data) == 2
@@ -2440,6 +2539,41 @@ async def test_scheduler_history_task_logs(db_session):
     checked = next(e for e in data if e["entry_type"] == "checked")
     assert checked["book_title"] == "Log Book B"
     assert checked["words_added"] == 0
+
+
+@pytest.mark.asyncio
+async def test_scheduler_history_task_logs_includes_error_entries(db_session):
+    async with AsyncTestingSessionLocal() as session:
+        book = await crud.create_book(
+            session,
+            schemas.BookCreate(
+                title="Errored Book",
+                author="Author",
+                immutable_path="err_i",
+                current_path="err_c",
+                source_type=models.SourceType.web,
+                source_url="http://example.com/err",
+            ),
+        )
+        task = await crud.create_update_task(session, total_books=1)
+        await crud.create_book_log(
+            session,
+            schemas.BookLogCreate(
+                book_id=book.id,
+                entry_type="error",
+                previous_chapter_count=12,
+                new_chapter_count=12,
+                words_added=0,
+            ),
+        )
+        await crud.fail_update_task(session, task)
+
+    response = client.get(f"/api/scheduler/history/{task.id}/logs")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["entry_type"] == "error"
+    assert data[0]["book_title"] == "Errored Book"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -5,9 +5,13 @@ from datetime import datetime, timezone
 from backend.app.services.update_scheduler import (
     OVERDUE_RUN_DELAY,
     WEB_NOVEL_UPDATE_INTERVAL,
+    calculate_next_daily_run_time,
     calculate_next_run_time,
     get_last_run_anchor,
+    get_next_run_time_for_task,
+    get_schedule_label,
 )
+from backend.app import models
 
 
 def _utc(year=2025, month=1, day=1, hour=12, minute=0):
@@ -82,3 +86,61 @@ class TestGetLastRunAnchor:
 
         result = get_last_run_anchor(FakeTask())
         assert result == _utc(hour=10)
+
+
+class TestGetNextRunTimeForTask:
+    def test_interrupted_incomplete_task_retries_soon(self):
+        class FakeTask:
+            status = "interrupted"
+            started_at = _utc(hour=10)
+            completed_at = _utc(hour=10, minute=15)
+            completed_books = 14
+            total_books = 30
+
+        now = _utc(hour=10, minute=16)
+        result = get_next_run_time_for_task(FakeTask(), now=now)
+        assert result == now + OVERDUE_RUN_DELAY
+
+    def test_completed_task_uses_normal_interval(self):
+        class FakeTask:
+            status = "completed"
+            started_at = _utc(hour=10)
+            completed_at = _utc(hour=11)
+            completed_books = 30
+            total_books = 30
+
+        now = _utc(hour=12)
+        result = get_next_run_time_for_task(FakeTask(), now=now)
+        assert result == _utc(year=2025, month=1, day=2, hour=11)
+
+    def test_daily_schedule_uses_fixed_local_time(self):
+        class FakeTask:
+            status = "completed"
+            started_at = _utc(hour=6)
+            completed_at = _utc(hour=7)
+            completed_books = 30
+            total_books = 30
+
+        settings = models.SchedulerSettings(
+            web_novel_schedule_hour=6,
+            web_novel_schedule_minute=30,
+            web_novel_schedule_timezone="America/New_York",
+        )
+        now = _utc(year=2025, month=1, day=1, hour=12)
+        result = get_next_run_time_for_task(FakeTask(), schedule_settings=settings, now=now)
+        assert result == _utc(year=2025, month=1, day=2, hour=11, minute=30)
+
+
+class TestDailyScheduleHelpers:
+    def test_calculate_next_daily_run_time(self):
+        now = _utc(year=2025, month=1, day=1, hour=12)
+        result = calculate_next_daily_run_time(6, 30, "America/New_York", now=now)
+        assert result == _utc(year=2025, month=1, day=2, hour=11, minute=30)
+
+    def test_get_schedule_label_for_daily_time(self):
+        settings = models.SchedulerSettings(
+            web_novel_schedule_hour=6,
+            web_novel_schedule_minute=30,
+            web_novel_schedule_timezone="America/New_York",
+        )
+        assert get_schedule_label(settings) == "Daily at 6:30 AM (America/New_York)"

--- a/frontend/src/components/SchedulerStatus.jsx
+++ b/frontend/src/components/SchedulerStatus.jsx
@@ -25,6 +25,14 @@ const fetchTaskLogs = async (taskId) => {
   return res.json();
 };
 
+function getBrowserTimezone() {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+  } catch {
+    return "UTC";
+  }
+}
+
 function timeAgo(dateStr) {
   if (!dateStr) return "Never";
   const diff = Date.now() - new Date(dateStr).getTime();
@@ -39,6 +47,14 @@ function timeAgo(dateStr) {
 function formatDate(dateStr) {
   if (!dateStr) return "";
   return new Date(dateStr).toLocaleString();
+}
+
+function toTimeInputValue(dateStr) {
+  if (!dateStr) return "06:00";
+  const date = new Date(dateStr);
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  return `${hours}:${minutes}`;
 }
 
 function formatTimeUntil(dateStr, now) {
@@ -80,6 +96,7 @@ function TaskLogsList({ taskId }) {
   const updatedLogs = logs.filter((l) => l.entry_type === "updated");
   const checkedLogs = logs.filter((l) => l.entry_type === "checked");
   const addedLogs = logs.filter((l) => l.entry_type === "added");
+  const errorLogs = logs.filter((l) => l.entry_type === "error");
 
   return (
     <div className="task-logs">
@@ -124,6 +141,19 @@ function TaskLogsList({ taskId }) {
           </ul>
         </div>
       )}
+      {errorLogs.length > 0 && (
+        <div>
+          <p className="task-logs-group-label">Errors ({errorLogs.length})</p>
+          <ul className="task-logs-list">
+            {errorLogs.map((log) => (
+              <li key={log.id} className="task-log-entry">
+                <span className="task-log-title">{log.book_title}</span>
+                <span className="task-log-detail">Update failed</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   );
 }
@@ -153,6 +183,9 @@ function TaskHistoryRow({ task }) {
 function SchedulerStatus({ onBack }) {
   const queryClient = useQueryClient();
   const [now, setNow] = useState(Date.now());
+  const [scheduleTime, setScheduleTime] = useState("06:00");
+  const [scheduleTimezone, setScheduleTimezone] = useState(() => getBrowserTimezone());
+  const [scheduleDirty, setScheduleDirty] = useState(false);
 
   useEffect(() => {
     const intervalId = window.setInterval(() => {
@@ -180,6 +213,12 @@ function SchedulerStatus({ onBack }) {
     refetchInterval: task?.status === "running" ? 5000 : false,
   });
 
+  useEffect(() => {
+    if (!job || scheduleDirty) return;
+    setScheduleTime(job.schedule_time_local || toTimeInputValue(job.next_run_at));
+    setScheduleTimezone(job.schedule_timezone || getBrowserTimezone());
+  }, [job, scheduleDirty]);
+
   const triggerMutation = useMutation({
     mutationFn: () =>
       fetch("/api/scheduler/trigger", { method: "POST" }).then((r) => r.json()),
@@ -187,6 +226,35 @@ function SchedulerStatus({ onBack }) {
       queryClient.invalidateQueries({ queryKey: ["scheduler-job"] });
       queryClient.invalidateQueries({ queryKey: ["scheduler-status"] });
       queryClient.invalidateQueries({ queryKey: ["scheduler-history"] });
+    },
+  });
+
+  const scheduleMutation = useMutation({
+    mutationFn: async ({ timeLocal, timezone }) => {
+      const res = await fetch("/api/scheduler/config", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ time_local: timeLocal, timezone }),
+      });
+      if (!res.ok) {
+        let detail = "Failed to update schedule";
+        try {
+          const body = await res.json();
+          if (body?.detail) {
+            detail = Array.isArray(body.detail)
+              ? body.detail.map((item) => item.msg || item).join(", ")
+              : body.detail;
+          }
+        } catch {
+          // Ignore JSON parse failures and keep the default message.
+        }
+        throw new Error(detail);
+      }
+      return res.json();
+    },
+    onSuccess: (data) => {
+      setScheduleDirty(false);
+      queryClient.setQueryData(["scheduler-job"], data);
     },
   });
 
@@ -206,30 +274,66 @@ function SchedulerStatus({ onBack }) {
         <h3>Automatic Schedule</h3>
         {jobLoading && <p>Loading...</p>}
         {job && (
-          <div className="scheduler-grid">
-            <div className="scheduler-stat">
-              <span className="hint">Schedule</span>
-              <strong className="scheduler-value">{job.schedule}</strong>
+          <>
+            <div className="scheduler-grid">
+              <div className="scheduler-stat">
+                <span className="hint">Schedule</span>
+                <strong className="scheduler-value">{job.schedule}</strong>
+              </div>
+              <div className="scheduler-stat">
+                <span className="hint">Next Run</span>
+                <strong className="scheduler-value">
+                  {job.next_run_at ? formatDate(job.next_run_at) : "Not scheduled"}
+                </strong>
+              </div>
+              <div className="scheduler-stat">
+                <span className="hint">Time Until Next Run</span>
+                <strong className="scheduler-value">
+                  {formatTimeUntil(job.next_run_at, now)}
+                </strong>
+              </div>
+              <div className="scheduler-stat">
+                <span className="hint">Run State</span>
+                <strong className="scheduler-value">
+                  {formatRunState(job)}
+                </strong>
+              </div>
             </div>
-            <div className="scheduler-stat">
-              <span className="hint">Next Run</span>
-              <strong className="scheduler-value">
-                {job.next_run_at ? formatDate(job.next_run_at) : "Not scheduled"}
-              </strong>
-            </div>
-            <div className="scheduler-stat">
-              <span className="hint">Time Until Next Run</span>
-              <strong className="scheduler-value">
-                {formatTimeUntil(job.next_run_at, now)}
-              </strong>
-            </div>
-            <div className="scheduler-stat">
-              <span className="hint">Run State</span>
-              <strong className="scheduler-value">
-                {formatRunState(job)}
-              </strong>
-            </div>
-          </div>
+            <form
+              onSubmit={(event) => {
+                event.preventDefault();
+                scheduleMutation.mutate({ timeLocal: scheduleTime, timezone: scheduleTimezone });
+              }}
+            >
+              <label>
+                Daily Run Time
+                <input
+                  type="time"
+                  value={scheduleTime}
+                  onChange={(event) => {
+                    setScheduleDirty(true);
+                    setScheduleTime(event.target.value);
+                  }}
+                />
+              </label>
+              <p className="hint">
+                {job.schedule_mode === "daily_time"
+                  ? `Saved in ${job.schedule_timezone}.`
+                  : `Saving will switch from the rolling 24-hour interval to a fixed daily time in ${scheduleTimezone}.`}
+              </p>
+              <div className="settings-actions">
+                <button type="submit" disabled={scheduleMutation.isPending}>
+                  {scheduleMutation.isPending ? "Saving..." : "Save Schedule"}
+                </button>
+                {scheduleMutation.isError && (
+                  <p className="error">Failed: {scheduleMutation.error.message}</p>
+                )}
+                {scheduleMutation.isSuccess && !scheduleMutation.isPending && (
+                  <p className="hint">Daily schedule updated.</p>
+                )}
+              </div>
+            </form>
+          </>
         )}
       </section>
 

--- a/frontend/src/components/SchedulerStatus.test.jsx
+++ b/frontend/src/components/SchedulerStatus.test.jsx
@@ -6,6 +6,9 @@ import { renderWithClient } from "../test-utils";
 const mockJob = {
   job_id: "update_web_novels",
   schedule: "Every 24 hours",
+  schedule_mode: "interval",
+  schedule_time_local: null,
+  schedule_timezone: null,
   next_run_at: new Date(Date.now() + 7200000).toISOString(),
   scheduler_running: true,
   run_in_progress: false,
@@ -60,6 +63,16 @@ const mockLogs = [
     entry_type: "checked",
     previous_chapter_count: 10,
     new_chapter_count: 10,
+    words_added: 0,
+    timestamp: new Date().toISOString(),
+  },
+  {
+    id: 3,
+    book_id: 12,
+    book_title: "Broken Orbit",
+    entry_type: "error",
+    previous_chapter_count: 7,
+    new_chapter_count: 7,
     words_added: 0,
     timestamp: new Date().toISOString(),
   },
@@ -174,6 +187,8 @@ describe("SchedulerStatus", () => {
     await waitFor(() => {
       expect(screen.getByText("Dragon's Lair")).toBeInTheDocument();
       expect(screen.getByText("Moonlight")).toBeInTheDocument();
+      expect(screen.getByText("Broken Orbit")).toBeInTheDocument();
+      expect(screen.getByText("Errors (1)")).toBeInTheDocument();
     });
 
     // Updated entry shows chapter and word counts
@@ -236,6 +251,46 @@ describe("SchedulerStatus", () => {
     await waitFor(() => {
       expect(screen.getByText("Current Run")).toBeInTheDocument();
       expect(screen.getAllByText("Running").length).toBeGreaterThan(0);
+    });
+  });
+
+  it("saves a daily scheduler time from the app", async () => {
+    const savedJob = {
+      ...mockJob,
+      schedule: "Daily at 6:30 AM (America/New_York)",
+      schedule_mode: "daily_time",
+      schedule_time_local: "06:30",
+      schedule_timezone: "America/New_York",
+    };
+
+    globalThis.fetch = vi.fn((url, options) => {
+      if (url === "/api/scheduler/config") {
+        expect(options.method).toBe("PUT");
+        expect(options.body).toContain("\"time_local\":\"06:30\"");
+        expect(options.body).toContain("\"timezone\":");
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(savedJob) });
+      }
+      if (url.includes("/api/scheduler/job")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(mockJob) });
+      }
+      if (url.includes("/api/scheduler/status")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(mockTask) });
+      }
+      if (url.includes("/api/scheduler/history")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+    });
+
+    renderWithClient(<SchedulerStatus onBack={() => {}} />);
+
+    const timeInput = await screen.findByLabelText("Daily Run Time");
+    fireEvent.change(timeInput, { target: { value: "06:30" } });
+    fireEvent.click(screen.getByText("Save Schedule"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Daily schedule updated.")).toBeInTheDocument();
+      expect(screen.getByText("Daily at 6:30 AM (America/New_York)")).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## What changed

This PR adds a configurable daily run time for the web novel scheduler and improves scheduled-run reporting when runs are interrupted or individual books fail.

Backend changes:
- add a migration-backed `scheduler_settings` table to persist the daily scheduler time and timezone
- add scheduler CRUD and a new `PUT /api/scheduler/config` endpoint
- update scheduler timing logic so the web novel job can run at a fixed daily local time instead of only a rolling 24-hour interval
- preserve the earlier scheduler fixes so interrupted runs retry quickly after restart and per-book failures are counted and logged as `error` entries

Frontend changes:
- add a schedule editor to the Scheduler page so the daily run time can be changed in-app
- surface scheduler mode/timezone metadata from the API
- show per-book error entries in scheduler run history

## Why it changed

The immediate trigger was that the main container restarts during Unraid's daily appdata backup. Backing the container up is desirable, so changing the web novel run to a safer time is a better fit than excluding the app from backups.

While investigating, we also found that interrupted runs and per-book failures made the scheduler UI under-report what had actually happened. This PR keeps that visibility fix alongside the scheduling change so the page reflects reality.

## Impact

Users can now set the daily web novel update time from `/scheduler` without editing deployment config manually.

Operationally, this makes it easy to move the scheduled run away from backup windows or other maintenance periods. The scheduler will store the selected local time and recalculate the next run immediately after saving.

## Root cause

The scheduler was not actually selecting only part of the library. The observed `14/30` pattern on the main instance came from the container restarting mid-run during the daily Unraid appdata backup. The app then marked the incomplete run on startup, which made the interruption visible as a partial run.

## Validation

- `./.venv/bin/pytest backend/tests/test_scheduler.py backend/tests/test_crud_modules.py -q`
- `./.venv/bin/pytest backend/tests/test_main.py -q -k 'scheduler'`
- `npm test -- --run src/components/SchedulerStatus.test.jsx`
- `make test-migrations`
- verified the migration upgrade path from `0013` to `0014`

## Notes

Backend-wide `flake8` still reports a pre-existing unrelated unused import in `backend/app/routers/cleaning.py`. The scheduler-related backend files added in this PR lint clean.
