### PR TITLE
[codex] simplify project docs and local e2e setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,34 @@
-.PHONY: run-ui run-backend run-db ensure-db fmt lint test test-migrations e2e e2e-debug
+.PHONY: help setup run-ui run-api run-db ensure-db migrate fmt lint test test-migrations e2e e2e-debug
+
+E2E_DB_CONTAINER ?= story-manager-e2e-db
+E2E_DB_PORT ?= 5434
+
+help:
+	@echo "Story Manager commands:"
+	@echo "  make setup            Install project dependencies"
+	@echo "  make ensure-db        Create or start the local PostgreSQL container"
+	@echo "  make migrate          Run Alembic migrations"
+	@echo "  make run-api          Run the FastAPI backend"
+	@echo "  make run-ui           Run the Vite frontend"
+	@echo "  make test             Run backend and frontend unit tests"
+	@echo "  make test-migrations  Run migrations against throwaway PostgreSQL"
+	@echo "  make e2e              Run Playwright E2E tests"
+	@echo "  make e2e-debug        Run Playwright E2E tests in debug mode"
+
+setup:
+	pyenv install -s
+	uv venv
+	uv pip install -e ".[dev]"
+	cd frontend && npm ci
 
 run-ui:
 	cd frontend && npm run dev
 
 run-api:
-	export PYTHONPATH=backend && .venv/bin/alembic -c backend/alembic.ini upgrade head && \
-	.venv/bin/uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+	$(MAKE) migrate
+	PYTHONPATH=backend .venv/bin/uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
 
-run-db:
-	docker run -d \
-	  --name story-manager-db \
-	  -e POSTGRES_DB=story_manager \
-	  -e POSTGRES_USER=storyuser \
-	  -e POSTGRES_PASSWORD=storypass \
-	  -p 5432:5432 \
-	  postgres:17
+run-db: ensure-db
 
 ensure-db:
 	@if docker ps --format '{{.Names}}' | grep -qx 'story-manager-db'; then \
@@ -37,6 +51,9 @@ ensure-db:
 		sleep 1; \
 	done; \
 	echo " Postgres is ready."
+
+migrate:
+	PYTHONPATH=. .venv/bin/alembic -c backend/alembic.ini upgrade head
 
 fmt:
 	.venv/bin/python3 -m black backend
@@ -68,9 +85,33 @@ test-migrations:
 	PYTHONPATH=. .venv/bin/alembic -c backend/alembic.ini upgrade head
 
 e2e:
-	$(MAKE) ensure-db
+	docker rm -f $(E2E_DB_CONTAINER) >/dev/null 2>&1 || true
+	docker run --name $(E2E_DB_CONTAINER) \
+	  -e POSTGRES_PASSWORD=postgres \
+	  -e POSTGRES_DB=story_manager \
+	  -p $(E2E_DB_PORT):5432 \
+	  -d postgres:17 >/dev/null
+	@trap 'docker rm -f $(E2E_DB_CONTAINER) >/dev/null 2>&1 || true' EXIT; \
+	until docker exec $(E2E_DB_CONTAINER) pg_isready -U postgres -d story_manager >/dev/null 2>&1; do \
+		printf "."; \
+		sleep 1; \
+	done; \
+	echo " E2E Postgres is ready."; \
+	export DATABASE_URL="postgresql+psycopg://postgres:postgres@localhost:$(E2E_DB_PORT)/story_manager"; \
 	cd frontend && npm run test:e2e
 
 e2e-debug:
-	$(MAKE) ensure-db
+	docker rm -f $(E2E_DB_CONTAINER) >/dev/null 2>&1 || true
+	docker run --name $(E2E_DB_CONTAINER) \
+	  -e POSTGRES_PASSWORD=postgres \
+	  -e POSTGRES_DB=story_manager \
+	  -p $(E2E_DB_PORT):5432 \
+	  -d postgres:17 >/dev/null
+	@trap 'docker rm -f $(E2E_DB_CONTAINER) >/dev/null 2>&1 || true' EXIT; \
+	until docker exec $(E2E_DB_CONTAINER) pg_isready -U postgres -d story_manager >/dev/null 2>&1; do \
+		printf "."; \
+		sleep 1; \
+	done; \
+	echo " E2E Postgres is ready."; \
+	export DATABASE_URL="postgresql+psycopg://postgres:postgres@localhost:$(E2E_DB_PORT)/story_manager"; \
 	cd frontend && npm run test:e2e:debug

--- a/README.md
+++ b/README.md
@@ -1,275 +1,77 @@
-# 📚 Story Manager: Your Personal Digital Library
+# Story Manager
 
-Story Manager is a self-hosted digital library and reader for your personal collection of EPUBs and web novels. It provides a clean web interface to manage your books and leverages the power of FanFicFare to keep your favorite web novels up-to-date automatically.
+Story Manager is a self-hosted library manager for EPUBs and web novels. It gives you a web UI for uploading, organizing, editing, and updating books, plus a read-only reader API for e-readers and OPDS clients.
 
+## Features
 
+- Manage uploaded EPUBs and tracked web novels in one library.
+- Download and refresh supported web novels with FanFicFare.
+- Preserve existing chapters when source sites remove older content.
+- Edit book metadata, covers, chapters, cleaning configs, and series information.
+- Expose read-only `/reader/*` endpoints secured by per-device API keys.
 
----
+## Stack
 
-## ✨ Core Features
+- Backend: FastAPI, SQLAlchemy, Alembic, APScheduler
+- Database: PostgreSQL
+- Frontend: React, Vite, TanStack Query
+- Packaging: Docker, Docker Compose
+- Tooling: `uv`, `pyenv`, `nvm`, npm, pytest, Vitest, Playwright
 
-* **Unified Library**: Manage both local EPUB files and web novels in one place.
-* **EPUB Upload**: Easily upload your existing `.epub` files directly through the web UI.
-* **Web Novel Tracking**: Simply add a URL, and InkWell will download the story and package it as an EPUB.
-* **Automatic Updates**: A background scheduler periodically checks for new chapters for all your tracked web novels using FanFicFare.
-* **Stub Protection**: InkWell is configured to **never delete old chapters**, so you won't lose content if an author removes it from the source to publish commercially.
-* **API-First Design**: A robust backend API allows for integration with other applications, such as a future mobile e-reader or audiobook player.
-* **(Future) Audiobook Conversion**: Planned integration for background text-to-speech conversion to turn any book in your library into an audiobook.
+## Quick Start
 
----
+The simplest deployment path is Docker Compose:
 
-## 🛠️ Technology Stack
-
-* **Backend**: Python with **FastAPI** for a high-performance API.
-* **Web Novel Fetching**: **FanFicFare** library.
-* **Task Scheduling**: **APScheduler** for periodic chapter updates.
-* **Database**: **SQLite** for simple, file-based storage of metadata.
-* **Frontend**: **React** (using Vite) for a modern, responsive user interface.
-* **Containerization**: **Docker** for easy deployment.
-
----
-
-## 🚀 Getting Started
-
-### Local Development Setup
-
-This project uses `uv` for python package management, `pyenv` for Python version management, and `nvm` for Node.js version management to ensure a consistent development environment.
-
-#### Prerequisites
-
-*   **uv**: Follow the official installation guides for your OS.
-*   **pyenv**: Follow the official installation guides for your OS.
-*   **nvm**: Follow the official `nvm` installation guide.
-*   **Docker**: Required for running the application with Docker Compose.
-
-#### Installation & Setup
-
-1.  **Clone the repository:**
-    ```bash
-    git clone https://github.com/jalbertcory/story-manager.git
-    cd story-manager
-    ```
-
-2.  **Set up the Backend (Python):**
-    *   Install the required Python version (this will be read from the `.python-version` file):
-        ```bash
-        pyenv install
-        ```
-    *   Create and activate a virtual environment:
-        ```bash
-        # Create the virtual environment
-        uv venv
-        # Activate the virtual environment
-        source .venv/bin/activate
-        ```
-    *   Install dependencies:
-        ```bash
-        uv pip install -e ".[dev]"
-        ```
-
-3.  **Set up the Database (PostgreSQL):**
-    *   Start PostgreSQL in Docker:
-        ```bash
-        make run-db
-        ```
-    *   Create a `.env` file in the project root with the database configuration:
-        ```bash
-        DATABASE_URL=postgresql+psycopg://storyuser:storypass@localhost:5432/story_manager
-        ```
-    *   To stop the database: `docker stop story-manager-db`
-    *   To start it again: `docker start story-manager-db`
-    *   To remove it completely: `docker rm -f story-manager-db`
-
-4.  **Run Database Migrations:**
-    *   Apply the database schema migrations (make sure your virtual environment is activated):
-        ```bash
-        # Activate the virtual environment first
-        source .venv/bin/activate
-        # Run migrations
-        alembic -c backend/alembic.ini upgrade head
-        ```
-
-5.  **Set up the Frontend (Node.js):**
-    *   Install and use the required Node.js version (this will be read from the `.nvmrc` file):
-        ```bash
-        nvm install
-        nvm use
-        ```
-    *   Install dependencies from the `frontend` directory:
-        ```bash
-        cd frontend
-        npm install
-        cd ..
-        ```
-
-6.  **Run the Application:**
-    *   **Backend**:
-        ```bash
-        # From the project root
-        make run-api
-        ```
-    *   **Frontend**:
-        ```bash
-        # From the project root, in a separate terminal
-        make run-ui
-        ```
-
-Your application should now be running!
-*   Web UI: `http://localhost:5173`
-*   API: `http://localhost:8000`
-
-### Reader API Keys
-
-Story Manager now includes a separate read-only reader API for e-readers and OPDS clients.
-
-Generate reader keys from the web UI:
-*   Open `Utilities`
-*   Use the `Reader API Keys` section
-*   Create one key per device, such as `Kobo` or `Boox`
-*   Copy the token when it is shown. It is only displayed once.
-
-Reader endpoints:
-*   `GET /reader/opds`
-*   `GET /reader/opds/catalog`
-*   `GET /reader/opds/search?q=...`
-*   `GET /reader/books/all`
-*   `GET /reader/updates?since=2026-03-14T12:00:00Z`
-*   `GET /reader/books/{id}`
-*   `GET /reader/books/{id}/download`
-*   `GET /reader/covers/{id}`
-
-Authentication options for reader clients:
-*   `Authorization: Bearer <token>`
-*   HTTP Basic auth with any username and the token as the password
-*   `?api_key=<token>` for clients that only support query-string credentials
-
-The `/reader/*` namespace is read-only by design. Existing `/api/*` routes remain admin-style application routes for the web UI.
-
----
-
-## 🐋 Deploy with Docker Compose
-
-The easiest way to run Story Manager is with Docker Compose. This method sets up the application and all its dependencies in a containerized environment.
-
-The web UI is exposed on port **7890**, and the API is on port **8000**.
-
-### Data Persistence
-
-The `docker-compose.yml` is configured to store persistent data on the host machine inside a `config` directory. When you first run the `docker compose up` command, Docker will automatically create this directory in the same folder where your `docker-compose.yml` file is located.
-
-This `config` directory will contain the following subdirectories:
-*   `config/library`: Stores your uploaded EPUB files and downloaded web novels.
-*   `config/fanficfare`: Optional FanFicFare overrides. If you place `config/fanficfare/personal.ini` here, Story Manager will load it after its built-in `personal.ini`, so your settings win.
-*   `config/pgdata`: Stores the PostgreSQL database.
-
-This setup ensures that your library and application data are preserved even if you stop or remove the container.
-
-### Optional FanFicFare Overrides
-
-Story Manager now uses FanFicFare's real EPUB update mode for tracked web novels. That means daily checks can reuse the existing immutable EPUB and avoid re-fetching every chapter on every run.
-
-If you want to customize FanFicFare behavior, create:
-
-```text
-config/fanficfare/personal.ini
-```
-
-That path works for both:
-- local development from the repository root
-- Docker deployments that mount `./config/fanficfare:/app/config:ro`
-
-Story Manager will load configs in this order:
-1. Built-in `backend/app/personal.ini`
-2. Optional mounted `config/fanficfare/personal.ini`
-
-Because FanFicFare applies later config files last, your mounted settings override the built-in defaults without replacing them entirely.
-
-If you need a different path, set `FFF_USER_CONFIG_PATH` in the container environment.
-
-### Running the Application
-
-To start the application, run the following command from the root of the repository:
 ```bash
 docker compose up -d
 ```
 
-If you access the web UI through a reverse proxy or custom hostname, set `VITE_ALLOWED_HOSTS` before starting the container. The value is a comma-separated list of hostnames that Vite should allow:
+The app is available at `http://localhost:8000`. Persistent data is stored under `./config`.
+
+For more deployment details, see [docs/deployment.md](docs/deployment.md).
+
+## Local Development
+
+Install the project runtimes:
 
 ```bash
-VITE_ALLOWED_HOSTS=story-reader.example.com docker compose up -d
+pyenv install
+nvm install
+uv venv
+source .venv/bin/activate
+uv pip install -e ".[dev]"
+cd frontend && npm ci && cd ..
 ```
 
-### Using on Unraid
+Start PostgreSQL and run the app:
 
-The provided `docker-compose.yml` is compatible with Unraid's Docker Compose Manager.
-
-1.  **Copy the `docker-compose.yml` file** to a new directory on your Unraid server (e.g., `/mnt/user/appdata/story-manager`).
-2.  **Review the Volume Mappings**: The `docker-compose.yml` uses relative paths for its volumes (`./config`). When you run it on Unraid, it will create the `config` directory inside the path you chose in step 1 (e.g., `/mnt/user/appdata/story-manager/config`). You don't need to edit the `docker-compose.yml` file if this is what you want.
-3.  **Start the Container**: From the directory containing `docker-compose.yml`, run `docker compose up -d`.
-4.  **Access Story Manager**: You can now access the web interface at `http://<UNRAID_HOST>:8000`.
-
----
-
-### Running tests
-
-To run e2e tests
-- `cd frontend && npm install && npx playwright install`
-- Go back to the root of the project and run `make e2e`
-- If you need to debug the tests, run `make e2e-debug`
-
-## Reverse Proxy Safety
-
-Story Manager does not yet have user login for the admin web UI. That means the existing `/api/*` routes are trusted admin routes, not internet-safe public routes.
-
-Safe deployment guidance:
-*   Expose `/reader/*` publicly only if needed for e-readers.
-*   Keep the admin UI and `/api/*` behind a VPN, Tailscale, local network, or an extra proxy auth layer such as Authelia, OAuth2 Proxy, or your reverse proxy's built-in access control.
-*   Terminate TLS at the proxy and redirect all HTTP traffic to HTTPS.
-*   Preserve the `Authorization` header so Bearer and Basic auth continue to work for `/reader/*`.
-*   Disable proxy caching for `/reader/*` responses that contain private library metadata.
-*   Set a reasonable request body limit on admin upload routes.
-
-Recommended layout:
-*   Public: `/reader/*`
-*   Private: `/`, `/api/*`
-
-Example Nginx sketch:
-
-```nginx
-server {
-    listen 443 ssl http2;
-    server_name books.example.com;
-
-    ssl_certificate /etc/letsencrypt/live/books.example.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/books.example.com/privkey.pem;
-
-    proxy_set_header Host $host;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
-    proxy_set_header Authorization $http_authorization;
-
-    location /reader/ {
-        proxy_pass http://127.0.0.1:8000;
-        proxy_buffering off;
-        add_header Cache-Control "private, no-store";
-    }
-
-    location /api/ {
-        allow 192.168.0.0/16;
-        allow 10.0.0.0/8;
-        allow 127.0.0.1;
-        deny all;
-        proxy_pass http://127.0.0.1:8000;
-    }
-
-    location / {
-        allow 192.168.0.0/16;
-        allow 10.0.0.0/8;
-        allow 127.0.0.1;
-        deny all;
-        proxy_pass http://127.0.0.1:8000;
-    }
-}
+```bash
+make ensure-db
+make run-api
+make run-ui
 ```
 
-If you do want the admin UI reachable over the internet, put the UI and `/api/*` behind a real authentication layer first. Reader API keys alone are not a substitute for admin authentication.
+The development UI runs at `http://localhost:5173`; the API runs at `http://localhost:8000`.
+
+Useful commands:
+
+```bash
+make migrate
+make test
+make test-migrations
+make e2e
+```
+
+For setup notes and testing details, see [docs/development.md](docs/development.md).
+
+## Reader API
+
+Story Manager includes a read-only API for e-readers and OPDS clients. Create one reader key per device from `Utilities` -> `Reader API Keys` in the web UI.
+
+See [docs/reader-api.md](docs/reader-api.md) for endpoint and authentication details.
+
+## Security
+
+The admin web UI and `/api/*` routes do not currently have built-in user login. Keep them on a private network, VPN, or behind a real authentication layer. The `/reader/*` routes are designed for read-only API-key access.
+
+See [docs/reverse-proxy.md](docs/reverse-proxy.md) before exposing anything publicly.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,7 @@ services:
   story-manager:
     build: .
     ports:
-      - "5173:5173"  # UI
-      - "8000:8000"  # API
+      - "8000:8000"  # UI + API
     volumes:
       - ./config/library:/app/library
       - ./config/fanficfare:/app/config:ro

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,56 @@
+# Deployment
+
+Docker Compose is the recommended deployment path.
+
+```bash
+docker compose up -d
+```
+
+The production container serves the built frontend and API from `http://localhost:8000`.
+
+## Data Persistence
+
+The default `docker-compose.yml` stores persistent data under `./config`:
+
+- `config/library`: uploaded EPUBs and downloaded web novels
+- `config/fanficfare`: optional FanFicFare user configuration
+- `config/pgdata`: PostgreSQL data
+
+The production image runs PostgreSQL inside the app container for simple self-hosting. If you split PostgreSQL into a separate service, set `DATABASE_URL` for the app container.
+
+## FanFicFare Overrides
+
+Story Manager uses FanFicFare's EPUB update mode for tracked web novels. Daily checks can reuse the existing immutable EPUB instead of fetching every chapter again.
+
+To customize FanFicFare behavior, create:
+
+```text
+config/fanficfare/personal.ini
+```
+
+Story Manager loads configs in this order:
+
+1. Built-in `backend/app/personal.ini`
+2. Optional mounted `config/fanficfare/personal.ini`
+
+Later FanFicFare configs override earlier values. To use a different path, set `FFF_USER_CONFIG_PATH`.
+
+## Reverse Proxy Hosts
+
+If you access the Vite development UI through a reverse proxy or custom hostname, set `VITE_ALLOWED_HOSTS`:
+
+```bash
+VITE_ALLOWED_HOSTS=story-reader.example.com make run-ui
+```
+
+The production container serves static frontend assets through FastAPI and does not need Vite host allow-listing.
+
+## Unraid
+
+The provided `docker-compose.yml` is compatible with Unraid's Docker Compose Manager.
+
+1. Copy `docker-compose.yml` to a directory such as `/mnt/user/appdata/story-manager`.
+2. Start the stack from that directory with `docker compose up -d`.
+3. Open `http://<UNRAID_HOST>:8000`.
+
+Relative volume paths create `config` inside the directory where the compose file lives.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,104 @@
+# Development
+
+This project uses Python 3.13.5, Node.js 22, PostgreSQL, `uv`, `pyenv`, and `nvm`.
+
+## First-Time Setup
+
+```bash
+git clone https://github.com/jalbertcory/story-manager.git
+cd story-manager
+
+pyenv install
+nvm install
+
+uv venv
+source .venv/bin/activate
+uv pip install -e ".[dev]"
+
+cd frontend
+npm ci
+cd ..
+```
+
+Create a root `.env` file for the local database:
+
+```text
+DATABASE_URL=postgresql+psycopg://storyuser:storypass@localhost:5432/story_manager
+```
+
+## Running Locally
+
+Start or create the local PostgreSQL container:
+
+```bash
+make ensure-db
+```
+
+Run migrations:
+
+```bash
+make migrate
+```
+
+Start the backend:
+
+```bash
+make run-api
+```
+
+Start the frontend in a separate terminal:
+
+```bash
+make run-ui
+```
+
+Local URLs:
+
+- Web UI: `http://localhost:5173`
+- API: `http://localhost:8000`
+- Health check: `http://localhost:8000/health`
+
+## Database
+
+Local development uses PostgreSQL in Docker:
+
+- Username: `storyuser`
+- Password: `storypass`
+- Database: `story_manager`
+- Port: `5432`
+
+Connect with:
+
+```bash
+psql -h localhost -p 5432 -U storyuser -d story_manager
+```
+
+Use Alembic migrations for database changes. Do not put one-time schema or data changes in application startup code.
+
+## Tests
+
+Run backend and frontend unit tests:
+
+```bash
+make test
+```
+
+Run migrations against a throwaway PostgreSQL container:
+
+```bash
+make test-migrations
+```
+
+Run Playwright E2E tests:
+
+```bash
+make e2e
+```
+
+Debug Playwright tests:
+
+```bash
+make e2e-debug
+```
+
+For local E2E tests, the Makefile starts a throwaway PostgreSQL container on port `5434`. Playwright starts dedicated backend and frontend dev servers on ports `18000` and `15173` unless `CI` is set.

--- a/docs/reader-api.md
+++ b/docs/reader-api.md
@@ -1,0 +1,41 @@
+# Reader API
+
+Story Manager includes a read-only reader API for e-readers and OPDS clients.
+
+## API Keys
+
+Create reader keys from the web UI:
+
+1. Open `Utilities`.
+2. Use the `Reader API Keys` section.
+3. Create one key per device, such as `Kobo` or `Boox`.
+4. Save the full token when it is shown. It is displayed only once.
+
+## Authentication
+
+Reader clients can authenticate with any of these options:
+
+```http
+Authorization: Bearer <token>
+```
+
+HTTP Basic auth with any username and the token as the password.
+
+```text
+?api_key=<token>
+```
+
+Use query-string credentials only for clients that cannot send headers.
+
+## Endpoints
+
+- `GET /reader/opds`
+- `GET /reader/opds/catalog`
+- `GET /reader/opds/search?q=...`
+- `GET /reader/books/all`
+- `GET /reader/updates?since=2026-03-14T12:00:00Z`
+- `GET /reader/books/{id}`
+- `GET /reader/books/{id}/download`
+- `GET /reader/covers/{id}`
+
+The `/reader/*` namespace is read-only. The existing `/api/*` routes are admin-style application routes for the web UI.

--- a/docs/reverse-proxy.md
+++ b/docs/reverse-proxy.md
@@ -1,0 +1,58 @@
+# Reverse Proxy Safety
+
+Story Manager does not yet have built-in user login for the admin web UI. The web UI and `/api/*` routes should be treated as trusted admin surfaces.
+
+Safe deployment guidance:
+
+- Expose `/reader/*` publicly only if needed for e-readers.
+- Keep `/` and `/api/*` behind a VPN, Tailscale, local network, or proxy authentication.
+- Terminate TLS at the proxy and redirect HTTP to HTTPS.
+- Preserve the `Authorization` header so Bearer and Basic auth work for `/reader/*`.
+- Disable proxy caching for `/reader/*` responses that contain private library metadata.
+- Set a reasonable request body limit on admin upload routes.
+
+Recommended layout:
+
+- Public: `/reader/*`
+- Private: `/`, `/api/*`
+
+Example Nginx sketch:
+
+```nginx
+server {
+    listen 443 ssl http2;
+    server_name books.example.com;
+
+    ssl_certificate /etc/letsencrypt/live/books.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/books.example.com/privkey.pem;
+
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Authorization $http_authorization;
+
+    location /reader/ {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_buffering off;
+        add_header Cache-Control "private, no-store";
+    }
+
+    location /api/ {
+        allow 192.168.0.0/16;
+        allow 10.0.0.0/8;
+        allow 127.0.0.1;
+        deny all;
+        proxy_pass http://127.0.0.1:8000;
+    }
+
+    location / {
+        allow 192.168.0.0/16;
+        allow 10.0.0.0/8;
+        allow 127.0.0.1;
+        deny all;
+        proxy_pass http://127.0.0.1:8000;
+    }
+}
+```
+
+If the admin UI needs to be reachable over the internet, put `/` and `/api/*` behind a real authentication layer first. Reader API keys are not a substitute for admin authentication.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,12 +1,15 @@
-# React + Vite
+# Frontend
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+The frontend is a React and Vite app for the Story Manager web UI.
 
-Currently, two official plugins are available:
+## Commands
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+```bash
+npm ci
+npm run dev
+npm run lint
+npm test -- --run
+npm run test:e2e
+```
 
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+During local development, Vite runs on `http://localhost:5173` and proxies `/api` requests to the backend on `http://localhost:8000`.

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,16 +1,28 @@
 import { defineConfig, devices } from "@playwright/test";
 
+const isCi = !!process.env.CI;
+const backendPort = process.env.PLAYWRIGHT_BACKEND_PORT || "18000";
+const frontendPort = process.env.PLAYWRIGHT_FRONTEND_PORT || "15173";
+const backendUrl = `http://127.0.0.1:${backendPort}`;
+const frontendUrl = `http://127.0.0.1:${frontendPort}`;
+
 /**
  * See https://playwright.dev/docs/test-configuration
  */
-const webServer = process.env.CI
+const webServer = isCi
   ? undefined
   : [
       {
         command:
-          "zsh -lc 'export PYTHONPATH=backend && .venv/bin/alembic -c backend/alembic.ini upgrade head && .venv/bin/uvicorn app.main:app --host 127.0.0.1 --port 8000'",
-        url: "http://127.0.0.1:8000",
+          `zsh -lc 'export PYTHONPATH=backend && .venv/bin/alembic -c backend/alembic.ini upgrade head && .venv/bin/uvicorn app.main:app --host 127.0.0.1 --port ${backendPort}'`,
+        url: backendUrl,
         cwd: "..",
+        reuseExistingServer: true,
+        timeout: 120 * 1000,
+      },
+      {
+        command: `VITE_API_TARGET=${backendUrl} npm run dev -- --host 127.0.0.1 --port ${frontendPort} --strictPort`,
+        url: frontendUrl,
         reuseExistingServer: true,
         timeout: 120 * 1000,
       },
@@ -31,7 +43,9 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: "http://localhost:8000",
+    baseURL:
+      process.env.PLAYWRIGHT_BASE_URL ||
+      (isCi ? "http://localhost:8000" : frontendUrl),
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -16,6 +16,7 @@ const parseAllowedHosts = (value) => {
 };
 
 const allowedHosts = parseAllowedHosts(process.env.VITE_ALLOWED_HOSTS);
+const apiTarget = process.env.VITE_API_TARGET || "http://localhost:8000";
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -26,7 +27,7 @@ export default defineConfig({
     strictPort: true,
     proxy: {
       "/api": {
-        target: "http://localhost:8000",
+        target: apiTarget,
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## Summary

- Replaced the long root README with a concise project entry point.
- Moved development, deployment, reader API, and reverse proxy guidance into focused docs under `docs/`.
- Fixed stale documentation around PostgreSQL, Story Manager naming, Docker Compose ports, and the frontend README.
- Added Makefile helpers and made local E2E run against a throwaway PostgreSQL container on dedicated test ports.

## Validation

- `make help`
- `cd frontend && npm run lint -- --max-warnings=0`
- `cd frontend && npx playwright test --list -c playwright.config.ts`
- `make test`
- `make e2e`
