### PR TITLE
[codex] Allow multiple metadata match candidates

### DIFF
--- a/backend/alembic/versions/0017_allow_multiple_metadata_match_candidates.py
+++ b/backend/alembic/versions/0017_allow_multiple_metadata_match_candidates.py
@@ -40,18 +40,14 @@ def downgrade():
     if not inspector.has_table("book_metadata_matches"):
         return
 
-    conn.execute(
-        sa.text(
-            """
+    conn.execute(sa.text("""
             DELETE FROM book_metadata_matches
             WHERE id NOT IN (
                 SELECT MAX(id)
                 FROM book_metadata_matches
                 GROUP BY book_id
             )
-            """
-        )
-    )
+            """))
 
     if not _book_match_unique_constraints(inspector):
         op.create_unique_constraint(

--- a/backend/alembic/versions/0017_allow_multiple_metadata_match_candidates.py
+++ b/backend/alembic/versions/0017_allow_multiple_metadata_match_candidates.py
@@ -1,0 +1,61 @@
+"""allow multiple metadata match candidates
+
+Revision ID: 0017
+Revises: 0016
+Create Date: 2026-04-28 00:00:00
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0017"
+down_revision = "0016"
+branch_labels = None
+depends_on = None
+
+
+def _book_match_unique_constraints(inspector):
+    return [
+        constraint["name"]
+        for constraint in inspector.get_unique_constraints("book_metadata_matches")
+        if set(constraint.get("column_names") or []) == {"book_id"} and constraint.get("name")
+    ]
+
+
+def upgrade():
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+
+    if not inspector.has_table("book_metadata_matches"):
+        return
+
+    for constraint_name in _book_match_unique_constraints(inspector):
+        op.drop_constraint(constraint_name, "book_metadata_matches", type_="unique")
+
+
+def downgrade():
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+
+    if not inspector.has_table("book_metadata_matches"):
+        return
+
+    conn.execute(
+        sa.text(
+            """
+            DELETE FROM book_metadata_matches
+            WHERE id NOT IN (
+                SELECT MAX(id)
+                FROM book_metadata_matches
+                GROUP BY book_id
+            )
+            """
+        )
+    )
+
+    if not _book_match_unique_constraints(inspector):
+        op.create_unique_constraint(
+            "uq_book_metadata_matches_book_id",
+            "book_metadata_matches",
+            ["book_id"],
+        )

--- a/backend/app/crud/__init__.py
+++ b/backend/app/crud/__init__.py
@@ -89,6 +89,7 @@ from .metadata import (  # noqa: F401
     get_metadata_inbox_entries,
     get_metadata_match,
     get_metadata_match_by_book_id,
+    get_metadata_matches_by_book_id,
     get_metadata_proposal,
     get_metadata_proposal_by_book_id,
     get_metadata_sync_job,

--- a/backend/app/crud/metadata.py
+++ b/backend/app/crud/metadata.py
@@ -111,8 +111,22 @@ async def fail_metadata_sync_job(db: AsyncSession, job: models.MetadataSyncJob, 
 
 
 async def get_metadata_match_by_book_id(db: AsyncSession, book_id: int) -> Optional[models.BookMetadataMatch]:
-    result = await db.execute(select(models.BookMetadataMatch).where(models.BookMetadataMatch.book_id == book_id))
+    result = await db.execute(
+        select(models.BookMetadataMatch)
+        .where(models.BookMetadataMatch.book_id == book_id)
+        .order_by(models.BookMetadataMatch.match_confidence.desc().nullslast(), models.BookMetadataMatch.id.desc())
+        .limit(1)
+    )
     return result.scalars().first()
+
+
+async def get_metadata_matches_by_book_id(db: AsyncSession, book_id: int) -> list[models.BookMetadataMatch]:
+    result = await db.execute(
+        select(models.BookMetadataMatch)
+        .where(models.BookMetadataMatch.book_id == book_id)
+        .order_by(models.BookMetadataMatch.match_confidence.desc().nullslast(), models.BookMetadataMatch.id.desc())
+    )
+    return result.scalars().all()
 
 
 async def get_metadata_match(db: AsyncSession, match_id: int) -> Optional[models.BookMetadataMatch]:
@@ -133,7 +147,7 @@ async def get_metadata_proposal(db: AsyncSession, proposal_id: int) -> Optional[
 async def get_metadata_inbox_entries(
     db: AsyncSession,
     limit: int = 100,
-) -> list[tuple[models.MetadataProposal, models.Book, Optional[models.BookMetadataMatch]]]:
+) -> list[tuple[models.MetadataProposal, models.Book, Optional[models.BookMetadataMatch], list[models.BookMetadataMatch]]]:
     result = await db.execute(
         select(models.MetadataProposal, models.Book, models.BookMetadataMatch)
         .join(models.Book, models.MetadataProposal.book_id == models.Book.id)
@@ -142,7 +156,12 @@ async def get_metadata_inbox_entries(
         .order_by(models.MetadataProposal.created_at.desc(), models.MetadataProposal.id.desc())
         .limit(limit)
     )
-    return result.all()
+    rows = result.all()
+    entries = []
+    for proposal, book, match in rows:
+        candidates = await get_metadata_matches_by_book_id(db, book.id)
+        entries.append((proposal, book, match, candidates))
+    return entries
 
 
 async def get_stale_books_for_metadata_sync(

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -101,7 +101,7 @@ class BookMetadataMatch(Base):
     __tablename__ = "book_metadata_matches"
 
     id = Column(Integer, primary_key=True, index=True)
-    book_id = Column(Integer, ForeignKey("books.id", ondelete="CASCADE"), nullable=False, unique=True, index=True)
+    book_id = Column(Integer, ForeignKey("books.id", ondelete="CASCADE"), nullable=False, index=True)
     status = Column(String, nullable=False, default="pending")
     source = Column(String, nullable=True)
     match_confidence = Column(Numeric(5, 4), nullable=True)

--- a/backend/app/routers/metadata.py
+++ b/backend/app/routers/metadata.py
@@ -40,7 +40,10 @@ async def get_metadata_inbox(
     db: AsyncSession = Depends(get_db),
 ) -> list[schemas.MetadataProposalSummary]:
     rows = await crud.get_metadata_inbox_entries(db, limit=limit)
-    return [build_metadata_proposal_summary(proposal, book, match) for proposal, book, match in rows]
+    return [
+        build_metadata_proposal_summary(proposal, book, match, candidate_matches=candidates)
+        for proposal, book, match, candidates in rows
+    ]
 
 
 @router.post("/api/metadata/matches/{match_id}/approve", response_model=schemas.MetadataMatch)
@@ -79,9 +82,10 @@ async def dismiss_proposal(
 
     book = await crud.get_book(db, proposal.book_id)
     match = await crud.get_metadata_match_by_book_id(db, proposal.book_id)
+    candidate_matches = await crud.get_metadata_matches_by_book_id(db, proposal.book_id)
     if book is None:
         raise HTTPException(status_code=404, detail="Book not found")
-    return build_metadata_proposal_summary(proposal, book, match)
+    return build_metadata_proposal_summary(proposal, book, match, candidate_matches=candidate_matches)
 
 
 @router.post("/api/metadata/sync-preview", response_model=schemas.MetadataSyncPreviewResponse)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -362,6 +362,7 @@ class MetadataProposalSummary(BaseModel):
     book_author: str
     book_series: Optional[str] = None
     match: Optional[MetadataMatch] = None
+    candidate_matches: List[MetadataMatch] = Field(default_factory=list)
     proposed_genre_tags: List[str] = Field(default_factory=list)
     possible_missing_series_books: List[str] = Field(default_factory=list)
     note: Optional[str] = None

--- a/backend/app/services/metadata_jobs.py
+++ b/backend/app/services/metadata_jobs.py
@@ -15,16 +15,22 @@ from .metadata_sync import (
     PROPOSAL_THRESHOLD,
     MetadataSuggestion,
     apply_suggestion_to_book,
-    generate_suggestions,
+    generate_candidate_suggestions,
 )
 
 logger = logging.getLogger(__name__)
 
 APPROVED_MATCH_STATUSES = {"approved", "auto_approved"}
+MAX_MATCH_CANDIDATES = 5
+AMBIGUOUS_MATCH_DELTA = 0.03
 
 
 def _match_same_remote(match: models.BookMetadataMatch, suggestion: MetadataSuggestion) -> bool:
     return (match.remote_ids or {}) == (suggestion.remote_ids or {})
+
+
+def _remote_signature_from_suggestion(suggestion: MetadataSuggestion) -> tuple[tuple[str, str], ...]:
+    return tuple(sorted((key, str(value)) for key, value in (suggestion.remote_ids or {}).items()))
 
 
 async def create_metadata_sync_job_request(
@@ -113,10 +119,12 @@ async def _sync_one_book(
     all_books: list[models.Book],
     checked_at: datetime,
 ) -> tuple[bool, bool, bool]:
-    suggestions = await generate_suggestions([book], all_books)
+    candidate_groups = await generate_candidate_suggestions([book], all_books, max_candidates=MAX_MATCH_CANDIDATES)
+    suggestions = candidate_groups[0]
     suggestion = suggestions[0]
 
-    existing_match = await crud.get_metadata_match_by_book_id(db, book.id)
+    existing_matches = await crud.get_metadata_matches_by_book_id(db, book.id)
+    existing_match = existing_matches[0] if existing_matches else None
     existing_proposal = await crud.get_metadata_proposal_by_book_id(db, book.id)
 
     matched = suggestion.matched
@@ -133,20 +141,56 @@ async def _sync_one_book(
         await db.commit()
         return False, False, False
 
+    has_close_alternative = any(
+        candidate.matched
+        and candidate.remote_ids != suggestion.remote_ids
+        and candidate.match_confidence >= suggestion.match_confidence - AMBIGUOUS_MATCH_DELTA
+        for candidate in suggestions[1:]
+    )
+
     if existing_match and existing_match.status == "rejected" and _match_same_remote(existing_match, suggestion):
         match_status = "rejected"
     elif (
         existing_match and existing_match.status in APPROVED_MATCH_STATUSES and _match_same_remote(existing_match, suggestion)
     ):
         match_status = existing_match.status
-    elif suggestion.match_confidence >= AUTO_APPROVE_THRESHOLD:
+    elif suggestion.match_confidence >= AUTO_APPROVE_THRESHOLD and not has_close_alternative:
         match_status = "auto_approved"
     elif suggestion.match_confidence >= PROPOSAL_THRESHOLD:
         match_status = "pending"
     else:
         match_status = "no_match"
 
-    match = _upsert_match(
+    candidate_matches: list[models.BookMetadataMatch] = []
+    if match_status in {"pending", *APPROVED_MATCH_STATUSES}:
+        existing_by_signature = {
+            tuple(sorted((key, str(value)) for key, value in (match.remote_ids or {}).items())): match
+            for match in existing_matches
+            if match.remote_ids
+        }
+        for index, candidate in enumerate(suggestions):
+            if not candidate.matched:
+                continue
+            candidate_status = match_status if index == 0 else "pending"
+            if candidate_status == "auto_approved" and index > 0:
+                candidate_status = "pending"
+            candidate_existing = existing_by_signature.get(_remote_signature_from_suggestion(candidate))
+            if candidate_existing and candidate_existing.status in {"approved", "auto_approved", "rejected"}:
+                candidate_status = candidate_existing.status
+            candidate_match = _upsert_match(
+                candidate_existing,
+                book_id=book.id,
+                status=candidate_status,
+                suggestion=candidate,
+                checked_at=checked_at,
+                preserve_approval=bool(candidate_existing and candidate_existing.status in APPROVED_MATCH_STATUSES),
+            )
+            if candidate_existing is None:
+                db.add(candidate_match)
+                await db.flush()
+            candidate_matches.append(candidate_match)
+
+    match = candidate_matches[0] if candidate_matches else _upsert_match(
         existing_match,
         book_id=book.id,
         status=match_status,
@@ -154,7 +198,7 @@ async def _sync_one_book(
         checked_at=checked_at,
         preserve_approval=bool(existing_match and existing_match.status in APPROVED_MATCH_STATUSES),
     )
-    if existing_match is None:
+    if not candidate_matches and existing_match is None:
         db.add(match)
         await db.flush()
 
@@ -302,8 +346,18 @@ async def reject_metadata_match(
     match.status = "rejected"
     match.rejected_at = datetime.now(timezone.utc)
     if proposal is not None:
-        proposal.status = "dismissed"
-        proposal.reviewed_at = datetime.now(timezone.utc)
+        remaining_matches = [
+            candidate
+            for candidate in await crud.get_metadata_matches_by_book_id(db, match.book_id)
+            if candidate.id != match.id and candidate.status == "pending"
+        ]
+        if remaining_matches:
+            proposal.status = "open"
+            if proposal.match_id == match.id:
+                proposal.match_id = remaining_matches[0].id
+        else:
+            proposal.status = "dismissed"
+            proposal.reviewed_at = datetime.now(timezone.utc)
 
     await db.commit()
     await db.refresh(match)
@@ -327,7 +381,10 @@ def build_metadata_proposal_summary(
     proposal: models.MetadataProposal,
     book: models.Book,
     match: Optional[models.BookMetadataMatch],
+    *,
+    candidate_matches: Optional[list[models.BookMetadataMatch]] = None,
 ) -> schemas.MetadataProposalSummary:
+    candidates = candidate_matches or ([match] if match is not None else [])
     return schemas.MetadataProposalSummary(
         id=proposal.id,
         book_id=book.id,
@@ -335,6 +392,7 @@ def build_metadata_proposal_summary(
         book_author=book.author,
         book_series=book.series,
         match=schemas.MetadataMatch.model_validate(match) if match is not None else None,
+        candidate_matches=[schemas.MetadataMatch.model_validate(candidate) for candidate in candidates],
         proposed_genre_tags=list(proposal.proposed_genre_tags or []),
         possible_missing_series_books=list(proposal.possible_missing_series_books or []),
         note=proposal.note,

--- a/backend/app/services/metadata_jobs.py
+++ b/backend/app/services/metadata_jobs.py
@@ -190,13 +190,17 @@ async def _sync_one_book(
                 await db.flush()
             candidate_matches.append(candidate_match)
 
-    match = candidate_matches[0] if candidate_matches else _upsert_match(
-        existing_match,
-        book_id=book.id,
-        status=match_status,
-        suggestion=suggestion if match_status != "no_match" else None,
-        checked_at=checked_at,
-        preserve_approval=bool(existing_match and existing_match.status in APPROVED_MATCH_STATUSES),
+    match = (
+        candidate_matches[0]
+        if candidate_matches
+        else _upsert_match(
+            existing_match,
+            book_id=book.id,
+            status=match_status,
+            suggestion=suggestion if match_status != "no_match" else None,
+            checked_at=checked_at,
+            preserve_approval=bool(existing_match and existing_match.status in APPROVED_MATCH_STATUSES),
+        )
     )
     if not candidate_matches and existing_match is None:
         db.add(match)

--- a/backend/app/services/metadata_sync.py
+++ b/backend/app/services/metadata_sync.py
@@ -39,6 +39,7 @@ GOOGLE_BOOKS_RETRY_ATTEMPTS = 2
 GOOGLE_BOOKS_USER_AGENT = "story-manager/0.1 (+https://developers.google.com/books)"
 AUTO_APPROVE_THRESHOLD = 0.92
 PROPOSAL_THRESHOLD = 0.75
+DEFAULT_MATCH_CANDIDATE_LIMIT = 5
 
 _TRAILING_PARENS_RE = re.compile(r"\s*\([^)]*\)\s*$")
 _TRAILING_SERIES_BOOK_RE = re.compile(r"\s*\([^)]*book\s+\d+[^)]*\)\s*$", re.IGNORECASE)
@@ -604,6 +605,69 @@ def _fetch_search_doc(
     return best_doc, best_score, None
 
 
+def _collect_search_doc_candidates(
+    book: models.Book,
+    *,
+    local_books_by_author: dict[str, list[models.Book]],
+    author_work_cache: dict[str, list[dict[str, Any]]],
+    limit: int = DEFAULT_MATCH_CANDIDATE_LIMIT,
+) -> list[tuple[dict[str, Any], float]]:
+    manual_remote_ids = _get_manual_remote_ids(book)
+    preferred_author_keys = _series_peer_author_keys(book, local_books_by_author)
+    manual_author_key = manual_remote_ids.get("open_library_author_key")
+    if manual_author_key:
+        preferred_author_keys.add(manual_author_key)
+
+    search_variants: list[dict[str, Any]] = []
+    if manual_remote_ids.get("isbn_13"):
+        search_variants.append({"isbn": manual_remote_ids["isbn_13"], "limit": 5})
+    if manual_remote_ids.get("isbn_10"):
+        search_variants.append({"isbn": manual_remote_ids["isbn_10"], "limit": 5})
+    for title_variant in _title_search_variants(book):
+        search_variants.append({"title": title_variant, "author": book.author, "limit": 5})
+
+    ranked: list[tuple[dict[str, Any], float, float]] = []
+    seen_searches: set[tuple[tuple[str, Any], ...]] = set()
+    seen_docs: set[str] = set()
+
+    for params in search_variants:
+        key = tuple(sorted(params.items()))
+        if key in seen_searches:
+            continue
+        seen_searches.add(key)
+
+        for doc in _fetch_search_docs(params):
+            doc_key = str(doc.get("key") or doc.get("cover_edition_key") or doc.get("title") or "")
+            if not doc_key or doc_key in seen_docs:
+                continue
+            score = _score_search_doc(book, doc)
+            threshold = 0.68 if preferred_author_keys or manual_remote_ids else 0.72
+            if score < threshold:
+                continue
+
+            ranking_score = score
+            doc_author_keys = doc.get("author_key") or []
+            if isinstance(doc_author_keys, str):
+                doc_author_keys = [doc_author_keys]
+            if preferred_author_keys and any(author_key in preferred_author_keys for author_key in doc_author_keys):
+                ranking_score += 0.08
+            seen_docs.add(doc_key)
+            ranked.append((doc, score, ranking_score))
+
+    series_doc, series_score = _fetch_series_context_doc(
+        book,
+        preferred_author_keys=preferred_author_keys,
+        author_work_cache=author_work_cache,
+    )
+    if series_doc is not None:
+        doc_key = str(series_doc.get("key") or series_doc.get("title") or "")
+        if doc_key and doc_key not in seen_docs:
+            ranked.append((series_doc, series_score, series_score + 0.08))
+
+    ranked.sort(key=lambda item: item[2], reverse=True)
+    return [(doc, score) for doc, score, _ranking_score in ranked[:limit]]
+
+
 def _fetch_google_books_match(book: models.Book) -> tuple[Optional[GoogleBooksMatch], float, Optional[str]]:
     if not _google_books_enabled():
         return None, 0.0, None
@@ -729,58 +793,13 @@ def _fetch_author_work_entries(
     return normalized_entries
 
 
-def _build_suggestion_for_book(
+def _build_open_library_suggestion(
     book: models.Book,
+    doc: dict[str, Any],
+    score: float,
     local_books_by_author: dict[str, list[models.Book]],
     author_work_cache: dict[str, list[dict[str, Any]]],
 ) -> MetadataSuggestion:
-    if not book.title or not book.author or book.author.strip().lower() == "pending":
-        return MetadataSuggestion(book=book, matched=False, note="Book is missing stable title/author metadata.")
-
-    google_match: Optional[GoogleBooksMatch] = None
-    try:
-        doc, score, note = _fetch_search_doc(
-            book,
-            local_books_by_author=local_books_by_author,
-            author_work_cache=author_work_cache,
-        )
-    except requests.RequestException:
-        logger.warning("Metadata sync request failed for %s by %s; continuing.", book.title, book.author)
-        doc, score, note = None, 0.0, "Open Library request failed."
-
-    if doc is None:
-        try:
-            google_match, google_score, google_note = _fetch_google_books_match(book)
-        except requests.RequestException:
-            logger.warning("Google Books metadata request failed for %s by %s; continuing.", book.title, book.author)
-            google_match, google_score, google_note = None, 0.0, "Google Books request failed."
-
-        if google_match is None:
-            return MetadataSuggestion(
-                book=book,
-                matched=False,
-                match_confidence=max(score, google_score),
-                note=google_note or note,
-            )
-
-        google_genre_tags = _derive_genre_tags(google_match.categories)
-        existing_tags = {tag.casefold() for tag in (book.genre_tags or [])}
-        new_tags = [tag for tag in google_genre_tags if tag.casefold() not in existing_tags]
-        return MetadataSuggestion(
-            book=book,
-            matched=True,
-            source="google_books",
-            match_confidence=google_match.match_confidence,
-            remote_title=google_match.title,
-            remote_author=google_match.authors[0] if google_match.authors else None,
-            remote_url=google_match.info_link,
-            genre_tags=google_genre_tags,
-            new_genre_tags=new_tags,
-            possible_missing_series_books=[],
-            remote_ids=google_match.remote_ids,
-            note=None if google_genre_tags else "Matched in Google Books, but no genre tags were found.",
-        )
-
     work_data = _fetch_work_data(doc)
     subjects = _extract_subjects(doc, work_data)
     genre_tags = _derive_genre_tags(subjects)
@@ -834,6 +853,91 @@ def _build_suggestion_for_book(
     )
 
 
+def _build_suggestion_for_book(
+    book: models.Book,
+    local_books_by_author: dict[str, list[models.Book]],
+    author_work_cache: dict[str, list[dict[str, Any]]],
+) -> MetadataSuggestion:
+    if not book.title or not book.author or book.author.strip().lower() == "pending":
+        return MetadataSuggestion(book=book, matched=False, note="Book is missing stable title/author metadata.")
+
+    google_match: Optional[GoogleBooksMatch] = None
+    try:
+        doc, score, note = _fetch_search_doc(
+            book,
+            local_books_by_author=local_books_by_author,
+            author_work_cache=author_work_cache,
+        )
+    except requests.RequestException:
+        logger.warning("Metadata sync request failed for %s by %s; continuing.", book.title, book.author)
+        doc, score, note = None, 0.0, "Open Library request failed."
+
+    if doc is None:
+        try:
+            google_match, google_score, google_note = _fetch_google_books_match(book)
+        except requests.RequestException:
+            logger.warning("Google Books metadata request failed for %s by %s; continuing.", book.title, book.author)
+            google_match, google_score, google_note = None, 0.0, "Google Books request failed."
+
+        if google_match is None:
+            return MetadataSuggestion(
+                book=book,
+                matched=False,
+                match_confidence=max(score, google_score),
+                note=google_note or note,
+            )
+
+        google_genre_tags = _derive_genre_tags(google_match.categories)
+        existing_tags = {tag.casefold() for tag in (book.genre_tags or [])}
+        new_tags = [tag for tag in google_genre_tags if tag.casefold() not in existing_tags]
+        return MetadataSuggestion(
+            book=book,
+            matched=True,
+            source="google_books",
+            match_confidence=google_match.match_confidence,
+            remote_title=google_match.title,
+            remote_author=google_match.authors[0] if google_match.authors else None,
+            remote_url=google_match.info_link,
+            genre_tags=google_genre_tags,
+            new_genre_tags=new_tags,
+            possible_missing_series_books=[],
+            remote_ids=google_match.remote_ids,
+            note=None if google_genre_tags else "Matched in Google Books, but no genre tags were found.",
+        )
+
+    return _build_open_library_suggestion(book, doc, score, local_books_by_author, author_work_cache)
+
+
+def _build_suggestions_for_book(
+    book: models.Book,
+    local_books_by_author: dict[str, list[models.Book]],
+    author_work_cache: dict[str, list[dict[str, Any]]],
+    *,
+    max_candidates: int = DEFAULT_MATCH_CANDIDATE_LIMIT,
+) -> list[MetadataSuggestion]:
+    if not book.title or not book.author or book.author.strip().lower() == "pending":
+        return [MetadataSuggestion(book=book, matched=False, note="Book is missing stable title/author metadata.")]
+
+    try:
+        candidates = _collect_search_doc_candidates(
+            book,
+            local_books_by_author=local_books_by_author,
+            author_work_cache=author_work_cache,
+            limit=max_candidates,
+        )
+    except requests.RequestException:
+        logger.warning("Metadata sync request failed for %s by %s; continuing.", book.title, book.author)
+        candidates = []
+
+    if candidates:
+        return [
+            _build_open_library_suggestion(book, doc, score, local_books_by_author, author_work_cache)
+            for doc, score in candidates
+        ]
+
+    return [_build_suggestion_for_book(book, local_books_by_author, author_work_cache)]
+
+
 async def _generate_suggestions(
     target_books: list[models.Book],
     all_books: list[models.Book],
@@ -849,11 +953,45 @@ async def _generate_suggestions(
     )
 
 
+async def _generate_candidate_suggestions(
+    target_books: list[models.Book],
+    all_books: list[models.Book],
+    *,
+    max_candidates: int = DEFAULT_MATCH_CANDIDATE_LIMIT,
+) -> list[list[MetadataSuggestion]]:
+    local_books_by_author: dict[str, list[models.Book]] = {}
+    for book in all_books:
+        local_books_by_author.setdefault(_normalize_text(book.author or ""), []).append(book)
+
+    author_work_cache: dict[str, list[dict[str, Any]]] = {}
+
+    return await asyncio.to_thread(
+        lambda: [
+            _build_suggestions_for_book(
+                book,
+                local_books_by_author,
+                author_work_cache,
+                max_candidates=max_candidates,
+            )
+            for book in target_books
+        ]
+    )
+
+
 async def generate_suggestions(
     target_books: list[models.Book],
     all_books: list[models.Book],
 ) -> list[MetadataSuggestion]:
     return await _generate_suggestions(target_books, all_books)
+
+
+async def generate_candidate_suggestions(
+    target_books: list[models.Book],
+    all_books: list[models.Book],
+    *,
+    max_candidates: int = DEFAULT_MATCH_CANDIDATE_LIMIT,
+) -> list[list[MetadataSuggestion]]:
+    return await _generate_candidate_suggestions(target_books, all_books, max_candidates=max_candidates)
 
 
 def apply_suggestion_to_book(

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -589,7 +589,67 @@ async def test_metadata_inbox_lists_pending_match_proposals(db_session):
     assert len(data) == 1
     assert data[0]["book_title"] == "Inbox Book"
     assert data[0]["match"]["status"] == "pending"
+    assert data[0]["candidate_matches"][0]["id"] == match.id
     assert data[0]["proposed_genre_tags"] == ["Fantasy"]
+
+
+@pytest.mark.asyncio
+async def test_metadata_job_keeps_close_match_candidates_for_human_selection(db_session, mocker):
+    from backend.app.services.metadata_jobs import process_metadata_sync_job
+
+    async with AsyncTestingSessionLocal() as session:
+        book = await crud.create_book(
+            session,
+            schemas.BookCreate(
+                title="Dragon Saga 7",
+                author="Alice Smith",
+                series="Dragon Saga",
+                immutable_path="dragon-7-immutable.epub",
+                current_path="dragon-7.epub",
+                source_type=models.SourceType.epub,
+            ),
+        )
+        job = await crud.create_metadata_sync_job(session, trigger="manual", book_ids=[book.id])
+
+    def fake_open_library_get(url, params=None, timeout=None, headers=None):
+        if url == "https://openlibrary.org/search.json":
+            return FakeRequestsResponse(
+                {
+                    "docs": [
+                        {
+                            "key": "/works/OL6W",
+                            "title": "Dragon Saga 6",
+                            "author_name": ["Alice Smith"],
+                            "author_key": ["OLA1A"],
+                        },
+                        {
+                            "key": "/works/OL8W",
+                            "title": "Dragon Saga 8",
+                            "author_name": ["Alice Smith"],
+                            "author_key": ["OLA1A"],
+                        },
+                    ]
+                }
+            )
+        if url in {"https://openlibrary.org/works/OL6W.json", "https://openlibrary.org/works/OL8W.json"}:
+            return FakeRequestsResponse({"subjects": ["Fantasy"]})
+        if url == "https://openlibrary.org/authors/OLA1A/works.json":
+            return FakeRequestsResponse({"entries": [{"title": "Dragon Saga 6"}, {"title": "Dragon Saga 8"}]})
+        raise AssertionError(f"Unexpected URL: {url}")
+
+    mocker.patch("backend.app.services.metadata_sync.requests.get", side_effect=fake_open_library_get)
+
+    async with AsyncTestingSessionLocal() as session:
+        await process_metadata_sync_job(session, job.id)
+
+    response = client.get("/api/metadata/inbox")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    candidate_titles = {candidate["remote_title"] for candidate in data[0]["candidate_matches"]}
+    assert candidate_titles == {"Dragon Saga 6", "Dragon Saga 8"}
+    assert data[0]["match"]["status"] == "pending"
 
 
 @pytest.mark.asyncio
@@ -640,6 +700,61 @@ async def test_approve_metadata_match_applies_genres_and_resolves_proposal(db_se
         assert stored_book.metadata_sync_source == "open_library"
         assert stored_match.status == "approved"
         assert stored_proposal.status == "resolved"
+
+
+@pytest.mark.asyncio
+async def test_reject_metadata_match_keeps_proposal_open_for_other_candidates(db_session):
+    async with AsyncTestingSessionLocal() as session:
+        book = await crud.create_book(
+            session,
+            schemas.BookCreate(
+                title="Candidate Book",
+                author="Candidate Author",
+                immutable_path="candidate-immutable.epub",
+                current_path="candidate.epub",
+                source_type=models.SourceType.epub,
+            ),
+        )
+        first_match = models.BookMetadataMatch(
+            book_id=book.id,
+            status="pending",
+            source="open_library",
+            match_confidence=0.9,
+            remote_title="Candidate Book 6",
+            remote_author="Candidate Author",
+            remote_ids={"open_library_work_key": "/works/OL6W"},
+        )
+        second_match = models.BookMetadataMatch(
+            book_id=book.id,
+            status="pending",
+            source="open_library",
+            match_confidence=0.89,
+            remote_title="Candidate Book 8",
+            remote_author="Candidate Author",
+            remote_ids={"open_library_work_key": "/works/OL8W"},
+        )
+        session.add_all([first_match, second_match])
+        await session.flush()
+        session.add(
+            models.MetadataProposal(
+                book_id=book.id,
+                match_id=first_match.id,
+                status="open",
+                proposed_genre_tags=["Fantasy"],
+                possible_missing_series_books=[],
+            )
+        )
+        await session.commit()
+
+    response = client.post(f"/api/metadata/matches/{first_match.id}/reject")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "rejected"
+
+    async with AsyncTestingSessionLocal() as session:
+        stored_proposal = await crud.get_metadata_proposal_by_book_id(session, book.id)
+        assert stored_proposal.status == "open"
+        assert stored_proposal.match_id == second_match.id
 
 
 @pytest.mark.asyncio

--- a/frontend/src/components/Utilities.jsx
+++ b/frontend/src/components/Utilities.jsx
@@ -76,10 +76,18 @@ function renderMetadataJobSummary(job) {
   return base;
 }
 
+function formatMetadataMatchOption(match) {
+  const title = match.remote_title || "Unknown title";
+  const author = match.remote_author ? ` by ${match.remote_author}` : "";
+  const confidence = match.match_confidence != null ? ` (${Math.round(match.match_confidence * 100)}%)` : "";
+  return `${title}${author}${confidence}`;
+}
+
 function Utilities({ onBack }) {
   const queryClient = useQueryClient();
   const [preview, setPreview] = useState(null);
   const [detectState, setDetectState] = useState(null); // null | "pending" | { updated, series_detected, error? }
+  const [selectedMatchIds, setSelectedMatchIds] = useState({});
 
   const previewMutation = useMutation({
     mutationFn: () => runCleanup(true),
@@ -312,18 +320,71 @@ function Utilities({ onBack }) {
                     background: "rgba(15, 23, 42, 0.35)",
                   }}
                 >
-                  <div style={{ display: "flex", justifyContent: "space-between", gap: "1rem", alignItems: "baseline" }}>
-                    <strong>{entry.book_title}</strong>
-                    <span className="hint">
-                      {entry.match?.status || entry.status}
-                    </span>
+                  {(() => {
+                    const candidateMatches = entry.candidate_matches?.length ? entry.candidate_matches : entry.match ? [entry.match] : [];
+                    const selectedMatchId = selectedMatchIds[entry.id] ?? entry.match?.id ?? candidateMatches[0]?.id;
+                    const selectedMatch = candidateMatches.find((match) => match.id === Number(selectedMatchId)) || entry.match;
+
+                    return (
+                      <>
+                  <div style={{ display: "flex", justifyContent: "space-between", gap: "1rem", alignItems: "flex-start" }}>
+                    <div>
+                      <strong>{entry.book_title}</strong>
+                      <span className="hint" style={{ marginLeft: "0.5rem" }}>
+                        {selectedMatch?.status || entry.status}
+                      </span>
+                    </div>
+                    <div className="settings-actions" style={{ marginTop: 0, flexShrink: 0 }}>
+                      {selectedMatch?.status === "pending" && selectedMatch?.id ? (
+                        <>
+                          <button
+                            onClick={() => approveMatchMutation.mutate(selectedMatch.id)}
+                            disabled={approveMatchMutation.isPending || rejectMatchMutation.isPending}
+                          >
+                            {approveMatchMutation.isPending ? "Approving…" : "Approve Match"}
+                          </button>
+                          <button
+                            className="btn-danger"
+                            onClick={() => rejectMatchMutation.mutate(selectedMatch.id)}
+                            disabled={approveMatchMutation.isPending || rejectMatchMutation.isPending}
+                          >
+                            {rejectMatchMutation.isPending ? "Rejecting…" : "Reject Match"}
+                          </button>
+                        </>
+                      ) : (
+                        <button
+                          className="btn-text"
+                          onClick={() => dismissProposalMutation.mutate(entry.id)}
+                          disabled={dismissProposalMutation.isPending}
+                        >
+                          {dismissProposalMutation.isPending ? "Dismissing…" : "Dismiss"}
+                        </button>
+                      )}
+                    </div>
                   </div>
                   <p className="hint" style={{ marginTop: "0.35rem" }}>{entry.book_author}</p>
-                  {entry.match && (
+                  {candidateMatches.length > 1 ? (
+                    <label className="hint" style={{ display: "grid", gap: "0.35rem", marginTop: "0.5rem" }}>
+                      Suggested match
+                      <select
+                        value={selectedMatchId || ""}
+                        onChange={(event) =>
+                          setSelectedMatchIds((current) => ({
+                            ...current,
+                            [entry.id]: Number(event.target.value),
+                          }))
+                        }
+                      >
+                        {candidateMatches.map((match) => (
+                          <option key={match.id} value={match.id}>
+                            {formatMetadataMatchOption(match)}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                  ) : selectedMatch && (
                     <p className="hint" style={{ marginTop: "0.5rem" }}>
-                      Suggested match: {entry.match.remote_title || "Unknown title"}
-                      {entry.match.remote_author ? ` by ${entry.match.remote_author}` : ""}
-                      {entry.match.match_confidence != null ? ` (${Math.round(entry.match.match_confidence * 100)}%)` : ""}
+                      Suggested match: {formatMetadataMatchOption(selectedMatch)}
                     </p>
                   )}
                   {entry.proposed_genre_tags.length > 0 && (
@@ -341,33 +402,9 @@ function Utilities({ onBack }) {
                       {entry.note}
                     </p>
                   )}
-                  <div className="settings-actions" style={{ marginTop: "0.75rem" }}>
-                    {entry.match?.status === "pending" && entry.match?.id ? (
-                      <>
-                        <button
-                          onClick={() => approveMatchMutation.mutate(entry.match.id)}
-                          disabled={approveMatchMutation.isPending || rejectMatchMutation.isPending}
-                        >
-                          {approveMatchMutation.isPending ? "Approving…" : "Approve Match"}
-                        </button>
-                        <button
-                          className="btn-danger"
-                          onClick={() => rejectMatchMutation.mutate(entry.match.id)}
-                          disabled={approveMatchMutation.isPending || rejectMatchMutation.isPending}
-                        >
-                          {rejectMatchMutation.isPending ? "Rejecting…" : "Reject Match"}
-                        </button>
                       </>
-                    ) : (
-                      <button
-                        className="btn-text"
-                        onClick={() => dismissProposalMutation.mutate(entry.id)}
-                        disabled={dismissProposalMutation.isPending}
-                      >
-                        {dismissProposalMutation.isPending ? "Dismissing…" : "Dismiss"}
-                      </button>
-                    )}
-                  </div>
+                    );
+                  })()}
                 </li>
               ))}
             </ul>

--- a/frontend/src/components/Utilities.test.jsx
+++ b/frontend/src/components/Utilities.test.jsx
@@ -191,6 +191,36 @@ describe("Utilities", () => {
                   approved_at: null,
                   rejected_at: null,
                 },
+                candidate_matches: [
+                  {
+                    id: 7,
+                    book_id: 1,
+                    status: "pending",
+                    source: "open_library",
+                    match_confidence: 0.93,
+                    remote_title: "Dragon One",
+                    remote_author: "Author A",
+                    remote_url: "https://openlibrary.org/works/OL1W",
+                    remote_ids: {},
+                    last_checked_at: "2026-03-29T00:00:02Z",
+                    approved_at: null,
+                    rejected_at: null,
+                  },
+                  {
+                    id: 8,
+                    book_id: 1,
+                    status: "pending",
+                    source: "open_library",
+                    match_confidence: 0.91,
+                    remote_title: "Dragon Eight",
+                    remote_author: "Author A",
+                    remote_url: "https://openlibrary.org/works/OL8W",
+                    remote_ids: {},
+                    last_checked_at: "2026-03-29T00:00:02Z",
+                    approved_at: null,
+                    rejected_at: null,
+                  },
+                ],
                 proposed_genre_tags: ["Fantasy"],
                 possible_missing_series_books: ["Dragon Two"],
                 note: null,
@@ -233,6 +263,18 @@ describe("Utilities", () => {
             }),
         });
       }
+      if (url === "/api/metadata/matches/8/approve" && options?.method === "POST") {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              id: 8,
+              book_id: 1,
+              status: "approved",
+              source: "open_library",
+            }),
+        });
+      }
 
       return Promise.resolve({ ok: true, json: () => Promise.resolve({ reprocessed: 0 }) });
     });
@@ -245,6 +287,7 @@ describe("Utilities", () => {
 
     expect(screen.getByText("Proposed genres: Fantasy")).toBeInTheDocument();
     expect(screen.getByText("Possible missing in series: Dragon Two")).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Suggested match"), { target: { value: "8" } });
 
     fireEvent.click(screen.getByRole("button", { name: "Queue Library Metadata Sync" }));
 
@@ -259,7 +302,7 @@ describe("Utilities", () => {
     fireEvent.click(screen.getByRole("button", { name: "Approve Match" }));
 
     await waitFor(() => {
-      expect(globalThis.fetch).toHaveBeenCalledWith("/api/metadata/matches/7/approve", {
+      expect(globalThis.fetch).toHaveBeenCalledWith("/api/metadata/matches/8/approve", {
         method: "POST",
       });
     });


### PR DESCRIPTION
## Summary
- allow books to keep multiple metadata match candidates instead of enforcing one match per book
- return candidate matches in the metadata inbox and let the Utilities UI approve/reject the selected candidate
- preserve proposals when rejecting one candidate if other pending candidates remain

## Validation
- `export PYTHONPATH=. && .venv/bin/python3 -m pytest -m "not integration" backend/tests/test_main.py -k "metadata"`
- `cd frontend && npm test -- --run src/components/Utilities.test.jsx`
- `make test-migrations`