### PR TITLE
[codex] Fix local FFF config detection and retry placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,10 @@ If you want to customize FanFicFare behavior, create:
 config/fanficfare/personal.ini
 ```
 
+That path works for both:
+- local development from the repository root
+- Docker deployments that mount `./config/fanficfare:/app/config:ro`
+
 Story Manager will load configs in this order:
 1. Built-in `backend/app/personal.ini`
 2. Optional mounted `config/fanficfare/personal.ini`

--- a/backend/app/crud/__init__.py
+++ b/backend/app/crud/__init__.py
@@ -17,6 +17,7 @@ from .books import (  # noqa: F401
     get_books_without_series,
     get_pending_web_books,
     get_web_books,
+    reset_failed_web_book_for_retry,
     search_books,
     touch_book_content,
     update_book,

--- a/backend/app/crud/books.py
+++ b/backend/app/crud/books.py
@@ -146,6 +146,31 @@ async def update_book(db: AsyncSession, book: models.Book, update_data: schemas.
     return book
 
 
+async def reset_failed_web_book_for_retry(
+    db: AsyncSession,
+    book: models.Book,
+    source_url: str,
+) -> models.Book:
+    """Reuse a failed web-import placeholder so the same URL can be retried."""
+    book.title = source_url
+    book.author = "Pending"
+    book.series = None
+    book.series_index = None
+    book.cover_path = None
+    book.immutable_path = None
+    book.current_path = None
+    book.master_word_count = None
+    book.current_word_count = None
+    book.removed_chapters = []
+    book.content_selectors = []
+    book.download_status = "pending"
+    book.source_url = source_url
+    book.source_type = models.SourceType.web
+    await db.commit()
+    await db.refresh(book)
+    return book
+
+
 async def detach_book_source(db: AsyncSession, book: models.Book) -> models.Book:
     """Clear a book's remote source metadata and treat it as a normal EPUB."""
     book.source_url = None

--- a/backend/app/routers/web_novels.py
+++ b/backend/app/routers/web_novels.py
@@ -11,6 +11,7 @@ from .. import crud, epub_editor, models, schemas
 from ..config import LIBRARY_PATH
 from ..database import get_db
 from ..services.epub_utils import get_epub_word_and_chapter_count
+from ..services.library_paths import build_book_paths
 from ..services.metadata_jobs import queue_metadata_sync_job
 from ..services.web_import_queue import get_web_import_queue
 from ..services.web_novel import download_web_novel
@@ -35,9 +36,20 @@ async def add_web_novel(
 ) -> models.Book:
     """Creates a pending book record immediately and queues the download."""
     source_url_str = str(request.url)
+    queue = get_web_import_queue()
 
     existing_book = await crud.get_book_by_source_url(db, source_url=source_url_str)
     if existing_book:
+        if (
+            existing_book.source_type == models.SourceType.web
+            and existing_book.download_status == "error"
+            and not existing_book.immutable_path
+            and not existing_book.current_path
+        ):
+            logger.info("Retrying failed web import placeholder for %s (book_id=%s).", source_url_str, existing_book.id)
+            retried_book = await crud.reset_failed_web_book_for_retry(db, existing_book, source_url_str)
+            await queue.enqueue(retried_book.id, source_url_str)
+            return retried_book
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=f"Book from URL {source_url_str} already exists in the library.",
@@ -51,7 +63,7 @@ async def add_web_novel(
         download_status="pending",
     )
     db_book = await crud.create_book(db=db, book=book_to_create)
-    await get_web_import_queue().enqueue(db_book.id, source_url_str)
+    await queue.enqueue(db_book.id, source_url_str)
     return db_book
 
 
@@ -63,6 +75,41 @@ async def refresh_book(book_id: int, db: AsyncSession = Depends(get_db)) -> mode
         raise HTTPException(status_code=404, detail="Book not found")
     if not db_book.source_url:
         raise HTTPException(status_code=400, detail="Book does not have a source URL to refresh from.")
+
+    if not db_book.immutable_path or not db_book.current_path:
+        result = await download_web_novel(db_book.source_url, overwrite=True)
+        if result is None:
+            raise HTTPException(status_code=500, detail="FanFicFare did not produce a refreshed EPUB.")
+        new_epub_path, metadata = result
+
+        immutable_path, current_path = build_book_paths(new_epub_path.name, metadata["author"])
+        new_epub_path.rename(immutable_path)
+        shutil.copyfile(immutable_path, current_path)
+
+        new_word_count, new_chapter_count = get_epub_word_and_chapter_count(current_path)
+        update_data = schemas.BookUpdate(**metadata)
+        updated_book = await crud.update_book(db=db, book=db_book, update_data=update_data)
+        updated_book.removed_chapters = []
+        updated_book.master_word_count = new_word_count
+        updated_book.current_word_count = new_word_count
+        updated_book.immutable_path = str(immutable_path.relative_to(LIBRARY_PATH.parent))
+        updated_book.current_path = str(current_path.relative_to(LIBRARY_PATH.parent))
+        updated_book.download_status = None
+        await crud.touch_book_content(db, updated_book)
+        await db.commit()
+        await db.refresh(updated_book)
+
+        log_entry = schemas.BookLogCreate(
+            book_id=updated_book.id,
+            entry_type="updated",
+            previous_chapter_count=0,
+            new_chapter_count=new_chapter_count,
+            words_added=new_word_count,
+        )
+        await crud.create_book_log(db, log_entry)
+        await epub_editor.apply_book_cleaning(updated_book, db)
+        await queue_metadata_sync_job(db, trigger="book_update", book_ids=[updated_book.id])
+        return updated_book
 
     immutable_path = LIBRARY_PATH.parent / db_book.immutable_path
     current_path = LIBRARY_PATH.parent / db_book.current_path

--- a/backend/app/services/web_novel.py
+++ b/backend/app/services/web_novel.py
@@ -29,7 +29,10 @@ logger = logging.getLogger(__name__)
 # call, defeating the purpose. This single lock ensures only one FFF invocation
 # runs at a time, preventing the before/after EPUB-detection race condition.
 _fff_lock = asyncio.Lock()
-_DEFAULT_USER_PERSONAL_INI = Path("/app/config/personal.ini")
+_DEFAULT_USER_PERSONAL_INI_CANDIDATES = (
+    (APP_DIR.parent.parent / "config" / "fanficfare" / "personal.ini").resolve(),
+    Path("/app/config/personal.ini"),
+)
 
 
 def _run_fff_main(args: List[str]) -> int:
@@ -51,9 +54,25 @@ def _get_optional_user_ini_path() -> Optional[Path]:
     if env_path is not None:
         stripped = env_path.strip()
         if not stripped:
+            logger.info("FFF_USER_CONFIG_PATH is set to an empty value; skipping optional FanFicFare config.")
             return None
-        return Path(stripped).expanduser()
-    return _DEFAULT_USER_PERSONAL_INI
+        resolved = Path(stripped).expanduser()
+        if not resolved.is_file():
+            logger.warning("FFF_USER_CONFIG_PATH points to %s, but that file was not found.", resolved)
+            return None
+        logger.info("Using FanFicFare user config from FFF_USER_CONFIG_PATH: %s", resolved)
+        return resolved
+
+    for candidate in _DEFAULT_USER_PERSONAL_INI_CANDIDATES:
+        if candidate.is_file():
+            logger.info("Using FanFicFare user config override: %s", candidate)
+            return candidate
+
+    logger.info(
+        "No optional FanFicFare user config found. Checked: %s",
+        ", ".join(str(candidate) for candidate in _DEFAULT_USER_PERSONAL_INI_CANDIDATES),
+    )
+    return None
 
 
 def _get_fff_config_paths() -> List[Path]:
@@ -73,6 +92,7 @@ def _get_fff_config_paths() -> List[Path]:
         except FileNotFoundError:
             # Another process may have removed it between is_file and resolve.
             pass
+    logger.info("FanFicFare config chain: %s", " -> ".join(str(path) for path in config_paths))
     return config_paths
 
 

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -764,6 +764,34 @@ async def test_add_existing_web_novel(db_session):
 
 
 @pytest.mark.asyncio
+async def test_add_failed_web_novel_retries_placeholder(db_session, mocker):
+    queue = mocker.Mock()
+    queue.enqueue = mocker.AsyncMock(return_value=True)
+    mocker.patch("backend.app.routers.web_novels.get_web_import_queue", return_value=queue)
+
+    async with AsyncTestingSessionLocal() as session:
+        book = await crud.create_book(
+            session,
+            schemas.BookCreate(
+                title="Download failed",
+                author="Pending",
+                source_url="https://example.com/story/retry",
+                source_type=models.SourceType.web,
+                download_status="error",
+            ),
+        )
+
+    response = client.post("/api/books/add_web_novel", json={"url": "https://example.com/story/retry"})
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["id"] == book.id
+    assert data["download_status"] == "pending"
+    assert data["title"] == "https://example.com/story/retry"
+    queue.enqueue.assert_awaited_once_with(book.id, "https://example.com/story/retry")
+
+
+@pytest.mark.asyncio
 async def test_library_validate_classifies_failed_web_import_placeholders(db_session):
     async with AsyncTestingSessionLocal() as session:
         await crud.create_book(
@@ -1256,6 +1284,52 @@ async def test_refresh_book_no_source_url(db_session):
 
     assert response.status_code == 400
     assert "does not have a source URL" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_refresh_failed_placeholder_downloads_fresh_epub(db_session, mocker):
+    library_path = Path("./library").resolve()
+    library_path.mkdir(exist_ok=True)
+    new_epub_path = library_path / "Recovered Title-rr_456.epub"
+    create_dummy_epub(new_epub_path, "Recovered Title", "Recovered Author")
+
+    download_mock = mocker.patch(
+        "backend.app.routers.web_novels.download_web_novel",
+        return_value=(
+            new_epub_path,
+            {"title": "Recovered Title", "author": "Recovered Author", "series": "Recovered Series"},
+        ),
+    )
+
+    async with AsyncTestingSessionLocal() as session:
+        book = await crud.create_book(
+            session,
+            schemas.BookCreate(
+                title="Download failed",
+                author="Pending",
+                source_url="https://example.com/story/recovered",
+                source_type=models.SourceType.web,
+                download_status="error",
+            ),
+        )
+
+    response = client.post(f"/api/books/{book.id}/refresh")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["title"] == "Recovered Title"
+    assert data["author"] == "Recovered Author"
+    assert data["series"] == "Recovered Series"
+    assert data["download_status"] is None
+    assert data["immutable_path"]
+    assert data["current_path"]
+    download_mock.assert_called_once_with("https://example.com/story/recovered", overwrite=True)
+
+    immutable_result_path = library_path.parent / data["immutable_path"]
+    current_result_path = library_path.parent / data["current_path"]
+    immutable_result_path.unlink()
+    current_result_path.unlink()
+    immutable_result_path.parent.rmdir()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_web_novel_service.py
+++ b/backend/tests/test_web_novel_service.py
@@ -136,3 +136,28 @@ async def test_download_web_novel_new_download_uses_story_manager_output_path(tm
     output_arg = f"output_filename={library_path.resolve()}/${{title}}-${{siteabbrev}}_${{storyId}}${{formatext}}"
     assert output_arg in args
     assert "https://www.royalroad.com/fiction/123" == args[-1]
+
+
+def test_get_fff_config_paths_prefers_local_repo_override(tmp_path, monkeypatch):
+    app_dir = tmp_path / "backend" / "app"
+    app_dir.mkdir(parents=True)
+    (app_dir / "personal.ini").write_text("[defaults]\nwrite_raw_metadata: true\n", encoding="utf-8")
+
+    local_user_ini = tmp_path / "config" / "fanficfare" / "personal.ini"
+    local_user_ini.parent.mkdir(parents=True)
+    local_user_ini.write_text("[defaults]\nslow_down_sleep_time: 1\n", encoding="utf-8")
+
+    monkeypatch.setattr(web_novel, "APP_DIR", app_dir)
+    monkeypatch.setattr(
+        web_novel,
+        "_DEFAULT_USER_PERSONAL_INI_CANDIDATES",
+        (
+            local_user_ini,
+            tmp_path / "missing-docker-path.ini",
+        ),
+    )
+    monkeypatch.delenv("FFF_USER_CONFIG_PATH", raising=False)
+
+    config_paths = web_novel._get_fff_config_paths()
+
+    assert config_paths == [app_dir / "personal.ini", local_user_ini]

--- a/frontend/src/components/BookSettings.jsx
+++ b/frontend/src/components/BookSettings.jsx
@@ -167,12 +167,13 @@ function BookSettings({ book, onBack }) {
   const { data: chapters = [], isLoading: chaptersLoading } = useQuery({
     queryKey: ["chapters", book.id],
     queryFn: fetchChapters,
+    enabled: Boolean(book.immutable_path),
   });
 
   const { data: cleanedChapters = [], isLoading: cleanedChaptersLoading } = useQuery({
     queryKey: ["cleaned-chapters", book.id],
     queryFn: fetchCleanedChapters,
-    enabled: chapterPreviewMode === "cleaned",
+    enabled: chapterPreviewMode === "cleaned" && Boolean(book.current_path),
   });
 
   const { data: matchedConfigs = [] } = useQuery({
@@ -755,7 +756,13 @@ function BookSettings({ book, onBack }) {
 
         {activeChaptersLoading && <p className="hint" style={{ marginTop: "0.5rem" }}>Loading chapters…</p>}
 
-        {chaptersExpanded && !activeChaptersLoading && (
+        {!book.immutable_path && (
+          <p className="hint" style={{ marginTop: "0.5rem" }}>
+            This web import does not have EPUB files yet. Retry the source download or delete the placeholder entry.
+          </p>
+        )}
+
+        {chaptersExpanded && !activeChaptersLoading && book.immutable_path && (
           <>
             {chapters.length > 10 && (
               <input


### PR DESCRIPTION
## What changed

This follow-up fixes two issues in the FanFicFare update work:

- local `config/fanficfare/personal.ini` overrides are now auto-detected and logged
- failed web-import placeholder books can now be retried cleanly

It also makes `Refresh from Source` work for failed placeholders that do not have EPUB files yet.

## Why this changed

The optional FanFicFare override file was only being auto-detected at `/app/config/personal.ini`, which works in Docker but not in a local checkout.

Separately, a failed web import could leave behind a placeholder record with the source URL reserved, which blocked re-adding the same URL and made retry awkward.

## User impact

Story Manager now logs whether it found and is using an optional FanFicFare user config, plus the final config chain passed to FFF.

For local development, `config/fanficfare/personal.ini` now works without needing an extra env var.

If a web novel import fails before EPUB files are created, re-adding the same URL will reuse the failed placeholder and queue it again instead of returning a duplicate conflict.

Failed placeholders can also be refreshed directly from the book screen, and the UI no longer tries to fetch chapter data for books that do not yet have EPUB files.

## Validation

- `uv run pytest backend/tests/test_web_novel_service.py backend/tests/test_main.py::test_add_failed_web_novel_retries_placeholder backend/tests/test_main.py::test_refresh_book backend/tests/test_main.py::test_refresh_failed_placeholder_downloads_fresh_epub backend/tests/test_main.py::test_update_web_novels_counts_and_logs_book_failures`
