### PR TITLE
Fix folder drag-drop (tab crash, folder picker, path sanitization)

### DIFF
--- a/backend/app/routers/upload.py
+++ b/backend/app/routers/upload.py
@@ -109,9 +109,12 @@ async def _upload_epub_bytes(filename: str, payload: bytes, db: AsyncSession) ->
     Raises HTTPException on duplicate or parse errors.
     """
     payload = _fix_nested_epub(payload)
+    # Strip any path components from the filename — some browsers (or the FileSystem API)
+    # may send a relative path like "folder/book.epub" instead of just "book.epub".
+    safe_filename = PurePosixPath(filename or "upload.epub").name or "upload.epub"
     LIBRARY_PATH.mkdir(exist_ok=True)
-    temp_immutable_path = LIBRARY_PATH / f"tmp_immutable_{filename}"
-    temp_current_path = LIBRARY_PATH / f"tmp_{filename}"
+    temp_immutable_path = LIBRARY_PATH / f"tmp_immutable_{safe_filename}"
+    temp_current_path = LIBRARY_PATH / f"tmp_{safe_filename}"
     with open(temp_immutable_path, "wb+") as f:
         f.write(payload)
 

--- a/frontend/src/components/AddBook.jsx
+++ b/frontend/src/components/AddBook.jsx
@@ -55,40 +55,52 @@ const formatSkippedMessage = (error) => {
   return message;
 };
 
+const readDirEntries = (reader) =>
+  new Promise((resolve, reject) => reader.readEntries(resolve, reject));
+
+const getFileFromEntry = (fileEntry) =>
+  new Promise((resolve, reject) => fileEntry.file(resolve, reject));
+
 const extractEpubsFromEntries = async (entries) => {
-  const readDir = (dirEntry) =>
-    new Promise((resolve) => {
-      const reader = dirEntry.createReader();
-      const all = [];
-      const batch = () => {
-        reader.readEntries(async (batchEntries) => {
-          if (!batchEntries.length) {
-            resolve(all);
-            return;
-          }
-          for (const entry of batchEntries) {
-            if (entry.isFile) {
-              if (entry.name.toLowerCase().endsWith(".epub")) {
-                all.push(await new Promise((r) => entry.file(r)));
-              }
-            } else if (entry.isDirectory) {
-              all.push(...(await readDir(entry)));
+  const readDir = async (dirEntry) => {
+    const reader = dirEntry.createReader();
+    const files = [];
+    let batch;
+    do {
+      batch = await readDirEntries(reader);
+      for (const entry of batch) {
+        if (entry.isFile) {
+          if (entry.name.toLowerCase().endsWith(".epub")) {
+            try {
+              files.push(await getFileFromEntry(entry));
+            } catch {
+              // skip unreadable files
             }
           }
-          batch();
-        });
-      };
-      batch();
-    });
+        } else if (entry.isDirectory) {
+          files.push(...(await readDir(entry)));
+        }
+      }
+    } while (batch.length > 0);
+    return files;
+  };
 
   const files = [];
   for (const entry of entries) {
     if (entry.isDirectory) {
-      files.push(...(await readDir(entry)));
+      try {
+        files.push(...(await readDir(entry)));
+      } catch {
+        // skip unreadable directories
+      }
     } else if (entry.isFile) {
       const lower = entry.name.toLowerCase();
       if (lower.endsWith(".epub") || lower.endsWith(".zip")) {
-        files.push(await new Promise((r) => entry.file(r)));
+        try {
+          files.push(await getFileFromEntry(entry));
+        } catch {
+          // skip
+        }
       }
     }
   }
@@ -285,7 +297,6 @@ const AddBook = forwardRef(function AddBook(_props, ref) {
             />
             <input
               type="file"
-              accept=".epub"
               multiple
               webkitdirectory=""
               onChange={handleFolderChange}


### PR DESCRIPTION
## Summary

Follow-up to #140. Testing revealed three bugs in the folder upload feature:

- **Tab crash on single folder drop** — `readDir` passed an `async` function as the callback to `FileSystemDirectoryReader.readEntries()`, which doesn't await it. Any failure in `entry.file()` left a Promise hanging forever, freezing the tab. Rewrote using dedicated `readDirEntries()` / `getFileFromEntry()` promise wrappers and a `do/while` loop so the next `readEntries` call only fires after the previous batch fully resolves.

- **"Browse folder" showed a file picker instead of a folder picker** — `accept=".epub"` on a `webkitdirectory` input overrides the folder-picker behaviour in Chrome/Safari, falling back to a regular file picker. Removed the `accept` attribute; the `handleFolderChange` handler already filters to `.epub` files.

- **"No such file or directory" on upload after folder drop** — The backend built the temp path as `LIBRARY_PATH / f"tmp_immutable_{filename}"`. Some browsers (and the FileSystem API) send a relative path like `"subfolder/book.epub"` rather than just `"book.epub"`, so the intermediate directory doesn't exist when Python calls `open()`. Fixed by stripping to the basename with `PurePosixPath(filename).name` before constructing the temp path.

## Test plan

- [ ] Drag a single folder onto the page — files queue without crashing
- [ ] Drag multiple folders — all nested EPUBs found and queued
- [ ] Click "Browse folder" — native folder picker opens (not a file picker)
- [ ] Upload EPUBs sourced from a folder drop — no backend path error
- [ ] All existing file/ZIP drag-drop and Browse files flows still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)