### PR TITLE
[codex] Fix FanFicFare update flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,28 @@ The `docker-compose.yml` is configured to store persistent data on the host mach
 
 This `config` directory will contain the following subdirectories:
 *   `config/library`: Stores your uploaded EPUB files and downloaded web novels.
+*   `config/fanficfare`: Optional FanFicFare overrides. If you place `config/fanficfare/personal.ini` here, Story Manager will load it after its built-in `personal.ini`, so your settings win.
 *   `config/pgdata`: Stores the PostgreSQL database.
 
 This setup ensures that your library and application data are preserved even if you stop or remove the container.
+
+### Optional FanFicFare Overrides
+
+Story Manager now uses FanFicFare's real EPUB update mode for tracked web novels. That means daily checks can reuse the existing immutable EPUB and avoid re-fetching every chapter on every run.
+
+If you want to customize FanFicFare behavior, create:
+
+```text
+config/fanficfare/personal.ini
+```
+
+Story Manager will load configs in this order:
+1. Built-in `backend/app/personal.ini`
+2. Optional mounted `config/fanficfare/personal.ini`
+
+Because FanFicFare applies later config files last, your mounted settings override the built-in defaults without replacing them entirely.
+
+If you need a different path, set `FFF_USER_CONFIG_PATH` in the container environment.
 
 ### Running the Application
 

--- a/backend/app/personal.ini
+++ b/backend/app/personal.ini
@@ -1,5 +1,3 @@
 [defaults]
-keep_old_chapters: true
-never_overwrite: true
 write_raw_metadata: true
 output_filename: library/${title}-${siteabbrev}_${storyId}${formatext}

--- a/backend/app/routers/web_novels.py
+++ b/backend/app/routers/web_novels.py
@@ -1,6 +1,7 @@
 """Web novel endpoints: add from URL, queue imports, and refresh from source."""
 
 import logging
+import shutil
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
@@ -67,11 +68,14 @@ async def refresh_book(book_id: int, db: AsyncSession = Depends(get_db)) -> mode
     current_path = LIBRARY_PATH.parent / db_book.current_path
 
     old_word_count, old_chapter_count = get_epub_word_and_chapter_count(current_path)
-    new_epub_path, metadata = await download_web_novel(db_book.source_url, overwrite=True)
+    result = await download_web_novel(db_book.source_url, overwrite=True, existing_epub_path=immutable_path)
+    if result is None:
+        raise HTTPException(status_code=500, detail="FanFicFare did not update the existing EPUB during refresh.")
+    new_epub_path, metadata = result
 
-    new_epub_path.rename(immutable_path)
-    with open(immutable_path, "rb") as f_in, open(current_path, "wb") as f_out:
-        f_out.write(f_in.read())
+    if new_epub_path != immutable_path:
+        new_epub_path.rename(immutable_path)
+    shutil.copyfile(immutable_path, current_path)
 
     new_word_count, new_chapter_count = get_epub_word_and_chapter_count(current_path)
 

--- a/backend/app/services/web_novel.py
+++ b/backend/app/services/web_novel.py
@@ -2,7 +2,10 @@
 
 import asyncio
 import logging
+import os
+import shutil
 import traceback
+import zipfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -10,9 +13,10 @@ import requests as http_requests
 from bs4 import BeautifulSoup
 from ebooklib import epub
 from fastapi import HTTPException, status
+from lxml import etree
 
 from .. import crud, epub_editor, schemas
-from ..config import LIBRARY_PATH
+from ..config import APP_DIR, LIBRARY_PATH
 from ..database import SessionLocal
 from .epub_utils import get_and_save_epub_cover, get_epub_word_and_chapter_count
 from .library_paths import build_book_paths
@@ -25,6 +29,7 @@ logger = logging.getLogger(__name__)
 # call, defeating the purpose. This single lock ensures only one FFF invocation
 # runs at a time, preventing the before/after EPUB-detection race condition.
 _fff_lock = asyncio.Lock()
+_DEFAULT_USER_PERSONAL_INI = Path("/app/config/personal.ini")
 
 
 def _run_fff_main(args: List[str]) -> int:
@@ -41,37 +46,182 @@ def _run_fff_main(args: List[str]) -> int:
         return 1
 
 
-async def download_web_novel(source_url: str, overwrite: bool = False) -> Optional[tuple[Path, Dict[str, Any]]]:
-    """
-    Downloads a web novel via FanFicFare and returns (epub_path, metadata) or None.
+def _get_optional_user_ini_path() -> Optional[Path]:
+    env_path = os.getenv("FFF_USER_CONFIG_PATH")
+    if env_path is not None:
+        stripped = env_path.strip()
+        if not stripped:
+            return None
+        return Path(stripped).expanduser()
+    return _DEFAULT_USER_PERSONAL_INI
 
-    Returns None only when overwrite=False and FFF determines the story has not been
-    updated since the last download. Use overwrite=True to force a re-download.
-    """
-    from ..config import APP_DIR
 
+def _get_fff_config_paths() -> List[Path]:
     ini_path = APP_DIR / "personal.ini"
-    LIBRARY_PATH.mkdir(exist_ok=True)
-
     if not ini_path.is_file():
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Server configuration error: personal.ini not found.",
         )
 
+    config_paths = [ini_path]
+    optional_user_ini = _get_optional_user_ini_path()
+    if optional_user_ini and optional_user_ini.is_file():
+        try:
+            if optional_user_ini.resolve() != ini_path.resolve():
+                config_paths.append(optional_user_ini)
+        except FileNotFoundError:
+            # Another process may have removed it between is_file and resolve.
+            pass
+    return config_paths
+
+
+def _get_story_manager_output_filename() -> str:
+    return str((LIBRARY_PATH / "${title}-${siteabbrev}_${storyId}${formatext}").resolve())
+
+
+def _get_epub_state(epub_path: Path) -> Optional[tuple[int, int]]:
+    if not epub_path.exists():
+        return None
+    stat = epub_path.stat()
+    return stat.st_mtime_ns, stat.st_size
+
+
+def _read_epub_metadata(epub_path: Path) -> Dict[str, Any]:
+    book = epub.read_epub(epub_path)
+    title = book.get_metadata("DC", "title")[0][0]
+    author = book.get_metadata("DC", "creator")[0][0]
+    try:
+        series_metadata = book.get_metadata("calibre", "series")
+    except KeyError:
+        series_metadata = []
+    series = series_metadata[0][0] if series_metadata else None
+    return {"title": title, "author": author, "series": series}
+
+
+def _get_rootfile_path(epub_path: Path) -> str:
+    with zipfile.ZipFile(epub_path) as archive:
+        container = etree.fromstring(archive.read("META-INF/container.xml"))
+    return container.xpath(
+        "/u:container/u:rootfiles/u:rootfile",
+        namespaces={"u": "urn:oasis:names:tc:opendocument:xmlns:container"},
+    )[0].get("full-path")
+
+
+def _get_epub_source_url(epub_path: Path) -> Optional[str]:
+    try:
+        rootfile_path = _get_rootfile_path(epub_path)
+        with zipfile.ZipFile(epub_path) as archive:
+            package = etree.fromstring(archive.read(rootfile_path))
+        matches = package.xpath(
+            "/opf:package/opf:metadata/dc:source",
+            namespaces={
+                "opf": "http://www.idpf.org/2007/opf",
+                "dc": "http://purl.org/dc/elements/1.1/",
+            },
+        )
+        if not matches:
+            return None
+        value = (matches[0].text or "").strip()
+        return value or None
+    except Exception as exc:
+        logger.warning("Failed reading dc:source from %s: %s", epub_path, exc)
+        return None
+
+
+def _sync_epub_source_url(epub_path: Path, source_url: str) -> None:
+    existing_source_url = _get_epub_source_url(epub_path)
+    if existing_source_url == source_url:
+        return
+
+    rootfile_path = _get_rootfile_path(epub_path)
+    temp_path = epub_path.with_suffix(f"{epub_path.suffix}.tmp")
+
+    with zipfile.ZipFile(epub_path) as src, zipfile.ZipFile(temp_path, "w") as dst:
+        package = etree.fromstring(src.read(rootfile_path))
+        metadata_nodes = package.xpath(
+            "/opf:package/opf:metadata",
+            namespaces={"opf": "http://www.idpf.org/2007/opf"},
+        )
+        if not metadata_nodes:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"EPUB metadata is missing from {epub_path}.",
+            )
+
+        metadata_node = metadata_nodes[0]
+        source_nodes = package.xpath(
+            "/opf:package/opf:metadata/dc:source",
+            namespaces={
+                "opf": "http://www.idpf.org/2007/opf",
+                "dc": "http://purl.org/dc/elements/1.1/",
+            },
+        )
+        if source_nodes:
+            source_node = source_nodes[0]
+        else:
+            source_node = etree.SubElement(
+                metadata_node,
+                "{http://purl.org/dc/elements/1.1/}source",
+            )
+        source_node.text = source_url
+
+        for info in src.infolist():
+            data = etree.tostring(package, encoding="utf-8", xml_declaration=True) if info.filename == rootfile_path else src.read(
+                info.filename
+            )
+            dst.writestr(info, data)
+
+    temp_path.replace(epub_path)
+    logger.info(
+        "Synchronized EPUB dc:source for %s from %r to %r.",
+        epub_path,
+        existing_source_url,
+        source_url,
+    )
+
+
+async def download_web_novel(
+    source_url: str,
+    overwrite: bool = False,
+    existing_epub_path: Optional[Path] = None,
+) -> Optional[tuple[Path, Dict[str, Any]]]:
+    """
+    Downloads a web novel via FanFicFare and returns (epub_path, metadata) or None.
+
+    Returns None only when overwrite=False and FFF determines the story has not been
+    updated since the last download. If existing_epub_path is provided, FFF updates
+    that EPUB in place using -u/-U and reuses previously downloaded chapters.
+    """
+    LIBRARY_PATH.mkdir(exist_ok=True)
+    config_paths = _get_fff_config_paths()
+
     async with _fff_lock:
-        before_epubs = {f: f.stat().st_mtime for f in LIBRARY_PATH.iterdir() if f.suffix == ".epub"}
-        args = [
-            "-c",
-            str(ini_path),
-            "-o",
-            f"output_dir={str(LIBRARY_PATH)}",
-            "--non-interactive",
-            "--debug",
-        ]
-        if overwrite:
-            args += ["-o", "always_overwrite=true"]
-        args.append(source_url)
+        args: List[str] = []
+        for config_path in config_paths:
+            args.extend(["-c", str(config_path)])
+        args.extend(["--non-interactive", "--debug"])
+
+        changed_epubs: List[Path] = []
+        updated_epub_path: Optional[Path] = None
+
+        if existing_epub_path is not None:
+            updated_epub_path = existing_epub_path.resolve()
+            if not updated_epub_path.is_file():
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail=f"Expected existing EPUB for update, but none was found at {updated_epub_path}.",
+                )
+            _sync_epub_source_url(updated_epub_path, source_url)
+            before_state = _get_epub_state(updated_epub_path)
+            args.append("-U" if overwrite else "-u")
+            args.append(str(updated_epub_path))
+        else:
+            before_epubs = {f: f.stat().st_mtime for f in LIBRARY_PATH.iterdir() if f.suffix == ".epub"}
+            args.extend(["-o", f"output_filename={_get_story_manager_output_filename()}"])
+            if overwrite:
+                args.extend(["-o", "always_overwrite=true"])
+            args.append(source_url)
 
         loop = asyncio.get_running_loop()
         result = await loop.run_in_executor(None, _run_fff_main, args)
@@ -81,28 +231,29 @@ async def download_web_novel(source_url: str, overwrite: bool = False) -> Option
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail=f"FanFicFare failed to download story. Error code: {result}.",
             )
-        changed_epubs = [
-            f
-            for f in LIBRARY_PATH.iterdir()
-            if f.suffix == ".epub" and (f not in before_epubs or f.stat().st_mtime > before_epubs[f])
-        ]
 
-    if not changed_epubs:
+        if updated_epub_path is not None:
+            after_state = _get_epub_state(updated_epub_path)
+            if after_state == before_state and not overwrite:
+                return None
+        else:
+            changed_epubs = [
+                f
+                for f in LIBRARY_PATH.iterdir()
+                if f.suffix == ".epub" and (f not in before_epubs or f.stat().st_mtime > before_epubs[f])
+            ]
+
+    if updated_epub_path is None and not changed_epubs:
         if not overwrite:
             return None
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="FanFicFare ran but no new or updated EPUB file was found.",
         )
-    new_epub_path = changed_epubs[0]
+    new_epub_path = updated_epub_path or changed_epubs[0]
 
     try:
-        book = epub.read_epub(new_epub_path)
-        title = book.get_metadata("DC", "title")[0][0]
-        author = book.get_metadata("DC", "creator")[0][0]
-        series_metadata = book.get_metadata("calibre", "series")
-        series = series_metadata[0][0] if series_metadata else None
-        return new_epub_path, {"title": title, "author": author, "series": series}
+        return new_epub_path, _read_epub_metadata(new_epub_path)
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -196,8 +347,7 @@ async def finish_web_novel_download(book_id: int, source_url: str) -> None:
 
             immutable_path, current_path = build_book_paths(new_epub_path.name, metadata["author"])
             new_epub_path.rename(immutable_path)
-            with open(immutable_path, "rb") as f_in, open(current_path, "wb") as f_out:
-                f_out.write(f_in.read())
+            shutil.copyfile(immutable_path, current_path)
 
             master_word_count = epub_editor.get_word_count(str(immutable_path))
             _, chapter_count = get_epub_word_and_chapter_count(current_path)
@@ -277,7 +427,7 @@ async def update_web_novels() -> None:
                 current_path = LIBRARY_PATH.parent / book.current_path
 
                 old_word_count, old_chapter_count = get_epub_word_and_chapter_count(immutable_path)
-                result = await download_web_novel(book.source_url)
+                result = await download_web_novel(book.source_url, existing_epub_path=immutable_path)
 
                 if result is None:
                     logger.info(f"No update available for {book.title} (FFF skipped).")
@@ -292,9 +442,9 @@ async def update_web_novels() -> None:
                     continue
 
                 new_epub_path, _ = result
-                new_epub_path.rename(immutable_path)
-                with open(immutable_path, "rb") as f_in, open(current_path, "wb") as f_out:
-                    f_out.write(f_in.read())
+                if new_epub_path != immutable_path:
+                    new_epub_path.rename(immutable_path)
+                shutil.copyfile(immutable_path, current_path)
 
                 new_word_count, new_chapter_count = get_epub_word_and_chapter_count(immutable_path)
 

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1184,20 +1184,22 @@ async def test_refresh_book(db_session, mocker):
     """
     Test refreshing a book from its source URL.
     """
-    # Mock the helper function to simulate a successful download and metadata parsing
     library_path = Path("./library").resolve()
-    new_epub_path = library_path / "Refreshed Title-Refreshed Author.epub"
-    mocker.patch(
+    library_path.mkdir(exist_ok=True)
+    author_dir = library_path / "Original Author"
+    author_dir.mkdir(exist_ok=True)
+    immutable_path = author_dir / "immutable_Original Title.epub"
+    current_path = author_dir / "Original Title.epub"
+    create_dummy_epub(immutable_path, "Original Title", "Original Author")
+    current_path.write_bytes(immutable_path.read_bytes())
+
+    download_mock = mocker.patch(
         "backend.app.routers.web_novels.download_web_novel",
         return_value=(
-            new_epub_path,
+            immutable_path,
             {"title": "Refreshed Title", "author": "Refreshed Author", "series": "Refreshed Series"},
         ),
     )
-
-    # Since we are not mocking the file system, we need to create the dummy files
-    library_path.mkdir(exist_ok=True)
-    create_dummy_epub(new_epub_path, "Refreshed Title", "Refreshed Author")
 
     async with AsyncTestingSessionLocal() as session:
         book = await crud.create_book(
@@ -1206,8 +1208,8 @@ async def test_refresh_book(db_session, mocker):
                 title="Original Title",
                 author="Original Author",
                 source_url="http://example.com/story/refresh",
-                immutable_path="p1i",
-                current_path="p1c",
+                immutable_path=str(immutable_path.relative_to(library_path.parent)),
+                current_path=str(current_path.relative_to(library_path.parent)),
                 source_type=models.SourceType.web,
             ),
         )
@@ -1221,10 +1223,16 @@ async def test_refresh_book(db_session, mocker):
     assert data["series"] == "Refreshed Series"
     assert data["master_word_count"] > 0
     assert data["current_word_count"] == data["master_word_count"]
+    download_mock.assert_called_once_with(
+        "http://example.com/story/refresh",
+        overwrite=True,
+        existing_epub_path=immutable_path,
+    )
 
     # Clean up dummy files
     (library_path.parent / data["immutable_path"]).unlink()
     (library_path.parent / data["current_path"]).unlink()
+    author_dir.rmdir()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_web_novel_service.py
+++ b/backend/tests/test_web_novel_service.py
@@ -1,0 +1,138 @@
+import zipfile
+from pathlib import Path
+
+import pytest
+from ebooklib import epub
+from lxml import etree
+
+from backend.app.services import web_novel
+
+
+def create_dummy_epub(filepath: Path, title: str, author: str):
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+    book = epub.EpubBook()
+    book.set_identifier("test-id")
+    book.set_title(title)
+    book.set_language("en")
+    book.add_author(author)
+
+    chapter = epub.EpubHtml(title="Chapter 1", file_name="chap_1.xhtml", lang="en")
+    chapter.content = "<h1>Chapter 1</h1><p>Hello world</p>"
+    book.add_item(chapter)
+    book.spine = ["nav", chapter]
+    book.toc = (chapter,)
+    book.add_item(epub.EpubNcx())
+    book.add_item(epub.EpubNav())
+
+    epub.write_epub(str(filepath), book, {})
+
+
+def set_dc_source(filepath: Path, source_url: str):
+    with zipfile.ZipFile(filepath) as archive:
+        container = etree.fromstring(archive.read("META-INF/container.xml"))
+        rootfile_path = container.xpath(
+            "/u:container/u:rootfiles/u:rootfile",
+            namespaces={"u": "urn:oasis:names:tc:opendocument:xmlns:container"},
+        )[0].get("full-path")
+        package = etree.fromstring(archive.read(rootfile_path))
+        package_bytes_by_name = {info.filename: archive.read(info.filename) for info in archive.infolist()}
+        infos = archive.infolist()
+
+    metadata = package.xpath(
+        "/opf:package/opf:metadata",
+        namespaces={"opf": "http://www.idpf.org/2007/opf"},
+    )[0]
+    source_nodes = package.xpath(
+        "/opf:package/opf:metadata/dc:source",
+        namespaces={
+            "opf": "http://www.idpf.org/2007/opf",
+            "dc": "http://purl.org/dc/elements/1.1/",
+        },
+    )
+    if source_nodes:
+        source_node = source_nodes[0]
+    else:
+        source_node = etree.SubElement(metadata, "{http://purl.org/dc/elements/1.1/}source")
+    source_node.text = source_url
+    package_bytes_by_name[rootfile_path] = etree.tostring(package, encoding="utf-8", xml_declaration=True)
+
+    temp_path = filepath.with_suffix(".tmp.epub")
+    with zipfile.ZipFile(temp_path, "w") as archive:
+        for info in infos:
+            archive.writestr(info, package_bytes_by_name[info.filename])
+    temp_path.replace(filepath)
+
+
+@pytest.mark.asyncio
+async def test_download_web_novel_existing_epub_uses_update_mode_and_user_config(tmp_path, monkeypatch, mocker):
+    library_path = tmp_path / "library"
+    library_path.mkdir()
+    monkeypatch.setattr(web_novel, "LIBRARY_PATH", library_path)
+
+    user_ini = tmp_path / "user-personal.ini"
+    user_ini.write_text("[defaults]\nslow_down_sleep_time: 1\n", encoding="utf-8")
+    monkeypatch.setenv("FFF_USER_CONFIG_PATH", str(user_ini))
+
+    existing_epub = library_path / "existing.epub"
+    create_dummy_epub(existing_epub, "Before", "Author")
+    set_dc_source(existing_epub, "https://www.royalroadcdn.com/public/covers-large/33600-stray-cat-strut.jpg?time=1666088451")
+
+    captured_args = {}
+    repaired_source = {}
+
+    def fake_fff_main(args):
+        captured_args["args"] = list(args)
+        repaired_source["value"] = web_novel._get_epub_source_url(existing_epub)
+        create_dummy_epub(existing_epub, "After", "Updated Author")
+        return 0
+
+    mocker.patch("backend.app.services.web_novel._run_fff_main", side_effect=fake_fff_main)
+
+    result = await web_novel.download_web_novel(
+        "https://example.com/story/1",
+        existing_epub_path=existing_epub,
+    )
+
+    assert result is not None
+    epub_path, metadata = result
+    assert epub_path == existing_epub
+    assert metadata == {"title": "After", "author": "Updated Author", "series": None}
+
+    args = captured_args["args"]
+    assert args.count("-c") == 2
+    assert str(web_novel.APP_DIR / "personal.ini") in args
+    assert str(user_ini) in args
+    assert "-u" in args
+    assert "-U" not in args
+    assert str(existing_epub) == args[-1]
+    assert repaired_source["value"] == "https://example.com/story/1"
+
+
+@pytest.mark.asyncio
+async def test_download_web_novel_new_download_uses_story_manager_output_path(tmp_path, monkeypatch, mocker):
+    library_path = tmp_path / "library"
+    library_path.mkdir()
+    monkeypatch.setattr(web_novel, "LIBRARY_PATH", library_path)
+    monkeypatch.delenv("FFF_USER_CONFIG_PATH", raising=False)
+
+    expected_output = library_path / "Fresh Title-rr_123.epub"
+    captured_args = {}
+
+    def fake_fff_main(args):
+        captured_args["args"] = list(args)
+        create_dummy_epub(expected_output, "Fresh Title", "Fresh Author")
+        return 0
+
+    mocker.patch("backend.app.services.web_novel._run_fff_main", side_effect=fake_fff_main)
+
+    result = await web_novel.download_web_novel("https://www.royalroad.com/fiction/123")
+
+    assert result is not None
+    epub_path, metadata = result
+    assert epub_path == expected_output
+    assert metadata == {"title": "Fresh Title", "author": "Fresh Author", "series": None}
+
+    args = captured_args["args"]
+    output_arg = f"output_filename={library_path.resolve()}/${{title}}-${{siteabbrev}}_${{storyId}}${{formatext}}"
+    assert output_arg in args
+    assert "https://www.royalroad.com/fiction/123" == args[-1]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,5 +7,6 @@ services:
       - "8000:8000"  # API
     volumes:
       - ./config/library:/app/library
+      - ./config/fanficfare:/app/config:ro
       - ./config/pgdata:/tmp/pgdata
     restart: unless-stopped


### PR DESCRIPTION
## What changed

This updates Story Manager's FanFicFare integration to use real EPUB update mode for tracked web novels instead of treating scheduled checks like fresh downloads.

It also adds layered `personal.ini` support so Story Manager loads its built-in FanFicFare config first and then an optional mounted user config file afterward.

## Why this changed

The previous flow was defensive, but it re-grabbed full books during update checks and generated more requests than necessary.

Switching to FFF's `-u` / `-U` flow lets existing immutable EPUBs be reused so old chapter content stays intact while only the needed update work is performed.

## Root cause

FFF update mode trusts the EPUB's embedded `dc:source` URL. Some older imported EPUBs had incorrect `dc:source` values, including cover-image URLs instead of story URLs.

That caused update failures for some books once Story Manager began calling FFF with `-u existing.epub`.

## User impact

Tracked web novels should update faster and with fewer requests.

Older books with bad embedded `dc:source` metadata will now self-heal during update because Story Manager synchronizes the immutable EPUB's `dc:source` to the database `source_url` before invoking FFF update mode.

Docker users can now optionally mount `config/fanficfare/personal.ini` to layer their own FanFicFare settings on top of Story Manager defaults.

## Validation

- `uv run pytest backend/tests/test_web_novel_service.py backend/tests/test_main.py::test_refresh_book backend/tests/test_main.py::test_update_web_novels_counts_and_logs_book_failures`
