### PR TITLE
[codex] Track web book update history

### DIFF
--- a/backend/app/crud/__init__.py
+++ b/backend/app/crud/__init__.py
@@ -42,6 +42,7 @@ from .logs import (  # noqa: F401
     create_book_log,
     create_update_task,
     fail_update_task,
+    get_book_logs,
     get_active_update_task,
     get_book_logs_for_task,
     get_latest_book_log,

--- a/backend/app/crud/logs.py
+++ b/backend/app/crud/logs.py
@@ -25,6 +25,13 @@ async def get_latest_book_log(db: AsyncSession, book_id: int) -> Optional[models
     return result.scalars().first()
 
 
+async def get_book_logs(db: AsyncSession, book_id: int) -> List[models.BookLog]:
+    result = await db.execute(
+        select(models.BookLog).filter(models.BookLog.book_id == book_id).order_by(models.BookLog.timestamp.asc())
+    )
+    return result.scalars().all()
+
+
 async def count_book_logs(db: AsyncSession, book_id: int) -> int:
     result = await db.execute(select(func.count(models.BookLog.id)).where(models.BookLog.book_id == book_id))
     return result.scalar() or 0

--- a/backend/app/routers/books.py
+++ b/backend/app/routers/books.py
@@ -109,10 +109,7 @@ def _build_chapter_update_history(
 
     if len(stats_points) >= 2:
         timestamps = [_as_utc(point.timestamp) for point in stats_points]
-        intervals = [
-            (current - previous).total_seconds() / 86400
-            for previous, current in zip(timestamps, timestamps[1:])
-        ]
+        intervals = [(current - previous).total_seconds() / 86400 for previous, current in zip(timestamps, timestamps[1:])]
         average_days_between_updates = sum(intervals) / len(intervals)
         predicted_next_update_at = timestamps[-1] + timedelta(days=average_days_between_updates)
 

--- a/backend/app/routers/books.py
+++ b/backend/app/routers/books.py
@@ -1,6 +1,7 @@
 """Book CRUD, search, chapter listing, and download endpoints."""
 
 import logging
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -17,6 +18,118 @@ from ..services.metadata_jobs import queue_metadata_sync_job
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+WORDS_PER_MONTH_WEEKS = 52 / 12
+CATCH_UP_SYNC_MIN_CHAPTERS = 5
+CATCH_UP_SYNC_MIN_WORDS = 20_000
+
+
+def _as_utc(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _chapter_delta(log: models.BookLog) -> int:
+    if log.previous_chapter_count is None or log.new_chapter_count is None:
+        return 0
+    return max(log.new_chapter_count - log.previous_chapter_count, 0)
+
+
+def _is_chapter_growth_log(log: models.BookLog) -> bool:
+    return (
+        log.entry_type == "updated"
+        and log.previous_chapter_count is not None
+        and log.previous_chapter_count > 0
+        and _chapter_delta(log) > 0
+    )
+
+
+def _is_initial_sync_log(log: models.BookLog) -> bool:
+    return log.entry_type == "added" and (log.new_chapter_count or 0) > 0
+
+
+def _build_chapter_update_history(
+    book_id: int,
+    logs: list[models.BookLog],
+    now: datetime | None = None,
+) -> schemas.BookChapterUpdateHistory:
+    points: list[schemas.BookChapterUpdateHistoryPoint] = []
+    seen_initial_sync = False
+    seen_post_initial_growth = False
+    for log in logs:
+        is_initial_sync = _is_initial_sync_log(log)
+        included_in_stats = _is_chapter_growth_log(log)
+        if not is_initial_sync and not included_in_stats:
+            continue
+        chapters_added = (log.new_chapter_count or 0) if is_initial_sync else _chapter_delta(log)
+        words_added = max(log.words_added or 0, 0)
+        is_catch_up_sync = (
+            included_in_stats
+            and seen_initial_sync
+            and not seen_post_initial_growth
+            and (chapters_added >= CATCH_UP_SYNC_MIN_CHAPTERS or words_added >= CATCH_UP_SYNC_MIN_WORDS)
+        )
+        included_in_stats = included_in_stats and not is_catch_up_sync
+        points.append(
+            schemas.BookChapterUpdateHistoryPoint(
+                id=log.id,
+                timestamp=log.timestamp,
+                entry_type=log.entry_type,
+                previous_chapter_count=log.previous_chapter_count,
+                new_chapter_count=log.new_chapter_count,
+                chapters_added=chapters_added,
+                words_added=words_added,
+                average_words_per_chapter=words_added / chapters_added if chapters_added else None,
+                included_in_stats=included_in_stats,
+                is_initial_sync=is_initial_sync,
+                is_catch_up_sync=is_catch_up_sync,
+            )
+        )
+        if is_initial_sync:
+            seen_initial_sync = True
+        elif _is_chapter_growth_log(log):
+            seen_post_initial_growth = True
+
+    stats_points = [point for point in points if point.included_in_stats]
+    total_words_added = sum(point.words_added for point in stats_points)
+    total_chapters_added = sum(point.chapters_added for point in stats_points)
+    average_words_per_week = None
+    average_words_per_month = None
+    average_days_between_updates = None
+    predicted_next_update_at = None
+    last_update_at = stats_points[-1].timestamp if stats_points else None
+
+    if stats_points:
+        now_utc = _as_utc(now or datetime.now(timezone.utc))
+        first_update_at = _as_utc(stats_points[0].timestamp)
+        elapsed_days = max((now_utc - first_update_at).total_seconds() / 86400, 1)
+        average_words_per_week = total_words_added / (elapsed_days / 7)
+        average_words_per_month = average_words_per_week * WORDS_PER_MONTH_WEEKS
+
+    if len(stats_points) >= 2:
+        timestamps = [_as_utc(point.timestamp) for point in stats_points]
+        intervals = [
+            (current - previous).total_seconds() / 86400
+            for previous, current in zip(timestamps, timestamps[1:])
+        ]
+        average_days_between_updates = sum(intervals) / len(intervals)
+        predicted_next_update_at = timestamps[-1] + timedelta(days=average_days_between_updates)
+
+    return schemas.BookChapterUpdateHistory(
+        book_id=book_id,
+        history=points,
+        summary=schemas.BookChapterUpdateHistorySummary(
+            total_update_events=len(stats_points),
+            total_chapters_added=total_chapters_added,
+            total_words_added=total_words_added,
+            average_words_per_week=average_words_per_week,
+            average_words_per_month=average_words_per_month,
+            average_days_between_updates=average_days_between_updates,
+            predicted_next_update_at=predicted_next_update_at,
+            last_update_at=last_update_at,
+        ),
+    )
 
 
 def _remove_book_files(book: models.Book) -> list[str]:
@@ -259,6 +372,16 @@ async def count_books_endpoint(q: Optional[str] = None, db: AsyncSession = Depen
 async def get_book_details(book_ids: List[int] = Query(alias="ids"), db: AsyncSession = Depends(get_db)) -> List[schemas.Book]:
     books = await crud.get_books_by_ids(db, book_ids=book_ids)
     return [schemas.Book.model_validate(book) for book in books]
+
+
+@router.get("/api/books/{book_id}/update-history", response_model=schemas.BookChapterUpdateHistory)
+async def get_book_update_history(book_id: int, db: AsyncSession = Depends(get_db)) -> schemas.BookChapterUpdateHistory:
+    db_book = await crud.get_book(db, book_id=book_id)
+    if db_book is None:
+        raise HTTPException(status_code=404, detail="Book not found")
+
+    logs = await crud.get_book_logs(db, book_id)
+    return _build_chapter_update_history(book_id, logs)
 
 
 @router.get("/api/books/{book_id}", response_model=schemas.Book)

--- a/backend/app/routers/reader.py
+++ b/backend/app/routers/reader.py
@@ -60,6 +60,12 @@ def _build_book_entry(book: models.Book, base_url: str) -> ET.Element:
     acq_link.set("href", f"{base_url}/reader/books/{book.id}/download")
     acq_link.set("type", "application/epub+zip")
 
+    if book.source_type == models.SourceType.web and book.source_url:
+        source_link = ET.SubElement(entry, f"{{{_ATOM_NS}}}link")
+        source_link.set("rel", "alternate")
+        source_link.set("href", book.source_url)
+        source_link.set("type", "text/html")
+
     if book.cover_path:
         img_link = ET.SubElement(entry, f"{{{_ATOM_NS}}}link")
         img_link.set("rel", "http://opds-spec.org/image")
@@ -107,6 +113,7 @@ def _reader_book_payload(
         "author": book.author,
         "series": book.series,
         "series_index": float(book.series_index) if book.series_index is not None else None,
+        "source_url": book.source_url if book.source_type == models.SourceType.web else None,
         "source_type": book.source_type,
         "content_updated_at": book.content_updated_at,
         "content_version": book.content_version,

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -179,6 +179,37 @@ class BookLogWithTitle(BookLog):
     book_title: str
 
 
+class BookChapterUpdateHistoryPoint(BaseModel):
+    id: int
+    timestamp: datetime
+    entry_type: str
+    previous_chapter_count: Optional[int] = None
+    new_chapter_count: Optional[int] = None
+    chapters_added: int
+    words_added: int
+    average_words_per_chapter: Optional[float] = None
+    included_in_stats: bool = False
+    is_initial_sync: bool = False
+    is_catch_up_sync: bool = False
+
+
+class BookChapterUpdateHistorySummary(BaseModel):
+    total_update_events: int
+    total_chapters_added: int
+    total_words_added: int
+    average_words_per_week: Optional[float] = None
+    average_words_per_month: Optional[float] = None
+    average_days_between_updates: Optional[float] = None
+    predicted_next_update_at: Optional[datetime] = None
+    last_update_at: Optional[datetime] = None
+
+
+class BookChapterUpdateHistory(BaseModel):
+    book_id: int
+    history: List[BookChapterUpdateHistoryPoint] = Field(default_factory=list)
+    summary: BookChapterUpdateHistorySummary
+
+
 class ApiKeyCreate(BaseModel):
     label: str
 
@@ -226,6 +257,7 @@ class ReaderBook(BaseModel):
     author: str
     series: Optional[str] = None
     series_index: Optional[float] = None
+    source_url: Optional[str] = None
     source_type: SourceType
     content_updated_at: datetime
     content_version: int

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -2678,6 +2678,97 @@ async def test_scheduler_history_task_logs_not_found(db_session):
     assert "not found" in response.json()["detail"].lower()
 
 
+@pytest.mark.asyncio
+async def test_book_update_history_uses_growth_logs(db_session):
+    async with AsyncTestingSessionLocal() as session:
+        book = await crud.create_book(
+            session,
+            schemas.BookCreate(
+                title="Growing Story",
+                author="Author",
+                immutable_path="growing_i",
+                current_path="growing_c",
+                source_type=models.SourceType.web,
+                source_url="https://example.com/growing",
+            ),
+        )
+
+        initial = await crud.create_book_log(
+            session,
+            schemas.BookLogCreate(
+                book_id=book.id,
+                entry_type="added",
+                new_chapter_count=100,
+                words_added=100000,
+            ),
+        )
+        catch_up_update = await crud.create_book_log(
+            session,
+            schemas.BookLogCreate(
+                book_id=book.id,
+                entry_type="updated",
+                previous_chapter_count=100,
+                new_chapter_count=115,
+                words_added=50000,
+            ),
+        )
+        first_update = await crud.create_book_log(
+            session,
+            schemas.BookLogCreate(
+                book_id=book.id,
+                entry_type="updated",
+                previous_chapter_count=115,
+                new_chapter_count=117,
+                words_added=5000,
+            ),
+        )
+        checked = await crud.create_book_log(
+            session,
+            schemas.BookLogCreate(
+                book_id=book.id,
+                entry_type="checked",
+                previous_chapter_count=117,
+                new_chapter_count=117,
+                words_added=0,
+            ),
+        )
+        second_update = await crud.create_book_log(
+            session,
+            schemas.BookLogCreate(
+                book_id=book.id,
+                entry_type="updated",
+                previous_chapter_count=117,
+                new_chapter_count=120,
+                words_added=9000,
+            ),
+        )
+
+        initial.timestamp = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        catch_up_update.timestamp = datetime(2026, 1, 8, tzinfo=timezone.utc)
+        first_update.timestamp = datetime(2026, 1, 15, tzinfo=timezone.utc)
+        checked.timestamp = datetime(2026, 1, 17, tzinfo=timezone.utc)
+        second_update.timestamp = datetime(2026, 1, 22, tzinfo=timezone.utc)
+        await session.commit()
+
+    response = client.get(f"/api/books/{book.id}/update-history")
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert [entry["words_added"] for entry in payload["history"]] == [100000, 50000, 5000, 9000]
+    assert [entry["chapters_added"] for entry in payload["history"]] == [100, 15, 2, 3]
+    assert payload["history"][0]["is_initial_sync"] is True
+    assert payload["history"][0]["included_in_stats"] is False
+    assert payload["history"][1]["is_catch_up_sync"] is True
+    assert payload["history"][1]["included_in_stats"] is False
+    assert payload["history"][2]["average_words_per_chapter"] == 2500
+    assert [entry["included_in_stats"] for entry in payload["history"][2:]] == [True, True]
+    assert payload["summary"]["total_update_events"] == 2
+    assert payload["summary"]["total_chapters_added"] == 5
+    assert payload["summary"]["total_words_added"] == 14000
+    assert payload["summary"]["average_days_between_updates"] == 7
+    assert payload["summary"]["predicted_next_update_at"].startswith("2026-01-29")
+
+
 # ─── detect_series_from_titles unit tests ────────────────────────────────────
 
 
@@ -3134,6 +3225,44 @@ async def test_reader_series_api_and_opds_feeds(db_session):
     assert self_links == ["http://testserver/reader/opds/series/Arcane%20Saga"]
     book_entries = books_root.findall(f"{ATOM}entry")
     assert [entry.findtext(f"{ATOM}title") for entry in book_entries] == ["Arcane Saga 1", "Arcane Saga 2"]
+
+
+@pytest.mark.asyncio
+async def test_reader_opds_and_json_include_web_book_source_url(db_session):
+    async with AsyncTestingSessionLocal() as session:
+        book = await crud.create_book(
+            session,
+            schemas.BookCreate(
+                title="Web Reader Story",
+                author="Author W",
+                immutable_path="library/immutable_web_reader.epub",
+                current_path="library/web_reader.epub",
+                source_type=models.SourceType.web,
+                source_url="https://example.com/story/reader",
+                current_word_count=1500,
+            ),
+        )
+
+    key_response = client.post("/api/reader-keys", json={"label": "Web Reader"})
+    assert key_response.status_code == 201
+    token = key_response.json()["token"]
+
+    books_response = client.get("/reader/books/all", auth=("reader", token))
+    assert books_response.status_code == 200
+    assert books_response.json()[0]["source_url"] == "https://example.com/story/reader"
+
+    import xml.etree.ElementTree as ET
+
+    ATOM = "{http://www.w3.org/2005/Atom}"
+    opds_response = client.get("/reader/opds/catalog", auth=("reader", token))
+    assert opds_response.status_code == 200
+    root = ET.fromstring(opds_response.content)
+    entry = root.find(f"{ATOM}entry")
+    assert entry is not None
+    alternate_links = [link for link in entry.findall(f"{ATOM}link") if link.get("rel") == "alternate"]
+    assert len(alternate_links) == 1
+    assert alternate_links[0].get("href") == "https://example.com/story/reader"
+    assert alternate_links[0].get("type") == "text/html"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -3230,7 +3230,7 @@ async def test_reader_series_api_and_opds_feeds(db_session):
 @pytest.mark.asyncio
 async def test_reader_opds_and_json_include_web_book_source_url(db_session):
     async with AsyncTestingSessionLocal() as session:
-        book = await crud.create_book(
+        await crud.create_book(
             session,
             schemas.BookCreate(
                 title="Web Reader Story",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1453,6 +1453,118 @@
   word-break: break-all;
 }
 
+/* ─── Chapter update history ─────────────────────────────── */
+.chapter-history-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.65rem;
+  margin-bottom: 0.9rem;
+}
+
+.chapter-history-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 0;
+  padding: 0.65rem 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface-2);
+}
+
+.chapter-history-stat strong {
+  font-size: 0.95rem;
+  overflow-wrap: anywhere;
+}
+
+.chapter-history-chart {
+  height: 150px;
+  display: flex;
+  align-items: end;
+  gap: 0.45rem;
+  padding: 0.75rem 0.75rem 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface-2);
+  overflow-x: auto;
+}
+
+.chapter-history-bar-wrap {
+  height: 100%;
+  min-width: 34px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.chapter-history-bar-stage {
+  flex: 1;
+  width: 100%;
+  display: flex;
+  align-items: end;
+}
+
+.chapter-history-bar {
+  width: 100%;
+  min-height: 8px;
+  border-radius: 4px 4px 2px 2px;
+  background: linear-gradient(180deg, var(--accent-hover), var(--accent));
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.chapter-history-bar-wrap span {
+  color: var(--text-muted);
+  font-size: 0.68rem;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.chapter-history-chart-empty {
+  margin: auto;
+  text-align: center;
+}
+
+.chapter-history-list {
+  list-style: none;
+  padding: 0;
+  margin: 0.75rem 0 0;
+  border-top: 1px solid var(--border);
+  max-height: 260px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--surface-3) transparent;
+}
+
+.chapter-history-list li {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.55rem 0;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.84rem;
+}
+
+.chapter-history-list span {
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.chapter-history-list strong {
+  text-align: right;
+  font-weight: 600;
+}
+
+@media (max-width: 480px) {
+  .chapter-history-list li {
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+  .chapter-history-list strong {
+    text-align: left;
+  }
+}
+
 /* ─── Selector Pills ─────────────────────────────────────── */
 .selector-pills {
 }

--- a/frontend/src/api/books.js
+++ b/frontend/src/api/books.js
@@ -104,6 +104,10 @@ export function getBookCleanedChapters(bookId) {
   return getJson(`/api/books/${bookId}/cleaned-chapters`, "Failed to fetch cleaned chapters");
 }
 
+export function getBookUpdateHistory(bookId) {
+  return getJson(`/api/books/${bookId}/update-history`, "Failed to fetch update history");
+}
+
 export function getMatchedConfigs(bookId) {
   return getJson(`/api/books/${bookId}/matched-config`, "Failed to fetch matched config");
 }

--- a/frontend/src/components/BookSettings.jsx
+++ b/frontend/src/components/BookSettings.jsx
@@ -8,6 +8,7 @@ import {
   getBook,
   getBookChapters,
   getBookCleanedChapters,
+  getBookUpdateHistory,
   getMatchedConfigs,
   previewCleaning,
   processBook,
@@ -33,6 +34,11 @@ const fetchCleanedChapters = async ({ queryKey }) => {
 const fetchMatchedConfig = async ({ queryKey }) => {
   const [_key, bookId] = queryKey;
   return getMatchedConfigs(bookId);
+};
+
+const fetchUpdateHistory = async ({ queryKey }) => {
+  const [_key, bookId] = queryKey;
+  return getBookUpdateHistory(bookId);
 };
 
 const COMMON_REMOTE_ID_KEYS = [
@@ -135,6 +141,149 @@ function SyncedGenreTagList({ tags }) {
         </span>
       ))}
     </div>
+  );
+}
+
+const EMPTY_UPDATE_HISTORY = {
+  history: [],
+  summary: {
+    total_update_events: 0,
+    total_chapters_added: 0,
+    total_words_added: 0,
+    average_words_per_week: null,
+    average_words_per_month: null,
+    average_days_between_updates: null,
+    predicted_next_update_at: null,
+    last_update_at: null,
+  },
+};
+
+function normalizeUpdateHistory(data) {
+  if (!data || !Array.isArray(data.history) || !data.summary) {
+    return EMPTY_UPDATE_HISTORY;
+  }
+  return data;
+}
+
+function formatNumber(value, options = {}) {
+  if (value == null || Number.isNaN(Number(value))) return "Not enough data";
+  return new Intl.NumberFormat(undefined, options).format(value);
+}
+
+function formatCompactNumber(value) {
+  if (value == null || Number.isNaN(Number(value))) return "0";
+  return new Intl.NumberFormat(undefined, {
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(value);
+}
+
+function formatDate(value) {
+  if (!value) return "Not enough data";
+  return new Date(value).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function formatHistoryEntryLabel(entry) {
+  if (entry.is_initial_sync) return "Initial sync";
+  if (entry.is_catch_up_sync) return "Catch-up sync";
+  return `+${entry.chapters_added} ch`;
+}
+
+function ChapterUpdateHistory({ updateHistory, isLoading, isError, error }) {
+  const { history, summary } = normalizeUpdateHistory(updateHistory);
+  const chartEntries = history.filter((entry) => entry.included_in_stats);
+  const maxWords = Math.max(...chartEntries.map((entry) => entry.words_added), 1);
+
+  return (
+    <section className="settings-section chapter-history-section">
+      <h3>Update History</h3>
+      {isLoading && <p className="hint">Loading update history...</p>}
+      {isError && (
+        <p className="error">
+          Update history failed: {error?.message || "Unable to load history"}
+        </p>
+      )}
+      {!isLoading && !isError && history.length === 0 && (
+        <p className="hint">
+          No tracked chapter updates yet. New chapter batches will appear here
+          after a refresh finds them.
+        </p>
+      )}
+      {!isLoading && !isError && history.length > 0 && (
+        <>
+          <div className="chapter-history-stats">
+            <div className="chapter-history-stat">
+              <span className="hint">Words / Week</span>
+              <strong>
+                {formatNumber(summary.average_words_per_week, {
+                  maximumFractionDigits: 0,
+                })}
+              </strong>
+            </div>
+            <div className="chapter-history-stat">
+              <span className="hint">Words / Month</span>
+              <strong>
+                {formatNumber(summary.average_words_per_month, {
+                  maximumFractionDigits: 0,
+                })}
+              </strong>
+            </div>
+            <div className="chapter-history-stat">
+              <span className="hint">Next Update</span>
+              <strong>{formatDate(summary.predicted_next_update_at)}</strong>
+            </div>
+          </div>
+
+          <div
+            className="chapter-history-chart"
+            aria-label="Words added by update date"
+          >
+            {chartEntries.length === 0 ? (
+              <p className="hint chapter-history-chart-empty">
+                No post-import chapter updates yet.
+              </p>
+            ) : (
+              chartEntries.slice(-12).map((entry) => {
+                const height = Math.max((entry.words_added / maxWords) * 100, 8);
+                return (
+                  <div className="chapter-history-bar-wrap" key={entry.id}>
+                    <div className="chapter-history-bar-stage">
+                      <div
+                        className="chapter-history-bar"
+                        style={{ height: `${height}%` }}
+                        title={`${formatDate(entry.timestamp)}: ${formatNumber(
+                          entry.words_added,
+                        )} words`}
+                      />
+                    </div>
+                    <span>{formatCompactNumber(entry.words_added)}</span>
+                  </div>
+                );
+              })
+            )}
+          </div>
+
+          <ul className="chapter-history-list">
+            {history
+              .slice()
+              .reverse()
+              .map((entry) => (
+                <li key={entry.id}>
+                  <span>{formatDate(entry.timestamp)}</span>
+                  <strong>
+                    {formatHistoryEntryLabel(entry)} ·{" "}
+                    {formatNumber(entry.words_added)} words
+                  </strong>
+                </li>
+              ))}
+          </ul>
+        </>
+      )}
+    </section>
   );
 }
 
@@ -283,6 +432,18 @@ function BookSettings({ book: initialBook, onBack }) {
     queryFn: fetchMatchedConfig,
   });
 
+  const {
+    data: updateHistory,
+    isLoading: updateHistoryLoading,
+    isError: updateHistoryIsError,
+    error: updateHistoryError,
+  } = useQuery({
+    queryKey: ["book-update-history", book.id, book.content_version],
+    queryFn: fetchUpdateHistory,
+    enabled: book.source_type === "web",
+    refetchInterval: isRefreshing ? 5000 : false,
+  });
+
   const { data: allSeries = [] } = useQuery({
     queryKey: ["series"],
     queryFn: getSeries,
@@ -316,6 +477,7 @@ function BookSettings({ book: initialBook, onBack }) {
     onSuccess: (updatedBook) => {
       queryClient.setQueryData(["book", book.id], updatedBook);
       queryClient.invalidateQueries({ queryKey: ["book-catalog"] });
+      queryClient.invalidateQueries({ queryKey: ["book-update-history", book.id] });
     },
   });
 
@@ -754,6 +916,15 @@ function BookSettings({ book: initialBook, onBack }) {
             </div>
           )}
         </section>
+      )}
+
+      {book.source_type === "web" && (
+        <ChapterUpdateHistory
+          updateHistory={updateHistory}
+          isLoading={updateHistoryLoading}
+          isError={updateHistoryIsError}
+          error={updateHistoryError}
+        />
       )}
 
       <section className="settings-section">

--- a/frontend/src/components/BookSettings.test.jsx
+++ b/frontend/src/components/BookSettings.test.jsx
@@ -260,6 +260,129 @@ describe("BookSettings", () => {
     expect(screen.getByText(/Synced from open_library on/)).toBeInTheDocument();
   });
 
+  it("shows chapter update history for web books", async () => {
+    const fetchMock = vi.fn((url) => {
+      if (
+        url === "/api/books/11/chapters" ||
+        url === "/api/books/11/matched-config" ||
+        url === "/api/series"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([]),
+        });
+      }
+      if (url === "/api/books/11/update-history") {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              book_id: 11,
+              history: [
+                {
+                  id: 0,
+                  timestamp: "2025-12-25T00:00:00Z",
+                  entry_type: "added",
+                  previous_chapter_count: null,
+                  new_chapter_count: 100,
+                  chapters_added: 100,
+                  words_added: 100000,
+                  average_words_per_chapter: 1000,
+                  included_in_stats: false,
+                  is_initial_sync: true,
+                },
+                {
+                  id: 1,
+                  timestamp: "2025-12-28T00:00:00Z",
+                  entry_type: "updated",
+                  previous_chapter_count: 100,
+                  new_chapter_count: 115,
+                  chapters_added: 15,
+                  words_added: 50000,
+                  average_words_per_chapter: 3333.33,
+                  included_in_stats: false,
+                  is_initial_sync: false,
+                  is_catch_up_sync: true,
+                },
+                {
+                  id: 2,
+                  timestamp: "2026-01-01T00:00:00Z",
+                  entry_type: "updated",
+                  previous_chapter_count: 10,
+                  new_chapter_count: 12,
+                  chapters_added: 2,
+                  words_added: 4000,
+                  average_words_per_chapter: 2000,
+                  included_in_stats: true,
+                  is_initial_sync: false,
+                  is_catch_up_sync: false,
+                },
+                {
+                  id: 3,
+                  timestamp: "2026-01-08T00:00:00Z",
+                  entry_type: "updated",
+                  previous_chapter_count: 12,
+                  new_chapter_count: 15,
+                  chapters_added: 3,
+                  words_added: 8000,
+                  average_words_per_chapter: 2666.67,
+                  included_in_stats: true,
+                  is_initial_sync: false,
+                  is_catch_up_sync: false,
+                },
+              ],
+              summary: {
+                total_update_events: 2,
+                total_chapters_added: 5,
+                total_words_added: 12000,
+                average_words_per_week: 6000,
+                average_words_per_month: 26000,
+                average_days_between_updates: 7,
+                predicted_next_update_at: "2026-01-15T00:00:00Z",
+                last_update_at: "2026-01-08T00:00:00Z",
+              },
+            }),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([]),
+      });
+    });
+    globalThis.fetch = fetchMock;
+
+    renderWithClient(
+      <BookSettings
+        book={{
+          id: 11,
+          title: "Growing Story",
+          author: "Author",
+          series: null,
+          series_index: null,
+          source_type: "web",
+          source_url: "https://example.com/growing",
+          immutable_path: "library/original.epub",
+          current_path: "library/current.epub",
+          removed_chapters: [],
+          content_selectors: [],
+          created_at: "2026-03-17T00:00:00Z",
+          content_updated_at: "2026-03-17T00:00:00Z",
+          content_version: 3,
+        }}
+        onBack={() => {}}
+      />,
+    );
+
+    expect(await screen.findByText("Words / Week")).toBeInTheDocument();
+    expect(screen.getByText("Update History")).toBeInTheDocument();
+    expect(screen.getByText("6,000")).toBeInTheDocument();
+    expect(screen.getByText(/\+3 ch/)).toBeInTheDocument();
+    expect(screen.getByText(/8,000 words/)).toBeInTheDocument();
+    expect(screen.getByText(/Initial sync/)).toBeInTheDocument();
+    expect(screen.getByText(/Catch-up sync/)).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledWith("/api/books/11/update-history");
+  });
+
   it("saves manual metadata identifiers", async () => {
     const fetchMock = vi.fn((url, options) => {
       if (


### PR DESCRIPTION
## Summary
- return source URLs for web books in reader JSON and OPDS entries
- derive web-book update history from existing book logs, including initial/catch-up classifications
- show update stats, a chart, and a scrollable history list on the book page

## Impact
Web readers can link back to the original source, and the app book page can distinguish regular update cadence from large initial or catch-up imports. No database migration is needed because the feature uses existing `book_logs` data.

## Validation
- `PYTHONPATH=. uv run pytest backend/tests -q`
- `npm run test -- --run`
- `npm run lint`
- `git diff --check`