### PR TITLE
[codex] Refactor catalog and settings structure

### DIFF
--- a/backend/app/routers/books.py
+++ b/backend/app/routers/books.py
@@ -1,7 +1,6 @@
 """Book CRUD, search, chapter listing, and download endpoints."""
 
 import logging
-from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -12,121 +11,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from .. import crud, epub_editor, models, schemas
 from ..config import LIBRARY_PATH
 from ..database import get_db
+from ..services.catalog import build_book_catalog, normalize_genre_tags
+from ..services.chapter_history import build_chapter_update_history
 from ..services.library_paths import remove_empty_parent_dirs
 from ..services.metadata_jobs import queue_metadata_sync_job
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
-
-WORDS_PER_MONTH_WEEKS = 52 / 12
-CATCH_UP_SYNC_MIN_CHAPTERS = 5
-CATCH_UP_SYNC_MIN_WORDS = 20_000
-
-
-def _as_utc(dt: datetime) -> datetime:
-    if dt.tzinfo is None:
-        return dt.replace(tzinfo=timezone.utc)
-    return dt.astimezone(timezone.utc)
-
-
-def _chapter_delta(log: models.BookLog) -> int:
-    if log.previous_chapter_count is None or log.new_chapter_count is None:
-        return 0
-    return max(log.new_chapter_count - log.previous_chapter_count, 0)
-
-
-def _is_chapter_growth_log(log: models.BookLog) -> bool:
-    return (
-        log.entry_type == "updated"
-        and log.previous_chapter_count is not None
-        and log.previous_chapter_count > 0
-        and _chapter_delta(log) > 0
-    )
-
-
-def _is_initial_sync_log(log: models.BookLog) -> bool:
-    return log.entry_type == "added" and (log.new_chapter_count or 0) > 0
-
-
-def _build_chapter_update_history(
-    book_id: int,
-    logs: list[models.BookLog],
-    now: datetime | None = None,
-) -> schemas.BookChapterUpdateHistory:
-    points: list[schemas.BookChapterUpdateHistoryPoint] = []
-    seen_initial_sync = False
-    seen_post_initial_growth = False
-    for log in logs:
-        is_initial_sync = _is_initial_sync_log(log)
-        included_in_stats = _is_chapter_growth_log(log)
-        if not is_initial_sync and not included_in_stats:
-            continue
-        chapters_added = (log.new_chapter_count or 0) if is_initial_sync else _chapter_delta(log)
-        words_added = max(log.words_added or 0, 0)
-        is_catch_up_sync = (
-            included_in_stats
-            and seen_initial_sync
-            and not seen_post_initial_growth
-            and (chapters_added >= CATCH_UP_SYNC_MIN_CHAPTERS or words_added >= CATCH_UP_SYNC_MIN_WORDS)
-        )
-        included_in_stats = included_in_stats and not is_catch_up_sync
-        points.append(
-            schemas.BookChapterUpdateHistoryPoint(
-                id=log.id,
-                timestamp=log.timestamp,
-                entry_type=log.entry_type,
-                previous_chapter_count=log.previous_chapter_count,
-                new_chapter_count=log.new_chapter_count,
-                chapters_added=chapters_added,
-                words_added=words_added,
-                average_words_per_chapter=words_added / chapters_added if chapters_added else None,
-                included_in_stats=included_in_stats,
-                is_initial_sync=is_initial_sync,
-                is_catch_up_sync=is_catch_up_sync,
-            )
-        )
-        if is_initial_sync:
-            seen_initial_sync = True
-        elif _is_chapter_growth_log(log):
-            seen_post_initial_growth = True
-
-    stats_points = [point for point in points if point.included_in_stats]
-    total_words_added = sum(point.words_added for point in stats_points)
-    total_chapters_added = sum(point.chapters_added for point in stats_points)
-    average_words_per_week = None
-    average_words_per_month = None
-    average_days_between_updates = None
-    predicted_next_update_at = None
-    last_update_at = stats_points[-1].timestamp if stats_points else None
-
-    if stats_points:
-        now_utc = _as_utc(now or datetime.now(timezone.utc))
-        first_update_at = _as_utc(stats_points[0].timestamp)
-        elapsed_days = max((now_utc - first_update_at).total_seconds() / 86400, 1)
-        average_words_per_week = total_words_added / (elapsed_days / 7)
-        average_words_per_month = average_words_per_week * WORDS_PER_MONTH_WEEKS
-
-    if len(stats_points) >= 2:
-        timestamps = [_as_utc(point.timestamp) for point in stats_points]
-        intervals = [(current - previous).total_seconds() / 86400 for previous, current in zip(timestamps, timestamps[1:])]
-        average_days_between_updates = sum(intervals) / len(intervals)
-        predicted_next_update_at = timestamps[-1] + timedelta(days=average_days_between_updates)
-
-    return schemas.BookChapterUpdateHistory(
-        book_id=book_id,
-        history=points,
-        summary=schemas.BookChapterUpdateHistorySummary(
-            total_update_events=len(stats_points),
-            total_chapters_added=total_chapters_added,
-            total_words_added=total_words_added,
-            average_words_per_week=average_words_per_week,
-            average_words_per_month=average_words_per_month,
-            average_days_between_updates=average_days_between_updates,
-            predicted_next_update_at=predicted_next_update_at,
-            last_update_at=last_update_at,
-        ),
-    )
 
 
 def _remove_book_files(book: models.Book) -> list[str]:
@@ -164,52 +56,6 @@ def _book_cleanup_preview(book: models.Book) -> dict[str, Any]:
     }
 
 
-def _normalize_genre_tags(tags: list[str]) -> list[str]:
-    normalized: list[str] = []
-    seen: set[str] = set()
-    for raw_tag in tags:
-        cleaned = raw_tag.strip()
-        if not cleaned:
-            continue
-        folded = cleaned.casefold()
-        if folded in seen:
-            continue
-        seen.add(folded)
-        normalized.append(cleaned)
-    return sorted(normalized, key=str.casefold)
-
-
-def _effective_genre_tags(book: models.Book, series_user_genre_tags: list[str] | None = None) -> list[str]:
-    return _normalize_genre_tags(
-        [
-            *(series_user_genre_tags or []),
-            *(book.user_genre_tags or []),
-            *(book.genre_tags or []),
-        ]
-    )
-
-
-async def _series_metadata_map(
-    db: AsyncSession,
-    books: list[models.Book],
-) -> dict[str, models.SeriesMetadata]:
-    series_names = sorted({book.series for book in books if book.series})
-    return await crud.get_series_metadata_for_names(db, series_names)
-
-
-def _serialize_catalog_book(
-    book: models.Book,
-    *,
-    series_user_genre_tags: list[str] | None = None,
-    effective_series_genre_tags: list[str] | None = None,
-) -> schemas.BookCatalogEntry:
-    payload = schemas.BookCatalogEntry.model_validate(book).model_dump()
-    payload["series_user_genre_tags"] = series_user_genre_tags or []
-    payload["effective_genre_tags"] = _effective_genre_tags(book, series_user_genre_tags)
-    payload["effective_series_genre_tags"] = effective_series_genre_tags or []
-    return schemas.BookCatalogEntry.model_validate(payload)
-
-
 @router.get("/api/books", response_model=List[schemas.Book])
 async def get_all_books(
     skip: int = 0,
@@ -229,27 +75,7 @@ async def get_book_catalog(
     sort_order: str = "asc",
     db: AsyncSession = Depends(get_db),
 ) -> List[schemas.BookCatalogEntry]:
-    books = await crud.get_book_catalog(db, q=q, sort_by=sort_by, sort_order=sort_order)
-    metadata_map = await _series_metadata_map(db, books)
-
-    series_books: dict[str, list[models.Book]] = {}
-    for book in books:
-        if book.series:
-            series_books.setdefault(book.series, []).append(book)
-
-    effective_series_tags: dict[str, list[str]] = {}
-    for series_name, group in series_books.items():
-        meta = metadata_map.get(series_name)
-        effective_series_tags[series_name] = crud.compute_effective_series_genre_tags(group, meta)
-
-    return [
-        _serialize_catalog_book(
-            book,
-            series_user_genre_tags=(metadata_map.get(book.series).user_genre_tags if book.series in metadata_map else []),
-            effective_series_genre_tags=effective_series_tags.get(book.series, []) if book.series else [],
-        )
-        for book in books
-    ]
+    return await build_book_catalog(db, q=q, sort_by=sort_by, sort_order=sort_order)
 
 
 @router.get("/api/series", response_model=List[str])
@@ -323,7 +149,7 @@ async def update_series_genres(
 
     crud.validate_genre_tags(body.user_genre_tags)
     canonical_name = books[0].series or series_name
-    user_genre_tags = _normalize_genre_tags(body.user_genre_tags)
+    user_genre_tags = normalize_genre_tags(body.user_genre_tags)
     metadata = await crud.set_series_user_genre_tags(
         db,
         series_name=canonical_name,
@@ -378,7 +204,7 @@ async def get_book_update_history(book_id: int, db: AsyncSession = Depends(get_d
         raise HTTPException(status_code=404, detail="Book not found")
 
     logs = await crud.get_book_logs(db, book_id)
-    return _build_chapter_update_history(book_id, logs)
+    return build_chapter_update_history(book_id, logs)
 
 
 @router.get("/api/books/{book_id}", response_model=schemas.Book)
@@ -401,7 +227,7 @@ async def update_book_details(
     previous_series = db_book.series
     previous_remote_ids = db_book.metadata_remote_ids
     if book_update.user_genre_tags is not None:
-        book_update.user_genre_tags = _normalize_genre_tags(book_update.user_genre_tags)
+        book_update.user_genre_tags = normalize_genre_tags(book_update.user_genre_tags)
     update_dict = book_update.model_dump(exclude_unset=True)
     updated_book = await crud.update_book(db=db, book=db_book, update_data=book_update)
     if "content_selectors" in update_dict or "removed_chapters" in update_dict:

--- a/backend/app/services/catalog.py
+++ b/backend/app/services/catalog.py
@@ -1,0 +1,81 @@
+"""Catalog serialization helpers for the library views."""
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import crud, models, schemas
+
+
+def normalize_genre_tags(tags: list[str]) -> list[str]:
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw_tag in tags:
+        cleaned = raw_tag.strip()
+        if not cleaned:
+            continue
+        folded = cleaned.casefold()
+        if folded in seen:
+            continue
+        seen.add(folded)
+        normalized.append(cleaned)
+    return sorted(normalized, key=str.casefold)
+
+
+def effective_genre_tags(book: models.Book, series_user_genre_tags: list[str] | None = None) -> list[str]:
+    return normalize_genre_tags(
+        [
+            *(series_user_genre_tags or []),
+            *(book.user_genre_tags or []),
+            *(book.genre_tags or []),
+        ]
+    )
+
+
+async def _series_metadata_map(
+    db: AsyncSession,
+    books: list[models.Book],
+) -> dict[str, models.SeriesMetadata]:
+    series_names = sorted({book.series for book in books if book.series})
+    return await crud.get_series_metadata_for_names(db, series_names)
+
+
+def serialize_catalog_book(
+    book: models.Book,
+    *,
+    series_user_genre_tags: list[str] | None = None,
+    effective_series_genre_tags: list[str] | None = None,
+) -> schemas.BookCatalogEntry:
+    payload = schemas.BookCatalogEntry.model_validate(book).model_dump()
+    payload["series_user_genre_tags"] = series_user_genre_tags or []
+    payload["effective_genre_tags"] = effective_genre_tags(book, series_user_genre_tags)
+    payload["effective_series_genre_tags"] = effective_series_genre_tags or []
+    return schemas.BookCatalogEntry.model_validate(payload)
+
+
+async def build_book_catalog(
+    db: AsyncSession,
+    *,
+    q: str | None = None,
+    sort_by: str = "title",
+    sort_order: str = "asc",
+) -> list[schemas.BookCatalogEntry]:
+    books = await crud.get_book_catalog(db, q=q, sort_by=sort_by, sort_order=sort_order)
+    metadata_map = await _series_metadata_map(db, books)
+
+    series_books: dict[str, list[models.Book]] = {}
+    for book in books:
+        if book.series:
+            series_books.setdefault(book.series, []).append(book)
+
+    effective_series_tags: dict[str, list[str]] = {}
+    for series_name, group in series_books.items():
+        meta = metadata_map.get(series_name)
+        effective_series_tags[series_name] = crud.compute_effective_series_genre_tags(group, meta)
+
+    return [
+        serialize_catalog_book(
+            book,
+            series_user_genre_tags=(metadata_map.get(book.series).user_genre_tags if book.series in metadata_map else []),
+            effective_series_genre_tags=effective_series_tags.get(book.series, []) if book.series else [],
+        )
+        for book in books
+    ]

--- a/backend/app/services/chapter_history.py
+++ b/backend/app/services/chapter_history.py
@@ -1,0 +1,114 @@
+"""Chapter update history summaries for web books."""
+
+from datetime import datetime, timedelta, timezone
+
+from .. import models, schemas
+
+WORDS_PER_MONTH_WEEKS = 52 / 12
+CATCH_UP_SYNC_MIN_CHAPTERS = 5
+CATCH_UP_SYNC_MIN_WORDS = 20_000
+
+
+def _as_utc(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _chapter_delta(log: models.BookLog) -> int:
+    if log.previous_chapter_count is None or log.new_chapter_count is None:
+        return 0
+    return max(log.new_chapter_count - log.previous_chapter_count, 0)
+
+
+def _is_chapter_growth_log(log: models.BookLog) -> bool:
+    return (
+        log.entry_type == "updated"
+        and log.previous_chapter_count is not None
+        and log.previous_chapter_count > 0
+        and _chapter_delta(log) > 0
+    )
+
+
+def _is_initial_sync_log(log: models.BookLog) -> bool:
+    return log.entry_type == "added" and (log.new_chapter_count or 0) > 0
+
+
+def build_chapter_update_history(
+    book_id: int,
+    logs: list[models.BookLog],
+    now: datetime | None = None,
+) -> schemas.BookChapterUpdateHistory:
+    points: list[schemas.BookChapterUpdateHistoryPoint] = []
+    seen_initial_sync = False
+    seen_post_initial_growth = False
+    for log in logs:
+        is_initial_sync = _is_initial_sync_log(log)
+        included_in_stats = _is_chapter_growth_log(log)
+        if not is_initial_sync and not included_in_stats:
+            continue
+        chapters_added = (log.new_chapter_count or 0) if is_initial_sync else _chapter_delta(log)
+        words_added = max(log.words_added or 0, 0)
+        is_catch_up_sync = (
+            included_in_stats
+            and seen_initial_sync
+            and not seen_post_initial_growth
+            and (chapters_added >= CATCH_UP_SYNC_MIN_CHAPTERS or words_added >= CATCH_UP_SYNC_MIN_WORDS)
+        )
+        included_in_stats = included_in_stats and not is_catch_up_sync
+        points.append(
+            schemas.BookChapterUpdateHistoryPoint(
+                id=log.id,
+                timestamp=log.timestamp,
+                entry_type=log.entry_type,
+                previous_chapter_count=log.previous_chapter_count,
+                new_chapter_count=log.new_chapter_count,
+                chapters_added=chapters_added,
+                words_added=words_added,
+                average_words_per_chapter=words_added / chapters_added if chapters_added else None,
+                included_in_stats=included_in_stats,
+                is_initial_sync=is_initial_sync,
+                is_catch_up_sync=is_catch_up_sync,
+            )
+        )
+        if is_initial_sync:
+            seen_initial_sync = True
+        elif _is_chapter_growth_log(log):
+            seen_post_initial_growth = True
+
+    stats_points = [point for point in points if point.included_in_stats]
+    total_words_added = sum(point.words_added for point in stats_points)
+    total_chapters_added = sum(point.chapters_added for point in stats_points)
+    average_words_per_week = None
+    average_words_per_month = None
+    average_days_between_updates = None
+    predicted_next_update_at = None
+    last_update_at = stats_points[-1].timestamp if stats_points else None
+
+    if stats_points:
+        now_utc = _as_utc(now or datetime.now(timezone.utc))
+        first_update_at = _as_utc(stats_points[0].timestamp)
+        elapsed_days = max((now_utc - first_update_at).total_seconds() / 86400, 1)
+        average_words_per_week = total_words_added / (elapsed_days / 7)
+        average_words_per_month = average_words_per_week * WORDS_PER_MONTH_WEEKS
+
+    if len(stats_points) >= 2:
+        timestamps = [_as_utc(point.timestamp) for point in stats_points]
+        intervals = [(current - previous).total_seconds() / 86400 for previous, current in zip(timestamps, timestamps[1:])]
+        average_days_between_updates = sum(intervals) / len(intervals)
+        predicted_next_update_at = timestamps[-1] + timedelta(days=average_days_between_updates)
+
+    return schemas.BookChapterUpdateHistory(
+        book_id=book_id,
+        history=points,
+        summary=schemas.BookChapterUpdateHistorySummary(
+            total_update_events=len(stats_points),
+            total_chapters_added=total_chapters_added,
+            total_words_added=total_words_added,
+            average_words_per_week=average_words_per_week,
+            average_words_per_month=average_words_per_month,
+            average_days_between_updates=average_days_between_updates,
+            predicted_next_update_at=predicted_next_update_at,
+            last_update_at=last_update_at,
+        ),
+    )

--- a/backend/app/services/metadata/__init__.py
+++ b/backend/app/services/metadata/__init__.py
@@ -1,0 +1,1 @@
+"""Metadata sync helper modules."""

--- a/backend/app/services/metadata/genres.py
+++ b/backend/app/services/metadata/genres.py
@@ -1,0 +1,65 @@
+"""Genre tag derivation and merging for metadata sync."""
+
+from collections.abc import Iterable
+
+from .scoring import normalize_text
+
+_GENRE_KEYWORDS = (
+    ("progression fantasy", "Progression Fantasy"),
+    ("urban fantasy", "Urban Fantasy"),
+    ("epic fantasy", "Epic Fantasy"),
+    ("science fiction", "Science Fiction"),
+    ("sci-fi", "Science Fiction"),
+    ("historical fiction", "Historical Fiction"),
+    ("young adult", "Young Adult"),
+    ("short stories", "Short Stories"),
+    ("detective", "Detective"),
+    ("thriller", "Thriller"),
+    ("mystery", "Mystery"),
+    ("fantasy", "Fantasy"),
+    ("romance", "Romance"),
+    ("horror", "Horror"),
+    ("adventure", "Adventure"),
+    ("dystopian", "Dystopian"),
+    ("dystopia", "Dystopian"),
+    ("paranormal", "Paranormal"),
+    ("supernatural", "Supernatural"),
+    ("crime", "Crime"),
+    ("literary", "Literary Fiction"),
+    ("humor", "Humor"),
+    ("satire", "Satire"),
+    ("steampunk", "Steampunk"),
+    ("cyberpunk", "Cyberpunk"),
+    ("litrpg", "LitRPG"),
+    ("mythology", "Mythology"),
+    ("war stories", "War"),
+    ("xianxia", "Xianxia"),
+    ("cultivation", "Cultivation"),
+)
+
+
+def derive_genre_tags(subjects: Iterable[str]) -> list[str]:
+    genres: list[str] = []
+    seen: set[str] = set()
+
+    for subject in subjects:
+        normalized = normalize_text(subject)
+        for keyword, canonical in _GENRE_KEYWORDS:
+            if keyword in normalized and canonical.casefold() not in seen:
+                seen.add(canonical.casefold())
+                genres.append(canonical)
+
+    return genres
+
+
+def merge_genre_tags(*groups: Iterable[str]) -> list[str]:
+    merged: list[str] = []
+    seen: set[str] = set()
+    for group in groups:
+        for tag in group:
+            folded = tag.casefold()
+            if folded in seen:
+                continue
+            seen.add(folded)
+            merged.append(tag)
+    return merged

--- a/backend/app/services/metadata/scoring.py
+++ b/backend/app/services/metadata/scoring.py
@@ -1,0 +1,25 @@
+"""Text normalization and match scoring helpers for metadata providers."""
+
+from difflib import SequenceMatcher
+import re
+
+_NON_ALNUM_RE = re.compile(r"[^a-z0-9]+")
+_SEPARATOR_RE = re.compile(r"[\s\-:,_]+")
+
+
+def normalize_text(value: str) -> str:
+    return _NON_ALNUM_RE.sub(" ", value.casefold()).strip()
+
+
+def normalize_series(value: str) -> str:
+    return _SEPARATOR_RE.sub(" ", value.casefold()).strip()
+
+
+def title_similarity(left: str, right: str) -> float:
+    left_norm = normalize_text(left)
+    right_norm = normalize_text(right)
+    if not left_norm or not right_norm:
+        return 0.0
+    if left_norm == right_norm:
+        return 1.0
+    return SequenceMatcher(a=left_norm, b=right_norm).ratio()

--- a/backend/app/services/metadata_sync.py
+++ b/backend/app/services/metadata_sync.py
@@ -9,8 +9,7 @@ import threading
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from difflib import SequenceMatcher
-from typing import Any, Iterable, Optional
+from typing import Any, Optional
 
 import requests
 from requests import exceptions as requests_exceptions
@@ -18,6 +17,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import crud, models, schemas
 from ..config import GOOGLE_BOOKS_API_KEY
+from .metadata.genres import derive_genre_tags as _derive_genre_tags
+from .metadata.genres import merge_genre_tags as _merge_genre_tags
+from .metadata.scoring import normalize_series as _normalize_series
+from .metadata.scoring import normalize_text as _normalize_text
+from .metadata.scoring import title_similarity as _title_similarity
 from .series import detect_series_from_titles
 
 logger = logging.getLogger(__name__)
@@ -36,47 +40,12 @@ GOOGLE_BOOKS_USER_AGENT = "story-manager/0.1 (+https://developers.google.com/boo
 AUTO_APPROVE_THRESHOLD = 0.92
 PROPOSAL_THRESHOLD = 0.75
 
-_NON_ALNUM_RE = re.compile(r"[^a-z0-9]+")
-_SEPARATOR_RE = re.compile(r"[\s\-:,_]+")
 _TRAILING_PARENS_RE = re.compile(r"\s*\([^)]*\)\s*$")
 _TRAILING_SERIES_BOOK_RE = re.compile(r"\s*\([^)]*book\s+\d+[^)]*\)\s*$", re.IGNORECASE)
 _TRAILING_PUNCTUATION_RE = re.compile(r"[\s:;,\-]+$")
 
 _request_lock = threading.Lock()
 _last_open_library_request_at = 0.0
-
-_GENRE_KEYWORDS = (
-    ("progression fantasy", "Progression Fantasy"),
-    ("urban fantasy", "Urban Fantasy"),
-    ("epic fantasy", "Epic Fantasy"),
-    ("science fiction", "Science Fiction"),
-    ("sci-fi", "Science Fiction"),
-    ("historical fiction", "Historical Fiction"),
-    ("young adult", "Young Adult"),
-    ("short stories", "Short Stories"),
-    ("detective", "Detective"),
-    ("thriller", "Thriller"),
-    ("mystery", "Mystery"),
-    ("fantasy", "Fantasy"),
-    ("romance", "Romance"),
-    ("horror", "Horror"),
-    ("adventure", "Adventure"),
-    ("dystopian", "Dystopian"),
-    ("dystopia", "Dystopian"),
-    ("paranormal", "Paranormal"),
-    ("supernatural", "Supernatural"),
-    ("crime", "Crime"),
-    ("literary", "Literary Fiction"),
-    ("humor", "Humor"),
-    ("satire", "Satire"),
-    ("steampunk", "Steampunk"),
-    ("cyberpunk", "Cyberpunk"),
-    ("litrpg", "LitRPG"),
-    ("mythology", "Mythology"),
-    ("war stories", "War"),
-    ("xianxia", "Xianxia"),
-    ("cultivation", "Cultivation"),
-)
 
 
 @dataclass
@@ -120,14 +89,6 @@ class GoogleBooksMatch:
     info_link: Optional[str]
     remote_ids: dict[str, str]
     match_confidence: float
-
-
-def _normalize_text(value: str) -> str:
-    return _NON_ALNUM_RE.sub(" ", value.casefold()).strip()
-
-
-def _normalize_series(value: str) -> str:
-    return _SEPARATOR_RE.sub(" ", value.casefold()).strip()
 
 
 def _respect_open_library_rate_limit() -> None:
@@ -204,16 +165,6 @@ def _request_google_books_json(path: str, *, params: Optional[dict[str, Any]] = 
     return {}
 
 
-def _title_similarity(left: str, right: str) -> float:
-    left_norm = _normalize_text(left)
-    right_norm = _normalize_text(right)
-    if not left_norm or not right_norm:
-        return 0.0
-    if left_norm == right_norm:
-        return 1.0
-    return SequenceMatcher(a=left_norm, b=right_norm).ratio()
-
-
 def _strip_trailing_metadata(value: str) -> str:
     cleaned = _TRAILING_SERIES_BOOK_RE.sub("", value).strip()
     if cleaned != value.strip():
@@ -285,33 +236,6 @@ def _extract_subjects(doc: dict[str, Any], work_data: dict[str, Any]) -> list[st
         seen.add(normalized)
         deduped.append(subject)
     return deduped
-
-
-def _derive_genre_tags(subjects: Iterable[str]) -> list[str]:
-    genres: list[str] = []
-    seen: set[str] = set()
-
-    for subject in subjects:
-        normalized = _normalize_text(subject)
-        for keyword, canonical in _GENRE_KEYWORDS:
-            if keyword in normalized and canonical.casefold() not in seen:
-                seen.add(canonical.casefold())
-                genres.append(canonical)
-
-    return genres
-
-
-def _merge_genre_tags(*groups: Iterable[str]) -> list[str]:
-    merged: list[str] = []
-    seen: set[str] = set()
-    for group in groups:
-        for tag in group:
-            folded = tag.casefold()
-            if folded in seen:
-                continue
-            seen.add(folded)
-            merged.append(tag)
-    return merged
 
 
 def _merge_remote_ids(*groups: dict[str, Any]) -> dict[str, Any]:

--- a/frontend/src/api/books.js
+++ b/frontend/src/api/books.js
@@ -1,6 +1,10 @@
-import { getJson, getOptionalJson, sendForm, sendJson, sendWithoutBody } from "./client";
+import { getJson, getOptionalJson, sendJson, sendWithoutBody } from "./client";
 
-export function buildBookCatalogPath({ q = "", sortBy = "title", sortOrder = "asc" }) {
+export function buildBookCatalogPath({
+  q = "",
+  sortBy = "title",
+  sortOrder = "asc",
+}) {
   const suffix = `sort_by=${encodeURIComponent(sortBy)}&sort_order=${encodeURIComponent(sortOrder)}`;
   if (!q) {
     return `/api/books/catalog?${suffix}`;
@@ -10,53 +14,6 @@ export function buildBookCatalogPath({ q = "", sortBy = "title", sortOrder = "as
 
 export function getBookCatalog(params) {
   return getJson(buildBookCatalogPath(params), "Failed to fetch books");
-}
-
-export function previewMetadataSync(bookIds = null) {
-  return sendJson("/api/metadata/sync-preview", {
-    body: { book_ids: bookIds },
-    fallbackMessage: "Failed to preview metadata sync",
-  });
-}
-
-export function applyMetadataSync(bookIds = null) {
-  return sendJson("/api/metadata/apply", {
-    body: { book_ids: bookIds },
-    fallbackMessage: "Failed to apply metadata sync",
-  });
-}
-
-export function queueMetadataSync(bookIds = null, trigger = "manual") {
-  return sendJson("/api/metadata/jobs", {
-    body: { book_ids: bookIds, trigger },
-    fallbackMessage: "Failed to queue metadata sync",
-  });
-}
-
-export function getLatestMetadataJob() {
-  return getOptionalJson("/api/metadata/jobs/latest");
-}
-
-export function getMetadataInbox() {
-  return getJson("/api/metadata/inbox", "Failed to load metadata inbox");
-}
-
-export function approveMetadataMatch(matchId) {
-  return sendWithoutBody(`/api/metadata/matches/${matchId}/approve`, {
-    fallbackMessage: "Failed to approve metadata match",
-  });
-}
-
-export function rejectMetadataMatch(matchId) {
-  return sendWithoutBody(`/api/metadata/matches/${matchId}/reject`, {
-    fallbackMessage: "Failed to reject metadata match",
-  });
-}
-
-export function dismissMetadataProposal(proposalId) {
-  return sendWithoutBody(`/api/metadata/proposals/${proposalId}/dismiss`, {
-    fallbackMessage: "Failed to dismiss metadata proposal",
-  });
 }
 
 export function getBook(bookId) {
@@ -101,45 +58,15 @@ export function getBookChapters(bookId) {
 }
 
 export function getBookCleanedChapters(bookId) {
-  return getJson(`/api/books/${bookId}/cleaned-chapters`, "Failed to fetch cleaned chapters");
+  return getJson(
+    `/api/books/${bookId}/cleaned-chapters`,
+    "Failed to fetch cleaned chapters",
+  );
 }
 
 export function getBookUpdateHistory(bookId) {
-  return getJson(`/api/books/${bookId}/update-history`, "Failed to fetch update history");
-}
-
-export function getMatchedConfigs(bookId) {
-  return getJson(`/api/books/${bookId}/matched-config`, "Failed to fetch matched config");
-}
-
-export function previewCleaning(bookId, data) {
-  return sendJson(`/api/books/${bookId}/preview-cleaning`, {
-    body: data,
-    fallbackMessage: "Preview failed",
-  });
-}
-
-export function uploadBookCover(bookId, file) {
-  const form = new FormData();
-  form.append("file", file);
-  return sendForm(`/api/books/${bookId}/cover`, form, {
-    fallbackMessage: "Cover upload failed",
-  });
-}
-
-export function retryBookCover(bookId) {
-  return sendWithoutBody(`/api/books/${bookId}/retry-cover`, {
-    fallbackMessage: "Failed to retry cover",
-  });
-}
-
-export function setBookCoverUrl(bookId, url) {
-  return sendJson(`/api/books/${bookId}/cover-url`, {
-    body: { url },
-    fallbackMessage: "Failed to set cover from URL",
-  });
-}
-
-export function getApiCoverUrl(bookId) {
-  return `/api/covers/${bookId}`;
+  return getJson(
+    `/api/books/${bookId}/update-history`,
+    "Failed to fetch update history",
+  );
 }

--- a/frontend/src/api/cleaning.js
+++ b/frontend/src/api/cleaning.js
@@ -1,0 +1,15 @@
+import { getJson, sendJson } from "./client";
+
+export function getMatchedConfigs(bookId) {
+  return getJson(
+    `/api/books/${bookId}/matched-config`,
+    "Failed to fetch matched config",
+  );
+}
+
+export function previewCleaning(bookId, data) {
+  return sendJson(`/api/books/${bookId}/preview-cleaning`, {
+    body: data,
+    fallbackMessage: "Preview failed",
+  });
+}

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -19,7 +19,10 @@ export async function getOptionalJson(path) {
   return response.json();
 }
 
-export async function sendJson(path, { method = "POST", body, fallbackMessage = "Request failed" } = {}) {
+export async function sendJson(
+  path,
+  { method = "POST", body, fallbackMessage = "Request failed" } = {},
+) {
   const response = await fetch(path, {
     method,
     headers: { "Content-Type": "application/json" },
@@ -34,7 +37,11 @@ export async function sendJson(path, { method = "POST", body, fallbackMessage = 
   return response.json();
 }
 
-export async function sendForm(path, body, { method = "POST", fallbackMessage = "Request failed" } = {}) {
+export async function sendForm(
+  path,
+  body,
+  { method = "POST", fallbackMessage = "Request failed" } = {},
+) {
   const response = await fetch(path, {
     method,
     body,
@@ -45,7 +52,10 @@ export async function sendForm(path, body, { method = "POST", fallbackMessage = 
   return response.json();
 }
 
-export async function sendWithoutBody(path, { method = "POST", fallbackMessage = "Request failed" } = {}) {
+export async function sendWithoutBody(
+  path,
+  { method = "POST", fallbackMessage = "Request failed" } = {},
+) {
   const response = await fetch(path, { method });
   if (!response.ok) {
     await parseError(response, fallbackMessage);

--- a/frontend/src/api/covers.js
+++ b/frontend/src/api/covers.js
@@ -1,0 +1,26 @@
+import { sendForm, sendJson, sendWithoutBody } from "./client";
+
+export function uploadBookCover(bookId, file) {
+  const form = new FormData();
+  form.append("file", file);
+  return sendForm(`/api/books/${bookId}/cover`, form, {
+    fallbackMessage: "Cover upload failed",
+  });
+}
+
+export function retryBookCover(bookId) {
+  return sendWithoutBody(`/api/books/${bookId}/retry-cover`, {
+    fallbackMessage: "Failed to retry cover",
+  });
+}
+
+export function setBookCoverUrl(bookId, url) {
+  return sendJson(`/api/books/${bookId}/cover-url`, {
+    body: { url },
+    fallbackMessage: "Failed to set cover from URL",
+  });
+}
+
+export function getApiCoverUrl(bookId) {
+  return `/api/covers/${bookId}`;
+}

--- a/frontend/src/api/metadata.js
+++ b/frontend/src/api/metadata.js
@@ -1,0 +1,48 @@
+import { getJson, getOptionalJson, sendJson, sendWithoutBody } from "./client";
+
+export function previewMetadataSync(bookIds = null) {
+  return sendJson("/api/metadata/sync-preview", {
+    body: { book_ids: bookIds },
+    fallbackMessage: "Failed to preview metadata sync",
+  });
+}
+
+export function applyMetadataSync(bookIds = null) {
+  return sendJson("/api/metadata/apply", {
+    body: { book_ids: bookIds },
+    fallbackMessage: "Failed to apply metadata sync",
+  });
+}
+
+export function queueMetadataSync(bookIds = null, trigger = "manual") {
+  return sendJson("/api/metadata/jobs", {
+    body: { book_ids: bookIds, trigger },
+    fallbackMessage: "Failed to queue metadata sync",
+  });
+}
+
+export function getLatestMetadataJob() {
+  return getOptionalJson("/api/metadata/jobs/latest");
+}
+
+export function getMetadataInbox() {
+  return getJson("/api/metadata/inbox", "Failed to load metadata inbox");
+}
+
+export function approveMetadataMatch(matchId) {
+  return sendWithoutBody(`/api/metadata/matches/${matchId}/approve`, {
+    fallbackMessage: "Failed to approve metadata match",
+  });
+}
+
+export function rejectMetadataMatch(matchId) {
+  return sendWithoutBody(`/api/metadata/matches/${matchId}/reject`, {
+    fallbackMessage: "Failed to reject metadata match",
+  });
+}
+
+export function dismissMetadataProposal(proposalId) {
+  return sendWithoutBody(`/api/metadata/proposals/${proposalId}/dismiss`, {
+    fallbackMessage: "Failed to dismiss metadata proposal",
+  });
+}

--- a/frontend/src/components/BookList.jsx
+++ b/frontend/src/components/BookList.jsx
@@ -1,7 +1,10 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
-import { getApiCoverUrl, updateBook } from "../api/books";
+import { updateBook } from "../api/books";
+import { buildCatalogGroups } from "../lib/catalogGrouping";
+import { BookCard, BookRow, GenreTagList } from "./book-list/BookCards";
+import { getCoverUrl, getSeriesGenreTags } from "./book-list/catalogDisplay";
 import {
   getSeries,
   mergeSeries,
@@ -9,159 +12,6 @@ import {
   reorderSeries,
   updateSeriesGenres,
 } from "../api/series";
-
-const NO_COVER_SVG =
-  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='250'%3E%3Crect width='200' height='250' fill='%23e0e0e0'/%3E%3Ctext x='100' y='125' dominant-baseline='middle' text-anchor='middle' font-family='sans-serif' font-size='14' fill='%23888'%3ENo Cover%3C/text%3E%3C/svg%3E";
-
-function getCoverUrl(book) {
-  if (!book.cover_path) {
-    return null;
-  }
-  return getApiCoverUrl(book.id);
-}
-
-function compareSeriesBooks(left, right) {
-  const leftIndex = left.series_index;
-  const rightIndex = right.series_index;
-
-  if (leftIndex != null && rightIndex != null && leftIndex !== rightIndex) {
-    return Number(leftIndex) - Number(rightIndex);
-  }
-  if (leftIndex != null && rightIndex == null) return -1;
-  if (leftIndex == null && rightIndex != null) return 1;
-
-  const byTitle = left.title.localeCompare(right.title);
-  if (byTitle !== 0) return byTitle;
-  return left.id - right.id;
-}
-
-function getEffectiveGenreTags(book) {
-  return book.effective_genre_tags || [];
-}
-
-function getSeriesGenreTags(books) {
-  if (!books.length) return [];
-  return books[0].effective_series_genre_tags || [];
-}
-
-function GenreTagList({ tags, className = "" }) {
-  if (!tags?.length) {
-    return null;
-  }
-
-  return (
-    <div className={`genre-tag-list ${className}`.trim()}>
-      {tags.map((tag) => (
-        <span key={tag} className="genre-tag">
-          {tag}
-        </span>
-      ))}
-    </div>
-  );
-}
-
-function BookCard({ book, onEdit }) {
-  const isPending = book.download_status === "pending";
-  const isError = book.download_status === "error";
-  const genreTags = getEffectiveGenreTags(book);
-
-  const handleCoverError = (e) => {
-    e.target.onerror = null;
-    e.target.src = NO_COVER_SVG;
-  };
-
-  const formattedDate = book.updated_at
-    ? new Date(book.updated_at).toLocaleDateString()
-    : null;
-
-  let coverContent;
-  if (isPending) {
-    coverContent = (
-      <div className="book-cover book-cover--placeholder">
-        <div className="spinner" />
-        <span>Downloading…</span>
-      </div>
-    );
-  } else if (isError) {
-    coverContent = (
-      <div className="book-cover book-cover--placeholder book-cover--error">
-        <span>⚠ Download failed</span>
-      </div>
-    );
-  } else if (book.cover_path) {
-    coverContent = (
-      <div className="book-cover-container">
-        <img
-          src={getCoverUrl(book)}
-          alt={`${book.title} cover`}
-          className="book-cover"
-          loading="lazy"
-          decoding="async"
-          onError={handleCoverError}
-        />
-        <div className="book-cover-title-overlay">{book.title}</div>
-      </div>
-    );
-  } else {
-    coverContent = (
-      <div className="book-cover book-cover--placeholder book-cover--no-cover">
-        <span className="book-no-cover-title">{book.title}</span>
-        {book.author && <span className="book-no-cover-author">{book.author}</span>}
-      </div>
-    );
-  }
-
-  const handleClick = (e) => {
-    if (isPending) return;
-    if (e.ctrlKey || e.metaKey || e.shiftKey || e.button === 1) return;
-    e.preventDefault();
-    onEdit(book);
-  };
-
-  return (
-    <a
-      href={isPending ? undefined : `/books/${book.id}`}
-      className={`book-card${isPending ? " book-card--pending" : ""}${isError ? " book-card--error" : ""}`}
-      onClick={handleClick}
-    >
-      {coverContent}
-      <div className="book-info">
-        <h3 title={isPending || isError ? book.source_url : book.title}>
-          {isPending
-            ? "Downloading…"
-            : isError
-              ? "Download failed"
-              : book.title}
-        </h3>
-        {!isPending && <p className="book-author">{book.author}</p>}
-        {!isPending && book.series && (
-          <p className="book-series">Series: {book.series}</p>
-        )}
-        {!isPending && <GenreTagList tags={genreTags} className="book-card-genres" />}
-        {!isPending && (
-          <p className="book-words">
-            {book.current_word_count != null
-              ? book.current_word_count.toLocaleString() + " words"
-              : "—"}
-          </p>
-        )}
-        {formattedDate && !isPending && (
-          <p className="book-updated">Updated: {formattedDate}</p>
-        )}
-        {book.source_type === "web" && !isPending && (
-          <span className="badge-web">Web</span>
-        )}
-        {isError && book.source_url && (
-          <p className="book-error-url" title={book.source_url}>
-            {book.source_url.length > 40
-              ? book.source_url.slice(0, 40) + "…"
-              : book.source_url}
-          </p>
-        )}
-      </div>
-    </a>
-  );
-}
 
 function SeriesSummaryRow({ series, books, onEdit, allSeries }) {
   const queryClient = useQueryClient();
@@ -178,7 +28,10 @@ function SeriesSummaryRow({ series, books, onEdit, allSeries }) {
     setOrderedBooks(books);
   }, [books]);
 
-  const seriesGenreTags = useMemo(() => getSeriesGenreTags(orderedBooks), [orderedBooks]);
+  const seriesGenreTags = useMemo(
+    () => getSeriesGenreTags(orderedBooks),
+    [orderedBooks],
+  );
 
   useEffect(() => {
     setGenreValue(seriesGenreTags.join(", "));
@@ -233,7 +86,9 @@ function SeriesSummaryRow({ series, books, onEdit, allSeries }) {
   });
 
   const summary = useMemo(() => {
-    const authors = [...new Set(orderedBooks.map((book) => book.author).filter(Boolean))];
+    const authors = [
+      ...new Set(orderedBooks.map((book) => book.author).filter(Boolean)),
+    ];
     const totalWords = orderedBooks.reduce(
       (sum, book) => sum + (book.current_word_count ?? 0),
       0,
@@ -241,7 +96,8 @@ function SeriesSummaryRow({ series, books, onEdit, allSeries }) {
     const coverBooks = orderedBooks
       .filter((book) => book.cover_path && !book.download_status)
       .slice(0, 4);
-    const coverBook = coverBooks[0] ??
+    const coverBook =
+      coverBooks[0] ??
       orderedBooks.find((book) => !book.download_status) ??
       orderedBooks[0];
 
@@ -261,7 +117,9 @@ function SeriesSummaryRow({ series, books, onEdit, allSeries }) {
     };
   }, [orderedBooks]);
 
-  const otherSeries = allSeries.filter((s) => s.toLowerCase() !== series.toLowerCase());
+  const otherSeries = allSeries.filter(
+    (s) => s.toLowerCase() !== series.toLowerCase(),
+  );
 
   const moveBook = (fromId, toId) => {
     if (fromId == null || toId == null || fromId === toId) return;
@@ -297,17 +155,19 @@ function SeriesSummaryRow({ series, books, onEdit, allSeries }) {
       <div className="series-header" onClick={toggleExpanded}>
         <div className="series-cover-stack">
           {summary.coverBooks.length > 1 ? (
-            summary.coverBooks.slice(0, 3).map((book, i) => (
-              <img
-                key={book.id}
-                src={getCoverUrl(book)}
-                alt={i === 0 ? `${series} cover` : ""}
-                className="series-cover-image series-cover-stacked"
-                style={{ "--stack-i": i }}
-                loading="lazy"
-                decoding="async"
-              />
-            ))
+            summary.coverBooks
+              .slice(0, 3)
+              .map((book, i) => (
+                <img
+                  key={book.id}
+                  src={getCoverUrl(book)}
+                  alt={i === 0 ? `${series} cover` : ""}
+                  className="series-cover-image series-cover-stacked"
+                  style={{ "--stack-i": i }}
+                  loading="lazy"
+                  decoding="async"
+                />
+              ))
           ) : summary.coverBook?.cover_path ? (
             <img
               src={getCoverUrl(summary.coverBook)}
@@ -318,7 +178,9 @@ function SeriesSummaryRow({ series, books, onEdit, allSeries }) {
             />
           ) : (
             <div className="series-cover-placeholder">
-              <span className="series-cover-placeholder-text">{series.charAt(0)}</span>
+              <span className="series-cover-placeholder-text">
+                {series.charAt(0)}
+              </span>
             </div>
           )}
         </div>
@@ -328,28 +190,43 @@ function SeriesSummaryRow({ series, books, onEdit, allSeries }) {
             {summary.hasWebNovel && <span className="badge-web">Web</span>}
           </div>
           <div className="series-meta">
-            <span className="series-meta-author">{summary.authors.join(", ") || "Unknown author"}</span>
+            <span className="series-meta-author">
+              {summary.authors.join(", ") || "Unknown author"}
+            </span>
           </div>
           <div className="series-stats">
             <span className="series-stat">
               <span className="series-stat-value">{books.length}</span>
-              <span className="series-stat-label">book{books.length !== 1 ? "s" : ""}</span>
+              <span className="series-stat-label">
+                book{books.length !== 1 ? "s" : ""}
+              </span>
             </span>
             {summary.totalWords > 0 && (
               <span className="series-stat">
-                <span className="series-stat-value">{formatWords(summary.totalWords)}</span>
+                <span className="series-stat-value">
+                  {formatWords(summary.totalWords)}
+                </span>
                 <span className="series-stat-label">words</span>
               </span>
             )}
             {summary.latestUpdate && (
               <span className="series-stat series-stat--date">
-                {summary.latestUpdate.toLocaleDateString(undefined, { month: "short", day: "numeric" })}
+                {summary.latestUpdate.toLocaleDateString(undefined, {
+                  month: "short",
+                  day: "numeric",
+                })}
               </span>
             )}
           </div>
-          <GenreTagList tags={seriesGenreTags} className="series-header-genres" />
+          <GenreTagList
+            tags={seriesGenreTags}
+            className="series-header-genres"
+          />
         </div>
-        <span className={`series-toggle${expanded ? " series-toggle--open" : ""}`} aria-hidden="true" />
+        <span
+          className={`series-toggle${expanded ? " series-toggle--open" : ""}`}
+          aria-hidden="true"
+        />
       </div>
       {expanded && (
         <div className="series-expanded">
@@ -407,11 +284,29 @@ function SeriesSummaryRow({ series, books, onEdit, allSeries }) {
                 placeholder="New series name"
                 autoFocus
               />
-              <button type="submit" className="btn" disabled={!renameValue.trim() || renameValue.trim() === series || renameMutation.isPending}>
+              <button
+                type="submit"
+                className="btn"
+                disabled={
+                  !renameValue.trim() ||
+                  renameValue.trim() === series ||
+                  renameMutation.isPending
+                }
+              >
                 {renameMutation.isPending ? "Saving..." : "Save"}
               </button>
-              <button type="button" className="btn btn-secondary" onClick={() => setEditing(null)}>Cancel</button>
-              {renameMutation.isError && <span className="error-text">{renameMutation.error.message}</span>}
+              <button
+                type="button"
+                className="btn btn-secondary"
+                onClick={() => setEditing(null)}
+              >
+                Cancel
+              </button>
+              {renameMutation.isError && (
+                <span className="error-text">
+                  {renameMutation.error.message}
+                </span>
+              )}
             </form>
           )}
           {editing === "merge" && (
@@ -438,11 +333,25 @@ function SeriesSummaryRow({ series, books, onEdit, allSeries }) {
                   <option key={s} value={s} />
                 ))}
               </datalist>
-              <button type="submit" className="btn" disabled={!mergeTarget.trim() || mergeMutation.isPending}>
+              <button
+                type="submit"
+                className="btn"
+                disabled={!mergeTarget.trim() || mergeMutation.isPending}
+              >
                 {mergeMutation.isPending ? "Merging..." : "Merge"}
               </button>
-              <button type="button" className="btn btn-secondary" onClick={() => setEditing(null)}>Cancel</button>
-              {mergeMutation.isError && <span className="error-text">{mergeMutation.error.message}</span>}
+              <button
+                type="button"
+                className="btn btn-secondary"
+                onClick={() => setEditing(null)}
+              >
+                Cancel
+              </button>
+              {mergeMutation.isError && (
+                <span className="error-text">
+                  {mergeMutation.error.message}
+                </span>
+              )}
             </form>
           )}
           {editing === "genres" && (
@@ -466,13 +375,25 @@ function SeriesSummaryRow({ series, books, onEdit, allSeries }) {
                 placeholder="Fantasy, Science Fiction, Progression Fantasy"
                 autoFocus
               />
-              <button type="submit" className="btn" disabled={genresMutation.isPending}>
+              <button
+                type="submit"
+                className="btn"
+                disabled={genresMutation.isPending}
+              >
                 {genresMutation.isPending ? "Saving..." : "Save"}
               </button>
-              <button type="button" className="btn btn-secondary" onClick={() => setEditing(null)}>
+              <button
+                type="button"
+                className="btn btn-secondary"
+                onClick={() => setEditing(null)}
+              >
                 Cancel
               </button>
-              {genresMutation.isError && <span className="error-text">{genresMutation.error.message}</span>}
+              {genresMutation.isError && (
+                <span className="error-text">
+                  {genresMutation.error.message}
+                </span>
+              )}
             </form>
           )}
           <div className="book-grid">
@@ -528,7 +449,11 @@ function LibraryViewTabs({ view, onChange, counts }) {
   ];
 
   return (
-    <div className="library-view-tabs" role="tablist" aria-label="Library views">
+    <div
+      className="library-view-tabs"
+      role="tablist"
+      aria-label="Library views"
+    >
       {tabs.map((tab) => (
         <button
           key={tab.id}
@@ -546,51 +471,6 @@ function LibraryViewTabs({ view, onChange, counts }) {
   );
 }
 
-function BookRow({ book, onEdit, actions = null, subtitle = null }) {
-  const genreTags = getEffectiveGenreTags(book);
-
-  const handleClick = (e) => {
-    if (e.ctrlKey || e.metaKey || e.shiftKey || e.button === 1) return;
-    e.preventDefault();
-    onEdit(book);
-  };
-
-  return (
-    <div className="book-row">
-      <a href={`/books/${book.id}`} className="book-row-main" onClick={handleClick}>
-        <div className="book-row-cover">
-          {book.cover_path ? (
-            <img
-              src={getCoverUrl(book)}
-              alt={`${book.title} cover`}
-              className="book-row-cover-image"
-              loading="lazy"
-              decoding="async"
-            />
-          ) : (
-            <div className="book-row-cover-placeholder">No cover</div>
-          )}
-        </div>
-        <div className="book-row-body">
-          <div className="book-row-title">{book.title}</div>
-          <div className="book-row-meta">
-            <span>{book.author || "Unknown author"}</span>
-            <span>
-              {book.current_word_count != null
-                ? `${book.current_word_count.toLocaleString()} words`
-                : "Word count unavailable"}
-            </span>
-            {book.source_type === "web" && <span className="badge-web">Web</span>}
-          </div>
-          {subtitle && <div className="book-row-subtitle">{subtitle}</div>}
-          <GenreTagList tags={genreTags} className="book-row-genres" />
-        </div>
-      </a>
-      {actions ? <div className="book-row-actions">{actions}</div> : null}
-    </div>
-  );
-}
-
 function StandaloneTagAction({ book, seriesOptions }) {
   const queryClient = useQueryClient();
   const [value, setValue] = useState(book.series || "");
@@ -600,7 +480,8 @@ function StandaloneTagAction({ book, seriesOptions }) {
   }, [book.id, book.series]);
 
   const saveMutation = useMutation({
-    mutationFn: (nextSeries) => updateBook(book.id, { series: nextSeries.trim() || null }),
+    mutationFn: (nextSeries) =>
+      updateBook(book.id, { series: nextSeries.trim() || null }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["book-catalog"] });
       queryClient.invalidateQueries({ queryKey: ["series"] });
@@ -634,7 +515,11 @@ function StandaloneTagAction({ book, seriesOptions }) {
           <option key={series} value={series} />
         ))}
       </datalist>
-      <button type="submit" className="btn" disabled={unchanged || saveMutation.isPending}>
+      <button
+        type="submit"
+        className="btn"
+        disabled={unchanged || saveMutation.isPending}
+      >
         {saveMutation.isPending ? "Saving..." : "Save"}
       </button>
     </form>
@@ -643,12 +528,20 @@ function StandaloneTagAction({ book, seriesOptions }) {
 
 const TAB_PAGE_SIZE = 30;
 
-function BookList({ books = [], onEdit, libraryView: libraryViewProp, onLibraryViewChange, sortBy = "title", sortOrder = "asc" }) {
+function BookList({
+  books = [],
+  onEdit,
+  libraryView: libraryViewProp,
+  onLibraryViewChange,
+  sortBy = "title",
+  sortOrder = "asc",
+}) {
   const sentinelRef = useRef(null);
   const [internalView, setInternalView] = useState("series");
   const libraryView = libraryViewProp ?? internalView;
   const [tabVisibleCount, setTabVisibleCount] = useState(TAB_PAGE_SIZE);
-  const [showStandaloneSeriesEdit, setShowStandaloneSeriesEdit] = useState(false);
+  const [showStandaloneSeriesEdit, setShowStandaloneSeriesEdit] =
+    useState(false);
 
   const { data: allSeries = [] } = useQuery({
     queryKey: ["series"],
@@ -662,62 +555,18 @@ function BookList({ books = [], onEdit, libraryView: libraryViewProp, onLibraryV
     setTabVisibleCount(TAB_PAGE_SIZE);
   };
 
-  const { seriesMap, sortedSeries, standaloneBooks, webBooks, counts } = useMemo(() => {
-    const sMap = {};
-    const standalone = [];
-    const web = [];
-
-    for (const book of books) {
-      if (book.source_type === "web" && !book.download_status) {
-        web.push(book);
-      }
-
-      if (book.series && !book.download_status) {
-        if (!sMap[book.series]) {
-          sMap[book.series] = [];
-        }
-        sMap[book.series].push(book);
-      } else if (book.source_type !== "web") {
-        standalone.push(book);
-      }
-    }
-
-    for (const seriesBooks of Object.values(sMap)) {
-      seriesBooks.sort(compareSeriesBooks);
-    }
-
-    const dir = sortOrder === "desc" ? -1 : 1;
-    const sorted = Object.keys(sMap).sort((a, b) => {
-      const booksA = sMap[a];
-      const booksB = sMap[b];
-      if (sortBy === "author") {
-        return dir * (booksA[0].author || "").localeCompare(booksB[0].author || "");
-      }
-      if (sortBy === "word_count") {
-        const wcA = booksA.reduce((sum, bk) => sum + (bk.current_word_count || 0), 0);
-        const wcB = booksB.reduce((sum, bk) => sum + (bk.current_word_count || 0), 0);
-        return dir * (wcA - wcB);
-      }
-      if (sortBy === "updated_at") {
-        const latestA = Math.max(...booksA.map((bk) => new Date(bk.updated_at || 0).getTime()));
-        const latestB = Math.max(...booksB.map((bk) => new Date(bk.updated_at || 0).getTime()));
-        return dir * (latestA - latestB);
-      }
-      return dir * a.localeCompare(b);
-    });
-    return {
-      seriesMap: sMap,
-      sortedSeries: sorted,
-      standaloneBooks: standalone,
-      webBooks: web,
-      counts: { series: sorted.length, standalone: standalone.length, web: web.length },
-    };
-  }, [books, sortBy, sortOrder]);
+  const { seriesMap, sortedSeries, standaloneBooks, webBooks, counts } =
+    useMemo(
+      () => buildCatalogGroups(books, sortBy, sortOrder),
+      [books, sortBy, sortOrder],
+    );
 
   const tabItems =
-    libraryView === "series" ? sortedSeries :
-    libraryView === "standalone" ? standaloneBooks :
-    webBooks;
+    libraryView === "series"
+      ? sortedSeries
+      : libraryView === "standalone"
+        ? standaloneBooks
+        : webBooks;
 
   useEffect(() => {
     const el = sentinelRef.current;
@@ -740,24 +589,29 @@ function BookList({ books = [], onEdit, libraryView: libraryViewProp, onLibraryV
 
   return (
     <div className="book-list">
-      <LibraryViewTabs view={libraryView} onChange={handleTabChange} counts={counts} />
-      {libraryView === "series" && (
-        sortedSeries.length ? (
-          sortedSeries.slice(0, tabVisibleCount).map((series) => (
-            <SeriesSummaryRow
-              key={series}
-              series={series}
-              books={seriesMap[series]}
-              onEdit={onEdit}
-              allSeries={allSeries}
-            />
-          ))
+      <LibraryViewTabs
+        view={libraryView}
+        onChange={handleTabChange}
+        counts={counts}
+      />
+      {libraryView === "series" &&
+        (sortedSeries.length ? (
+          sortedSeries
+            .slice(0, tabVisibleCount)
+            .map((series) => (
+              <SeriesSummaryRow
+                key={series}
+                series={series}
+                books={seriesMap[series]}
+                onEdit={onEdit}
+                allSeries={allSeries}
+              />
+            ))
         ) : (
           <p>No series found.</p>
-        )
-      )}
-      {libraryView === "standalone" && (
-        standaloneBooks.length ? (
+        ))}
+      {libraryView === "standalone" &&
+        (standaloneBooks.length ? (
           <>
             <div className="standalone-header">
               <button
@@ -774,12 +628,18 @@ function BookList({ books = [], onEdit, libraryView: libraryViewProp, onLibraryV
                   key={book.id}
                   book={book}
                   onEdit={onEdit}
-                  subtitle={book.series ? `Series: ${book.series}` : "No series assigned"}
+                  subtitle={
+                    book.series
+                      ? `Series: ${book.series}`
+                      : "No series assigned"
+                  }
                   actions={
                     showStandaloneSeriesEdit && !book.download_status ? (
                       <StandaloneTagAction
                         book={book}
-                        seriesOptions={allSeries.filter((series) => series !== book.series)}
+                        seriesOptions={allSeries.filter(
+                          (series) => series !== book.series,
+                        )}
                       />
                     ) : null
                   }
@@ -789,10 +649,9 @@ function BookList({ books = [], onEdit, libraryView: libraryViewProp, onLibraryV
           </>
         ) : (
           <p>No standalone books found.</p>
-        )
-      )}
-      {libraryView === "web" && (
-        webBooks.length ? (
+        ))}
+      {libraryView === "web" &&
+        (webBooks.length ? (
           <div className="book-rows book-rows--web">
             {webBooks.slice(0, tabVisibleCount).map((book) => (
               <BookRow
@@ -805,8 +664,7 @@ function BookList({ books = [], onEdit, libraryView: libraryViewProp, onLibraryV
           </div>
         ) : (
           <p>No web novels found.</p>
-        )
-      )}
+        ))}
       <div ref={sentinelRef} style={{ height: 1 }} />
     </div>
   );

--- a/frontend/src/components/BookSettings.jsx
+++ b/frontend/src/components/BookSettings.jsx
@@ -1,26 +1,34 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 
 import {
   deleteBook,
   detachBookSource,
-  getApiCoverUrl,
   getBook,
   getBookChapters,
   getBookCleanedChapters,
   getBookUpdateHistory,
-  getMatchedConfigs,
-  previewCleaning,
   processBook,
-  queueMetadataSync,
   refreshBook,
+  updateBook,
+} from "../api/books";
+import { getMatchedConfigs, previewCleaning } from "../api/cleaning";
+import {
+  getApiCoverUrl,
   retryBookCover,
   setBookCoverUrl,
-  updateBook,
   uploadBookCover,
-} from "../api/books";
+} from "../api/covers";
+import { queueMetadataSync } from "../api/metadata";
 import { getSeries } from "../api/series";
 import BookSettingsChapters from "./BookSettingsChapters";
+import {
+  ChapterUpdateHistory,
+  SelectorPills,
+  SourceTagList,
+  SyncedGenreTagList,
+} from "./book-settings/BookSettingsSections";
+import { useBookSettingsForm } from "./book-settings/useBookSettingsForm";
 
 const fetchChapters = async ({ queryKey }) => {
   const [_key, bookId] = queryKey;
@@ -41,258 +49,6 @@ const fetchUpdateHistory = async ({ queryKey }) => {
   const [_key, bookId] = queryKey;
   return getBookUpdateHistory(bookId);
 };
-
-const COMMON_REMOTE_ID_KEYS = [
-  "isbn_10",
-  "isbn_13",
-  "google_books_volume_id",
-  "open_library_work_key",
-  "open_library_edition_key",
-  "open_library_author_key",
-];
-
-function splitRemoteIds(remoteIds) {
-  const source = remoteIds && typeof remoteIds === "object" ? remoteIds : {};
-  const common = {};
-  COMMON_REMOTE_ID_KEYS.forEach((key) => {
-    common[key] = source[key] || "";
-  });
-
-  const extras = Object.fromEntries(
-    Object.entries(source).filter(
-      ([key]) => !COMMON_REMOTE_ID_KEYS.includes(key),
-    ),
-  );
-
-  return {
-    common,
-    extrasJson: Object.keys(extras).length
-      ? JSON.stringify(extras, null, 2)
-      : "",
-  };
-}
-
-function SelectorPills({ selectors, onChange }) {
-  const [inputValue, setInputValue] = useState("");
-
-  const addSelector = () => {
-    const trimmed = inputValue.trim();
-    if (trimmed && !selectors.includes(trimmed)) {
-      onChange([...selectors, trimmed]);
-    }
-    setInputValue("");
-  };
-
-  const removeSelector = (sel) => {
-    onChange(selectors.filter((s) => s !== sel));
-  };
-
-  return (
-    <div className="selector-pills">
-      <div className="pills">
-        {selectors.map((sel) => (
-          <span key={sel} className="pill">
-            {sel}
-            <button className="pill-remove" onClick={() => removeSelector(sel)}>
-              ×
-            </button>
-          </span>
-        ))}
-      </div>
-      <div className="pill-input">
-        <input
-          type="text"
-          placeholder="Add CSS selector, e.g. div.note"
-          value={inputValue}
-          onChange={(e) => setInputValue(e.target.value)}
-          onKeyDown={(e) => e.key === "Enter" && addSelector()}
-        />
-        <button onClick={addSelector}>Add</button>
-      </div>
-    </div>
-  );
-}
-
-function SourceTagList({ tags }) {
-  if (!tags?.length) return null;
-
-  return (
-    <div className="source-tag-list" aria-label="Source tags">
-      {tags.map((tag) => (
-        <span key={tag} className="source-tag">
-          {tag}
-        </span>
-      ))}
-    </div>
-  );
-}
-
-function SyncedGenreTagList({ tags }) {
-  if (!tags?.length) {
-    return (
-      <span className="settings-empty-value">No synced genre tags yet</span>
-    );
-  }
-
-  return (
-    <div className="genre-tag-list" aria-label="Synced genre tags">
-      {tags.map((tag) => (
-        <span key={tag} className="genre-tag">
-          {tag}
-        </span>
-      ))}
-    </div>
-  );
-}
-
-const EMPTY_UPDATE_HISTORY = {
-  history: [],
-  summary: {
-    total_update_events: 0,
-    total_chapters_added: 0,
-    total_words_added: 0,
-    average_words_per_week: null,
-    average_words_per_month: null,
-    average_days_between_updates: null,
-    predicted_next_update_at: null,
-    last_update_at: null,
-  },
-};
-
-function normalizeUpdateHistory(data) {
-  if (!data || !Array.isArray(data.history) || !data.summary) {
-    return EMPTY_UPDATE_HISTORY;
-  }
-  return data;
-}
-
-function formatNumber(value, options = {}) {
-  if (value == null || Number.isNaN(Number(value))) return "Not enough data";
-  return new Intl.NumberFormat(undefined, options).format(value);
-}
-
-function formatCompactNumber(value) {
-  if (value == null || Number.isNaN(Number(value))) return "0";
-  return new Intl.NumberFormat(undefined, {
-    notation: "compact",
-    maximumFractionDigits: 1,
-  }).format(value);
-}
-
-function formatDate(value) {
-  if (!value) return "Not enough data";
-  return new Date(value).toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
-}
-
-function formatHistoryEntryLabel(entry) {
-  if (entry.is_initial_sync) return "Initial sync";
-  if (entry.is_catch_up_sync) return "Catch-up sync";
-  return `+${entry.chapters_added} ch`;
-}
-
-function ChapterUpdateHistory({ updateHistory, isLoading, isError, error }) {
-  const { history, summary } = normalizeUpdateHistory(updateHistory);
-  const chartEntries = history.filter((entry) => entry.included_in_stats);
-  const maxWords = Math.max(
-    ...chartEntries.map((entry) => entry.words_added),
-    1,
-  );
-
-  return (
-    <section className="settings-section chapter-history-section">
-      <h3>Update History</h3>
-      {isLoading && <p className="hint">Loading update history...</p>}
-      {isError && (
-        <p className="error">
-          Update history failed: {error?.message || "Unable to load history"}
-        </p>
-      )}
-      {!isLoading && !isError && history.length === 0 && (
-        <p className="hint">
-          No tracked chapter updates yet. New chapter batches will appear here
-          after a refresh finds them.
-        </p>
-      )}
-      {!isLoading && !isError && history.length > 0 && (
-        <>
-          <div className="chapter-history-stats">
-            <div className="chapter-history-stat">
-              <span className="hint">Words / Week</span>
-              <strong>
-                {formatNumber(summary.average_words_per_week, {
-                  maximumFractionDigits: 0,
-                })}
-              </strong>
-            </div>
-            <div className="chapter-history-stat">
-              <span className="hint">Words / Month</span>
-              <strong>
-                {formatNumber(summary.average_words_per_month, {
-                  maximumFractionDigits: 0,
-                })}
-              </strong>
-            </div>
-            <div className="chapter-history-stat">
-              <span className="hint">Next Update</span>
-              <strong>{formatDate(summary.predicted_next_update_at)}</strong>
-            </div>
-          </div>
-
-          <div
-            className="chapter-history-chart"
-            aria-label="Words added by update date"
-          >
-            {chartEntries.length === 0 ? (
-              <p className="hint chapter-history-chart-empty">
-                No post-import chapter updates yet.
-              </p>
-            ) : (
-              chartEntries.slice(-12).map((entry) => {
-                const height = Math.max(
-                  (entry.words_added / maxWords) * 100,
-                  8,
-                );
-                return (
-                  <div className="chapter-history-bar-wrap" key={entry.id}>
-                    <div className="chapter-history-bar-stage">
-                      <div
-                        className="chapter-history-bar"
-                        style={{ height: `${height}%` }}
-                        title={`${formatDate(entry.timestamp)}: ${formatNumber(
-                          entry.words_added,
-                        )} words`}
-                      />
-                    </div>
-                    <span>{formatCompactNumber(entry.words_added)}</span>
-                  </div>
-                );
-              })
-            )}
-          </div>
-
-          <ul className="chapter-history-list">
-            {history
-              .slice()
-              .reverse()
-              .map((entry) => (
-                <li key={entry.id}>
-                  <span>{formatDate(entry.timestamp)}</span>
-                  <strong>
-                    {formatHistoryEntryLabel(entry)} ·{" "}
-                    {formatNumber(entry.words_added)} words
-                  </strong>
-                </li>
-              ))}
-          </ul>
-        </>
-      )}
-    </section>
-  );
-}
 
 function BookSettings({ book: initialBook, onBack }) {
   const queryClient = useQueryClient();
@@ -333,93 +89,51 @@ function BookSettings({ book: initialBook, onBack }) {
   // copy at the same deterministic URL.
   const [coverVersion, setCoverVersion] = useState(0);
 
-  const [title, setTitle] = useState(initialBook.title || "");
-  const [author, setAuthor] = useState(initialBook.author || "");
-  const [series, setSeries] = useState(initialBook.series || "");
-  const [seriesIndex, setSeriesIndex] = useState(
-    initialBook.series_index != null ? String(initialBook.series_index) : "",
-  );
-  const [notes, setNotes] = useState(initialBook.notes || "");
-  const [isbn10, setIsbn10] = useState(
-    initialBook.metadata_remote_ids?.isbn_10 || "",
-  );
-  const [isbn13, setIsbn13] = useState(
-    initialBook.metadata_remote_ids?.isbn_13 || "",
-  );
-  const [googleBooksVolumeId, setGoogleBooksVolumeId] = useState(
-    initialBook.metadata_remote_ids?.google_books_volume_id || "",
-  );
-  const [openLibraryWorkKey, setOpenLibraryWorkKey] = useState(
-    initialBook.metadata_remote_ids?.open_library_work_key || "",
-  );
-  const [openLibraryEditionKey, setOpenLibraryEditionKey] = useState(
-    initialBook.metadata_remote_ids?.open_library_edition_key || "",
-  );
-  const [openLibraryAuthorKey, setOpenLibraryAuthorKey] = useState(
-    initialBook.metadata_remote_ids?.open_library_author_key || "",
-  );
-  const [otherRemoteIdsJson, setOtherRemoteIdsJson] = useState(
-    splitRemoteIds(initialBook.metadata_remote_ids).extrasJson,
-  );
-  const [identifierError, setIdentifierError] = useState("");
-  const [userGenreTags, setUserGenreTags] = useState(
-    (initialBook.user_genre_tags || []).join(", "),
-  );
-  const [removedChapters, setRemovedChapters] = useState(
-    initialBook.removed_chapters || [],
-  );
-  const [contentSelectors, setContentSelectors] = useState(
-    initialBook.content_selectors || [],
-  );
-  const [previewResult, setPreviewResult] = useState(null);
+  const {
+    title,
+    setTitle,
+    author,
+    setAuthor,
+    series,
+    setSeries,
+    seriesIndex,
+    setSeriesIndex,
+    notes,
+    setNotes,
+    isbn10,
+    setIsbn10,
+    isbn13,
+    setIsbn13,
+    googleBooksVolumeId,
+    setGoogleBooksVolumeId,
+    openLibraryWorkKey,
+    setOpenLibraryWorkKey,
+    openLibraryEditionKey,
+    setOpenLibraryEditionKey,
+    openLibraryAuthorKey,
+    setOpenLibraryAuthorKey,
+    otherRemoteIdsJson,
+    setOtherRemoteIdsJson,
+    identifierError,
+    userGenreTags,
+    setUserGenreTags,
+    removedChapters,
+    setRemovedChapters,
+    contentSelectors,
+    setContentSelectors,
+    previewResult,
+    setPreviewResult,
+    chapterSearch,
+    setChapterSearch,
+    chaptersExpanded,
+    setChaptersExpanded,
+    chapterPreviewMode,
+    setChapterPreviewMode,
+    identifiersExpanded,
+    setIdentifiersExpanded,
+    getUpdatedFields,
+  } = useBookSettingsForm(initialBook);
   const [previewedChapter, setPreviewedChapter] = useState(null);
-  const [chapterSearch, setChapterSearch] = useState("");
-  const [chaptersExpanded, setChaptersExpanded] = useState(false);
-  const [chapterPreviewMode, setChapterPreviewMode] = useState("original");
-  const [identifiersExpanded, setIdentifiersExpanded] = useState(false);
-
-  // Reset form state when the parent navigates to a different book. We key this
-  // on the initial prop (not the polled `book`) so background refetches — e.g.
-  // while a refresh is in-flight — don't wipe out in-progress edits.
-  useEffect(() => {
-    setTitle(initialBook.title || "");
-    setAuthor(initialBook.author || "");
-    setSeries(initialBook.series || "");
-    setSeriesIndex(
-      initialBook.series_index != null ? String(initialBook.series_index) : "",
-    );
-    setNotes(initialBook.notes || "");
-    setIsbn10(initialBook.metadata_remote_ids?.isbn_10 || "");
-    setIsbn13(initialBook.metadata_remote_ids?.isbn_13 || "");
-    setGoogleBooksVolumeId(
-      initialBook.metadata_remote_ids?.google_books_volume_id || "",
-    );
-    setOpenLibraryWorkKey(
-      initialBook.metadata_remote_ids?.open_library_work_key || "",
-    );
-    setOpenLibraryEditionKey(
-      initialBook.metadata_remote_ids?.open_library_edition_key || "",
-    );
-    setOpenLibraryAuthorKey(
-      initialBook.metadata_remote_ids?.open_library_author_key || "",
-    );
-    setOtherRemoteIdsJson(
-      splitRemoteIds(initialBook.metadata_remote_ids).extrasJson,
-    );
-    setIdentifierError("");
-    setUserGenreTags((initialBook.user_genre_tags || []).join(", "));
-    setRemovedChapters(initialBook.removed_chapters || []);
-    setContentSelectors(initialBook.content_selectors || []);
-    setPreviewResult(null);
-    setChapterSearch("");
-    setChaptersExpanded(false);
-    setChapterPreviewMode("original");
-    setIdentifiersExpanded(false);
-  }, [initialBook]);
-
-  useEffect(() => {
-    setPreviewResult(null);
-  }, [contentSelectors, removedChapters]);
 
   const { data: chapters = [], isLoading: chaptersLoading } = useQuery({
     queryKey: ["chapters", book.id],
@@ -554,60 +268,6 @@ function BookSettings({ book: initialBook, onBack }) {
   const metadataSyncMutation = useMutation({
     mutationFn: () => queueMetadataSync([book.id], "manual"),
   });
-
-  const getUpdatedFields = () => {
-    let extraRemoteIds = {};
-    if (otherRemoteIdsJson.trim()) {
-      try {
-        const parsed = JSON.parse(otherRemoteIdsJson);
-        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-          setIdentifierError("Other identifiers must be a JSON object.");
-          return null;
-        }
-        extraRemoteIds = parsed;
-      } catch {
-        setIdentifierError("Other identifiers must be valid JSON.");
-        return null;
-      }
-    }
-
-    setIdentifierError("");
-
-    const metadataRemoteIds = {
-      ...extraRemoteIds,
-      ...(isbn10.trim() ? { isbn_10: isbn10.trim() } : {}),
-      ...(isbn13.trim() ? { isbn_13: isbn13.trim() } : {}),
-      ...(googleBooksVolumeId.trim()
-        ? { google_books_volume_id: googleBooksVolumeId.trim() }
-        : {}),
-      ...(openLibraryWorkKey.trim()
-        ? { open_library_work_key: openLibraryWorkKey.trim() }
-        : {}),
-      ...(openLibraryEditionKey.trim()
-        ? { open_library_edition_key: openLibraryEditionKey.trim() }
-        : {}),
-      ...(openLibraryAuthorKey.trim()
-        ? { open_library_author_key: openLibraryAuthorKey.trim() }
-        : {}),
-    };
-
-    return {
-      title,
-      author,
-      series: series.trim() || null,
-      series_index: seriesIndex.trim() ? Number.parseFloat(seriesIndex) : null,
-      user_genre_tags: userGenreTags
-        .split(",")
-        .map((tag) => tag.trim())
-        .filter(Boolean),
-      metadata_remote_ids: Object.keys(metadataRemoteIds).length
-        ? metadataRemoteIds
-        : null,
-      removed_chapters: removedChapters,
-      content_selectors: contentSelectors,
-      notes: notes || null,
-    };
-  };
 
   const handleSave = () => {
     const payload = getUpdatedFields();

--- a/frontend/src/components/Utilities.jsx
+++ b/frontend/src/components/Utilities.jsx
@@ -7,7 +7,7 @@ import {
   getMetadataInbox,
   queueMetadataSync,
   rejectMetadataMatch,
-} from "../api/books";
+} from "../api/metadata";
 import ReaderKeys from "./ReaderKeys.jsx";
 
 function formatBytes(bytes) {

--- a/frontend/src/components/book-list/BookCards.jsx
+++ b/frontend/src/components/book-list/BookCards.jsx
@@ -1,0 +1,182 @@
+import { getCoverUrl } from "./catalogDisplay";
+
+const NO_COVER_SVG =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='250'%3E%3Crect width='200' height='250' fill='%23e0e0e0'/%3E%3Ctext x='100' y='125' dominant-baseline='middle' text-anchor='middle' font-family='sans-serif' font-size='14' fill='%23888'%3ENo Cover%3C/text%3E%3C/svg%3E";
+
+function getEffectiveGenreTags(book) {
+  return book.effective_genre_tags || [];
+}
+
+export function GenreTagList({ tags, className = "" }) {
+  if (!tags?.length) {
+    return null;
+  }
+
+  return (
+    <div className={`genre-tag-list ${className}`.trim()}>
+      {tags.map((tag) => (
+        <span key={tag} className="genre-tag">
+          {tag}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export function BookCard({ book, onEdit }) {
+  const isPending = book.download_status === "pending";
+  const isError = book.download_status === "error";
+  const genreTags = getEffectiveGenreTags(book);
+
+  const handleCoverError = (e) => {
+    e.target.onerror = null;
+    e.target.src = NO_COVER_SVG;
+  };
+
+  const formattedDate = book.updated_at
+    ? new Date(book.updated_at).toLocaleDateString()
+    : null;
+
+  let coverContent;
+  if (isPending) {
+    coverContent = (
+      <div className="book-cover book-cover--placeholder">
+        <div className="spinner" />
+        <span>Downloading…</span>
+      </div>
+    );
+  } else if (isError) {
+    coverContent = (
+      <div className="book-cover book-cover--placeholder book-cover--error">
+        <span>⚠ Download failed</span>
+      </div>
+    );
+  } else if (book.cover_path) {
+    coverContent = (
+      <div className="book-cover-container">
+        <img
+          src={getCoverUrl(book)}
+          alt={`${book.title} cover`}
+          className="book-cover"
+          loading="lazy"
+          decoding="async"
+          onError={handleCoverError}
+        />
+        <div className="book-cover-title-overlay">{book.title}</div>
+      </div>
+    );
+  } else {
+    coverContent = (
+      <div className="book-cover book-cover--placeholder book-cover--no-cover">
+        <span className="book-no-cover-title">{book.title}</span>
+        {book.author && (
+          <span className="book-no-cover-author">{book.author}</span>
+        )}
+      </div>
+    );
+  }
+
+  const handleClick = (e) => {
+    if (isPending) return;
+    if (e.ctrlKey || e.metaKey || e.shiftKey || e.button === 1) return;
+    e.preventDefault();
+    onEdit(book);
+  };
+
+  return (
+    <a
+      href={isPending ? undefined : `/books/${book.id}`}
+      className={`book-card${isPending ? " book-card--pending" : ""}${isError ? " book-card--error" : ""}`}
+      onClick={handleClick}
+    >
+      {coverContent}
+      <div className="book-info">
+        <h3 title={isPending || isError ? book.source_url : book.title}>
+          {isPending
+            ? "Downloading…"
+            : isError
+              ? "Download failed"
+              : book.title}
+        </h3>
+        {!isPending && <p className="book-author">{book.author}</p>}
+        {!isPending && book.series && (
+          <p className="book-series">Series: {book.series}</p>
+        )}
+        {!isPending && (
+          <GenreTagList tags={genreTags} className="book-card-genres" />
+        )}
+        {!isPending && (
+          <p className="book-words">
+            {book.current_word_count != null
+              ? book.current_word_count.toLocaleString() + " words"
+              : "—"}
+          </p>
+        )}
+        {formattedDate && !isPending && (
+          <p className="book-updated">Updated: {formattedDate}</p>
+        )}
+        {book.source_type === "web" && !isPending && (
+          <span className="badge-web">Web</span>
+        )}
+        {isError && book.source_url && (
+          <p className="book-error-url" title={book.source_url}>
+            {book.source_url.length > 40
+              ? book.source_url.slice(0, 40) + "…"
+              : book.source_url}
+          </p>
+        )}
+      </div>
+    </a>
+  );
+}
+
+export function BookRow({ book, onEdit, actions = null, subtitle = null }) {
+  const genreTags = getEffectiveGenreTags(book);
+
+  const handleClick = (e) => {
+    if (e.ctrlKey || e.metaKey || e.shiftKey || e.button === 1) return;
+    e.preventDefault();
+    onEdit(book);
+  };
+
+  return (
+    <div className="book-row">
+      <a
+        href={`/books/${book.id}`}
+        className="book-row-main"
+        onClick={handleClick}
+      >
+        <div className="book-row-cover">
+          {book.cover_path ? (
+            <img
+              src={getCoverUrl(book)}
+              alt={`${book.title} cover`}
+              className="book-row-cover-image"
+              loading="lazy"
+              decoding="async"
+            />
+          ) : (
+            <div className="book-row-cover-placeholder">No cover</div>
+          )}
+        </div>
+        <div className="book-row-body">
+          <div className="book-row-title">{book.title}</div>
+          <div className="book-row-meta">
+            <span>{book.author || "Unknown author"}</span>
+            <span>
+              {book.current_word_count != null
+                ? `${book.current_word_count.toLocaleString()} words`
+                : "Word count unavailable"}
+            </span>
+            {book.source_type === "web" && (
+              <span className="badge-web">Web</span>
+            )}
+          </div>
+          {subtitle && <div className="book-row-subtitle">{subtitle}</div>}
+          <GenreTagList tags={genreTags} className="book-row-genres" />
+        </div>
+      </a>
+      {actions ? <div className="book-row-actions">{actions}</div> : null}
+    </div>
+  );
+}

--- a/frontend/src/components/book-list/catalogDisplay.js
+++ b/frontend/src/components/book-list/catalogDisplay.js
@@ -1,0 +1,13 @@
+import { getApiCoverUrl } from "../../api/covers";
+
+export function getCoverUrl(book) {
+  if (!book.cover_path) {
+    return null;
+  }
+  return getApiCoverUrl(book.id);
+}
+
+export function getSeriesGenreTags(books) {
+  if (!books.length) return [];
+  return books[0].effective_series_genre_tags || [];
+}

--- a/frontend/src/components/book-settings/BookSettingsSections.jsx
+++ b/frontend/src/components/book-settings/BookSettingsSections.jsx
@@ -1,0 +1,228 @@
+import { useState } from "react";
+
+export function SelectorPills({ selectors, onChange }) {
+  const [inputValue, setInputValue] = useState("");
+
+  const addSelector = () => {
+    const trimmed = inputValue.trim();
+    if (trimmed && !selectors.includes(trimmed)) {
+      onChange([...selectors, trimmed]);
+    }
+    setInputValue("");
+  };
+
+  const removeSelector = (sel) => {
+    onChange(selectors.filter((s) => s !== sel));
+  };
+
+  return (
+    <div className="selector-pills">
+      <div className="pills">
+        {selectors.map((sel) => (
+          <span key={sel} className="pill">
+            {sel}
+            <button className="pill-remove" onClick={() => removeSelector(sel)}>
+              ×
+            </button>
+          </span>
+        ))}
+      </div>
+      <div className="pill-input">
+        <input
+          type="text"
+          placeholder="Add CSS selector, e.g. div.note"
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && addSelector()}
+        />
+        <button onClick={addSelector}>Add</button>
+      </div>
+    </div>
+  );
+}
+
+export function SourceTagList({ tags }) {
+  if (!tags?.length) return null;
+
+  return (
+    <div className="source-tag-list" aria-label="Source tags">
+      {tags.map((tag) => (
+        <span key={tag} className="source-tag">
+          {tag}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export function SyncedGenreTagList({ tags }) {
+  if (!tags?.length) {
+    return (
+      <span className="settings-empty-value">No synced genre tags yet</span>
+    );
+  }
+
+  return (
+    <div className="genre-tag-list" aria-label="Synced genre tags">
+      {tags.map((tag) => (
+        <span key={tag} className="genre-tag">
+          {tag}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+const EMPTY_UPDATE_HISTORY = {
+  history: [],
+  summary: {
+    total_update_events: 0,
+    total_chapters_added: 0,
+    total_words_added: 0,
+    average_words_per_week: null,
+    average_words_per_month: null,
+    average_days_between_updates: null,
+    predicted_next_update_at: null,
+    last_update_at: null,
+  },
+};
+
+function normalizeUpdateHistory(data) {
+  if (!data || !Array.isArray(data.history) || !data.summary) {
+    return EMPTY_UPDATE_HISTORY;
+  }
+  return data;
+}
+
+function formatNumber(value, options = {}) {
+  if (value == null || Number.isNaN(Number(value))) return "Not enough data";
+  return new Intl.NumberFormat(undefined, options).format(value);
+}
+
+function formatCompactNumber(value) {
+  if (value == null || Number.isNaN(Number(value))) return "0";
+  return new Intl.NumberFormat(undefined, {
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(value);
+}
+
+function formatDate(value) {
+  if (!value) return "Not enough data";
+  return new Date(value).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function formatHistoryEntryLabel(entry) {
+  if (entry.is_initial_sync) return "Initial sync";
+  if (entry.is_catch_up_sync) return "Catch-up sync";
+  return `+${entry.chapters_added} ch`;
+}
+
+export function ChapterUpdateHistory({
+  updateHistory,
+  isLoading,
+  isError,
+  error,
+}) {
+  const { history, summary } = normalizeUpdateHistory(updateHistory);
+  const chartEntries = history.filter((entry) => entry.included_in_stats);
+  const maxWords = Math.max(
+    ...chartEntries.map((entry) => entry.words_added),
+    1,
+  );
+
+  return (
+    <section className="settings-section chapter-history-section">
+      <h3>Update History</h3>
+      {isLoading && <p className="hint">Loading update history...</p>}
+      {isError && (
+        <p className="error">
+          Update history failed: {error?.message || "Unable to load history"}
+        </p>
+      )}
+      {!isLoading && !isError && history.length === 0 && (
+        <p className="hint">
+          No tracked chapter updates yet. New chapter batches will appear here
+          after a refresh finds them.
+        </p>
+      )}
+      {!isLoading && !isError && history.length > 0 && (
+        <>
+          <div className="chapter-history-stats">
+            <div className="chapter-history-stat">
+              <span className="hint">Words / Week</span>
+              <strong>
+                {formatNumber(summary.average_words_per_week, {
+                  maximumFractionDigits: 0,
+                })}
+              </strong>
+            </div>
+            <div className="chapter-history-stat">
+              <span className="hint">Words / Month</span>
+              <strong>
+                {formatNumber(summary.average_words_per_month, {
+                  maximumFractionDigits: 0,
+                })}
+              </strong>
+            </div>
+            <div className="chapter-history-stat">
+              <span className="hint">Next Update</span>
+              <strong>{formatDate(summary.predicted_next_update_at)}</strong>
+            </div>
+          </div>
+
+          <div
+            className="chapter-history-chart"
+            aria-label="Words added by update date"
+          >
+            {chartEntries.length === 0 ? (
+              <p className="hint chapter-history-chart-empty">
+                No post-import chapter updates yet.
+              </p>
+            ) : (
+              chartEntries.slice(-12).map((entry) => {
+                const height = Math.max(
+                  (entry.words_added / maxWords) * 100,
+                  8,
+                );
+                return (
+                  <div className="chapter-history-bar-wrap" key={entry.id}>
+                    <div className="chapter-history-bar-stage">
+                      <div
+                        className="chapter-history-bar"
+                        style={{ height: `${height}%` }}
+                        title={`${formatDate(entry.timestamp)}: ${formatNumber(
+                          entry.words_added,
+                        )} words`}
+                      />
+                    </div>
+                    <span>{formatCompactNumber(entry.words_added)}</span>
+                  </div>
+                );
+              })
+            )}
+          </div>
+
+          <ul className="chapter-history-list">
+            {history
+              .slice()
+              .reverse()
+              .map((entry) => (
+                <li key={entry.id}>
+                  <span>{formatDate(entry.timestamp)}</span>
+                  <strong>
+                    {formatHistoryEntryLabel(entry)} ·{" "}
+                    {formatNumber(entry.words_added)} words
+                  </strong>
+                </li>
+              ))}
+          </ul>
+        </>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/book-settings/remoteIds.js
+++ b/frontend/src/components/book-settings/remoteIds.js
@@ -1,0 +1,29 @@
+const COMMON_REMOTE_ID_KEYS = [
+  "isbn_10",
+  "isbn_13",
+  "google_books_volume_id",
+  "open_library_work_key",
+  "open_library_edition_key",
+  "open_library_author_key",
+];
+
+export function splitRemoteIds(remoteIds) {
+  const source = remoteIds && typeof remoteIds === "object" ? remoteIds : {};
+  const common = {};
+  COMMON_REMOTE_ID_KEYS.forEach((key) => {
+    common[key] = source[key] || "";
+  });
+
+  const extras = Object.fromEntries(
+    Object.entries(source).filter(
+      ([key]) => !COMMON_REMOTE_ID_KEYS.includes(key),
+    ),
+  );
+
+  return {
+    common,
+    extrasJson: Object.keys(extras).length
+      ? JSON.stringify(extras, null, 2)
+      : "",
+  };
+}

--- a/frontend/src/components/book-settings/useBookSettingsForm.js
+++ b/frontend/src/components/book-settings/useBookSettingsForm.js
@@ -1,0 +1,188 @@
+import { useEffect, useState } from "react";
+
+import { splitRemoteIds } from "./remoteIds";
+
+export function useBookSettingsForm(initialBook) {
+  const [title, setTitle] = useState(initialBook.title || "");
+  const [author, setAuthor] = useState(initialBook.author || "");
+  const [series, setSeries] = useState(initialBook.series || "");
+  const [seriesIndex, setSeriesIndex] = useState(
+    initialBook.series_index != null ? String(initialBook.series_index) : "",
+  );
+  const [notes, setNotes] = useState(initialBook.notes || "");
+  const [isbn10, setIsbn10] = useState(
+    initialBook.metadata_remote_ids?.isbn_10 || "",
+  );
+  const [isbn13, setIsbn13] = useState(
+    initialBook.metadata_remote_ids?.isbn_13 || "",
+  );
+  const [googleBooksVolumeId, setGoogleBooksVolumeId] = useState(
+    initialBook.metadata_remote_ids?.google_books_volume_id || "",
+  );
+  const [openLibraryWorkKey, setOpenLibraryWorkKey] = useState(
+    initialBook.metadata_remote_ids?.open_library_work_key || "",
+  );
+  const [openLibraryEditionKey, setOpenLibraryEditionKey] = useState(
+    initialBook.metadata_remote_ids?.open_library_edition_key || "",
+  );
+  const [openLibraryAuthorKey, setOpenLibraryAuthorKey] = useState(
+    initialBook.metadata_remote_ids?.open_library_author_key || "",
+  );
+  const [otherRemoteIdsJson, setOtherRemoteIdsJson] = useState(
+    splitRemoteIds(initialBook.metadata_remote_ids).extrasJson,
+  );
+  const [identifierError, setIdentifierError] = useState("");
+  const [userGenreTags, setUserGenreTags] = useState(
+    (initialBook.user_genre_tags || []).join(", "),
+  );
+  const [removedChapters, setRemovedChapters] = useState(
+    initialBook.removed_chapters || [],
+  );
+  const [contentSelectors, setContentSelectors] = useState(
+    initialBook.content_selectors || [],
+  );
+  const [previewResult, setPreviewResult] = useState(null);
+  const [chapterSearch, setChapterSearch] = useState("");
+  const [chaptersExpanded, setChaptersExpanded] = useState(false);
+  const [chapterPreviewMode, setChapterPreviewMode] = useState("original");
+  const [identifiersExpanded, setIdentifiersExpanded] = useState(false);
+
+  useEffect(() => {
+    setTitle(initialBook.title || "");
+    setAuthor(initialBook.author || "");
+    setSeries(initialBook.series || "");
+    setSeriesIndex(
+      initialBook.series_index != null ? String(initialBook.series_index) : "",
+    );
+    setNotes(initialBook.notes || "");
+    setIsbn10(initialBook.metadata_remote_ids?.isbn_10 || "");
+    setIsbn13(initialBook.metadata_remote_ids?.isbn_13 || "");
+    setGoogleBooksVolumeId(
+      initialBook.metadata_remote_ids?.google_books_volume_id || "",
+    );
+    setOpenLibraryWorkKey(
+      initialBook.metadata_remote_ids?.open_library_work_key || "",
+    );
+    setOpenLibraryEditionKey(
+      initialBook.metadata_remote_ids?.open_library_edition_key || "",
+    );
+    setOpenLibraryAuthorKey(
+      initialBook.metadata_remote_ids?.open_library_author_key || "",
+    );
+    setOtherRemoteIdsJson(
+      splitRemoteIds(initialBook.metadata_remote_ids).extrasJson,
+    );
+    setIdentifierError("");
+    setUserGenreTags((initialBook.user_genre_tags || []).join(", "));
+    setRemovedChapters(initialBook.removed_chapters || []);
+    setContentSelectors(initialBook.content_selectors || []);
+    setPreviewResult(null);
+    setChapterSearch("");
+    setChaptersExpanded(false);
+    setChapterPreviewMode("original");
+    setIdentifiersExpanded(false);
+  }, [initialBook]);
+
+  useEffect(() => {
+    setPreviewResult(null);
+  }, [contentSelectors, removedChapters]);
+
+  const getUpdatedFields = () => {
+    let extraRemoteIds = {};
+    if (otherRemoteIdsJson.trim()) {
+      try {
+        const parsed = JSON.parse(otherRemoteIdsJson);
+        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+          setIdentifierError("Other identifiers must be a JSON object.");
+          return null;
+        }
+        extraRemoteIds = parsed;
+      } catch {
+        setIdentifierError("Other identifiers must be valid JSON.");
+        return null;
+      }
+    }
+
+    setIdentifierError("");
+
+    const metadataRemoteIds = {
+      ...extraRemoteIds,
+      ...(isbn10.trim() ? { isbn_10: isbn10.trim() } : {}),
+      ...(isbn13.trim() ? { isbn_13: isbn13.trim() } : {}),
+      ...(googleBooksVolumeId.trim()
+        ? { google_books_volume_id: googleBooksVolumeId.trim() }
+        : {}),
+      ...(openLibraryWorkKey.trim()
+        ? { open_library_work_key: openLibraryWorkKey.trim() }
+        : {}),
+      ...(openLibraryEditionKey.trim()
+        ? { open_library_edition_key: openLibraryEditionKey.trim() }
+        : {}),
+      ...(openLibraryAuthorKey.trim()
+        ? { open_library_author_key: openLibraryAuthorKey.trim() }
+        : {}),
+    };
+
+    return {
+      title,
+      author,
+      series: series.trim() || null,
+      series_index: seriesIndex.trim() ? Number.parseFloat(seriesIndex) : null,
+      user_genre_tags: userGenreTags
+        .split(",")
+        .map((tag) => tag.trim())
+        .filter(Boolean),
+      metadata_remote_ids: Object.keys(metadataRemoteIds).length
+        ? metadataRemoteIds
+        : null,
+      removed_chapters: removedChapters,
+      content_selectors: contentSelectors,
+      notes: notes || null,
+    };
+  };
+
+  return {
+    title,
+    setTitle,
+    author,
+    setAuthor,
+    series,
+    setSeries,
+    seriesIndex,
+    setSeriesIndex,
+    notes,
+    setNotes,
+    isbn10,
+    setIsbn10,
+    isbn13,
+    setIsbn13,
+    googleBooksVolumeId,
+    setGoogleBooksVolumeId,
+    openLibraryWorkKey,
+    setOpenLibraryWorkKey,
+    openLibraryEditionKey,
+    setOpenLibraryEditionKey,
+    openLibraryAuthorKey,
+    setOpenLibraryAuthorKey,
+    otherRemoteIdsJson,
+    setOtherRemoteIdsJson,
+    identifierError,
+    userGenreTags,
+    setUserGenreTags,
+    removedChapters,
+    setRemovedChapters,
+    contentSelectors,
+    setContentSelectors,
+    previewResult,
+    setPreviewResult,
+    chapterSearch,
+    setChapterSearch,
+    chaptersExpanded,
+    setChaptersExpanded,
+    chapterPreviewMode,
+    setChapterPreviewMode,
+    identifiersExpanded,
+    setIdentifiersExpanded,
+    getUpdatedFields,
+  };
+}

--- a/frontend/src/lib/catalogGrouping.js
+++ b/frontend/src/lib/catalogGrouping.js
@@ -1,0 +1,83 @@
+export function compareSeriesBooks(left, right) {
+  const leftIndex = left.series_index;
+  const rightIndex = right.series_index;
+
+  if (leftIndex != null && rightIndex != null && leftIndex !== rightIndex) {
+    return Number(leftIndex) - Number(rightIndex);
+  }
+  if (leftIndex != null && rightIndex == null) return -1;
+  if (leftIndex == null && rightIndex != null) return 1;
+
+  const byTitle = left.title.localeCompare(right.title);
+  if (byTitle !== 0) return byTitle;
+  return left.id - right.id;
+}
+
+export function buildCatalogGroups(books, sortBy = "title", sortOrder = "asc") {
+  const seriesMap = {};
+  const standaloneBooks = [];
+  const webBooks = [];
+
+  for (const book of books) {
+    if (book.source_type === "web" && !book.download_status) {
+      webBooks.push(book);
+    }
+
+    if (book.series && !book.download_status) {
+      if (!seriesMap[book.series]) {
+        seriesMap[book.series] = [];
+      }
+      seriesMap[book.series].push(book);
+    } else if (book.source_type !== "web") {
+      standaloneBooks.push(book);
+    }
+  }
+
+  for (const seriesBooks of Object.values(seriesMap)) {
+    seriesBooks.sort(compareSeriesBooks);
+  }
+
+  const dir = sortOrder === "desc" ? -1 : 1;
+  const sortedSeries = Object.keys(seriesMap).sort((a, b) => {
+    const booksA = seriesMap[a];
+    const booksB = seriesMap[b];
+    if (sortBy === "author") {
+      return (
+        dir * (booksA[0].author || "").localeCompare(booksB[0].author || "")
+      );
+    }
+    if (sortBy === "word_count") {
+      const wcA = booksA.reduce(
+        (sum, bk) => sum + (bk.current_word_count || 0),
+        0,
+      );
+      const wcB = booksB.reduce(
+        (sum, bk) => sum + (bk.current_word_count || 0),
+        0,
+      );
+      return dir * (wcA - wcB);
+    }
+    if (sortBy === "updated_at") {
+      const latestA = Math.max(
+        ...booksA.map((bk) => new Date(bk.updated_at || 0).getTime()),
+      );
+      const latestB = Math.max(
+        ...booksB.map((bk) => new Date(bk.updated_at || 0).getTime()),
+      );
+      return dir * (latestA - latestB);
+    }
+    return dir * a.localeCompare(b);
+  });
+
+  return {
+    seriesMap,
+    sortedSeries,
+    standaloneBooks,
+    webBooks,
+    counts: {
+      series: sortedSeries.length,
+      standalone: standaloneBooks.length,
+      web: webBooks.length,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Move catalog serialization and chapter update history calculations out of the books router into focused backend services.
- Split metadata sync scoring and genre helpers into smaller metadata modules.
- Split frontend API calls by domain and move large BookSettings/BookList helper logic into smaller component and utility modules.

## Impact
This is a structural/readability refactor intended to keep behavior stable while making the main router and large React components easier to scan and maintain.

## Validation
- `flake8` on touched backend files
- `npm run lint`
- `pytest -m "not integration" backend/tests`
- `npm test -- --run`