### PR TITLE
Fix EPUB import crash when series volumes share the same filename

### DIFF
--- a/backend/app/routers/upload.py
+++ b/backend/app/routers/upload.py
@@ -9,6 +9,7 @@ from typing import List, Optional
 from ebooklib import epub
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
 from pydantic import BaseModel
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import crud, epub_editor, models, schemas
@@ -153,7 +154,7 @@ async def _upload_epub_bytes(filename: str, payload: bytes, db: AsyncSession) ->
 
         # Restore missing files for the existing book record.
         logger.info("Restoring missing files for '%s' by '%s' (id=%s)", title, author, existing.id)
-        immutable_path, current_path = build_book_paths(filename, author)
+        immutable_path, current_path = build_book_paths(f"{title} - {author}.epub", author)
         temp_immutable_path.replace(immutable_path)
         temp_current_path.replace(current_path)
 
@@ -172,7 +173,7 @@ async def _upload_epub_bytes(filename: str, payload: bytes, db: AsyncSession) ->
         await epub_editor.apply_book_cleaning(existing, db)
         return existing
 
-    immutable_path, current_path = build_book_paths(filename, author)
+    immutable_path, current_path = build_book_paths(f"{title} - {author}.epub", author)
     temp_immutable_path.replace(immutable_path)
     temp_current_path.replace(current_path)
 
@@ -215,7 +216,16 @@ async def _upload_epub_bytes(filename: str, payload: bytes, db: AsyncSession) ->
         current_word_count=master_word_count,
     )
 
-    db_book = await crud.create_book(db=db, book=book_to_create)
+    try:
+        db_book = await crud.create_book(db=db, book=book_to_create)
+    except IntegrityError:
+        await db.rollback()
+        immutable_path.unlink(missing_ok=True)
+        current_path.unlink(missing_ok=True)
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"A book with title '{title}' by '{author}' already exists at the target path",
+        )
 
     cover_path = get_and_save_epub_cover(epub_path=immutable_path, book_id=db_book.id)
     if cover_path:

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1004,8 +1004,9 @@ async def test_upload_epub(db_session):
     epub_filename = "Uploaded Book.epub"
     epub_filepath = library_path / epub_filename
     author_dir = library_path / "Uploader"
-    immutable_filepath = author_dir / f"immutable_{epub_filename}"
-    current_filepath = author_dir / epub_filename
+    stored_filename = "Uploaded Book - Uploader.epub"
+    immutable_filepath = author_dir / f"immutable_{stored_filename}"
+    current_filepath = author_dir / stored_filename
 
     # Create a dummy epub file
     create_dummy_epub(epub_filepath, "Uploaded Book", "Uploader", "Upload Series")
@@ -1024,8 +1025,8 @@ async def test_upload_epub(db_session):
     assert data["title"] == "Uploaded Book"
     assert data["author"] == "Uploader"
     assert data["series"] == "Upload Series"
-    assert data["immutable_path"] == str(Path("library") / "Uploader" / f"immutable_{epub_filename}")
-    assert data["current_path"] == str(Path("library") / "Uploader" / epub_filename)
+    assert data["immutable_path"] == str(Path("library") / "Uploader" / f"immutable_{stored_filename}")
+    assert data["current_path"] == str(Path("library") / "Uploader" / stored_filename)
     assert data["master_word_count"] > 0
     assert data["current_word_count"] == data["master_word_count"]
 
@@ -1075,12 +1076,12 @@ async def test_upload_zip_with_nested_epubs(db_session):
     assert {item["book"]["title"] for item in data} == {"Nested One", "Nested Two"}
     assert all(item["filename"].startswith("batch-upload.zip:collection/") for item in data)
 
-    # Imported books are written into author folders using a flattened version of the nested archive path.
+    # Imported books are written into author folders named by title and author from epub metadata.
     for expected_path in [
-        library_path / "Author One" / "collection_one_Nested One.epub",
-        library_path / "Author One" / "immutable_collection_one_Nested One.epub",
-        library_path / "Author Two" / "collection_two_Nested Two.epub",
-        library_path / "Author Two" / "immutable_collection_two_Nested Two.epub",
+        library_path / "Author One" / "Nested One - Author One.epub",
+        library_path / "Author One" / "immutable_Nested One - Author One.epub",
+        library_path / "Author Two" / "Nested Two - Author Two.epub",
+        library_path / "Author Two" / "immutable_Nested Two - Author Two.epub",
     ]:
         assert expected_path.exists()
         expected_path.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary

- **Root cause**: `build_book_paths` derived the library file path from the uploaded filename rather than the book's metadata. Some publishers release all volumes in a series with an identical filename (e.g. `Unintended Cultivator_ Volume S - Eric Dontigney.epub`), so the second upload would hit a `UniqueViolation` on `books.current_path`.
- **Session poisoning**: The `UniqueViolation` left the SQLAlchemy session in a rolled-back state. The batch endpoint only caught `HTTPException`, so the poisoned session propagated to the series-detection query at the end of the request, crashing the entire upload.
- **Fix 1**: Use `f"{title} - {author}.epub"` (from epub DC metadata) as the base for path generation in both the new-book and file-restore paths. Titles are already the duplicate-detection key, so this keeps paths consistent with that invariant.
- **Fix 2**: Wrap `crud.create_book` in a `try/except IntegrityError`, roll back the session, clean up the orphaned files, and raise `HTTPException(409)` so the batch loop can continue processing remaining files.

## Test plan

- [ ] Upload a batch of EPUBs where multiple files share the same filename but have different DC:title metadata — all should import successfully with distinct paths
- [ ] Upload a single EPUB that already exists (same title+author) — should still return 409 as before
- [ ] Upload a mixed batch where one file is a true duplicate and others are new — duplicate should be skipped, new books should import and series detection should still run

🤖 Generated with [Claude Code](https://claude.com/claude-code)