### PR TITLE
[codex] Normalize oversized EPUB prose blocks

### DIFF
--- a/backend/app/epub_editor.py
+++ b/backend/app/epub_editor.py
@@ -8,6 +8,9 @@ from ebooklib import epub
 from bs4 import BeautifulSoup
 import re
 
+from . import models
+from .services.epub_utils import normalize_xhtml_prose_blocks
+
 logger = logging.getLogger(__name__)
 
 
@@ -159,6 +162,7 @@ def process_epub(
     removed_chapters: list[str],
     content_selectors: list[str],
     chapter_selectors: list[str] = [],
+    normalize_prose_blocks: bool = False,
 ) -> int | None:
     """Process an epub, returning the new word count if changed, or None if unchanged."""
     book = epub.read_epub(immutable_path)
@@ -190,6 +194,9 @@ def process_epub(
                 for selector in content_selectors:
                     for elem in soup.select(selector):
                         elem.decompose()
+                if normalize_prose_blocks:
+                    normalized_content, _ = normalize_xhtml_prose_blocks(str(soup))
+                    soup = BeautifulSoup(normalized_content, "html.parser")
                 item.set_content(str(soup).encode("utf-8"))
             new_book.add_item(item)
 
@@ -265,7 +272,8 @@ async def apply_book_cleaning(book, db, force: bool = False, cleaning_configs: l
 
     removed_chapters, content_selectors, chapter_selectors = _merge_cleaning_rules(book, configs)
 
-    has_rules = bool(chapter_selectors or content_selectors or removed_chapters)
+    normalize_prose_blocks = book.source_type == models.SourceType.web
+    has_rules = bool(chapter_selectors or content_selectors or removed_chapters or normalize_prose_blocks)
 
     # Nothing to do — skip the (potentially expensive) epub rewrite
     if not has_rules:
@@ -292,6 +300,7 @@ async def apply_book_cleaning(book, db, force: bool = False, cleaning_configs: l
             removed_chapters,
             content_selectors,
             chapter_selectors,
+            normalize_prose_blocks=normalize_prose_blocks,
         )
         if word_count is None:
             if force:

--- a/backend/app/services/epub_utils.py
+++ b/backend/app/services/epub_utils.py
@@ -1,14 +1,16 @@
-"""Lightweight EPUB helpers: word/chapter counting and cover extraction."""
+"""Lightweight EPUB helpers: word/chapter counting, cover extraction, and XHTML cleanup."""
 
+import copy
 import logging
 import posixpath
+import re
 import zipfile
 from pathlib import Path, PurePosixPath
 from typing import Optional
 from urllib.parse import unquote
 
 import ebooklib
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, NavigableString, Tag
 from ebooklib import epub
 from lxml import etree
 
@@ -31,6 +33,30 @@ IMAGE_EXTENSION_BY_MEDIA_TYPE = {
 }
 SYNTHETIC_SUBJECTS = {"Completed", "In-Progress", "Unknown"}
 SYNTHETIC_SUBJECT_PREFIXES = ("Last Update:", "Last Update Year/Month:")
+PROSE_BLOCK_MAX_CHARS = 2500
+PROSE_BLOCK_TARGET_CHARS = 1500
+RISKY_PROSE_DESCENDANTS = {
+    "a",
+    "audio",
+    "button",
+    "code",
+    "form",
+    "iframe",
+    "img",
+    "input",
+    "math",
+    "object",
+    "pre",
+    "rp",
+    "rt",
+    "ruby",
+    "select",
+    "svg",
+    "table",
+    "textarea",
+    "video",
+}
+SENTENCE_END_RE = re.compile(r"(?<=[.!?])\s+")
 # Intentionally duplicated in migration 0015 — migrations must be self-contained.
 SCRIBBLEHUB_GENRES = {
     "Action",
@@ -71,6 +97,177 @@ SCRIBBLEHUB_GENRES = {
     "Yaoi",
     "Yuri",
 }
+
+
+def _prose_text_length(tag: Tag) -> int:
+    return len(tag.get_text(" ", strip=True))
+
+
+def _has_risky_prose_descendant(tag: Tag) -> bool:
+    return tag.find(RISKY_PROSE_DESCENDANTS) is not None
+
+
+def _clone_empty_tag(soup: BeautifulSoup, source: Tag) -> Tag:
+    clone = soup.new_tag(source.name)
+    clone.attrs = copy.deepcopy(source.attrs)
+    return clone
+
+
+def _append_copied_children(target: Tag, children: list) -> None:
+    for child in children:
+        target.append(copy.copy(child) if isinstance(child, NavigableString) else copy.deepcopy(child))
+
+
+def _trim_empty_edge_text(children: list) -> list:
+    trimmed = list(children)
+    while trimmed and isinstance(trimmed[0], NavigableString) and not str(trimmed[0]).strip():
+        trimmed.pop(0)
+    while trimmed and isinstance(trimmed[-1], NavigableString) and not str(trimmed[-1]).strip():
+        trimmed.pop()
+    return trimmed
+
+
+def _split_children_on_double_br(children: list) -> list[list]:
+    chunks: list[list] = []
+    current: list = []
+    index = 0
+
+    while index < len(children):
+        child = children[index]
+        if isinstance(child, Tag) and child.name == "br":
+            run: list = [child]
+            br_count = 1
+            index += 1
+            while index < len(children):
+                next_child = children[index]
+                if isinstance(next_child, Tag) and next_child.name == "br":
+                    run.append(next_child)
+                    br_count += 1
+                    index += 1
+                    continue
+                if isinstance(next_child, NavigableString) and not str(next_child).strip():
+                    run.append(next_child)
+                    index += 1
+                    continue
+                break
+
+            if br_count >= 2:
+                trimmed = _trim_empty_edge_text(current)
+                if trimmed:
+                    chunks.append(trimmed)
+                current = []
+            else:
+                current.extend(run)
+            continue
+
+        current.append(child)
+        index += 1
+
+    trimmed = _trim_empty_edge_text(current)
+    if trimmed:
+        chunks.append(trimmed)
+    return chunks
+
+
+def _split_text_at_sentence_boundaries(text: str) -> list[str]:
+    stripped = text.strip()
+    if len(stripped) <= PROSE_BLOCK_MAX_CHARS:
+        return [stripped] if stripped else []
+
+    sentences = [sentence for sentence in SENTENCE_END_RE.split(stripped) if sentence]
+    if len(sentences) < 2:
+        return [stripped]
+
+    chunks: list[str] = []
+    current = ""
+    for sentence in sentences:
+        candidate = f"{current} {sentence}".strip() if current else sentence.strip()
+        if current and len(candidate) > PROSE_BLOCK_TARGET_CHARS:
+            chunks.append(current)
+            current = sentence.strip()
+        else:
+            current = candidate
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def _replace_paragraph_with_chunks(paragraph: Tag, replacements: list[Tag]) -> None:
+    for replacement in replacements:
+        paragraph.insert_before(replacement)
+    paragraph.decompose()
+
+
+def _split_oversized_paragraph(soup: BeautifulSoup, paragraph: Tag) -> bool:
+    if _prose_text_length(paragraph) <= PROSE_BLOCK_MAX_CHARS:
+        return False
+    if _has_risky_prose_descendant(paragraph):
+        return False
+
+    br_chunks = _split_children_on_double_br(list(paragraph.children))
+    if len(br_chunks) > 1:
+        replacements: list[Tag] = []
+        for chunk in br_chunks:
+            replacement = _clone_empty_tag(soup, paragraph)
+            _append_copied_children(replacement, chunk)
+            if _prose_text_length(replacement) > PROSE_BLOCK_MAX_CHARS and not replacement.find(True):
+                for text_chunk in _split_text_at_sentence_boundaries(replacement.get_text(" ", strip=True)):
+                    text_replacement = _clone_empty_tag(soup, paragraph)
+                    text_replacement.string = text_chunk
+                    replacements.append(text_replacement)
+            else:
+                replacements.append(replacement)
+        _replace_paragraph_with_chunks(paragraph, replacements)
+        return True
+
+    if paragraph.find(True):
+        return False
+
+    text_chunks = _split_text_at_sentence_boundaries(paragraph.get_text(" ", strip=True))
+    if len(text_chunks) <= 1:
+        return False
+
+    replacements = []
+    for text_chunk in text_chunks:
+        replacement = _clone_empty_tag(soup, paragraph)
+        replacement.string = text_chunk
+        replacements.append(replacement)
+    _replace_paragraph_with_chunks(paragraph, replacements)
+    return True
+
+
+def normalize_xhtml_prose_blocks(content: str | bytes) -> tuple[bytes, bool]:
+    """Split oversized prose paragraphs into smaller XHTML block elements."""
+    soup = BeautifulSoup(content, "html.parser")
+    changed = False
+
+    for paragraph in list(soup.find_all("p")):
+        if _split_oversized_paragraph(soup, paragraph):
+            changed = True
+
+    return str(soup).encode("utf-8"), changed
+
+
+def normalize_epub_prose_blocks(epub_path: Path) -> bool:
+    """Normalize oversized prose paragraphs in XHTML/HTML entries inside an EPUB."""
+    temp_path = epub_path.with_suffix(f"{epub_path.suffix}.tmp")
+    changed = False
+
+    with zipfile.ZipFile(epub_path) as src, zipfile.ZipFile(temp_path, "w") as dst:
+        for info in src.infolist():
+            data = src.read(info.filename)
+            if info.filename.lower().endswith((".xhtml", ".html", ".htm")):
+                normalized, entry_changed = normalize_xhtml_prose_blocks(data)
+                if entry_changed:
+                    data = normalized
+                    changed = True
+            dst.writestr(info, data)
+
+    if changed:
+        temp_path.replace(epub_path)
+    else:
+        temp_path.unlink(missing_ok=True)
+    return changed
 
 
 def get_epub_word_and_chapter_count(epub_path: Path) -> tuple[int, int]:

--- a/backend/app/services/web_novel.py
+++ b/backend/app/services/web_novel.py
@@ -16,7 +16,12 @@ from .. import crud, epub_editor, schemas
 from ..config import LIBRARY_PATH
 from ..database import SessionLocal
 from .cover_collectors import collect_cover
-from .epub_utils import get_and_save_epub_cover, get_epub_tag_metadata, get_epub_word_and_chapter_count
+from .epub_utils import (
+    get_and_save_epub_cover,
+    get_epub_tag_metadata,
+    get_epub_word_and_chapter_count,
+    normalize_epub_prose_blocks,
+)
 from .fanficfare_config import get_fff_config_paths
 from .library_paths import build_book_paths
 from .metadata_jobs import queue_metadata_sync_job
@@ -227,6 +232,7 @@ async def download_web_novel(
             detail="FanFicFare ran but no new or updated EPUB file was found.",
         )
     new_epub_path = updated_epub_path or changed_epubs[0]
+    normalize_epub_prose_blocks(new_epub_path)
 
     try:
         return new_epub_path, _read_epub_metadata(new_epub_path)

--- a/backend/tests/test_epub_editor.py
+++ b/backend/tests/test_epub_editor.py
@@ -1,0 +1,53 @@
+import zipfile
+from pathlib import Path
+
+from bs4 import BeautifulSoup
+from ebooklib import epub
+
+from backend.app import epub_editor
+from backend.app.services.epub_utils import PROSE_BLOCK_MAX_CHARS
+
+
+def _create_epub(filepath: Path, chapter_html: str) -> None:
+    book = epub.EpubBook()
+    book.set_identifier("test-id")
+    book.set_title("Normalizer Test")
+    book.set_language("en")
+    book.add_author("Test Author")
+
+    chapter = epub.EpubHtml(title="Chapter 1", file_name="chap_1.xhtml", lang="en")
+    chapter.content = chapter_html
+    book.add_item(chapter)
+    book.spine = ["nav", chapter]
+    book.toc = (chapter,)
+    book.add_item(epub.EpubNcx())
+    book.add_item(epub.EpubNav())
+
+    epub.write_epub(str(filepath), book, {})
+
+
+def _chapter_soup(epub_path: Path) -> BeautifulSoup:
+    with zipfile.ZipFile(epub_path) as archive:
+        chapter_name = next(name for name in archive.namelist() if name.endswith("chap_1.xhtml"))
+        return BeautifulSoup(archive.read(chapter_name), "html.parser")
+
+
+def test_process_epub_normalizes_oversized_prose_blocks(tmp_path):
+    immutable_path = tmp_path / "immutable.epub"
+    current_path = tmp_path / "current.epub"
+    parts = ["First sentence. " * 90, "Second sentence. " * 90, "Third sentence. " * 90]
+    _create_epub(immutable_path, f"<h1>Chapter 1</h1><p>{'<br/><br/>'.join(parts)}</p>")
+
+    word_count = epub_editor.process_epub(
+        str(immutable_path),
+        str(current_path),
+        removed_chapters=[],
+        content_selectors=[],
+        normalize_prose_blocks=True,
+    )
+
+    soup = _chapter_soup(current_path)
+    paragraphs = soup.find_all("p")
+    assert word_count is not None
+    assert len(paragraphs) == 3
+    assert all(len(p.get_text(" ", strip=True)) <= PROSE_BLOCK_MAX_CHARS for p in paragraphs)

--- a/backend/tests/test_epub_utils.py
+++ b/backend/tests/test_epub_utils.py
@@ -1,7 +1,15 @@
 import zipfile
 from pathlib import Path
 
-from backend.app.services.epub_utils import get_and_save_epub_cover, get_epub_genre_tags, get_epub_source_tags
+from bs4 import BeautifulSoup
+
+from backend.app.services.epub_utils import (
+    PROSE_BLOCK_MAX_CHARS,
+    get_and_save_epub_cover,
+    get_epub_genre_tags,
+    get_epub_source_tags,
+    normalize_xhtml_prose_blocks,
+)
 
 
 def write_minimal_epub(epub_path: Path, opf: str, entries: dict[str, bytes] | None = None) -> None:
@@ -21,6 +29,86 @@ def write_minimal_epub(epub_path: Path, opf: str, entries: dict[str, bytes] | No
         archive.writestr("content.opf", opf)
         for name, content in (entries or {}).items():
             archive.writestr(name, content)
+
+
+def _paragraph_texts(content: bytes) -> list[str]:
+    soup = BeautifulSoup(content, "html.parser")
+    return [p.get_text(" ", strip=True) for p in soup.find_all("p")]
+
+
+def test_normalize_xhtml_prose_blocks_leaves_normal_paragraphs_unchanged():
+    html = b"<html><body><p>First paragraph.</p><p><em>Second</em> paragraph.</p></body></html>"
+
+    normalized, changed = normalize_xhtml_prose_blocks(html)
+
+    assert changed is False
+    assert normalized == html
+
+
+def test_normalize_xhtml_prose_blocks_splits_double_br_paragraph_breaks():
+    parts = [
+        "First sentence. " * 80,
+        "Second sentence. " * 80,
+        "Third sentence. " * 80,
+    ]
+    html = f"<html><body><p class='chapter'>{'<br/><br/>'.join(parts)}</p></body></html>"
+
+    normalized, changed = normalize_xhtml_prose_blocks(html)
+
+    soup = BeautifulSoup(normalized, "html.parser")
+    paragraphs = soup.find_all("p")
+    assert changed is True
+    assert len(paragraphs) == 3
+    assert [p.get("class") for p in paragraphs] == [["chapter"], ["chapter"], ["chapter"]]
+    assert _paragraph_texts(normalized) == [part.strip() for part in parts]
+    assert all(len(text) <= PROSE_BLOCK_MAX_CHARS for text in _paragraph_texts(normalized))
+
+
+def test_normalize_xhtml_prose_blocks_splits_simple_prose_at_sentence_boundaries():
+    text = " ".join(f"This is sentence number {index} with enough words to make the paragraph long." for index in range(180))
+    html = f"<html><body><p>{text}</p></body></html>"
+
+    normalized, changed = normalize_xhtml_prose_blocks(html)
+
+    paragraphs = _paragraph_texts(normalized)
+    assert changed is True
+    assert len(paragraphs) > 1
+    assert " ".join(paragraphs) == text
+    assert all(len(text) <= PROSE_BLOCK_MAX_CHARS for text in paragraphs)
+
+
+def test_normalize_xhtml_prose_blocks_preserves_inline_formatting_when_splitting_on_breaks():
+    first = "<em>First emphasized sentence.</em> " + ("More first text. " * 120)
+    second = "<strong>Second bold sentence.</strong> <span>More second text.</span> " + ("Tail text. " * 130)
+    html = f"<html><body><p>{first}<br/><br/>{second}</p></body></html>"
+
+    normalized, changed = normalize_xhtml_prose_blocks(html)
+
+    soup = BeautifulSoup(normalized, "html.parser")
+    paragraphs = soup.find_all("p")
+    assert changed is True
+    assert len(paragraphs) == 2
+    assert paragraphs[0].find("em").get_text(strip=True) == "First emphasized sentence."
+    assert paragraphs[1].find("strong").get_text(strip=True) == "Second bold sentence."
+    assert paragraphs[1].find("span").get_text(strip=True) == "More second text."
+
+
+def test_normalize_xhtml_prose_blocks_skips_risky_and_non_prose_structures():
+    long_text = "Risky sentence. " * 260
+    html = f"""<html><body>
+<p>{long_text}<a href="chapter.xhtml">linked text</a><br/><br/>{long_text}</p>
+<p>{long_text}<code>code text</code><br/><br/>{long_text}</p>
+<pre>{long_text}<br/><br/>{long_text}</pre>
+<table><tr><td>{long_text}</td></tr></table>
+</body></html>"""
+
+    normalized, changed = normalize_xhtml_prose_blocks(html)
+
+    soup = BeautifulSoup(normalized, "html.parser")
+    assert changed is False
+    assert len(soup.find_all("p")) == 2
+    assert len(soup.find_all("pre")) == 1
+    assert len(soup.find_all("table")) == 1
 
 
 def test_get_and_save_epub_cover_uses_epub3_cover_image_property(tmp_path, monkeypatch):

--- a/backend/tests/test_web_novel_service.py
+++ b/backend/tests/test_web_novel_service.py
@@ -87,6 +87,7 @@ async def test_download_web_novel_existing_epub_uses_update_mode_and_user_config
         return 0
 
     mocker.patch("backend.app.services.web_novel._run_fff_main", side_effect=fake_fff_main)
+    normalize_mock = mocker.patch("backend.app.services.web_novel.normalize_epub_prose_blocks")
 
     result = await web_novel.download_web_novel(
         "https://example.com/story/1",
@@ -106,6 +107,7 @@ async def test_download_web_novel_existing_epub_uses_update_mode_and_user_config
     assert "-U" not in args
     assert str(existing_epub) == args[-1]
     assert repaired_source["value"] == "https://example.com/story/1"
+    normalize_mock.assert_called_once_with(existing_epub)
 
 
 @pytest.mark.asyncio
@@ -124,6 +126,7 @@ async def test_download_web_novel_new_download_uses_story_manager_output_path(tm
         return 0
 
     mocker.patch("backend.app.services.web_novel._run_fff_main", side_effect=fake_fff_main)
+    normalize_mock = mocker.patch("backend.app.services.web_novel.normalize_epub_prose_blocks")
 
     result = await web_novel.download_web_novel("https://www.royalroad.com/fiction/123")
 
@@ -136,6 +139,7 @@ async def test_download_web_novel_new_download_uses_story_manager_output_path(tm
     output_arg = f"output_filename={library_path.resolve()}/${{title}}-${{siteabbrev}}_${{storyId}}${{formatext}}"
     assert output_arg in args
     assert "https://www.royalroad.com/fiction/123" == args[-1]
+    normalize_mock.assert_called_once_with(expected_output)
 
 
 def test_get_fff_config_paths_prefers_local_repo_override(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add EPUB/XHTML prose block normalization for oversized web-story paragraphs
- split double-`<br>` mega-paragraphs into real paragraph blocks, with sentence-boundary fallback for simple prose
- run normalization for FanFicFare web downloads/updates and web-source reprocess flows

## Why
Readium TTS can only seek to block-level content elements by CSS selector. Some generated EPUB chapters serialized most chapter text into one giant `<p>`, so starting TTS near the end of a chapter could jump back to the beginning of that paragraph. This gives generated EPUB XHTML better block granularity for seeking, highlighting, pagination, and TTS startup.

## Validation
- `PYTHONPATH=. uv run pytest backend/tests -q`
- `git diff --check`
