### PR TITLE
Add global drag-and-drop and folder upload

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -5,6 +5,17 @@
   padding: 1.5rem 1.25rem 3rem;
 }
 
+.app-container.drag-over::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  border: 3px solid var(--accent);
+  border-radius: var(--radius);
+  pointer-events: none;
+  z-index: 1000;
+  background: rgba(98, 114, 234, 0.03);
+}
+
 .app-header {
   display: flex;
   align-items: center;
@@ -302,6 +313,30 @@
 .drop-zone:hover .drop-zone-empty svg,
 .drop-zone.dragging .drop-zone-empty svg {
   opacity: 0.85;
+}
+.drop-zone-browse {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.8rem;
+  margin-top: 0.1rem;
+}
+.browse-link {
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  font-size: inherit;
+  padding: 0;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.browse-link:hover {
+  opacity: 0.8;
+}
+.browse-sep {
+  color: var(--text-muted);
+  user-select: none;
 }
 .file-list {
   list-style: none;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import "./App.css";
 import { getAuthStatus, logout } from "./api/auth";
 import { getBook } from "./api/books";
@@ -27,7 +27,9 @@ function App() {
   const [activeTab, setActiveTab] = useState("library");
   const [libraryView, setLibraryView] = useState("series");
   const [addBookOpen, setAddBookOpen] = useState(false);
+  const [globalDragging, setGlobalDragging] = useState(false);
   const [authStatus, setAuthStatus] = useState(null);
+  const addBookRef = useRef(null);
   const debouncedQuery = useDebouncedValue(q.trim(), 300);
 
   useEffect(() => {
@@ -249,7 +251,7 @@ function App() {
               >
                 Add Books
               </summary>
-              <AddBook />
+              <AddBook ref={addBookRef} />
             </details>
             {isLoading && <p>Loading...</p>}
             {error && <p className="error">{error.message}</p>}
@@ -266,8 +268,43 @@ function App() {
     }
   };
 
+  const handleGlobalDragOver = (e) => {
+    e.preventDefault();
+    setGlobalDragging(true);
+  };
+
+  const handleGlobalDragLeave = (e) => {
+    if (!e.currentTarget.contains(e.relatedTarget)) {
+      setGlobalDragging(false);
+    }
+  };
+
+  const handleGlobalDrop = (e) => {
+    e.preventDefault();
+    setGlobalDragging(false);
+    const entries = Array.from(e.dataTransfer.items)
+      .map((item) => item.webkitGetAsEntry?.())
+      .filter(Boolean);
+    const hasRelevant = entries.some(
+      (entry) =>
+        entry.isDirectory ||
+        entry.name.toLowerCase().endsWith(".epub") ||
+        entry.name.toLowerCase().endsWith(".zip")
+    );
+    if (hasRelevant) {
+      setActiveTab("library");
+      setAddBookOpen(true);
+      addBookRef.current?.addFilesFromEntries(entries);
+    }
+  };
+
   return (
-    <div className="app-container">
+    <div
+      className={`app-container${globalDragging ? " drag-over" : ""}`}
+      onDragOver={handleGlobalDragOver}
+      onDragLeave={handleGlobalDragLeave}
+      onDrop={handleGlobalDrop}
+    >
       <header className="app-header">
         <h1>Story Manager</h1>
         {authStatus.mode === "password" && (

--- a/frontend/src/components/AddBook.jsx
+++ b/frontend/src/components/AddBook.jsx
@@ -153,8 +153,26 @@ const AddBook = forwardRef(function AddBook(_props, ref) {
     const entries = Array.from(e.dataTransfer.items)
       .map((item) => item.webkitGetAsEntry?.())
       .filter(Boolean);
-    const newFiles = await extractEpubsFromEntries(entries);
-    setFiles((prev) => [...prev, ...newFiles]);
+    if (entries.length > 0) {
+      const newFiles = await extractEpubsFromEntries(entries);
+      setFiles((prev) => [...prev, ...newFiles]);
+    } else {
+      // Fallback for environments where webkitGetAsEntry is unavailable (e.g. synthetic events in tests).
+      // items[n].getAsFile() is more reliable than dataTransfer.files for programmatic DataTransfer objects.
+      const seen = new Set();
+      const newFiles = [
+        ...Array.from(e.dataTransfer.items)
+          .filter((item) => item.kind === "file")
+          .map((item) => item.getAsFile()),
+        ...Array.from(e.dataTransfer.files),
+      ]
+        .filter((f) => f && !seen.has(f.name) && seen.add(f.name))
+        .filter((f) => {
+          const lower = f.name.toLowerCase();
+          return lower.endsWith(".epub") || lower.endsWith(".zip");
+        });
+      setFiles((prev) => [...prev, ...newFiles]);
+    }
   };
 
   const handleSubmit = async (e) => {

--- a/frontend/src/components/AddBook.jsx
+++ b/frontend/src/components/AddBook.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { forwardRef, useImperativeHandle, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
 const uploadEpubs = async (files) => {
@@ -55,7 +55,47 @@ const formatSkippedMessage = (error) => {
   return message;
 };
 
-function AddBook() {
+const extractEpubsFromEntries = async (entries) => {
+  const readDir = (dirEntry) =>
+    new Promise((resolve) => {
+      const reader = dirEntry.createReader();
+      const all = [];
+      const batch = () => {
+        reader.readEntries(async (batchEntries) => {
+          if (!batchEntries.length) {
+            resolve(all);
+            return;
+          }
+          for (const entry of batchEntries) {
+            if (entry.isFile) {
+              if (entry.name.toLowerCase().endsWith(".epub")) {
+                all.push(await new Promise((r) => entry.file(r)));
+              }
+            } else if (entry.isDirectory) {
+              all.push(...(await readDir(entry)));
+            }
+          }
+          batch();
+        });
+      };
+      batch();
+    });
+
+  const files = [];
+  for (const entry of entries) {
+    if (entry.isDirectory) {
+      files.push(...(await readDir(entry)));
+    } else if (entry.isFile) {
+      const lower = entry.name.toLowerCase();
+      if (lower.endsWith(".epub") || lower.endsWith(".zip")) {
+        files.push(await new Promise((r) => entry.file(r)));
+      }
+    }
+  }
+  return files;
+};
+
+const AddBook = forwardRef(function AddBook(_props, ref) {
   const queryClient = useQueryClient();
   const [files, setFiles] = useState([]);
   const [urls, setUrls] = useState([""]);
@@ -63,9 +103,25 @@ function AddBook() {
   const [pending, setPending] = useState(false);
   const [results, setResults] = useState(null);
   const fileInputRef = useRef(null);
+  const folderInputRef = useRef(null);
+
+  useImperativeHandle(ref, () => ({
+    addFilesFromEntries: async (entries) => {
+      const newFiles = await extractEpubsFromEntries(entries);
+      if (newFiles.length > 0) setFiles((prev) => [...prev, ...newFiles]);
+    },
+  }));
 
   const handleFileChange = (e) => {
     setFiles((prev) => [...prev, ...Array.from(e.target.files)]);
+    e.target.value = "";
+  };
+
+  const handleFolderChange = (e) => {
+    const epubs = Array.from(e.target.files).filter((f) =>
+      f.name.toLowerCase().endsWith(".epub")
+    );
+    setFiles((prev) => [...prev, ...epubs]);
     e.target.value = "";
   };
 
@@ -80,22 +136,25 @@ function AddBook() {
 
   const handleDragOver = (e) => {
     e.preventDefault();
+    e.stopPropagation();
     setDragging(true);
   };
 
   const handleDragLeave = (e) => {
     e.preventDefault();
+    e.stopPropagation();
     setDragging(false);
   };
 
-  const handleDrop = (e) => {
+  const handleDrop = async (e) => {
     e.preventDefault();
+    e.stopPropagation();
     setDragging(false);
-    const dropped = Array.from(e.dataTransfer.files).filter((f) => {
-      const lower = f.name.toLowerCase();
-      return lower.endsWith(".epub") || lower.endsWith(".zip");
-    });
-    setFiles((prev) => [...prev, ...dropped]);
+    const entries = Array.from(e.dataTransfer.items)
+      .map((item) => item.webkitGetAsEntry?.())
+      .filter(Boolean);
+    const newFiles = await extractEpubsFromEntries(entries);
+    setFiles((prev) => [...prev, ...newFiles]);
   };
 
   const handleSubmit = async (e) => {
@@ -177,7 +236,24 @@ function AddBook() {
                   <path d="M12 16V6m0 0l-4 4m4-4l4 4" strokeLinecap="round" strokeLinejoin="round"/>
                   <path d="M20 16.7V19a2 2 0 01-2 2H6a2 2 0 01-2-2v-2.3" strokeLinecap="round" strokeLinejoin="round"/>
                 </svg>
-                <span>Drop EPUBs or ZIPs here, or click to browse</span>
+                <span>Drop EPUBs, ZIPs, or folders here</span>
+                <div className="drop-zone-browse">
+                  <button
+                    type="button"
+                    className="browse-link"
+                    onClick={(e) => { e.stopPropagation(); fileInputRef.current.click(); }}
+                  >
+                    Browse files
+                  </button>
+                  <span className="browse-sep">·</span>
+                  <button
+                    type="button"
+                    className="browse-link"
+                    onClick={(e) => { e.stopPropagation(); folderInputRef.current.click(); }}
+                  >
+                    Browse folder
+                  </button>
+                </div>
               </div>
             )}
             <input
@@ -187,6 +263,15 @@ function AddBook() {
               multiple
               onChange={handleFileChange}
               ref={fileInputRef}
+              style={{ display: "none" }}
+            />
+            <input
+              type="file"
+              accept=".epub"
+              multiple
+              webkitdirectory=""
+              onChange={handleFolderChange}
+              ref={folderInputRef}
               style={{ display: "none" }}
             />
           </div>
@@ -262,6 +347,6 @@ function AddBook() {
       )}
     </div>
   );
-}
+});
 
 export default AddBook;

--- a/frontend/tests-e2e/EpubEditor.spec.js
+++ b/frontend/tests-e2e/EpubEditor.spec.js
@@ -50,9 +50,15 @@ test("EpubEditor interactions", async ({ page }) => {
     "application/epub+zip",
   );
 
-  await page.getByRole("button", { name: /add book/i }).click();
+  await Promise.all([
+    page.waitForResponse((r) => r.url().includes("/api/books/upload_epubs") && r.status() === 200),
+    page.getByRole("button", { name: /add book/i }).click(),
+  ]);
 
   await page.reload();
+
+  // Narrow the library down so "Test Book" is in the first page (list renders 30 items at a time).
+  await page.getByPlaceholder("Search by title, author, series, or tag").fill("Test Book");
 
   // Standalone books now live behind their own tab in the library.
   await page.getByRole("tab", { name: /standalone/i }).click();
@@ -91,6 +97,7 @@ test("EpubEditor interactions", async ({ page }) => {
   await expect(page.getByRole("button", { name: /save & rebuild epub/i })).toBeEnabled();
   await page.getByRole("button", { name: /back/i }).click();
   await expect(page.getByText("Story Manager")).toBeVisible();
+  await page.getByPlaceholder("Search by title, author, series, or tag").fill("Test Book");
   await page.getByRole("tab", { name: /standalone/i }).click();
 
   // Verify the word count has changed


### PR DESCRIPTION
## Summary

- Dragging any EPUB, ZIP, or folder anywhere on the UI automatically opens the Add Books panel and queues the files — no more hunting for the button
- Folders are traversed recursively client-side via the FileSystem API (`webkitGetAsEntry`), so you can drop a folder full of EPUBs without zipping it first
- A **Browse folder** button is now shown in the drop zone alongside the existing Browse files link

## How it works

- `AddBook` is converted to a `forwardRef` component exposing `addFilesFromEntries` via `useImperativeHandle`
- The `app-container` div gets global `dragover`/`dragleave`/`drop` handlers; when a relevant drop is detected it switches to the Library tab, opens the Add Books panel, and passes the entries to `AddBook`
- The drop zone's own handlers call `stopPropagation` so a drop directly on the zone doesn't also fire the global handler
- Folder selection via the browser picker uses `<input webkitdirectory>`, filtered to `.epub` files

## Test plan

- [ ] Drop a single EPUB anywhere outside the drop zone — panel opens with file queued
- [ ] Drop a ZIP anywhere outside the drop zone — panel opens with file queued
- [ ] Drop a folder anywhere — panel opens with all nested EPUBs recursively found
- [ ] Drop directly onto the drop zone — still works, files added without doubling
- [ ] Click "Browse folder" — native folder picker opens, EPUBs from selected folder are added
- [ ] Drop a non-EPUB/non-ZIP file — nothing happens (panel does not open)
- [ ] While on the Configs tab, drop an EPUB — switches to Library tab and opens panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)