### PR TITLE
[codex] harden admin auth and chapter previews

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
@@ -25,19 +25,14 @@ jobs:
         uv venv
         source .venv/bin/activate
         uv pip install -e ".[dev]"
-    - name: Format with black
+    - name: Check formatting with black
       run: |
         source .venv/bin/activate
-        black backend
-    - name: Fix with autoflake
+        black --check backend
+    - name: Check unused imports with autoflake
       run: |
         source .venv/bin/activate
-        autoflake --in-place --remove-all-unused-imports --recursive backend
-    - name: Commit formatting changes
-      uses: stefanzweifel/git-auto-commit-action@v5
-      with:
-        commit_message: 'chore: format python code'
-        file_pattern: backend/**/*.py
+        autoflake --check --remove-all-unused-imports --recursive backend
     - name: Lint with flake8
       run: |
         source .venv/bin/activate
@@ -68,7 +63,7 @@ jobs:
   lint-ui:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     defaults:
       run:
         working-directory: frontend
@@ -83,12 +78,7 @@ jobs:
     - name: Install dependencies
       run: npm ci
     - name: Lint with eslint
-      run: npm run lint -- --fix
-    - name: Commit formatting changes
-      uses: stefanzweifel/git-auto-commit-action@v5
-      with:
-        commit_message: 'chore: format frontend code'
-        file_pattern: "frontend/**/*.{js,jsx}"
+      run: npm run lint -- --max-warnings=0
 
   ui-tests:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ See [docs/reader-api.md](docs/reader-api.md) for endpoint and authentication det
 
 ## Security
 
-The admin web UI and `/api/*` routes do not currently have built-in user login. Keep them on a private network, VPN, or behind a real authentication layer. The `/reader/*` routes are designed for read-only API-key access.
+The `/reader/*` routes are read-only and use per-device API keys. The admin web UI and `/api/*` routes can use built-in password auth by setting `STORY_MANAGER_ADMIN_PASSWORD`.
+
+If you already protect the app with a reverse proxy or Cloudflare Access, set `STORY_MANAGER_AUTH_MODE=disabled` and let that outer layer own admin authentication.
 
 See [docs/reverse-proxy.md](docs/reverse-proxy.md) before exposing anything publicly.

--- a/backend/app/admin_auth_middleware.py
+++ b/backend/app/admin_auth_middleware.py
@@ -1,0 +1,30 @@
+"""Middleware that protects admin API routes when password auth is enabled."""
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+from .auth import ADMIN_AUTH_COOKIE, is_admin_auth_enabled, validate_admin_session_token
+
+
+class AdminAuthMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next) -> Response:
+        if not self._requires_admin_auth(request):
+            return await call_next(request)
+
+        try:
+            authenticated = validate_admin_session_token(request.cookies.get(ADMIN_AUTH_COOKIE))
+        except RuntimeError as exc:
+            return JSONResponse(status_code=500, content={"detail": str(exc)})
+
+        if not authenticated:
+            return JSONResponse(status_code=401, content={"detail": "Admin authentication required"})
+
+        return await call_next(request)
+
+    @staticmethod
+    def _requires_admin_auth(request: Request) -> bool:
+        if not is_admin_auth_enabled():
+            return False
+        path = request.url.path
+        return path.startswith("/api/") and not path.startswith("/api/auth/")

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,10 +1,14 @@
-"""Reader API key helpers and authentication dependencies."""
+"""Reader API key helpers and admin authentication dependencies."""
 
 from __future__ import annotations
 
+import base64
+import binascii
 import hashlib
 import hmac
+import os
 import secrets
+import time
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -19,6 +23,11 @@ from .database import get_db
 _bearer = HTTPBearer(auto_error=False)
 _basic = HTTPBasic(auto_error=False)
 
+ADMIN_AUTH_COOKIE = "story_manager_admin"
+ADMIN_AUTH_DISABLED = "disabled"
+ADMIN_AUTH_PASSWORD = "password"
+ADMIN_SESSION_SECONDS = 60 * 60 * 24 * 14
+
 
 def _now_utc() -> datetime:
     return datetime.now(timezone.utc)
@@ -26,6 +35,65 @@ def _now_utc() -> datetime:
 
 def hash_token(token: str) -> str:
     return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def get_admin_auth_mode() -> str:
+    configured_mode = os.getenv("STORY_MANAGER_AUTH_MODE", "").strip().lower()
+    if configured_mode:
+        return configured_mode
+    return ADMIN_AUTH_PASSWORD if os.getenv("STORY_MANAGER_ADMIN_PASSWORD") else ADMIN_AUTH_DISABLED
+
+
+def is_admin_auth_enabled() -> bool:
+    return get_admin_auth_mode() == ADMIN_AUTH_PASSWORD
+
+
+def _admin_password() -> Optional[str]:
+    password = os.getenv("STORY_MANAGER_ADMIN_PASSWORD")
+    return password if password else None
+
+
+def _admin_session_secret() -> Optional[str]:
+    return os.getenv("STORY_MANAGER_ADMIN_SESSION_SECRET") or _admin_password()
+
+
+def verify_admin_password(password: str) -> bool:
+    expected = _admin_password()
+    if expected is None:
+        return False
+    return hmac.compare_digest(password, expected)
+
+
+def _sign_admin_payload(payload: str) -> str:
+    secret = _admin_session_secret()
+    if secret is None:
+        raise RuntimeError("Admin auth is enabled but no admin password/session secret is configured")
+    return hmac.new(secret.encode("utf-8"), payload.encode("utf-8"), hashlib.sha256).hexdigest()
+
+
+def create_admin_session_token(now: int | None = None) -> str:
+    expires_at = (now or int(time.time())) + ADMIN_SESSION_SECONDS
+    payload = base64.urlsafe_b64encode(str(expires_at).encode("ascii")).decode("ascii").rstrip("=")
+    signature = _sign_admin_payload(payload)
+    return f"{payload}.{signature}"
+
+
+def validate_admin_session_token(token: str | None, now: int | None = None) -> bool:
+    if not token or "." not in token:
+        return False
+
+    payload, signature = token.split(".", 1)
+    expected_signature = _sign_admin_payload(payload)
+    if not hmac.compare_digest(signature, expected_signature):
+        return False
+
+    try:
+        padded = payload + "=" * (-len(payload) % 4)
+        expires_at = int(base64.urlsafe_b64decode(padded.encode("ascii")).decode("ascii"))
+    except (binascii.Error, ValueError, UnicodeDecodeError):
+        return False
+
+    return expires_at > (now or int(time.time()))
 
 
 def generate_reader_token() -> tuple[str, str]:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,12 +13,13 @@ from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from . import crud
+from .admin_auth_middleware import AdminAuthMiddleware
 from .config import LIBRARY_PATH
 from .errors import install_error_handlers
 from .middleware import RequestIdMiddleware
 from .database import SessionLocal, get_db
 from .logging_config import setup_logging
-from .routers import api_keys, books, cleaning, covers, metadata, reader, scheduler, storage, upload, web_novels
+from .routers import api_keys, auth, books, cleaning, covers, metadata, reader, scheduler, storage, upload, web_novels
 from .services.metadata_sync_queue import get_metadata_sync_queue
 from .services.refresh_queue import get_refresh_queue
 from .services.update_scheduler import get_scheduler, schedule_next_metadata_recheck, schedule_next_web_novel_update
@@ -76,6 +77,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(title="Story Manager", lifespan=lifespan)
 install_error_handlers(app)
 app.add_middleware(RequestIdMiddleware)
+app.add_middleware(AdminAuthMiddleware)
 app.mount(
     "/library/covers",
     StaticFiles(directory=str((LIBRARY_PATH / "covers").resolve()), check_dir=False),
@@ -90,6 +92,7 @@ app.include_router(covers.router)
 app.include_router(scheduler.router)
 app.include_router(storage.router)
 app.include_router(api_keys.router)
+app.include_router(auth.router)
 app.include_router(reader.router)
 app.include_router(metadata.router)
 

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,0 +1,60 @@
+"""Admin authentication endpoints."""
+
+from fastapi import APIRouter, HTTPException, Request, Response, status
+from pydantic import BaseModel
+
+from ..auth import (
+    ADMIN_AUTH_COOKIE,
+    ADMIN_AUTH_DISABLED,
+    ADMIN_SESSION_SECONDS,
+    create_admin_session_token,
+    get_admin_auth_mode,
+    is_admin_auth_enabled,
+    validate_admin_session_token,
+    verify_admin_password,
+)
+
+router = APIRouter()
+
+
+class AdminAuthStatus(BaseModel):
+    mode: str
+    authenticated: bool
+
+
+class AdminLoginRequest(BaseModel):
+    password: str
+
+
+@router.get("/api/auth/status", response_model=AdminAuthStatus)
+async def auth_status(request: Request) -> AdminAuthStatus:
+    mode = get_admin_auth_mode()
+    authenticated = not is_admin_auth_enabled()
+    if is_admin_auth_enabled():
+        authenticated = validate_admin_session_token(request.cookies.get(ADMIN_AUTH_COOKIE))
+    return AdminAuthStatus(mode=mode, authenticated=authenticated)
+
+
+@router.post("/api/auth/login", response_model=AdminAuthStatus)
+async def login(request: AdminLoginRequest, response: Response) -> AdminAuthStatus:
+    if not is_admin_auth_enabled():
+        return AdminAuthStatus(mode=ADMIN_AUTH_DISABLED, authenticated=True)
+
+    if not verify_admin_password(request.password):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid password")
+
+    response.set_cookie(
+        ADMIN_AUTH_COOKIE,
+        create_admin_session_token(),
+        max_age=ADMIN_SESSION_SECONDS,
+        httponly=True,
+        samesite="lax",
+        secure=False,
+    )
+    return AdminAuthStatus(mode=get_admin_auth_mode(), authenticated=True)
+
+
+@router.post("/api/auth/logout", response_model=AdminAuthStatus)
+async def logout(response: Response) -> AdminAuthStatus:
+    response.delete_cookie(ADMIN_AUTH_COOKIE, samesite="lax", secure=False)
+    return AdminAuthStatus(mode=get_admin_auth_mode(), authenticated=not is_admin_auth_enabled())

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,54 @@
+"""Shared backend test fixtures."""
+
+import pytest_asyncio
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from backend.app.database import Base, get_db
+from backend.app.main import app
+
+SQLALCHEMY_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
+
+
+@pytest_asyncio.fixture
+async def sqlite_sessionmaker():
+    engine = create_async_engine(
+        SQLALCHEMY_DATABASE_URL,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    sessionmaker = async_sessionmaker(autocommit=False, autoflush=False, bind=engine, expire_on_commit=False)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    try:
+        yield sessionmaker
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def db(sqlite_sessionmaker):
+    async with sqlite_sessionmaker() as session:
+        yield session
+
+
+@pytest_asyncio.fixture
+async def app_client(sqlite_sessionmaker):
+    async def override_get_db():
+        async with sqlite_sessionmaker() as session:
+            yield session
+
+    original_override = app.dependency_overrides.get(get_db)
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+    yield client
+
+    if original_override is not None:
+        app.dependency_overrides[get_db] = original_override
+    else:
+        app.dependency_overrides.pop(get_db, None)

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,6 +1,13 @@
 """Tests for authentication: token generation, hashing, prefix extraction."""
 
-from backend.app.auth import generate_reader_token, hash_token, _extract_prefix
+from backend.app.auth import (
+    create_admin_session_token,
+    generate_reader_token,
+    hash_token,
+    validate_admin_session_token,
+    verify_admin_password,
+    _extract_prefix,
+)
 
 
 class TestGenerateReaderToken:
@@ -55,3 +62,25 @@ class TestExtractPrefix:
 
     def test_empty_string(self):
         assert _extract_prefix("") is None
+
+
+class TestAdminAuth:
+    def test_verify_admin_password_uses_env(self, monkeypatch):
+        monkeypatch.setenv("STORY_MANAGER_ADMIN_PASSWORD", "secret")
+
+        assert verify_admin_password("secret") is True
+        assert verify_admin_password("wrong") is False
+
+    def test_admin_session_token_expires(self, monkeypatch):
+        monkeypatch.setenv("STORY_MANAGER_ADMIN_PASSWORD", "secret")
+        token = create_admin_session_token(now=100)
+
+        assert validate_admin_session_token(token, now=101) is True
+        assert validate_admin_session_token(token, now=60 * 60 * 24 * 15) is False
+
+    def test_admin_session_token_rejects_tampering(self, monkeypatch):
+        monkeypatch.setenv("STORY_MANAGER_ADMIN_PASSWORD", "secret")
+        token = create_admin_session_token(now=100)
+        tampered = token.replace(".", "x.", 1)
+
+        assert validate_admin_session_token(tampered, now=101) is False

--- a/backend/tests/test_crud_modules.py
+++ b/backend/tests/test_crud_modules.py
@@ -1,31 +1,8 @@
 """Tests for the refactored CRUD modules: series, cleaning, api_keys."""
 
 import pytest
-import pytest_asyncio
-from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
-from sqlalchemy.pool import StaticPool
 
-from backend.app.database import Base
 from backend.app import models, schemas, crud
-
-SQLALCHEMY_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
-
-engine = create_async_engine(
-    SQLALCHEMY_DATABASE_URL,
-    connect_args={"check_same_thread": False},
-    poolclass=StaticPool,
-)
-AsyncTestingSessionLocal = async_sessionmaker(autocommit=False, autoflush=False, bind=engine, expire_on_commit=False)
-
-
-@pytest_asyncio.fixture(scope="function")
-async def db():
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    async with AsyncTestingSessionLocal() as session:
-        yield session
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.drop_all)
 
 
 async def _create_book(db, title="Book", author="Author", series=None, **kwargs):

--- a/backend/tests/test_errors_and_health.py
+++ b/backend/tests/test_errors_and_health.py
@@ -1,52 +1,12 @@
 """Tests for structured error responses and the health check endpoint."""
 
 import pytest
-import pytest_asyncio
-from fastapi.testclient import TestClient
-from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
-from sqlalchemy.pool import StaticPool
-
-from backend.app.main import app
-from backend.app.database import Base, get_db
-
-SQLALCHEMY_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
-
-engine = create_async_engine(
-    SQLALCHEMY_DATABASE_URL,
-    connect_args={"check_same_thread": False},
-    poolclass=StaticPool,
-)
-AsyncTestingSessionLocal = async_sessionmaker(autocommit=False, autoflush=False, bind=engine, expire_on_commit=False)
-
-
-async def override_get_db():
-    async with AsyncTestingSessionLocal() as session:
-        yield session
-
-
-@pytest_asyncio.fixture(scope="function")
-async def db_session():
-    # Save and restore the original override to avoid interfering with other test files
-    original_override = app.dependency_overrides.get(get_db)
-    app.dependency_overrides[get_db] = override_get_db
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    yield
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.drop_all)
-    if original_override is not None:
-        app.dependency_overrides[get_db] = original_override
-    else:
-        app.dependency_overrides.pop(get_db, None)
-
-
-client = TestClient(app)
 
 
 class TestStructuredErrors:
     @pytest.mark.asyncio
-    async def test_404_returns_structured_error(self, db_session):
-        response = client.get("/api/books/99999")
+    async def test_404_returns_structured_error(self, app_client):
+        response = app_client.get("/api/books/99999")
         assert response.status_code == 404
         data = response.json()
         assert "error" in data
@@ -55,8 +15,8 @@ class TestStructuredErrors:
         assert data["status_code"] == 404
 
     @pytest.mark.asyncio
-    async def test_400_returns_structured_error(self, db_session):
-        response = client.post("/api/books/add_web_novel", json={"url": "not-a-url"})
+    async def test_400_returns_structured_error(self, app_client):
+        response = app_client.post("/api/books/add_web_novel", json={"url": "not-a-url"})
         # Pydantic validation returns 422
         assert response.status_code in (400, 422)
         data = response.json()
@@ -65,9 +25,37 @@ class TestStructuredErrors:
 
 class TestHealthCheck:
     @pytest.mark.asyncio
-    async def test_health_check_returns_healthy(self, db_session):
-        response = client.get("/health")
+    async def test_health_check_returns_healthy(self, app_client):
+        response = app_client.get("/health")
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == "healthy"
         assert data["database"] == "connected"
+
+
+class TestAdminApiAuth:
+    @pytest.mark.asyncio
+    async def test_admin_api_requires_login_when_password_auth_enabled(self, app_client, monkeypatch):
+        monkeypatch.setenv("STORY_MANAGER_AUTH_MODE", "password")
+        monkeypatch.setenv("STORY_MANAGER_ADMIN_PASSWORD", "secret")
+
+        unauthorized = app_client.get("/api/books")
+        assert unauthorized.status_code == 401
+
+        bad_login = app_client.post("/api/auth/login", json={"password": "wrong"})
+        assert bad_login.status_code == 401
+
+        login = app_client.post("/api/auth/login", json={"password": "secret"})
+        assert login.status_code == 200
+        assert login.json()["authenticated"] is True
+
+        authorized = app_client.get("/api/books")
+        assert authorized.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_admin_api_allows_disabled_auth_mode(self, app_client, monkeypatch):
+        monkeypatch.setenv("STORY_MANAGER_AUTH_MODE", "disabled")
+        monkeypatch.setenv("STORY_MANAGER_ADMIN_PASSWORD", "secret")
+
+        response = app_client.get("/api/books")
+        assert response.status_code == 200

--- a/backend/tests/test_refresh_queue.py
+++ b/backend/tests/test_refresh_queue.py
@@ -3,33 +3,10 @@
 import asyncio
 
 import pytest
-import pytest_asyncio
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
-from sqlalchemy.pool import StaticPool
 
 from backend.app import crud, models, schemas
-from backend.app.database import Base
 from backend.app.services import refresh_queue as refresh_queue_mod
 from backend.app.services import web_novel as web_novel_mod
-
-SQLALCHEMY_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
-
-engine = create_async_engine(
-    SQLALCHEMY_DATABASE_URL,
-    connect_args={"check_same_thread": False},
-    poolclass=StaticPool,
-)
-AsyncTestingSessionLocal = async_sessionmaker(autocommit=False, autoflush=False, bind=engine, expire_on_commit=False)
-
-
-@pytest_asyncio.fixture(scope="function")
-async def db():
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    async with AsyncTestingSessionLocal() as session:
-        yield session
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.drop_all)
 
 
 async def _make_web_book(db, **overrides):
@@ -163,7 +140,7 @@ async def test_refresh_queue_continues_after_worker_exception(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_refresh_queue_requeue_pending_books_uses_crud(monkeypatch, db):
+async def test_refresh_queue_requeue_pending_books_uses_crud(monkeypatch, db, sqlite_sessionmaker):
     queued = await _make_web_book(db, source_url="https://example.com/q")
     queued.refresh_status = "queued"
     processing = await _make_web_book(db, source_url="https://example.com/p")
@@ -173,7 +150,7 @@ async def test_refresh_queue_requeue_pending_books_uses_crud(monkeypatch, db):
 
     # Point the queue module's SessionLocal at the test database so
     # requeue_pending_books sees our fixture rows.
-    monkeypatch.setattr(refresh_queue_mod, "SessionLocal", AsyncTestingSessionLocal)
+    monkeypatch.setattr(refresh_queue_mod, "SessionLocal", sqlite_sessionmaker)
 
     enqueued: list[int] = []
 
@@ -192,7 +169,7 @@ async def test_refresh_queue_requeue_pending_books_uses_crud(monkeypatch, db):
 
 
 @pytest.mark.asyncio
-async def test_run_book_refresh_marks_error_when_no_source_url(monkeypatch, db):
+async def test_run_book_refresh_marks_error_when_no_source_url(monkeypatch, db, sqlite_sessionmaker):
     # Build a web book with no source_url (sneak past the schema by creating
     # it as epub first and then mutating source_type).
     book = await crud.create_book(
@@ -209,7 +186,7 @@ async def test_run_book_refresh_marks_error_when_no_source_url(monkeypatch, db):
     book.source_url = None
     await db.commit()
 
-    monkeypatch.setattr(web_novel_mod, "SessionLocal", AsyncTestingSessionLocal)
+    monkeypatch.setattr(web_novel_mod, "SessionLocal", sqlite_sessionmaker)
 
     await web_novel_mod.run_book_refresh(book.id)
 
@@ -219,7 +196,7 @@ async def test_run_book_refresh_marks_error_when_no_source_url(monkeypatch, db):
 
 
 @pytest.mark.asyncio
-async def test_run_book_refresh_marks_error_when_download_fails(monkeypatch, db):
+async def test_run_book_refresh_marks_error_when_download_fails(monkeypatch, db, sqlite_sessionmaker):
     book = await _make_web_book(
         db,
         source_url="https://example.com/story/fail",
@@ -228,7 +205,7 @@ async def test_run_book_refresh_marks_error_when_download_fails(monkeypatch, db)
     )
     await db.commit()
 
-    monkeypatch.setattr(web_novel_mod, "SessionLocal", AsyncTestingSessionLocal)
+    monkeypatch.setattr(web_novel_mod, "SessionLocal", sqlite_sessionmaker)
 
     def broken_word_count(path):
         raise RuntimeError("cannot read epub")
@@ -246,8 +223,8 @@ async def test_run_book_refresh_marks_error_when_download_fails(monkeypatch, db)
 
 
 @pytest.mark.asyncio
-async def test_run_book_refresh_swallows_missing_book(monkeypatch, db):
+async def test_run_book_refresh_swallows_missing_book(monkeypatch, db, sqlite_sessionmaker):
     """Worker should no-op cleanly when the book was deleted between enqueue and run."""
-    monkeypatch.setattr(web_novel_mod, "SessionLocal", AsyncTestingSessionLocal)
+    monkeypatch.setattr(web_novel_mod, "SessionLocal", sqlite_sessionmaker)
     # Should not raise even though book 99999 does not exist.
     await web_novel_mod.run_book_refresh(99999)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -18,6 +18,29 @@ The default `docker-compose.yml` stores persistent data under `./config`:
 
 The production image runs PostgreSQL inside the app container for simple self-hosting. If you split PostgreSQL into a separate service, set `DATABASE_URL` for the app container.
 
+## Admin Authentication
+
+By default, Story Manager preserves the historical local-network behavior: if no admin password is configured, the admin UI and `/api/*` routes do not require built-in login.
+
+To enable built-in admin password auth, set:
+
+```bash
+STORY_MANAGER_AUTH_MODE=password
+STORY_MANAGER_ADMIN_PASSWORD=change-me
+```
+
+The app stores a signed, HTTP-only session cookie after login. To keep sessions valid across container restarts without using the password as the signing key, also set:
+
+```bash
+STORY_MANAGER_ADMIN_SESSION_SECRET=long-random-value
+```
+
+If the app is already protected by a reverse proxy, Tailscale, Authelia, OAuth2 Proxy, or Cloudflare Access, disable built-in auth explicitly:
+
+```bash
+STORY_MANAGER_AUTH_MODE=disabled
+```
+
 ## FanFicFare Overrides
 
 Story Manager uses FanFicFare's EPUB update mode for tracked web novels. Daily checks can reuse the existing immutable EPUB instead of fetching every chapter again.

--- a/docs/reverse-proxy.md
+++ b/docs/reverse-proxy.md
@@ -1,11 +1,13 @@
 # Reverse Proxy Safety
 
-Story Manager does not yet have built-in user login for the admin web UI. The web UI and `/api/*` routes should be treated as trusted admin surfaces.
+Story Manager can protect the admin web UI and `/api/*` routes with built-in password auth by setting `STORY_MANAGER_AUTH_MODE=password` and `STORY_MANAGER_ADMIN_PASSWORD`.
+
+If you use a reverse proxy or Cloudflare Access as the admin auth layer, set `STORY_MANAGER_AUTH_MODE=disabled` and keep the proxy rules strict. Reader API keys only protect `/reader/*`; they are not admin credentials.
 
 Safe deployment guidance:
 
 - Expose `/reader/*` publicly only if needed for e-readers.
-- Keep `/` and `/api/*` behind a VPN, Tailscale, local network, or proxy authentication.
+- Keep `/` and `/api/*` behind built-in password auth, a VPN, Tailscale, local network, or proxy authentication.
 - Terminate TLS at the proxy and redirect HTTP to HTTPS.
 - Preserve the `Authorization` header so Bearer and Basic auth work for `/reader/*`.
 - Disable proxy caching for `/reader/*` responses that contain private library metadata.
@@ -55,4 +57,4 @@ server {
 }
 ```
 
-If the admin UI needs to be reachable over the internet, put `/` and `/api/*` behind a real authentication layer first. Reader API keys are not a substitute for admin authentication.
+If the admin UI needs to be reachable over the internet, put `/` and `/api/*` behind built-in password auth or a real upstream authentication layer first.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@tanstack/react-query": "^5.99.0",
+        "dompurify": "^3.4.1",
         "react": "^19.2.5",
         "react-dom": "^19.2.5"
       },
@@ -1310,6 +1311,13 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
@@ -1754,6 +1762,15 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.340",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.99.0",
+    "dompurify": "^3.4.1",
     "react": "^19.2.5",
     "react-dom": "^19.2.5"
   },

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -17,6 +17,18 @@
   margin-right: auto;
 }
 
+.login-panel {
+  display: flex;
+  justify-content: center;
+  padding: 3rem 1rem;
+}
+
+.login-form {
+  width: min(100%, 28rem);
+  display: grid;
+  gap: 1rem;
+}
+
 /* ─── Main Tabs ──────────────────────────────────────────── */
 .main-tabs {
   display: flex;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useState } from "react";
 import "./App.css";
+import { getAuthStatus, logout } from "./api/auth";
 import { getBook } from "./api/books";
+import AdminLogin from "./components/AdminLogin.jsx";
 import BookList from "./components/BookList";
 import BookSettings from "./components/BookSettings";
 import AddBook from "./components/AddBook.jsx";
@@ -10,7 +12,12 @@ import Logs from "./components/Logs.jsx";
 import Utilities from "./components/Utilities.jsx";
 import useDebouncedValue from "./hooks/useDebouncedValue";
 import useLibraryCatalog from "./hooks/useLibraryCatalog";
-import { buildBookPath, buildTabPath, parseLocation, TABS } from "./lib/navigation";
+import {
+  buildBookPath,
+  buildTabPath,
+  parseLocation,
+  TABS,
+} from "./lib/navigation";
 
 function App() {
   const [q, setQ] = useState("");
@@ -20,33 +27,53 @@ function App() {
   const [activeTab, setActiveTab] = useState("library");
   const [libraryView, setLibraryView] = useState("series");
   const [addBookOpen, setAddBookOpen] = useState(false);
+  const [authStatus, setAuthStatus] = useState(null);
   const debouncedQuery = useDebouncedValue(q.trim(), 300);
 
-  const applyLocation = useCallback(async (pathname, hash, stateData = null) => {
-    const parsed = parseLocation(pathname, hash);
-    if (parsed.view === "book") {
-      if (stateData?.id === parsed.bookId) {
-        setEditingBook(stateData);
-        return;
+  useEffect(() => {
+    let mounted = true;
+    getAuthStatus().then((status) => {
+      if (mounted) {
+        setAuthStatus(status);
       }
-
-      const book = await getBook(parsed.bookId);
-      if (book) {
-        setEditingBook(book);
-        return;
-      }
-
-      window.history.replaceState({ view: "tab", tab: "library" }, "", buildTabPath("library", "series"));
-      setEditingBook(null);
-      setActiveTab("library");
-      setLibraryView("series");
-      return;
-    }
-
-    setEditingBook(null);
-    setActiveTab(parsed.tab);
-    setLibraryView(parsed.libraryView);
+    });
+    return () => {
+      mounted = false;
+    };
   }, []);
+
+  const applyLocation = useCallback(
+    async (pathname, hash, stateData = null) => {
+      const parsed = parseLocation(pathname, hash);
+      if (parsed.view === "book") {
+        if (stateData?.id === parsed.bookId) {
+          setEditingBook(stateData);
+          return;
+        }
+
+        const book = await getBook(parsed.bookId);
+        if (book) {
+          setEditingBook(book);
+          return;
+        }
+
+        window.history.replaceState(
+          { view: "tab", tab: "library" },
+          "",
+          buildTabPath("library", "series"),
+        );
+        setEditingBook(null);
+        setActiveTab("library");
+        setLibraryView("series");
+        return;
+      }
+
+      setEditingBook(null);
+      setActiveTab(parsed.tab);
+      setLibraryView(parsed.libraryView);
+    },
+    [],
+  );
 
   const navigate = (view, data = null) => {
     if (view === "book" && data?.id) {
@@ -63,20 +90,34 @@ function App() {
 
   const handleLibraryViewChange = (view) => {
     setLibraryView(view);
-    window.history.pushState({ view: "tab", tab: "library" }, "", buildTabPath("library", view));
+    window.history.pushState(
+      { view: "tab", tab: "library" },
+      "",
+      buildTabPath("library", view),
+    );
   };
 
   useEffect(() => {
+    if (!authStatus?.authenticated) {
+      return;
+    }
     void applyLocation(window.location.pathname, window.location.hash);
-  }, [applyLocation]);
+  }, [applyLocation, authStatus?.authenticated]);
 
   useEffect(() => {
+    if (!authStatus?.authenticated) {
+      return undefined;
+    }
     const onPop = (e) => {
-      void applyLocation(window.location.pathname, window.location.hash, e.state?.data ?? null);
+      void applyLocation(
+        window.location.pathname,
+        window.location.hash,
+        e.state?.data ?? null,
+      );
     };
     window.addEventListener("popstate", onPop);
     return () => window.removeEventListener("popstate", onPop);
-  }, [applyLocation]);
+  }, [applyLocation, authStatus?.authenticated]);
 
   const {
     data: catalog = [],
@@ -86,6 +127,7 @@ function App() {
     q: debouncedQuery,
     sortBy,
     sortOrder,
+    enabled: Boolean(authStatus?.authenticated),
   });
 
   const handleClearSearch = () => {
@@ -108,6 +150,26 @@ function App() {
     }
   };
 
+  const handleLogout = async () => {
+    const nextStatus = await logout();
+    setAuthStatus(nextStatus);
+  };
+
+  if (authStatus === null) {
+    return (
+      <div className="app-container">
+        <header className="app-header">
+          <h1>Story Manager</h1>
+        </header>
+        <p>Loading...</p>
+      </div>
+    );
+  }
+
+  if (!authStatus.authenticated) {
+    return <AdminLogin onAuthenticated={setAuthStatus} />;
+  }
+
   if (editingBook) {
     return (
       <BookSettings book={editingBook} onBack={() => window.history.back()} />
@@ -129,8 +191,18 @@ function App() {
           <>
             <div className="search-controls">
               <div className="search-input-wrap">
-                <svg className="search-icon" viewBox="0 0 20 20" fill="currentColor" width="16" height="16">
-                  <path fillRule="evenodd" d="M9 3.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM2 9a7 7 0 1112.45 4.38l3.09 3.08a.75.75 0 11-1.06 1.06l-3.09-3.08A7 7 0 012 9z" clipRule="evenodd" />
+                <svg
+                  className="search-icon"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                  width="16"
+                  height="16"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M9 3.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM2 9a7 7 0 1112.45 4.38l3.09 3.08a.75.75 0 11-1.06 1.06l-3.09-3.08A7 7 0 012 9z"
+                    clipRule="evenodd"
+                  />
                 </svg>
                 <input
                   type="text"
@@ -139,7 +211,11 @@ function App() {
                   onChange={(e) => setQ(e.target.value)}
                 />
                 {q && (
-                  <button className="search-clear" onClick={handleClearSearch} aria-label="Clear search">
+                  <button
+                    className="search-clear"
+                    onClick={handleClearSearch}
+                    aria-label="Clear search"
+                  >
                     ×
                   </button>
                 )}
@@ -154,7 +230,11 @@ function App() {
                   <option value="word_count">Word Count</option>
                   <option value="updated_at">Last Updated</option>
                 </select>
-                <button className="sort-order-btn" onClick={handleToggleSortOrder} aria-label="Toggle sort order">
+                <button
+                  className="sort-order-btn"
+                  onClick={handleToggleSortOrder}
+                  aria-label="Toggle sort order"
+                >
                   {sortOrder === "asc" ? "↑" : "↓"}
                 </button>
               </div>
@@ -173,7 +253,14 @@ function App() {
             </details>
             {isLoading && <p>Loading...</p>}
             {error && <p className="error">{error.message}</p>}
-            <BookList books={catalog} onEdit={handleEdit} libraryView={libraryView} onLibraryViewChange={handleLibraryViewChange} sortBy={sortBy} sortOrder={sortOrder} />
+            <BookList
+              books={catalog}
+              onEdit={handleEdit}
+              libraryView={libraryView}
+              onLibraryViewChange={handleLibraryViewChange}
+              sortBy={sortBy}
+              sortOrder={sortOrder}
+            />
           </>
         );
     }
@@ -183,6 +270,11 @@ function App() {
     <div className="app-container">
       <header className="app-header">
         <h1>Story Manager</h1>
+        {authStatus.mode === "password" && (
+          <button className="btn-text" onClick={handleLogout}>
+            Sign Out
+          </button>
+        )}
       </header>
       <nav className="main-tabs">
         {TABS.map((tab) => (

--- a/frontend/src/api/auth.js
+++ b/frontend/src/api/auth.js
@@ -1,0 +1,32 @@
+import { sendJson, sendWithoutBody } from "./client";
+
+const DISABLED_STATUS = { mode: "disabled", authenticated: true };
+
+export async function getAuthStatus() {
+  try {
+    const response = await fetch("/api/auth/status");
+    if (!response.ok) {
+      return DISABLED_STATUS;
+    }
+    const status = await response.json();
+    if (!status || typeof status !== "object" || !("authenticated" in status)) {
+      return DISABLED_STATUS;
+    }
+    return status;
+  } catch {
+    return DISABLED_STATUS;
+  }
+}
+
+export async function login(password) {
+  return sendJson("/api/auth/login", {
+    body: { password },
+    fallbackMessage: "Login failed",
+  });
+}
+
+export async function logout() {
+  return sendWithoutBody("/api/auth/logout", {
+    fallbackMessage: "Logout failed",
+  });
+}

--- a/frontend/src/components/AdminLogin.jsx
+++ b/frontend/src/components/AdminLogin.jsx
@@ -1,0 +1,63 @@
+import { useState } from "react";
+
+import { login } from "../api/auth";
+
+function AdminLogin({ onAuthenticated }) {
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setError("");
+    setIsSubmitting(true);
+    try {
+      const status = await login(password);
+      if (status.authenticated) {
+        onAuthenticated(status);
+      } else {
+        setError("Login failed");
+      }
+    } catch (err) {
+      setError(err.message || "Login failed");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="app-container">
+      <header className="app-header">
+        <h1>Story Manager</h1>
+      </header>
+      <main className="login-panel">
+        <form className="login-form" onSubmit={handleSubmit}>
+          <h2>Admin Login</h2>
+          <label>
+            Password
+            <input
+              type="password"
+              value={password}
+              autoFocus
+              onChange={(event) => setPassword(event.target.value)}
+            />
+          </label>
+          <button
+            className="btn-primary"
+            type="submit"
+            disabled={!password || isSubmitting}
+          >
+            {isSubmitting ? "Signing in..." : "Sign In"}
+          </button>
+          {error && (
+            <p className="error" role="alert">
+              {error}
+            </p>
+          )}
+        </form>
+      </main>
+    </div>
+  );
+}
+
+export default AdminLogin;

--- a/frontend/src/components/BookSettings.jsx
+++ b/frontend/src/components/BookSettings.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useMemo } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 
 import {
@@ -20,6 +20,7 @@ import {
   uploadBookCover,
 } from "../api/books";
 import { getSeries } from "../api/series";
+import BookSettingsChapters from "./BookSettingsChapters";
 
 const fetchChapters = async ({ queryKey }) => {
   const [_key, bookId] = queryKey;
@@ -196,7 +197,10 @@ function formatHistoryEntryLabel(entry) {
 function ChapterUpdateHistory({ updateHistory, isLoading, isError, error }) {
   const { history, summary } = normalizeUpdateHistory(updateHistory);
   const chartEntries = history.filter((entry) => entry.included_in_stats);
-  const maxWords = Math.max(...chartEntries.map((entry) => entry.words_added), 1);
+  const maxWords = Math.max(
+    ...chartEntries.map((entry) => entry.words_added),
+    1,
+  );
 
   return (
     <section className="settings-section chapter-history-section">
@@ -248,7 +252,10 @@ function ChapterUpdateHistory({ updateHistory, isLoading, isError, error }) {
               </p>
             ) : (
               chartEntries.slice(-12).map((entry) => {
-                const height = Math.max((entry.words_added / maxWords) * 100, 8);
+                const height = Math.max(
+                  (entry.words_added / maxWords) * 100,
+                  8,
+                );
                 return (
                   <div className="chapter-history-bar-wrap" key={entry.id}>
                     <div className="chapter-history-bar-stage">
@@ -477,7 +484,9 @@ function BookSettings({ book: initialBook, onBack }) {
     onSuccess: (updatedBook) => {
       queryClient.setQueryData(["book", book.id], updatedBook);
       queryClient.invalidateQueries({ queryKey: ["book-catalog"] });
-      queryClient.invalidateQueries({ queryKey: ["book-update-history", book.id] });
+      queryClient.invalidateQueries({
+        queryKey: ["book-update-history", book.id],
+      });
     },
   });
 
@@ -645,11 +654,6 @@ function BookSettings({ book: initialBook, onBack }) {
     setPreviewedChapter((prev) => (prev === filename ? null : filename));
   };
 
-  const getBodyContent = (html) => {
-    const match = html.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
-    return match ? match[1] : html;
-  };
-
   const isBusy =
     saveMutation.isPending ||
     processMutation.isPending ||
@@ -659,17 +663,6 @@ function BookSettings({ book: initialBook, onBack }) {
     isRefreshing;
   const canDetachWebMarker =
     book.source_type === "web" && book.immutable_path && book.current_path;
-
-  const activeChapters =
-    chapterPreviewMode === "cleaned" ? cleanedChapters : chapters;
-  const activeChaptersLoading =
-    chapterPreviewMode === "cleaned" ? cleanedChaptersLoading : chaptersLoading;
-
-  const filteredChapters = useMemo(() => {
-    if (!chapterSearch.trim()) return activeChapters;
-    const q = chapterSearch.toLowerCase();
-    return activeChapters.filter((ch) => ch.title.toLowerCase().includes(q));
-  }, [activeChapters, chapterSearch]);
 
   return (
     <div className="book-settings">
@@ -1097,115 +1090,23 @@ function BookSettings({ book: initialBook, onBack }) {
         </div>
       </section>
 
-      <section className="settings-section">
-        <div className="chapter-section-header">
-          <h3>
-            Chapters
-            {activeChapters.length > 0 && (
-              <span className="chapter-count"> ({activeChapters.length})</span>
-            )}
-          </h3>
-          <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
-            {chaptersExpanded && (
-              <select
-                value={chapterPreviewMode}
-                onChange={(e) => setChapterPreviewMode(e.target.value)}
-                className="chapter-preview-mode-select"
-              >
-                <option value="original">Original</option>
-                <option value="cleaned">Cleaned</option>
-              </select>
-            )}
-            <button
-              className="btn-text"
-              onClick={() => setChaptersExpanded((e) => !e)}
-              disabled={activeChaptersLoading}
-            >
-              {chaptersExpanded ? "▲ Collapse" : "▼ Expand"}
-            </button>
-          </div>
-        </div>
-
-        {activeChaptersLoading && (
-          <p className="hint" style={{ marginTop: "0.5rem" }}>
-            Loading chapters…
-          </p>
-        )}
-
-        {!book.immutable_path && (
-          <p className="hint" style={{ marginTop: "0.5rem" }}>
-            This web import does not have EPUB files yet. Retry the source
-            download or delete the placeholder entry.
-          </p>
-        )}
-
-        {chaptersExpanded && !activeChaptersLoading && book.immutable_path && (
-          <>
-            {chapters.length > 10 && (
-              <input
-                className="chapter-search"
-                type="text"
-                placeholder="Filter chapters…"
-                value={chapterSearch}
-                onChange={(e) => setChapterSearch(e.target.value)}
-              />
-            )}
-            <div className="chapter-list-scroll">
-              <ul className="chapter-list">
-                {filteredChapters.length === 0 ? (
-                  <li className="chapter-no-results">
-                    No chapters match your search.
-                  </li>
-                ) : (
-                  filteredChapters.map((chapter) => {
-                    const isRemoved =
-                      chapterPreviewMode === "original" &&
-                      removedChapters.includes(chapter.filename);
-                    const isPreviewed = previewedChapter === chapter.filename;
-                    return (
-                      <li
-                        key={chapter.filename}
-                        className={isRemoved ? "removed" : ""}
-                      >
-                        <div className="chapter-row">
-                          {chapterPreviewMode === "original" ? (
-                            <label>
-                              <input
-                                type="checkbox"
-                                checked={!isRemoved}
-                                onChange={() => toggleChapter(chapter.filename)}
-                              />
-                              {chapter.title}
-                            </label>
-                          ) : (
-                            <span>{chapter.title}</span>
-                          )}
-                          <button
-                            className="btn-text chapter-preview-toggle"
-                            onClick={() =>
-                              toggleChapterPreview(chapter.filename)
-                            }
-                          >
-                            {isPreviewed ? "▲ Hide" : "▼ Preview"}
-                          </button>
-                        </div>
-                        {isPreviewed && (
-                          <div
-                            className="chapter-preview"
-                            dangerouslySetInnerHTML={{
-                              __html: getBodyContent(chapter.content),
-                            }}
-                          />
-                        )}
-                      </li>
-                    );
-                  })
-                )}
-              </ul>
-            </div>
-          </>
-        )}
-      </section>
+      <BookSettingsChapters
+        book={book}
+        chapters={chapters}
+        cleanedChapters={cleanedChapters}
+        chaptersLoading={chaptersLoading}
+        cleanedChaptersLoading={cleanedChaptersLoading}
+        chaptersExpanded={chaptersExpanded}
+        setChaptersExpanded={setChaptersExpanded}
+        chapterPreviewMode={chapterPreviewMode}
+        setChapterPreviewMode={setChapterPreviewMode}
+        chapterSearch={chapterSearch}
+        setChapterSearch={setChapterSearch}
+        removedChapters={removedChapters}
+        toggleChapter={toggleChapter}
+        previewedChapter={previewedChapter}
+        toggleChapterPreview={toggleChapterPreview}
+      />
 
       <section className="settings-section actions-bar">
         <div className="actions-primary">

--- a/frontend/src/components/BookSettingsChapters.jsx
+++ b/frontend/src/components/BookSettingsChapters.jsx
@@ -1,0 +1,146 @@
+import { useMemo } from "react";
+
+import { sanitizeChapterHtml } from "../lib/chapterHtml";
+
+function BookSettingsChapters({
+  book,
+  chapters,
+  cleanedChapters,
+  chaptersLoading,
+  cleanedChaptersLoading,
+  chaptersExpanded,
+  setChaptersExpanded,
+  chapterPreviewMode,
+  setChapterPreviewMode,
+  chapterSearch,
+  setChapterSearch,
+  removedChapters,
+  toggleChapter,
+  previewedChapter,
+  toggleChapterPreview,
+}) {
+  const activeChapters =
+    chapterPreviewMode === "cleaned" ? cleanedChapters : chapters;
+  const activeChaptersLoading =
+    chapterPreviewMode === "cleaned" ? cleanedChaptersLoading : chaptersLoading;
+
+  const filteredChapters = useMemo(() => {
+    if (!chapterSearch.trim()) return activeChapters;
+    const query = chapterSearch.toLowerCase();
+    return activeChapters.filter((chapter) =>
+      chapter.title.toLowerCase().includes(query),
+    );
+  }, [activeChapters, chapterSearch]);
+
+  return (
+    <section className="settings-section">
+      <div className="chapter-section-header">
+        <h3>
+          Chapters
+          {activeChapters.length > 0 && (
+            <span className="chapter-count"> ({activeChapters.length})</span>
+          )}
+        </h3>
+        <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+          {chaptersExpanded && (
+            <select
+              value={chapterPreviewMode}
+              onChange={(event) => setChapterPreviewMode(event.target.value)}
+              className="chapter-preview-mode-select"
+            >
+              <option value="original">Original</option>
+              <option value="cleaned">Cleaned</option>
+            </select>
+          )}
+          <button
+            className="btn-text"
+            onClick={() => setChaptersExpanded((expanded) => !expanded)}
+            disabled={activeChaptersLoading}
+          >
+            {chaptersExpanded ? "▲ Collapse" : "▼ Expand"}
+          </button>
+        </div>
+      </div>
+
+      {activeChaptersLoading && (
+        <p className="hint" style={{ marginTop: "0.5rem" }}>
+          Loading chapters…
+        </p>
+      )}
+
+      {!book.immutable_path && (
+        <p className="hint" style={{ marginTop: "0.5rem" }}>
+          This web import does not have EPUB files yet. Retry the source
+          download or delete the placeholder entry.
+        </p>
+      )}
+
+      {chaptersExpanded && !activeChaptersLoading && book.immutable_path && (
+        <>
+          {chapters.length > 10 && (
+            <input
+              className="chapter-search"
+              type="text"
+              placeholder="Filter chapters…"
+              value={chapterSearch}
+              onChange={(event) => setChapterSearch(event.target.value)}
+            />
+          )}
+          <div className="chapter-list-scroll">
+            <ul className="chapter-list">
+              {filteredChapters.length === 0 ? (
+                <li className="chapter-no-results">
+                  No chapters match your search.
+                </li>
+              ) : (
+                filteredChapters.map((chapter) => {
+                  const isRemoved =
+                    chapterPreviewMode === "original" &&
+                    removedChapters.includes(chapter.filename);
+                  const isPreviewed = previewedChapter === chapter.filename;
+                  return (
+                    <li
+                      key={chapter.filename}
+                      className={isRemoved ? "removed" : ""}
+                    >
+                      <div className="chapter-row">
+                        {chapterPreviewMode === "original" ? (
+                          <label>
+                            <input
+                              type="checkbox"
+                              checked={!isRemoved}
+                              onChange={() => toggleChapter(chapter.filename)}
+                            />
+                            {chapter.title}
+                          </label>
+                        ) : (
+                          <span>{chapter.title}</span>
+                        )}
+                        <button
+                          className="btn-text chapter-preview-toggle"
+                          onClick={() => toggleChapterPreview(chapter.filename)}
+                        >
+                          {isPreviewed ? "▲ Hide" : "▼ Preview"}
+                        </button>
+                      </div>
+                      {isPreviewed && (
+                        <div
+                          className="chapter-preview"
+                          dangerouslySetInnerHTML={{
+                            __html: sanitizeChapterHtml(chapter.content),
+                          }}
+                        />
+                      )}
+                    </li>
+                  );
+                })
+              )}
+            </ul>
+          </div>
+        </>
+      )}
+    </section>
+  );
+}
+
+export default BookSettingsChapters;

--- a/frontend/src/components/BookSettingsChapters.test.jsx
+++ b/frontend/src/components/BookSettingsChapters.test.jsx
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { sanitizeChapterHtml } from "../lib/chapterHtml";
+
+describe("sanitizeChapterHtml", () => {
+  it("strips scripts and event handlers from chapter previews", () => {
+    const html = `
+      <html>
+        <body>
+          <h1 onclick="alert('x')">Chapter</h1>
+          <script>alert("x")</script>
+          <p>Safe text</p>
+        </body>
+      </html>
+    `;
+
+    const result = sanitizeChapterHtml(html);
+
+    expect(result).toContain("<h1>Chapter</h1>");
+    expect(result).toContain("<p>Safe text</p>");
+    expect(result).not.toContain("script");
+    expect(result).not.toContain("onclick");
+  });
+});

--- a/frontend/src/hooks/useLibraryCatalog.js
+++ b/frontend/src/hooks/useLibraryCatalog.js
@@ -2,10 +2,11 @@ import { useQuery } from "@tanstack/react-query";
 
 import { getBookCatalog } from "../api/books";
 
-function useLibraryCatalog({ q, sortBy, sortOrder }) {
+function useLibraryCatalog({ q, sortBy, sortOrder, enabled = true }) {
   return useQuery({
     queryKey: ["book-catalog", { q, sortBy, sortOrder }],
     queryFn: () => getBookCatalog({ q, sortBy, sortOrder }),
+    enabled,
     refetchInterval: ({ state }) => {
       const books = state.data ?? [];
       const hasInFlight = books.some(

--- a/frontend/src/lib/chapterHtml.js
+++ b/frontend/src/lib/chapterHtml.js
@@ -1,0 +1,12 @@
+import DOMPurify from "dompurify";
+
+function getBodyContent(html) {
+  const match = html.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
+  return match ? match[1] : html;
+}
+
+export function sanitizeChapterHtml(html) {
+  return DOMPurify.sanitize(getBodyContent(html), {
+    USE_PROFILES: { html: true },
+  });
+}


### PR DESCRIPTION
## Summary

- Add optional built-in admin password auth for `/api/*`, with `STORY_MANAGER_AUTH_MODE=disabled` for reverse-proxy or Cloudflare Access deployments.
- Add frontend login/logout flow and auth status handling while preserving default no-auth behavior when no password is configured.
- Sanitize EPUB chapter preview HTML with DOMPurify and extract the chapter section out of `BookSettings`.
- Consolidate repeated backend SQLite test setup into shared fixtures for several test modules.
- Switch CI lint jobs from auto-fixing/committing to check-only behavior.
- Document the new auth environment variables and reverse-proxy mode.

## Validation

- `.venv/bin/python3 -m flake8 backend`
- `cd frontend && npm run lint -- --max-warnings=0`
- `export PYTHONPATH=. && .venv/bin/python3 -m pytest backend/tests/test_auth.py backend/tests/test_errors_and_health.py backend/tests/test_crud_modules.py backend/tests/test_refresh_queue.py`
- `cd frontend && npm test -- --run src/App.test.jsx src/components/BookSettingsChapters.test.jsx`
- `.venv/bin/python3 -m black --check backend`
- `.venv/bin/autoflake --check --remove-all-unused-imports --recursive backend`
- `make test`
- `make e2e`
