### PR TITLE
Run manual book refresh on a background queue

### DIFF
--- a/backend/alembic/versions/0016_add_refresh_status_to_books.py
+++ b/backend/alembic/versions/0016_add_refresh_status_to_books.py
@@ -1,0 +1,39 @@
+"""add refresh_status to books
+
+Revision ID: 0016
+Revises: 0015
+Create Date: 2026-04-16 00:00:00
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0016"
+down_revision = "0015"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+
+    if not inspector.has_table("books"):
+        return
+
+    columns = {column["name"] for column in inspector.get_columns("books")}
+    if "refresh_status" not in columns:
+        op.add_column("books", sa.Column("refresh_status", sa.String(), nullable=True))
+
+
+def downgrade():
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+
+    if not inspector.has_table("books"):
+        return
+
+    columns = {column["name"] for column in inspector.get_columns("books")}
+    if "refresh_status" in columns:
+        op.drop_column("books", "refresh_status")

--- a/backend/app/crud/__init__.py
+++ b/backend/app/crud/__init__.py
@@ -15,6 +15,7 @@ from .books import (  # noqa: F401
     get_books_by_author,
     get_books_by_ids,
     get_books_without_series,
+    get_pending_refresh_books,
     get_pending_web_books,
     get_web_books,
     reset_failed_web_book_for_retry,

--- a/backend/app/crud/books.py
+++ b/backend/app/crud/books.py
@@ -67,6 +67,17 @@ async def get_pending_web_books(db: AsyncSession) -> List[models.Book]:
     return result.scalars().all()
 
 
+async def get_pending_refresh_books(db: AsyncSession) -> List[models.Book]:
+    """Return web books whose refresh job was in-flight, so the queue can resume them."""
+    result = await db.execute(
+        select(models.Book).filter(
+            models.Book.source_type == models.SourceType.web,
+            models.Book.refresh_status.in_(["queued", "processing"]),
+        )
+    )
+    return result.scalars().all()
+
+
 async def get_books(
     db: AsyncSession,
     skip: int = 0,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,6 +20,7 @@ from .database import SessionLocal, get_db
 from .logging_config import setup_logging
 from .routers import api_keys, books, cleaning, covers, metadata, reader, scheduler, storage, upload, web_novels
 from .services.metadata_sync_queue import get_metadata_sync_queue
+from .services.refresh_queue import get_refresh_queue
 from .services.update_scheduler import get_scheduler, schedule_next_metadata_recheck, schedule_next_web_novel_update
 from .services.web_import_queue import get_web_import_queue
 
@@ -28,6 +29,7 @@ logger = logging.getLogger(__name__)
 _console_handler, _mem_handler = setup_logging()
 _scheduler = get_scheduler()
 _web_import_queue = get_web_import_queue()
+_refresh_queue = get_refresh_queue()
 _metadata_sync_queue = get_metadata_sync_queue()
 
 
@@ -44,11 +46,15 @@ async def lifespan(app: FastAPI):
     async with SessionLocal() as db:
         await crud.reset_stuck_update_tasks(db)
     await _web_import_queue.start()
+    await _refresh_queue.start()
     if not is_test_app:
         await _metadata_sync_queue.start()
     requeued = await _web_import_queue.requeue_pending_books()
     if requeued:
         logger.info("Re-queued %s pending web novel imports.", requeued)
+    refresh_requeued = await _refresh_queue.requeue_pending_books()
+    if refresh_requeued:
+        logger.info("Re-queued %s in-flight book refreshes.", refresh_requeued)
     if not is_test_app:
         metadata_requeued = await _metadata_sync_queue.requeue_pending_jobs()
         if metadata_requeued:
@@ -60,6 +66,7 @@ async def lifespan(app: FastAPI):
         await schedule_next_metadata_recheck()
     yield
     await _web_import_queue.stop()
+    await _refresh_queue.stop()
     if not is_test_app:
         await _metadata_sync_queue.stop()
     if _scheduler.running:

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -35,6 +35,9 @@ class Book(Base):
     cover_path = Column(String, nullable=True)
     notes = Column(String, nullable=True)
     download_status = Column(String, nullable=True)
+    # Tracks the lifecycle of a "refresh from source" job independently from the
+    # initial download state. Values: None (idle), "queued", "processing", "error".
+    refresh_status = Column(String, nullable=True)
 
     # Timestamps
     created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/backend/app/routers/web_novels.py
+++ b/backend/app/routers/web_novels.py
@@ -1,20 +1,15 @@
 """Web novel endpoints: add from URL, queue imports, and refresh from source."""
 
 import logging
-import shutil
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from .. import crud, epub_editor, models, schemas
-from ..config import LIBRARY_PATH
+from .. import crud, models, schemas
 from ..database import get_db
-from ..services.epub_utils import get_epub_word_and_chapter_count
-from ..services.library_paths import build_book_paths
-from ..services.metadata_jobs import queue_metadata_sync_job
+from ..services.refresh_queue import get_refresh_queue
 from ..services.web_import_queue import get_web_import_queue
-from ..services.web_novel import download_web_novel
 
 logger = logging.getLogger(__name__)
 
@@ -67,90 +62,38 @@ async def add_web_novel(
     return db_book
 
 
-@router.post("/api/books/{book_id}/refresh", response_model=schemas.Book)
+@router.post(
+    "/api/books/{book_id}/refresh",
+    response_model=schemas.Book,
+    status_code=status.HTTP_202_ACCEPTED,
+)
 async def refresh_book(book_id: int, db: AsyncSession = Depends(get_db)) -> models.Book:
-    """Re-downloads a web novel from its source URL and applies cleaning."""
+    """Queue a background refresh of a web novel from its source URL.
+
+    Returns 202 Accepted immediately with the book's updated ``refresh_status``.
+    Clients should poll ``GET /api/books/{book_id}`` until ``refresh_status`` is
+    null (success) or ``"error"``. The actual work — re-downloading via
+    FanFicFare, rebuilding the cleaned EPUB, re-syncing metadata — runs on the
+    single-worker :class:`RefreshQueue`, the same lane used by the scheduled
+    daily update job.
+    """
     db_book = await crud.get_book(db, book_id=book_id)
     if db_book is None:
         raise HTTPException(status_code=404, detail="Book not found")
     if not db_book.source_url:
         raise HTTPException(status_code=400, detail="Book does not have a source URL to refresh from.")
 
-    if not db_book.immutable_path or not db_book.current_path:
-        result = await download_web_novel(db_book.source_url, overwrite=True)
-        if result is None:
-            raise HTTPException(status_code=500, detail="FanFicFare did not produce a refreshed EPUB.")
-        new_epub_path, metadata = result
-
-        immutable_path, current_path = build_book_paths(new_epub_path.name, metadata["author"])
-        new_epub_path.rename(immutable_path)
-        shutil.copyfile(immutable_path, current_path)
-
-        new_word_count, new_chapter_count = get_epub_word_and_chapter_count(current_path)
-        update_data = schemas.BookUpdate(**metadata)
-        updated_book = await crud.update_book(db=db, book=db_book, update_data=update_data)
-        updated_book.removed_chapters = []
-        updated_book.master_word_count = new_word_count
-        updated_book.current_word_count = new_word_count
-        updated_book.immutable_path = str(immutable_path.relative_to(LIBRARY_PATH.parent))
-        updated_book.current_path = str(current_path.relative_to(LIBRARY_PATH.parent))
-        updated_book.download_status = None
-        await crud.touch_book_content(db, updated_book)
+    queue = get_refresh_queue()
+    # If a refresh is already queued/running for this book, treat the request as a
+    # no-op rather than doubling it up — return the current status so the client
+    # can begin polling.
+    if db_book.refresh_status not in ("queued", "processing"):
+        db_book.refresh_status = "queued"
         await db.commit()
-        await db.refresh(updated_book)
+        await db.refresh(db_book)
 
-        log_entry = schemas.BookLogCreate(
-            book_id=updated_book.id,
-            entry_type="updated",
-            previous_chapter_count=0,
-            new_chapter_count=new_chapter_count,
-            words_added=new_word_count,
-        )
-        await crud.create_book_log(db, log_entry)
-        await epub_editor.apply_book_cleaning(updated_book, db)
-        await queue_metadata_sync_job(db, trigger="book_update", book_ids=[updated_book.id])
-        return updated_book
-
-    immutable_path = LIBRARY_PATH.parent / db_book.immutable_path
-    current_path = LIBRARY_PATH.parent / db_book.current_path
-
-    old_word_count, old_chapter_count = get_epub_word_and_chapter_count(current_path)
-    result = await download_web_novel(db_book.source_url, overwrite=True, existing_epub_path=immutable_path)
-    if result is None:
-        raise HTTPException(status_code=500, detail="FanFicFare did not update the existing EPUB during refresh.")
-    new_epub_path, metadata = result
-
-    if new_epub_path != immutable_path:
-        new_epub_path.rename(immutable_path)
-    shutil.copyfile(immutable_path, current_path)
-
-    new_word_count, new_chapter_count = get_epub_word_and_chapter_count(current_path)
-
-    if new_chapter_count > old_chapter_count:
-        logger.info(f"Found {new_chapter_count - old_chapter_count} new chapters for {db_book.title}.")
-        log_entry = schemas.BookLogCreate(
-            book_id=db_book.id,
-            entry_type="updated",
-            previous_chapter_count=old_chapter_count,
-            new_chapter_count=new_chapter_count,
-            words_added=new_word_count - old_word_count,
-        )
-        await crud.create_book_log(db, log_entry)
-
-    update_data = schemas.BookUpdate(**metadata)
-    updated_book = await crud.update_book(db=db, book=db_book, update_data=update_data)
-
-    # Reset per-source processing state; preserve per-book content_selectors
-    updated_book.removed_chapters = []
-    updated_book.master_word_count = new_word_count
-    updated_book.current_word_count = new_word_count
-    await crud.touch_book_content(db, updated_book)
-    await db.commit()
-    await db.refresh(updated_book)
-
-    await epub_editor.apply_book_cleaning(updated_book, db)
-    await queue_metadata_sync_job(db, trigger="book_update", book_ids=[updated_book.id])
-    return updated_book
+    await queue.enqueue(db_book.id)
+    return db_book
 
 
 @router.post("/api/books/{book_id}/detach-source", response_model=schemas.Book)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -30,6 +30,7 @@ class BookBase(BaseModel):
     content_selectors: Optional[List[str]] = Field(default_factory=list)
     notes: Optional[str] = None
     download_status: Optional[str] = None
+    refresh_status: Optional[str] = None
 
 
 # Pydantic model for creating a new book.
@@ -79,6 +80,7 @@ class BookCatalogEntry(BaseModel):
     current_word_count: Optional[int] = None
     updated_at: Optional[datetime] = None
     download_status: Optional[str] = None
+    refresh_status: Optional[str] = None
 
 
 # Pydantic model for creating a new book log.

--- a/backend/app/services/refresh_queue.py
+++ b/backend/app/services/refresh_queue.py
@@ -1,0 +1,85 @@
+"""Single-worker queue for manual 'refresh from source' jobs."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Optional
+
+from .. import crud
+from ..database import SessionLocal
+from .web_novel import run_book_refresh
+
+logger = logging.getLogger(__name__)
+
+
+class RefreshQueue:
+    """App-scoped queue that processes one book refresh at a time.
+
+    Mirrors :class:`WebImportQueue` — a single asyncio worker drains a queue
+    of book IDs, running :func:`run_book_refresh` for each. The book's
+    ``refresh_status`` column is the source of truth for UI polling; this
+    queue only tracks in-memory set membership to avoid double-enqueueing.
+    """
+
+    def __init__(self) -> None:
+        self._queue: asyncio.Queue[Optional[int]] = asyncio.Queue()
+        self._queued_book_ids: set[int] = set()
+        self._worker_task: Optional[asyncio.Task[None]] = None
+
+    async def start(self) -> None:
+        if self._worker_task and not self._worker_task.done():
+            return
+        self._worker_task = asyncio.create_task(self._run(), name="refresh-worker")
+
+    async def stop(self) -> None:
+        if not self._worker_task:
+            return
+        await self._queue.put(None)
+        await self._worker_task
+        self._worker_task = None
+        self._queued_book_ids.clear()
+
+    async def enqueue(self, book_id: int) -> bool:
+        if book_id in self._queued_book_ids:
+            return False
+        self._queued_book_ids.add(book_id)
+        await self._queue.put(book_id)
+        return True
+
+    async def requeue_pending_books(self) -> int:
+        """Resume any refreshes that were in-flight when the app was last shut down."""
+        async with SessionLocal() as db:
+            books = await crud.get_pending_refresh_books(db)
+
+        queued = 0
+        for book in books:
+            if not book.source_url:
+                continue
+            if await self.enqueue(book.id):
+                queued += 1
+        return queued
+
+    async def _run(self) -> None:
+        while True:
+            item = await self._queue.get()
+            try:
+                if item is None:
+                    return
+
+                book_id = item
+                try:
+                    await run_book_refresh(book_id)
+                except Exception:
+                    logger.exception("Unhandled exception while refreshing book %s.", book_id)
+                finally:
+                    self._queued_book_ids.discard(book_id)
+            finally:
+                self._queue.task_done()
+
+
+_refresh_queue = RefreshQueue()
+
+
+def get_refresh_queue() -> RefreshQueue:
+    return _refresh_queue

--- a/backend/app/services/web_novel.py
+++ b/backend/app/services/web_novel.py
@@ -315,6 +315,131 @@ async def finish_web_novel_download(book_id: int, source_url: str) -> None:
         await queue_metadata_sync_job(db, trigger="new_book", book_ids=[db_book.id])
 
 
+async def run_book_refresh(book_id: int) -> None:
+    """Re-download a single web novel from its source URL and apply cleaning.
+
+    This mirrors what the scheduled ``update_web_novels`` job does for one book,
+    but also handles web imports that never finished their initial download
+    (no ``immutable_path``/``current_path``). Updates ``book.refresh_status``
+    throughout: "processing" while running, ``None`` on success, and "error"
+    on any failure.
+    """
+    async with SessionLocal() as db:
+        db_book = await crud.get_book(db, book_id=book_id)
+        if db_book is None:
+            logger.error("Refresh worker: book %s not found.", book_id)
+            return
+        if not db_book.source_url:
+            logger.warning("Refresh worker: book %s has no source_url.", book_id)
+            db_book.refresh_status = "error"
+            await db.commit()
+            return
+
+        db_book.refresh_status = "processing"
+        await db.commit()
+        await db.refresh(db_book)
+
+        try:
+            if not db_book.immutable_path or not db_book.current_path:
+                result = await download_web_novel(db_book.source_url, overwrite=True)
+                if result is None:
+                    raise RuntimeError("FanFicFare did not produce a refreshed EPUB.")
+                new_epub_path, metadata = result
+
+                immutable_path, current_path = build_book_paths(new_epub_path.name, metadata["author"])
+                new_epub_path.rename(immutable_path)
+                shutil.copyfile(immutable_path, current_path)
+
+                new_word_count, new_chapter_count = get_epub_word_and_chapter_count(current_path)
+                update_data = schemas.BookUpdate(**metadata)
+                updated_book = await crud.update_book(db=db, book=db_book, update_data=update_data)
+                updated_book.removed_chapters = []
+                updated_book.master_word_count = new_word_count
+                updated_book.current_word_count = new_word_count
+                updated_book.immutable_path = str(immutable_path.relative_to(LIBRARY_PATH.parent))
+                updated_book.current_path = str(current_path.relative_to(LIBRARY_PATH.parent))
+                updated_book.download_status = None
+                await crud.touch_book_content(db, updated_book)
+                await db.commit()
+                await db.refresh(updated_book)
+
+                log_entry = schemas.BookLogCreate(
+                    book_id=updated_book.id,
+                    entry_type="updated",
+                    previous_chapter_count=0,
+                    new_chapter_count=new_chapter_count,
+                    words_added=new_word_count,
+                )
+                await crud.create_book_log(db, log_entry)
+                await epub_editor.apply_book_cleaning(updated_book, db)
+                await queue_metadata_sync_job(db, trigger="book_update", book_ids=[updated_book.id])
+
+                updated_book.refresh_status = None
+                await db.commit()
+                return
+
+            immutable_path = LIBRARY_PATH.parent / db_book.immutable_path
+            current_path = LIBRARY_PATH.parent / db_book.current_path
+
+            old_word_count, old_chapter_count = get_epub_word_and_chapter_count(current_path)
+            result = await download_web_novel(
+                db_book.source_url, overwrite=True, existing_epub_path=immutable_path
+            )
+            if result is None:
+                raise RuntimeError("FanFicFare did not update the existing EPUB during refresh.")
+            new_epub_path, metadata = result
+
+            if new_epub_path != immutable_path:
+                new_epub_path.rename(immutable_path)
+            shutil.copyfile(immutable_path, current_path)
+
+            new_word_count, new_chapter_count = get_epub_word_and_chapter_count(current_path)
+
+            if new_chapter_count > old_chapter_count:
+                logger.info(
+                    "Found %s new chapters for %s.",
+                    new_chapter_count - old_chapter_count,
+                    db_book.title,
+                )
+                log_entry = schemas.BookLogCreate(
+                    book_id=db_book.id,
+                    entry_type="updated",
+                    previous_chapter_count=old_chapter_count,
+                    new_chapter_count=new_chapter_count,
+                    words_added=new_word_count - old_word_count,
+                )
+                await crud.create_book_log(db, log_entry)
+
+            update_data = schemas.BookUpdate(**metadata)
+            updated_book = await crud.update_book(db=db, book=db_book, update_data=update_data)
+
+            # Reset per-source processing state; preserve per-book content_selectors
+            updated_book.removed_chapters = []
+            updated_book.master_word_count = new_word_count
+            updated_book.current_word_count = new_word_count
+            await crud.touch_book_content(db, updated_book)
+            await db.commit()
+            await db.refresh(updated_book)
+
+            await epub_editor.apply_book_cleaning(updated_book, db)
+            await queue_metadata_sync_job(db, trigger="book_update", book_ids=[updated_book.id])
+
+            updated_book.refresh_status = None
+            await db.commit()
+        except Exception as exc:
+            logger.error(
+                "Manual refresh failed for book %s: %s\n%s",
+                book_id,
+                exc,
+                traceback.format_exc(),
+            )
+            try:
+                db_book.refresh_status = "error"
+                await db.commit()
+            except Exception:
+                logger.exception("Failed to mark refresh_status=error for book %s", book_id)
+
+
 async def update_web_novels() -> None:
     """Scheduler job: checks all web novels for updates every 24 hours."""
     logger.info("Starting web novel update job.")

--- a/backend/app/services/web_novel.py
+++ b/backend/app/services/web_novel.py
@@ -382,9 +382,7 @@ async def run_book_refresh(book_id: int) -> None:
             current_path = LIBRARY_PATH.parent / db_book.current_path
 
             old_word_count, old_chapter_count = get_epub_word_and_chapter_count(current_path)
-            result = await download_web_novel(
-                db_book.source_url, overwrite=True, existing_epub_path=immutable_path
-            )
+            result = await download_web_novel(db_book.source_url, overwrite=True, existing_epub_path=immutable_path)
             if result is None:
                 raise RuntimeError("FanFicFare did not update the existing EPUB during refresh.")
             new_epub_path, metadata = result

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1210,9 +1210,7 @@ async def test_update_book_details(db_session):
 
 @pytest.mark.asyncio
 async def test_refresh_book(db_session, mocker):
-    """
-    Test refreshing a book from its source URL.
-    """
+    """Refresh now enqueues a background job and returns 202 with queued status."""
     library_path = Path("./library").resolve()
     library_path.mkdir(exist_ok=True)
     author_dir = library_path / "Original Author"
@@ -1222,19 +1220,9 @@ async def test_refresh_book(db_session, mocker):
     create_dummy_epub(immutable_path, "Original Title", "Original Author")
     current_path.write_bytes(immutable_path.read_bytes())
 
-    download_mock = mocker.patch(
-        "backend.app.routers.web_novels.download_web_novel",
-        return_value=(
-            immutable_path,
-            {
-                "title": "Refreshed Title",
-                "author": "Refreshed Author",
-                "series": "Refreshed Series",
-                "genre_tags": ["Action"],
-                "source_tags": ["Character Growth"],
-            },
-        ),
-    )
+    queue = mocker.Mock()
+    queue.enqueue = mocker.AsyncMock(return_value=True)
+    mocker.patch("backend.app.routers.web_novels.get_refresh_queue", return_value=queue)
 
     async with AsyncTestingSessionLocal() as session:
         book = await crud.create_book(
@@ -1251,25 +1239,54 @@ async def test_refresh_book(db_session, mocker):
 
     response = client.post(f"/api/books/{book.id}/refresh")
 
-    assert response.status_code == 200
+    assert response.status_code == 202
     data = response.json()
-    assert data["title"] == "Refreshed Title"
-    assert data["author"] == "Refreshed Author"
-    assert data["series"] == "Refreshed Series"
-    assert data["genre_tags"] == ["Action"]
-    assert data["source_tags"] == ["Character Growth"]
-    assert data["master_word_count"] > 0
-    assert data["current_word_count"] == data["master_word_count"]
-    download_mock.assert_called_once_with(
-        "http://example.com/story/refresh",
-        overwrite=True,
-        existing_epub_path=immutable_path,
-    )
+    assert data["id"] == book.id
+    assert data["refresh_status"] == "queued"
+    # Book content should not have changed yet — only the status flipped.
+    assert data["title"] == "Original Title"
+    assert data["author"] == "Original Author"
+    queue.enqueue.assert_awaited_once_with(book.id)
+
+    async with AsyncTestingSessionLocal() as session:
+        persisted = await crud.get_book(session, book_id=book.id)
+        assert persisted.refresh_status == "queued"
 
     # Clean up dummy files
-    (library_path.parent / data["immutable_path"]).unlink()
-    (library_path.parent / data["current_path"]).unlink()
+    immutable_path.unlink()
+    current_path.unlink()
     author_dir.rmdir()
+
+
+@pytest.mark.asyncio
+async def test_refresh_book_while_already_queued_is_idempotent(db_session, mocker):
+    """A second refresh while one is still queued/processing should not flip status back."""
+    queue = mocker.Mock()
+    queue.enqueue = mocker.AsyncMock(return_value=False)
+    mocker.patch("backend.app.routers.web_novels.get_refresh_queue", return_value=queue)
+
+    async with AsyncTestingSessionLocal() as session:
+        book = await crud.create_book(
+            session,
+            schemas.BookCreate(
+                title="Title",
+                author="Author",
+                source_url="http://example.com/story/already-queued",
+                immutable_path="p1i",
+                current_path="p1c",
+                source_type=models.SourceType.web,
+            ),
+        )
+        book.refresh_status = "processing"
+        await session.commit()
+
+    response = client.post(f"/api/books/{book.id}/refresh")
+
+    assert response.status_code == 202
+    data = response.json()
+    # Still "processing" — the endpoint should not step on an in-flight job.
+    assert data["refresh_status"] == "processing"
+    queue.enqueue.assert_awaited_once_with(book.id)
 
 
 @pytest.mark.asyncio
@@ -1296,19 +1313,11 @@ async def test_refresh_book_no_source_url(db_session):
 
 
 @pytest.mark.asyncio
-async def test_refresh_failed_placeholder_downloads_fresh_epub(db_session, mocker):
-    library_path = Path("./library").resolve()
-    library_path.mkdir(exist_ok=True)
-    new_epub_path = library_path / "Recovered Title-rr_456.epub"
-    create_dummy_epub(new_epub_path, "Recovered Title", "Recovered Author")
-
-    download_mock = mocker.patch(
-        "backend.app.routers.web_novels.download_web_novel",
-        return_value=(
-            new_epub_path,
-            {"title": "Recovered Title", "author": "Recovered Author", "series": "Recovered Series"},
-        ),
-    )
+async def test_refresh_failed_placeholder_enqueues_refresh(db_session, mocker):
+    """Refresh for a failed placeholder (no EPUB yet) enqueues a job without touching files."""
+    queue = mocker.Mock()
+    queue.enqueue = mocker.AsyncMock(return_value=True)
+    mocker.patch("backend.app.routers.web_novels.get_refresh_queue", return_value=queue)
 
     async with AsyncTestingSessionLocal() as session:
         book = await crud.create_book(
@@ -1324,21 +1333,13 @@ async def test_refresh_failed_placeholder_downloads_fresh_epub(db_session, mocke
 
     response = client.post(f"/api/books/{book.id}/refresh")
 
-    assert response.status_code == 200
+    assert response.status_code == 202
     data = response.json()
-    assert data["title"] == "Recovered Title"
-    assert data["author"] == "Recovered Author"
-    assert data["series"] == "Recovered Series"
-    assert data["download_status"] is None
-    assert data["immutable_path"]
-    assert data["current_path"]
-    download_mock.assert_called_once_with("https://example.com/story/recovered", overwrite=True)
-
-    immutable_result_path = library_path.parent / data["immutable_path"]
-    current_result_path = library_path.parent / data["current_path"]
-    immutable_result_path.unlink()
-    current_result_path.unlink()
-    immutable_result_path.parent.rmdir()
+    assert data["id"] == book.id
+    assert data["refresh_status"] == "queued"
+    # download_status is not cleared at enqueue time — the worker clears it on success.
+    assert data["download_status"] == "error"
+    queue.enqueue.assert_awaited_once_with(book.id)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_refresh_queue.py
+++ b/backend/tests/test_refresh_queue.py
@@ -1,0 +1,257 @@
+"""Tests for RefreshQueue, run_book_refresh, and crud.get_pending_refresh_books."""
+
+import asyncio
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from backend.app import crud, models, schemas
+from backend.app.database import Base
+from backend.app.services import refresh_queue as refresh_queue_mod
+from backend.app.services import web_novel as web_novel_mod
+
+SQLALCHEMY_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
+
+engine = create_async_engine(
+    SQLALCHEMY_DATABASE_URL,
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+AsyncTestingSessionLocal = async_sessionmaker(
+    autocommit=False, autoflush=False, bind=engine, expire_on_commit=False
+)
+
+
+@pytest_asyncio.fixture(scope="function")
+async def db():
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    async with AsyncTestingSessionLocal() as session:
+        yield session
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+
+async def _make_web_book(db, **overrides):
+    payload = dict(
+        title="Web Book",
+        author="Author",
+        source_url="https://example.com/story/1",
+        source_type=models.SourceType.web,
+    )
+    payload.update(overrides)
+    return await crud.create_book(db, schemas.BookCreate(**payload))
+
+
+@pytest.mark.asyncio
+async def test_get_pending_refresh_books_returns_queued_and_processing(db):
+    queued = await _make_web_book(db, source_url="https://example.com/a")
+    queued.refresh_status = "queued"
+    processing = await _make_web_book(db, source_url="https://example.com/b")
+    processing.refresh_status = "processing"
+    errored = await _make_web_book(db, source_url="https://example.com/c")
+    errored.refresh_status = "error"
+    idle = await _make_web_book(db, source_url="https://example.com/d")
+    # Non-web book with a queued-looking status should not appear.
+    non_web = await crud.create_book(
+        db,
+        schemas.BookCreate(
+            title="Not web",
+            author="Author",
+            source_type=models.SourceType.epub,
+            immutable_path="p1",
+            current_path="p2",
+        ),
+    )
+    non_web.refresh_status = "queued"
+    await db.commit()
+
+    pending = await crud.get_pending_refresh_books(db)
+    ids = {book.id for book in pending}
+
+    assert queued.id in ids
+    assert processing.id in ids
+    assert errored.id not in ids
+    assert idle.id not in ids
+    assert non_web.id not in ids
+
+
+class _RecordingQueue:
+    """Captures book_ids as run_book_refresh is invoked from the worker."""
+
+    def __init__(self):
+        self.calls: list[int] = []
+        self.started = asyncio.Event()
+
+    async def __call__(self, book_id: int) -> None:
+        self.calls.append(book_id)
+        self.started.set()
+
+
+@pytest.mark.asyncio
+async def test_refresh_queue_enqueue_is_idempotent(monkeypatch):
+    recorder = _RecordingQueue()
+    # Block the worker so we can observe set membership mid-flight.
+    block = asyncio.Event()
+
+    async def slow_refresh(book_id: int) -> None:
+        recorder.calls.append(book_id)
+        await block.wait()
+
+    monkeypatch.setattr(refresh_queue_mod, "run_book_refresh", slow_refresh)
+    queue = refresh_queue_mod.RefreshQueue()
+    await queue.start()
+    try:
+        assert await queue.enqueue(42) is True
+        # While the worker is blocked on the first item, a second enqueue for
+        # the same id should short-circuit.
+        assert await queue.enqueue(42) is False
+        # A different id should still be accepted.
+        assert await queue.enqueue(43) is True
+    finally:
+        block.set()
+        await queue.stop()
+
+    # Both unique ids were eventually processed.
+    assert sorted(recorder.calls) == [42, 43]
+
+
+@pytest.mark.asyncio
+async def test_refresh_queue_worker_invokes_run_book_refresh(monkeypatch):
+    done = asyncio.Event()
+    processed: list[int] = []
+
+    async def fake_refresh(book_id: int) -> None:
+        processed.append(book_id)
+        done.set()
+
+    monkeypatch.setattr(refresh_queue_mod, "run_book_refresh", fake_refresh)
+    queue = refresh_queue_mod.RefreshQueue()
+    await queue.start()
+    try:
+        await queue.enqueue(7)
+        await asyncio.wait_for(done.wait(), timeout=1)
+    finally:
+        await queue.stop()
+
+    assert processed == [7]
+
+
+@pytest.mark.asyncio
+async def test_refresh_queue_continues_after_worker_exception(monkeypatch):
+    """An exception inside run_book_refresh must not kill the worker loop."""
+    second_done = asyncio.Event()
+    seen: list[int] = []
+
+    async def fake_refresh(book_id: int) -> None:
+        seen.append(book_id)
+        if book_id == 1:
+            raise RuntimeError("boom")
+        second_done.set()
+
+    monkeypatch.setattr(refresh_queue_mod, "run_book_refresh", fake_refresh)
+    queue = refresh_queue_mod.RefreshQueue()
+    await queue.start()
+    try:
+        await queue.enqueue(1)
+        await queue.enqueue(2)
+        await asyncio.wait_for(second_done.wait(), timeout=1)
+    finally:
+        await queue.stop()
+
+    assert seen == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_refresh_queue_requeue_pending_books_uses_crud(monkeypatch, db):
+    queued = await _make_web_book(db, source_url="https://example.com/q")
+    queued.refresh_status = "queued"
+    processing = await _make_web_book(db, source_url="https://example.com/p")
+    processing.refresh_status = "processing"
+    idle = await _make_web_book(db, source_url="https://example.com/i")
+    await db.commit()
+
+    # Point the queue module's SessionLocal at the test database so
+    # requeue_pending_books sees our fixture rows.
+    monkeypatch.setattr(refresh_queue_mod, "SessionLocal", AsyncTestingSessionLocal)
+
+    enqueued: list[int] = []
+
+    async def fake_enqueue(self, book_id):
+        enqueued.append(book_id)
+        return True
+
+    queue = refresh_queue_mod.RefreshQueue()
+    monkeypatch.setattr(refresh_queue_mod.RefreshQueue, "enqueue", fake_enqueue)
+
+    count = await queue.requeue_pending_books()
+
+    assert count == 2
+    assert sorted(enqueued) == sorted([queued.id, processing.id])
+    assert idle.id not in enqueued
+
+
+@pytest.mark.asyncio
+async def test_run_book_refresh_marks_error_when_no_source_url(monkeypatch, db):
+    # Build a web book with no source_url (sneak past the schema by creating
+    # it as epub first and then mutating source_type).
+    book = await crud.create_book(
+        db,
+        schemas.BookCreate(
+            title="No URL",
+            author="Author",
+            source_type=models.SourceType.epub,
+            immutable_path="p1",
+            current_path="p2",
+        ),
+    )
+    book.source_type = models.SourceType.web
+    book.source_url = None
+    await db.commit()
+
+    monkeypatch.setattr(web_novel_mod, "SessionLocal", AsyncTestingSessionLocal)
+
+    await web_novel_mod.run_book_refresh(book.id)
+
+    refreshed = await crud.get_book(db, book_id=book.id)
+    await db.refresh(refreshed)
+    assert refreshed.refresh_status == "error"
+
+
+@pytest.mark.asyncio
+async def test_run_book_refresh_marks_error_when_download_fails(monkeypatch, db):
+    book = await _make_web_book(
+        db,
+        source_url="https://example.com/story/fail",
+        immutable_path="library/Author/immutable.epub",
+        current_path="library/Author/current.epub",
+    )
+    await db.commit()
+
+    monkeypatch.setattr(web_novel_mod, "SessionLocal", AsyncTestingSessionLocal)
+
+    def broken_word_count(path):
+        raise RuntimeError("cannot read epub")
+
+    # get_epub_word_and_chapter_count is the first call that touches disk in
+    # the "has existing paths" branch — failing it short-circuits the job into
+    # the error handler without requiring real EPUB files on disk.
+    monkeypatch.setattr(
+        web_novel_mod, "get_epub_word_and_chapter_count", broken_word_count
+    )
+
+    await web_novel_mod.run_book_refresh(book.id)
+
+    refreshed = await crud.get_book(db, book_id=book.id)
+    await db.refresh(refreshed)
+    assert refreshed.refresh_status == "error"
+
+
+@pytest.mark.asyncio
+async def test_run_book_refresh_swallows_missing_book(monkeypatch, db):
+    """Worker should no-op cleanly when the book was deleted between enqueue and run."""
+    monkeypatch.setattr(web_novel_mod, "SessionLocal", AsyncTestingSessionLocal)
+    # Should not raise even though book 99999 does not exist.
+    await web_novel_mod.run_book_refresh(99999)

--- a/backend/tests/test_refresh_queue.py
+++ b/backend/tests/test_refresh_queue.py
@@ -19,9 +19,7 @@ engine = create_async_engine(
     connect_args={"check_same_thread": False},
     poolclass=StaticPool,
 )
-AsyncTestingSessionLocal = async_sessionmaker(
-    autocommit=False, autoflush=False, bind=engine, expire_on_commit=False
-)
+AsyncTestingSessionLocal = async_sessionmaker(autocommit=False, autoflush=False, bind=engine, expire_on_commit=False)
 
 
 @pytest_asyncio.fixture(scope="function")
@@ -238,9 +236,7 @@ async def test_run_book_refresh_marks_error_when_download_fails(monkeypatch, db)
     # get_epub_word_and_chapter_count is the first call that touches disk in
     # the "has existing paths" branch — failing it short-circuits the job into
     # the error handler without requiring real EPUB files on disk.
-    monkeypatch.setattr(
-        web_novel_mod, "get_epub_word_and_chapter_count", broken_word_count
-    )
+    monkeypatch.setattr(web_novel_mod, "get_epub_word_and_chapter_count", broken_word_count)
 
     await web_novel_mod.run_book_refresh(book.id)
 

--- a/frontend/src/components/BookSettings.jsx
+++ b/frontend/src/components/BookSettings.jsx
@@ -5,6 +5,7 @@ import {
   deleteBook,
   detachBookSource,
   getApiCoverUrl,
+  getBook,
   getBookChapters,
   getBookCleanedChapters,
   getMatchedConfigs,
@@ -137,43 +138,82 @@ function SyncedGenreTagList({ tags }) {
   );
 }
 
-function BookSettings({ book, onBack }) {
+function BookSettings({ book: initialBook, onBack }) {
   const queryClient = useQueryClient();
   const coverInputRef = useRef(null);
 
-  const [title, setTitle] = useState(book.title || "");
-  const [author, setAuthor] = useState(book.author || "");
-  const [series, setSeries] = useState(book.series || "");
+  // Poll the individual book while a refresh is in-flight so the UI reflects
+  // backend state without the user navigating away. The query is seeded with
+  // the book the parent passed so the page renders immediately; staleTime is
+  // Infinity so we only hit the network when the refetchInterval fires or when
+  // a mutation explicitly invalidates this key.
+  const { data: polledBook } = useQuery({
+    queryKey: ["book", initialBook.id],
+    queryFn: () => getBook(initialBook.id),
+    initialData: initialBook,
+    staleTime: Infinity,
+    refetchInterval: ({ state }) => {
+      const current = state.data;
+      if (!current || typeof current !== "object" || !current.id) return false;
+      return current.refresh_status === "queued" ||
+        current.refresh_status === "processing"
+        ? 2000
+        : false;
+    },
+  });
+
+  // Guard against malformed responses (e.g., a test mock's catch-all): if the
+  // polled value doesn't look like a book, fall back to the prop.
+  const book =
+    polledBook && typeof polledBook === "object" && polledBook.id
+      ? polledBook
+      : initialBook;
+  const isRefreshing =
+    book.refresh_status === "queued" || book.refresh_status === "processing";
+  const refreshErrored = book.refresh_status === "error";
+
+  // Cache-buster for the cover <img> — incremented whenever a cover mutation
+  // succeeds so the browser fetches the freshly-saved file instead of a stale
+  // copy at the same deterministic URL.
+  const [coverVersion, setCoverVersion] = useState(0);
+
+  const [title, setTitle] = useState(initialBook.title || "");
+  const [author, setAuthor] = useState(initialBook.author || "");
+  const [series, setSeries] = useState(initialBook.series || "");
   const [seriesIndex, setSeriesIndex] = useState(
-    book.series_index != null ? String(book.series_index) : "",
+    initialBook.series_index != null ? String(initialBook.series_index) : "",
   );
-  const [notes, setNotes] = useState(book.notes || "");
-  const [isbn10, setIsbn10] = useState(book.metadata_remote_ids?.isbn_10 || "");
-  const [isbn13, setIsbn13] = useState(book.metadata_remote_ids?.isbn_13 || "");
+  const [notes, setNotes] = useState(initialBook.notes || "");
+  const [isbn10, setIsbn10] = useState(
+    initialBook.metadata_remote_ids?.isbn_10 || "",
+  );
+  const [isbn13, setIsbn13] = useState(
+    initialBook.metadata_remote_ids?.isbn_13 || "",
+  );
   const [googleBooksVolumeId, setGoogleBooksVolumeId] = useState(
-    book.metadata_remote_ids?.google_books_volume_id || "",
+    initialBook.metadata_remote_ids?.google_books_volume_id || "",
   );
   const [openLibraryWorkKey, setOpenLibraryWorkKey] = useState(
-    book.metadata_remote_ids?.open_library_work_key || "",
+    initialBook.metadata_remote_ids?.open_library_work_key || "",
   );
   const [openLibraryEditionKey, setOpenLibraryEditionKey] = useState(
-    book.metadata_remote_ids?.open_library_edition_key || "",
+    initialBook.metadata_remote_ids?.open_library_edition_key || "",
   );
   const [openLibraryAuthorKey, setOpenLibraryAuthorKey] = useState(
-    book.metadata_remote_ids?.open_library_author_key || "",
+    initialBook.metadata_remote_ids?.open_library_author_key || "",
   );
   const [otherRemoteIdsJson, setOtherRemoteIdsJson] = useState(
-    splitRemoteIds(book.metadata_remote_ids).extrasJson,
+    splitRemoteIds(initialBook.metadata_remote_ids).extrasJson,
   );
   const [identifierError, setIdentifierError] = useState("");
   const [userGenreTags, setUserGenreTags] = useState(
-    (book.user_genre_tags || []).join(", "),
+    (initialBook.user_genre_tags || []).join(", "),
   );
   const [removedChapters, setRemovedChapters] = useState(
-    book.removed_chapters || [],
+    initialBook.removed_chapters || [],
   );
   const [contentSelectors, setContentSelectors] = useState(
-    book.content_selectors || [],
+    initialBook.content_selectors || [],
   );
   const [previewResult, setPreviewResult] = useState(null);
   const [previewedChapter, setPreviewedChapter] = useState(null);
@@ -182,37 +222,44 @@ function BookSettings({ book, onBack }) {
   const [chapterPreviewMode, setChapterPreviewMode] = useState("original");
   const [identifiersExpanded, setIdentifiersExpanded] = useState(false);
 
+  // Reset form state when the parent navigates to a different book. We key this
+  // on the initial prop (not the polled `book`) so background refetches — e.g.
+  // while a refresh is in-flight — don't wipe out in-progress edits.
   useEffect(() => {
-    setTitle(book.title || "");
-    setAuthor(book.author || "");
-    setSeries(book.series || "");
-    setSeriesIndex(book.series_index != null ? String(book.series_index) : "");
-    setNotes(book.notes || "");
-    setIsbn10(book.metadata_remote_ids?.isbn_10 || "");
-    setIsbn13(book.metadata_remote_ids?.isbn_13 || "");
+    setTitle(initialBook.title || "");
+    setAuthor(initialBook.author || "");
+    setSeries(initialBook.series || "");
+    setSeriesIndex(
+      initialBook.series_index != null ? String(initialBook.series_index) : "",
+    );
+    setNotes(initialBook.notes || "");
+    setIsbn10(initialBook.metadata_remote_ids?.isbn_10 || "");
+    setIsbn13(initialBook.metadata_remote_ids?.isbn_13 || "");
     setGoogleBooksVolumeId(
-      book.metadata_remote_ids?.google_books_volume_id || "",
+      initialBook.metadata_remote_ids?.google_books_volume_id || "",
     );
     setOpenLibraryWorkKey(
-      book.metadata_remote_ids?.open_library_work_key || "",
+      initialBook.metadata_remote_ids?.open_library_work_key || "",
     );
     setOpenLibraryEditionKey(
-      book.metadata_remote_ids?.open_library_edition_key || "",
+      initialBook.metadata_remote_ids?.open_library_edition_key || "",
     );
     setOpenLibraryAuthorKey(
-      book.metadata_remote_ids?.open_library_author_key || "",
+      initialBook.metadata_remote_ids?.open_library_author_key || "",
     );
-    setOtherRemoteIdsJson(splitRemoteIds(book.metadata_remote_ids).extrasJson);
+    setOtherRemoteIdsJson(
+      splitRemoteIds(initialBook.metadata_remote_ids).extrasJson,
+    );
     setIdentifierError("");
-    setUserGenreTags((book.user_genre_tags || []).join(", "));
-    setRemovedChapters(book.removed_chapters || []);
-    setContentSelectors(book.content_selectors || []);
+    setUserGenreTags((initialBook.user_genre_tags || []).join(", "));
+    setRemovedChapters(initialBook.removed_chapters || []);
+    setContentSelectors(initialBook.content_selectors || []);
     setPreviewResult(null);
     setChapterSearch("");
     setChaptersExpanded(false);
     setChapterPreviewMode("original");
     setIdentifiersExpanded(false);
-  }, [book]);
+  }, [initialBook]);
 
   useEffect(() => {
     setPreviewResult(null);
@@ -260,11 +307,15 @@ function BookSettings({ book, onBack }) {
     },
   });
 
+  // Kicks off an async refresh job and returns immediately. The useQuery above
+  // polls until the book's refresh_status goes back to null (or "error"). We
+  // keep the user on the page so they can see the progress and the final result
+  // without having to rediscover the book in the catalog.
   const refreshMutation = useMutation({
     mutationFn: () => refreshBook(book.id),
-    onSuccess: () => {
+    onSuccess: (updatedBook) => {
+      queryClient.setQueryData(["book", book.id], updatedBook);
       queryClient.invalidateQueries({ queryKey: ["book-catalog"] });
-      onBack();
     },
   });
 
@@ -295,22 +346,36 @@ function BookSettings({ book, onBack }) {
 
   const [coverUrl, setCoverUrl] = useState("");
 
+  // Cover files live at a deterministic URL (/api/covers/{book_id}), so the
+  // browser happily caches them. Whenever any cover mutation succeeds we bump
+  // `coverVersion` and append it as a cache-busting query param on the <img>,
+  // forcing the browser to fetch the freshly-written file.
+  const bumpCoverVersion = () => setCoverVersion((v) => v + 1);
+
   const coverMutation = useMutation({
     mutationFn: (file) => uploadBookCover(book.id, file),
-    onSuccess: () =>
-      queryClient.invalidateQueries({ queryKey: ["book-catalog"] }),
+    onSuccess: () => {
+      bumpCoverVersion();
+      queryClient.invalidateQueries({ queryKey: ["book-catalog"] });
+      queryClient.invalidateQueries({ queryKey: ["book", book.id] });
+    },
   });
 
   const retryCoverMutation = useMutation({
     mutationFn: () => retryBookCover(book.id),
-    onSuccess: () =>
-      queryClient.invalidateQueries({ queryKey: ["book-catalog"] }),
+    onSuccess: () => {
+      bumpCoverVersion();
+      queryClient.invalidateQueries({ queryKey: ["book-catalog"] });
+      queryClient.invalidateQueries({ queryKey: ["book", book.id] });
+    },
   });
 
   const coverUrlMutation = useMutation({
     mutationFn: (url) => setBookCoverUrl(book.id, url),
     onSuccess: () => {
+      bumpCoverVersion();
       queryClient.invalidateQueries({ queryKey: ["book-catalog"] });
+      queryClient.invalidateQueries({ queryKey: ["book", book.id] });
       setCoverUrl("");
     },
   });
@@ -428,7 +493,8 @@ function BookSettings({ book, onBack }) {
     processMutation.isPending ||
     refreshMutation.isPending ||
     detachSourceMutation.isPending ||
-    deleteMutation.isPending;
+    deleteMutation.isPending ||
+    isRefreshing;
   const canDetachWebMarker =
     book.source_type === "web" && book.immutable_path && book.current_path;
 
@@ -449,13 +515,33 @@ function BookSettings({ book, onBack }) {
         <button
           className="btn-text"
           onClick={onBack}
-          disabled={isBusy}
+          disabled={
+            saveMutation.isPending ||
+            processMutation.isPending ||
+            refreshMutation.isPending ||
+            detachSourceMutation.isPending ||
+            deleteMutation.isPending
+          }
           style={{ flexShrink: 0 }}
         >
           ← Back
         </button>
         <h2>{book.title}</h2>
       </div>
+
+      {isRefreshing && (
+        <div className="hint" role="status" style={{ marginBottom: "0.75rem" }}>
+          {book.refresh_status === "queued"
+            ? "This book is queued for refresh. It will start once the previous job finishes."
+            : "Refreshing from source — pulling new chapters via FanFicFare. This can take a few minutes for long stories."}
+        </div>
+      )}
+      {refreshErrored && (
+        <p className="error" role="alert">
+          The last refresh attempt failed. Check the logs, then click “Refresh
+          from Source” to try again.
+        </p>
+      )}
 
       <section className="settings-section">
         <h3>Metadata</h3>
@@ -540,7 +626,7 @@ function BookSettings({ book, onBack }) {
           <div className="settings-cover-aside">
             {book.cover_path ? (
               <img
-                src={getApiCoverUrl(book.id)}
+                src={`${getApiCoverUrl(book.id)}?v=${coverVersion}`}
                 alt="Cover"
                 className="settings-cover-img"
               />
@@ -971,8 +1057,12 @@ function BookSettings({ book, onBack }) {
           {book.source_type === "web" && (
             <button onClick={() => refreshMutation.mutate()} disabled={isBusy}>
               {refreshMutation.isPending
-                ? "Refreshing..."
-                : "Refresh from Source"}
+                ? "Queueing…"
+                : book.refresh_status === "queued"
+                  ? "Queued for refresh…"
+                  : book.refresh_status === "processing"
+                    ? "Refreshing from source…"
+                    : "Refresh from Source"}
             </button>
           )}
         </div>

--- a/frontend/src/hooks/useLibraryCatalog.js
+++ b/frontend/src/hooks/useLibraryCatalog.js
@@ -8,7 +8,13 @@ function useLibraryCatalog({ q, sortBy, sortOrder }) {
     queryFn: () => getBookCatalog({ q, sortBy, sortOrder }),
     refetchInterval: ({ state }) => {
       const books = state.data ?? [];
-      return books.some((book) => book.download_status === "pending") ? 2000 : false;
+      const hasInFlight = books.some(
+        (book) =>
+          book.download_status === "pending" ||
+          book.refresh_status === "queued" ||
+          book.refresh_status === "processing",
+      );
+      return hasInFlight ? 2000 : false;
     },
   });
 }


### PR DESCRIPTION
## Summary
- Move the "refresh from source" endpoint off the request path: `POST /api/books/{id}/refresh` now returns `202 Accepted` immediately, enqueues the job on a new single-worker `RefreshQueue` (mirrors the existing web-import lane), and the BookSettings page polls `/api/books/{id}` until `refresh_status` clears.
- New nullable `refresh_status` column (migration `0016`) — values are `"queued" | "processing" | "error" | null` — so the UI can show queued / in-progress / errored banners and the queue can resume in-flight jobs after a restart via `requeue_pending_books`.
- Extract the actual download / cleaning / metadata-sync work into `services.web_novel.run_book_refresh`; the router is now a thin shim that flips status and enqueues. The endpoint is idempotent: calling it while a refresh is already `queued`/`processing` does not reset the status or double-enqueue.
- Frontend: cover `<img>` now cache-busts on mutation (deterministic `/api/covers/{id}` was being served stale), the catalog polls while any book has a refresh in-flight, and form state is keyed on the initial prop so background polls don't clobber in-progress edits.

## Test plan
- [x] `make test` — 191 backend + 29 frontend tests pass locally
- [x] `flake8 backend` clean; `npm run lint` clean
- [x] Alembic migration `0015 -> 0016` round-trips cleanly against a populated local Postgres DB
- [x] New `test_refresh_queue.py` covers: `get_pending_refresh_books` filter; `RefreshQueue` enqueue idempotency; worker survives an exception; `requeue_pending_books` uses the CRUD filter; `run_book_refresh` marks `refresh_status="error"` on missing source URL and on download failure; worker no-ops cleanly for a missing book
- [x] Updated `test_main.py::test_refresh_book` and the failed-placeholder test to the new async contract (202 + `queued` status + queue.enqueue assertion)
- [ ] Manual smoke: hit "Refresh from Source" in the UI on a real web novel, confirm the banner renders and clears