### PR TITLE
Add functional EPUB-to-audiobook pipeline with offline harness

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,8 @@
 .github
 .idea
 .venv
+.venv-*
+**/.venv
 **/__pycache__
 **/.pytest_cache
 **/*.pyc

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN chmod +x run-container.sh
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
     && /root/.local/bin/uv pip install --system --no-cache .
 
+RUN python -m spacy download en_core_web_sm
+
 RUN npm --prefix frontend ci && npm --prefix frontend run build
 
 EXPOSE 8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,12 @@ COPY run-container.sh run-container.sh
 
 RUN chmod +x run-container.sh
 
+RUN rm -f /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends ffmpeg \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
     && /root/.local/bin/uv export --quiet --frozen --no-dev --no-emit-project --format requirements-txt -o /tmp/requirements.txt \
     && /root/.local/bin/uv pip install --system --no-cache -r /tmp/requirements.txt \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
     && /root/.local/bin/uv pip install --system --no-cache -r /tmp/requirements.txt \
     && /root/.local/bin/uv pip install --system --no-cache --no-deps .
 
+RUN python -m spacy download en_core_web_sm
+
 RUN npm --prefix frontend ci && npm --prefix frontend run build
 
 EXPOSE 8000

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,7 +1,7 @@
 FROM python:3.13-slim
 
 # Install PostgreSQL and Node.js
-RUN apt-get update && apt-get install -y curl ffmpeg postgresql postgresql-contrib \
+RUN apt-get update && apt-get install -y curl postgresql postgresql-contrib \
     && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y nodejs \
     && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,7 +1,7 @@
 FROM python:3.13-slim
 
 # Install PostgreSQL and Node.js
-RUN apt-get update && apt-get install -y curl postgresql postgresql-contrib \
+RUN apt-get update && apt-get install -y curl ffmpeg postgresql postgresql-contrib \
     && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y nodejs \
     && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup setup-omnivoice run-omnivoice run-ui run-api run-db ensure-db migrate fmt lint test test-migrations e2e e2e-debug
+.PHONY: help setup setup-omnivoice run-omnivoice pull-ollama-model run-ui run-api run-db ensure-db migrate fmt lint test test-migrations e2e e2e-debug
 
 E2E_DB_CONTAINER ?= story-manager-e2e-db
 E2E_DB_PORT ?= 5434
@@ -13,6 +13,7 @@ help:
 	@echo "  make run-ui           Run the Vite frontend"
 	@echo "  make setup-omnivoice  Install official OmniVoice in an isolated environment"
 	@echo "  make run-omnivoice    Run the local MPS/CUDA/CPU OmniVoice adapter"
+	@echo "  make pull-ollama-model Pull the recommended local audiobook LLM"
 	@echo "  make test             Run backend and frontend unit tests"
 	@echo "  make test-migrations  Run migrations against throwaway PostgreSQL"
 	@echo "  make e2e              Run Playwright E2E tests"
@@ -30,6 +31,9 @@ setup-omnivoice:
 run-omnivoice: setup-omnivoice
 	PYTORCH_ENABLE_MPS_FALLBACK=1 services/omnivoice/.venv/bin/uvicorn \
 		services.omnivoice.server:app --host 127.0.0.1 --port $(OMNIVOICE_PORT)
+
+pull-ollama-model:
+	ollama pull qwen3.5:9b
 
 run-ui:
 	cd frontend && npm run dev

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
-.PHONY: help setup run-ui run-api run-db ensure-db migrate fmt lint test test-migrations e2e e2e-debug
+.PHONY: help setup setup-omnivoice run-omnivoice run-ui run-api run-db ensure-db migrate fmt lint test test-migrations e2e e2e-debug
 
 E2E_DB_CONTAINER ?= story-manager-e2e-db
 E2E_DB_PORT ?= 5434
+OMNIVOICE_PORT ?= 8001
 
 help:
 	@echo "Story Manager commands:"
@@ -10,6 +11,8 @@ help:
 	@echo "  make migrate          Run Alembic migrations"
 	@echo "  make run-api          Run the FastAPI backend"
 	@echo "  make run-ui           Run the Vite frontend"
+	@echo "  make setup-omnivoice  Install official OmniVoice in an isolated environment"
+	@echo "  make run-omnivoice    Run the local MPS/CUDA/CPU OmniVoice adapter"
 	@echo "  make test             Run backend and frontend unit tests"
 	@echo "  make test-migrations  Run migrations against throwaway PostgreSQL"
 	@echo "  make e2e              Run Playwright E2E tests"
@@ -20,6 +23,13 @@ setup:
 	uv venv
 	uv pip install -e ".[dev]"
 	cd frontend && npm ci
+
+setup-omnivoice:
+	uv sync --project services/omnivoice --python 3.13
+
+run-omnivoice: setup-omnivoice
+	PYTORCH_ENABLE_MPS_FALLBACK=1 services/omnivoice/.venv/bin/uvicorn \
+		services.omnivoice.server:app --host 127.0.0.1 --port $(OMNIVOICE_PORT)
 
 run-ui:
 	cd frontend && npm run dev

--- a/README.md
+++ b/README.md
@@ -57,10 +57,14 @@ Useful commands:
 
 ```bash
 make migrate
+make run-omnivoice
 make test
 make test-migrations
 make e2e
 ```
+
+`make run-omnivoice` installs and runs the optional official local OmniVoice adapter for real audiobook speech.
+See [services/omnivoice/README.md](services/omnivoice/README.md) for hardware notes and configuration.
 
 For setup notes and testing details, see [docs/development.md](docs/development.md).
 

--- a/backend/alembic/versions/0018_audiobook_pipeline.py
+++ b/backend/alembic/versions/0018_audiobook_pipeline.py
@@ -1,0 +1,85 @@
+"""audiobook pipeline tables and book pipeline status column
+
+Revision ID: 0018
+Revises: 0017
+Create Date: 2026-05-07 00:00:00
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0018"
+down_revision = "0017"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "audiobook_settings",
+        sa.Column("id", sa.Integer, primary_key=True, index=True),
+        sa.Column("llm_provider", sa.String, nullable=True),
+        sa.Column("llm_api_key", sa.String, nullable=True),
+        sa.Column("llm_base_url", sa.String, nullable=True),
+        sa.Column("llm_model", sa.String, nullable=True),
+        sa.Column("omnivoice_endpoint", sa.String, nullable=True),
+        sa.Column("roster_prompt_template", sa.Text, nullable=True),
+        sa.Column("diarization_prompt_template", sa.Text, nullable=True),
+    )
+
+    op.create_table(
+        "audiobook_chapters",
+        sa.Column("id", sa.Integer, primary_key=True, index=True),
+        sa.Column("book_id", sa.Integer, sa.ForeignKey("books.id", ondelete="CASCADE"), nullable=False, index=True),
+        sa.Column("chapter_number", sa.Integer, nullable=False),
+        sa.Column("smil_file_path", sa.String, nullable=True),
+        sa.Column("audio_file_path", sa.String, nullable=True),
+        sa.Column("needs_reassembly", sa.Boolean, nullable=False, server_default="false"),
+    )
+
+    op.create_table(
+        "audiobook_characters",
+        sa.Column("id", sa.Integer, primary_key=True, index=True),
+        sa.Column("book_id", sa.Integer, sa.ForeignKey("books.id", ondelete="CASCADE"), nullable=False, index=True),
+        sa.Column("name", sa.String, nullable=False),
+        sa.Column("description", sa.Text, nullable=True),
+        sa.Column("voice_design_prompt", sa.String, nullable=True),
+        sa.Column("is_narrator", sa.Boolean, nullable=False, server_default="false"),
+    )
+
+    op.create_table(
+        "audiobook_sentences",
+        sa.Column("id", sa.Integer, primary_key=True, index=True),
+        sa.Column(
+            "chapter_id",
+            sa.Integer,
+            sa.ForeignKey("audiobook_chapters.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "character_id",
+            sa.Integer,
+            sa.ForeignKey("audiobook_characters.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("html_element_id", sa.String, nullable=False),
+        sa.Column("sequence_order", sa.Integer, nullable=False),
+        sa.Column("original_text", sa.Text, nullable=False),
+        sa.Column("tagged_text", sa.Text, nullable=True),
+        sa.Column("audio_file_path", sa.String, nullable=True),
+        sa.Column("audio_duration_ms", sa.Integer, nullable=True),
+        sa.Column("status", sa.String, nullable=False, server_default="pending_diarization"),
+    )
+    op.create_index("ix_audiobook_sentences_status", "audiobook_sentences", ["status"])
+
+    op.add_column("books", sa.Column("audiobook_pipeline_status", sa.String, nullable=True))
+
+
+def downgrade():
+    op.drop_column("books", "audiobook_pipeline_status")
+    op.drop_index("ix_audiobook_sentences_status", table_name="audiobook_sentences")
+    op.drop_table("audiobook_sentences")
+    op.drop_table("audiobook_characters")
+    op.drop_table("audiobook_chapters")
+    op.drop_table("audiobook_settings")

--- a/backend/alembic/versions/0018_audiobook_pipeline.py
+++ b/backend/alembic/versions/0018_audiobook_pipeline.py
@@ -32,6 +32,7 @@ def upgrade():
         sa.Column("id", sa.Integer, primary_key=True, index=True),
         sa.Column("book_id", sa.Integer, sa.ForeignKey("books.id", ondelete="CASCADE"), nullable=False, index=True),
         sa.Column("chapter_number", sa.Integer, nullable=False),
+        sa.Column("content_file_name", sa.String, nullable=True),
         sa.Column("smil_file_path", sa.String, nullable=True),
         sa.Column("audio_file_path", sa.String, nullable=True),
         sa.Column("needs_reassembly", sa.Boolean, nullable=False, server_default="false"),
@@ -73,11 +74,16 @@ def upgrade():
     )
     op.create_index("ix_audiobook_sentences_status", "audiobook_sentences", ["status"])
 
+    op.add_column(
+        "books",
+        sa.Column("audiobook_enabled", sa.Boolean, nullable=False, server_default="false"),
+    )
     op.add_column("books", sa.Column("audiobook_pipeline_status", sa.String, nullable=True))
 
 
 def downgrade():
     op.drop_column("books", "audiobook_pipeline_status")
+    op.drop_column("books", "audiobook_enabled")
     op.drop_index("ix_audiobook_sentences_status", table_name="audiobook_sentences")
     op.drop_table("audiobook_sentences")
     op.drop_table("audiobook_characters")

--- a/backend/alembic/versions/0019_audiobook_pipeline_controls.py
+++ b/backend/alembic/versions/0019_audiobook_pipeline_controls.py
@@ -1,0 +1,29 @@
+"""add resumable audiobook pipeline controls
+
+Revision ID: 0019
+Revises: 0018
+Create Date: 2026-07-13 00:00:00
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0019"
+down_revision = "0018"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("books", sa.Column("audiobook_stop_after_phase", sa.String(), nullable=True))
+    op.add_column(
+        "books",
+        sa.Column("audiobook_pause_requested", sa.Boolean(), nullable=False, server_default="false"),
+    )
+    op.add_column("books", sa.Column("audiobook_last_error", sa.Text(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("books", "audiobook_last_error")
+    op.drop_column("books", "audiobook_pause_requested")
+    op.drop_column("books", "audiobook_stop_after_phase")

--- a/backend/alembic/versions/0020_audiobook_observability.py
+++ b/backend/alembic/versions/0020_audiobook_observability.py
@@ -1,0 +1,61 @@
+"""add audiobook LLM observability and batch controls
+
+Revision ID: 0020
+Revises: 0019
+Create Date: 2026-07-14 00:00:00
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0020"
+down_revision = "0019"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("books", sa.Column("audiobook_summary", sa.Text(), nullable=True))
+    op.add_column(
+        "books",
+        sa.Column("audiobook_progress_current", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.add_column(
+        "books",
+        sa.Column("audiobook_progress_total", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.add_column("books", sa.Column("audiobook_progress_detail", sa.String(), nullable=True))
+    op.add_column("books", sa.Column("audiobook_pipeline_started_at", sa.DateTime(timezone=True), nullable=True))
+    op.add_column("books", sa.Column("audiobook_pipeline_updated_at", sa.DateTime(timezone=True), nullable=True))
+    op.add_column("books", sa.Column("audiobook_batch_limit", sa.Integer(), nullable=True))
+    op.add_column(
+        "books",
+        sa.Column("audiobook_llm_requests", sa.Integer(), nullable=False, server_default="0"),
+    )
+
+    op.add_column("audiobook_chapters", sa.Column("summary", sa.Text(), nullable=True))
+    op.add_column(
+        "audiobook_chapters",
+        sa.Column("summary_updated_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column("audiobook_characters", sa.Column("aliases", sa.JSON(), nullable=True))
+    op.add_column("audiobook_characters", sa.Column("evidence", sa.JSON(), nullable=True))
+    op.add_column("audiobook_sentences", sa.Column("speaker_confidence", sa.Float(), nullable=True))
+    op.add_column("audiobook_sentences", sa.Column("speaker_reason", sa.Text(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("audiobook_sentences", "speaker_reason")
+    op.drop_column("audiobook_sentences", "speaker_confidence")
+    op.drop_column("audiobook_characters", "evidence")
+    op.drop_column("audiobook_characters", "aliases")
+    op.drop_column("audiobook_chapters", "summary_updated_at")
+    op.drop_column("audiobook_chapters", "summary")
+    op.drop_column("books", "audiobook_llm_requests")
+    op.drop_column("books", "audiobook_batch_limit")
+    op.drop_column("books", "audiobook_pipeline_updated_at")
+    op.drop_column("books", "audiobook_pipeline_started_at")
+    op.drop_column("books", "audiobook_progress_detail")
+    op.drop_column("books", "audiobook_progress_total")
+    op.drop_column("books", "audiobook_progress_current")
+    op.drop_column("books", "audiobook_summary")

--- a/backend/alembic/versions/0021_series_roster_and_chapter_previews.py
+++ b/backend/alembic/versions/0021_series_roster_and_chapter_previews.py
@@ -1,0 +1,70 @@
+"""add shared series rosters and manual chapter preview state
+
+Revision ID: 0021
+Revises: 0020
+Create Date: 2026-07-15 00:00:00
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0021"
+down_revision = "0020"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "audiobook_series_characters",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("series_name", sa.String(), nullable=False),
+        sa.Column("canonical_name", sa.String(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("voice_design_prompt", sa.String(), nullable=True),
+        sa.Column("is_narrator", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column("aliases", sa.JSON(), nullable=True),
+        sa.Column("evidence", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.UniqueConstraint("series_name", "canonical_name", name="uq_audiobook_series_character"),
+    )
+    op.create_index(
+        "ix_audiobook_series_characters_series_name",
+        "audiobook_series_characters",
+        ["series_name"],
+    )
+    op.add_column("audiobook_characters", sa.Column("series_character_id", sa.Integer(), nullable=True))
+    op.create_index(
+        "ix_audiobook_characters_series_character_id",
+        "audiobook_characters",
+        ["series_character_id"],
+    )
+    op.create_foreign_key(
+        "fk_audiobook_characters_series_character_id",
+        "audiobook_characters",
+        "audiobook_series_characters",
+        ["series_character_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.add_column("audiobook_chapters", sa.Column("preview_status", sa.String(), nullable=True))
+    op.add_column("audiobook_chapters", sa.Column("preview_error", sa.Text(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("audiobook_chapters", "preview_error")
+    op.drop_column("audiobook_chapters", "preview_status")
+    op.drop_constraint(
+        "fk_audiobook_characters_series_character_id",
+        "audiobook_characters",
+        type_="foreignkey",
+    )
+    op.drop_index("ix_audiobook_characters_series_character_id", table_name="audiobook_characters")
+    op.drop_column("audiobook_characters", "series_character_id")
+    op.drop_index(
+        "ix_audiobook_series_characters_series_name",
+        table_name="audiobook_series_characters",
+    )
+    op.drop_table("audiobook_series_characters")

--- a/backend/app/crud/__init__.py
+++ b/backend/app/crud/__init__.py
@@ -1,5 +1,7 @@
 """CRUD operations package — re-exports all functions for backward compatibility."""
 
+from . import audiobook  # noqa: F401
+
 from .books import (  # noqa: F401
     count_books,
     create_book,

--- a/backend/app/crud/audiobook.py
+++ b/backend/app/crud/audiobook.py
@@ -1,0 +1,340 @@
+"""CRUD operations for the audiobook pipeline tables."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlalchemy import select, update, func
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..models import AudiobookSettings, AudiobookChapter, AudiobookCharacter, AudiobookSentence, Book
+
+
+# ---------------------------------------------------------------------------
+# Settings
+# ---------------------------------------------------------------------------
+
+
+async def get_audiobook_settings(db: AsyncSession) -> Optional[AudiobookSettings]:
+    result = await db.execute(select(AudiobookSettings).limit(1))
+    return result.scalar_one_or_none()
+
+
+async def upsert_audiobook_settings(db: AsyncSession, data: dict) -> AudiobookSettings:
+    settings = await get_audiobook_settings(db)
+    if settings is None:
+        settings = AudiobookSettings(**data)
+        db.add(settings)
+    else:
+        for key, value in data.items():
+            setattr(settings, key, value)
+    await db.commit()
+    await db.refresh(settings)
+    return settings
+
+
+# ---------------------------------------------------------------------------
+# Book pipeline status
+# ---------------------------------------------------------------------------
+
+
+async def set_book_pipeline_status(db: AsyncSession, book_id: int, status: Optional[str]) -> None:
+    await db.execute(update(Book).where(Book.id == book_id).values(audiobook_pipeline_status=status))
+    await db.commit()
+
+
+async def get_in_progress_audiobook_books(db: AsyncSession) -> list[Book]:
+    active_statuses = ["ingesting", "roster_gen", "diarizing", "audio_gen", "assembling"]
+    result = await db.execute(select(Book).where(Book.audiobook_pipeline_status.in_(active_statuses)))
+    return list(result.scalars().all())
+
+
+# ---------------------------------------------------------------------------
+# Chapters
+# ---------------------------------------------------------------------------
+
+
+async def create_chapter(db: AsyncSession, book_id: int, chapter_number: int) -> AudiobookChapter:
+    chapter = AudiobookChapter(book_id=book_id, chapter_number=chapter_number)
+    db.add(chapter)
+    await db.flush()
+    return chapter
+
+
+async def get_chapters_for_book(db: AsyncSession, book_id: int) -> list[AudiobookChapter]:
+    result = await db.execute(
+        select(AudiobookChapter)
+        .where(AudiobookChapter.book_id == book_id)
+        .order_by(AudiobookChapter.chapter_number)
+    )
+    return list(result.scalars().all())
+
+
+async def get_chapters_needing_reassembly(db: AsyncSession, book_id: int) -> list[AudiobookChapter]:
+    result = await db.execute(
+        select(AudiobookChapter)
+        .where(AudiobookChapter.book_id == book_id, AudiobookChapter.needs_reassembly.is_(True))
+        .order_by(AudiobookChapter.chapter_number)
+    )
+    return list(result.scalars().all())
+
+
+async def update_chapter_assembly(
+    db: AsyncSession,
+    chapter_id: int,
+    audio_file_path: str,
+    smil_file_path: str,
+) -> None:
+    await db.execute(
+        update(AudiobookChapter)
+        .where(AudiobookChapter.id == chapter_id)
+        .values(audio_file_path=audio_file_path, smil_file_path=smil_file_path, needs_reassembly=False)
+    )
+    await db.commit()
+
+
+async def flag_chapter_for_reassembly(db: AsyncSession, chapter_id: int) -> None:
+    await db.execute(
+        update(AudiobookChapter).where(AudiobookChapter.id == chapter_id).values(needs_reassembly=True)
+    )
+    await db.commit()
+
+
+async def delete_chapters_for_book(db: AsyncSession, book_id: int) -> None:
+    chapters = await get_chapters_for_book(db, book_id)
+    for ch in chapters:
+        await db.delete(ch)
+    await db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Characters
+# ---------------------------------------------------------------------------
+
+
+async def create_characters_bulk(db: AsyncSession, book_id: int, characters_data: list[dict]) -> list[AudiobookCharacter]:
+    chars = [AudiobookCharacter(book_id=book_id, **c) for c in characters_data]
+    db.add_all(chars)
+    await db.commit()
+    for c in chars:
+        await db.refresh(c)
+    return chars
+
+
+async def get_characters_for_book(db: AsyncSession, book_id: int) -> list[AudiobookCharacter]:
+    result = await db.execute(
+        select(AudiobookCharacter)
+        .where(AudiobookCharacter.book_id == book_id)
+        .order_by(AudiobookCharacter.is_narrator.desc(), AudiobookCharacter.name)
+    )
+    return list(result.scalars().all())
+
+
+async def get_character(db: AsyncSession, char_id: int) -> Optional[AudiobookCharacter]:
+    return await db.get(AudiobookCharacter, char_id)
+
+
+async def update_character(db: AsyncSession, char_id: int, data: dict) -> Optional[AudiobookCharacter]:
+    char = await db.get(AudiobookCharacter, char_id)
+    if char is None:
+        return None
+    for key, value in data.items():
+        setattr(char, key, value)
+    await db.commit()
+    await db.refresh(char)
+    return char
+
+
+async def cascade_voice_change(db: AsyncSession, char_id: int) -> None:
+    """Reset audio for all sentences by this character and flag affected chapters."""
+    await db.execute(
+        update(AudiobookSentence)
+        .where(AudiobookSentence.character_id == char_id)
+        .values(status="ready_for_audio", audio_file_path=None, audio_duration_ms=None)
+    )
+    result = await db.execute(
+        select(AudiobookSentence.chapter_id)
+        .where(AudiobookSentence.character_id == char_id)
+        .distinct()
+    )
+    chapter_ids = [row[0] for row in result.all()]
+    if chapter_ids:
+        await db.execute(
+            update(AudiobookChapter)
+            .where(AudiobookChapter.id.in_(chapter_ids))
+            .values(needs_reassembly=True)
+        )
+    await db.commit()
+
+
+async def delete_characters_for_book(db: AsyncSession, book_id: int) -> None:
+    chars = await get_characters_for_book(db, book_id)
+    for c in chars:
+        await db.delete(c)
+    await db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Sentences
+# ---------------------------------------------------------------------------
+
+
+async def create_sentences_bulk(db: AsyncSession, chapter_id: int, sentences_data: list[dict]) -> int:
+    sentences = [AudiobookSentence(chapter_id=chapter_id, **s) for s in sentences_data]
+    db.add_all(sentences)
+    await db.commit()
+    return len(sentences)
+
+
+async def get_sentences_for_chapter(db: AsyncSession, chapter_id: int) -> list[AudiobookSentence]:
+    result = await db.execute(
+        select(AudiobookSentence)
+        .where(AudiobookSentence.chapter_id == chapter_id)
+        .order_by(AudiobookSentence.sequence_order)
+    )
+    return list(result.scalars().all())
+
+
+async def get_sentences_paginated(
+    db: AsyncSession,
+    book_id: int,
+    page: int = 1,
+    limit: int = 50,
+    chapter_id: Optional[int] = None,
+) -> tuple[list[AudiobookSentence], int]:
+    base_query = (
+        select(AudiobookSentence)
+        .join(AudiobookChapter, AudiobookSentence.chapter_id == AudiobookChapter.id)
+        .where(AudiobookChapter.book_id == book_id)
+    )
+    count_query = (
+        select(func.count())
+        .select_from(AudiobookSentence)
+        .join(AudiobookChapter, AudiobookSentence.chapter_id == AudiobookChapter.id)
+        .where(AudiobookChapter.book_id == book_id)
+    )
+    if chapter_id is not None:
+        base_query = base_query.where(AudiobookSentence.chapter_id == chapter_id)
+        count_query = count_query.where(AudiobookSentence.chapter_id == chapter_id)
+
+    total_result = await db.execute(count_query)
+    total = total_result.scalar_one()
+
+    result = await db.execute(
+        base_query
+        .order_by(AudiobookChapter.chapter_number, AudiobookSentence.sequence_order)
+        .offset((page - 1) * limit)
+        .limit(limit)
+    )
+    return list(result.scalars().all()), total
+
+
+async def get_sentences_pending_diarization(
+    db: AsyncSession, book_id: int, limit: int = 50
+) -> list[AudiobookSentence]:
+    result = await db.execute(
+        select(AudiobookSentence)
+        .join(AudiobookChapter, AudiobookSentence.chapter_id == AudiobookChapter.id)
+        .where(
+            AudiobookChapter.book_id == book_id,
+            AudiobookSentence.status == "pending_diarization",
+        )
+        .order_by(AudiobookChapter.chapter_number, AudiobookSentence.sequence_order)
+        .limit(limit)
+    )
+    return list(result.scalars().all())
+
+
+async def get_sentences_ready_for_audio(
+    db: AsyncSession, book_id: int, limit: int = 20
+) -> list[AudiobookSentence]:
+    result = await db.execute(
+        select(AudiobookSentence)
+        .join(AudiobookChapter, AudiobookSentence.chapter_id == AudiobookChapter.id)
+        .where(
+            AudiobookChapter.book_id == book_id,
+            AudiobookSentence.status == "ready_for_audio",
+        )
+        .order_by(AudiobookChapter.chapter_number, AudiobookSentence.sequence_order)
+        .limit(limit)
+    )
+    return list(result.scalars().all())
+
+
+async def update_sentence_diarization(
+    db: AsyncSession, sentence_id: int, character_id: Optional[int], tagged_text: str
+) -> None:
+    await db.execute(
+        update(AudiobookSentence)
+        .where(AudiobookSentence.id == sentence_id)
+        .values(character_id=character_id, tagged_text=tagged_text, status="ready_for_audio")
+    )
+    await db.commit()
+
+
+async def update_sentence_audio(
+    db: AsyncSession, sentence_id: int, audio_file_path: str, audio_duration_ms: int
+) -> None:
+    await db.execute(
+        update(AudiobookSentence)
+        .where(AudiobookSentence.id == sentence_id)
+        .values(audio_file_path=audio_file_path, audio_duration_ms=audio_duration_ms, status="audio_generated")
+    )
+    await db.commit()
+
+
+async def update_sentence_speaker(
+    db: AsyncSession, sentence_id: int, character_id: Optional[int], tagged_text: str
+) -> Optional[AudiobookSentence]:
+    """Update sentence speaker/tags and cascade invalidation to the parent chapter."""
+    sentence = await db.get(AudiobookSentence, sentence_id)
+    if sentence is None:
+        return None
+    sentence.character_id = character_id
+    sentence.tagged_text = tagged_text
+    sentence.status = "ready_for_audio"
+    sentence.audio_file_path = None
+    sentence.audio_duration_ms = None
+    await db.execute(
+        update(AudiobookChapter)
+        .where(AudiobookChapter.id == sentence.chapter_id)
+        .values(needs_reassembly=True)
+    )
+    await db.commit()
+    await db.refresh(sentence)
+    return sentence
+
+
+async def count_sentences_by_status(db: AsyncSession, book_id: int) -> dict[str, int]:
+    result = await db.execute(
+        select(AudiobookSentence.status, func.count())
+        .join(AudiobookChapter, AudiobookSentence.chapter_id == AudiobookChapter.id)
+        .where(AudiobookChapter.book_id == book_id)
+        .group_by(AudiobookSentence.status)
+    )
+    return {row[0]: row[1] for row in result.all()}
+
+
+async def chapter_all_audio_generated(db: AsyncSession, chapter_id: int) -> bool:
+    result = await db.execute(
+        select(func.count())
+        .select_from(AudiobookSentence)
+        .where(
+            AudiobookSentence.chapter_id == chapter_id,
+            AudiobookSentence.status != "audio_generated",
+        )
+    )
+    return result.scalar_one() == 0
+
+
+async def all_sentences_audio_generated(db: AsyncSession, book_id: int) -> bool:
+    result = await db.execute(
+        select(func.count())
+        .select_from(AudiobookSentence)
+        .join(AudiobookChapter, AudiobookSentence.chapter_id == AudiobookChapter.id)
+        .where(
+            AudiobookChapter.book_id == book_id,
+            AudiobookSentence.status != "audio_generated",
+        )
+    )
+    return result.scalar_one() == 0

--- a/backend/app/crud/audiobook.py
+++ b/backend/app/crud/audiobook.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Optional
 
-from sqlalchemy import select, update, func
+from sqlalchemy import func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..models import AudiobookSettings, AudiobookChapter, AudiobookCharacter, AudiobookSentence, Book
@@ -44,7 +44,12 @@ async def set_book_pipeline_status(db: AsyncSession, book_id: int, status: Optio
 
 async def get_in_progress_audiobook_books(db: AsyncSession) -> list[Book]:
     active_statuses = ["ingesting", "roster_gen", "diarizing", "audio_gen", "assembling"]
-    result = await db.execute(select(Book).where(Book.audiobook_pipeline_status.in_(active_statuses)))
+    result = await db.execute(
+        select(Book).where(
+            Book.audiobook_enabled.is_(True),
+            Book.audiobook_pipeline_status.in_(active_statuses),
+        )
+    )
     return list(result.scalars().all())
 
 
@@ -53,8 +58,13 @@ async def get_in_progress_audiobook_books(db: AsyncSession) -> list[Book]:
 # ---------------------------------------------------------------------------
 
 
-async def create_chapter(db: AsyncSession, book_id: int, chapter_number: int) -> AudiobookChapter:
-    chapter = AudiobookChapter(book_id=book_id, chapter_number=chapter_number)
+async def create_chapter(
+    db: AsyncSession,
+    book_id: int,
+    chapter_number: int,
+    content_file_name: Optional[str] = None,
+) -> AudiobookChapter:
+    chapter = AudiobookChapter(book_id=book_id, chapter_number=chapter_number, content_file_name=content_file_name)
     db.add(chapter)
     await db.flush()
     return chapter
@@ -71,6 +81,22 @@ async def get_chapters_needing_reassembly(db: AsyncSession, book_id: int) -> lis
     result = await db.execute(
         select(AudiobookChapter)
         .where(AudiobookChapter.book_id == book_id, AudiobookChapter.needs_reassembly.is_(True))
+        .order_by(AudiobookChapter.chapter_number)
+    )
+    return list(result.scalars().all())
+
+
+async def get_chapters_pending_assembly(db: AsyncSession, book_id: int) -> list[AudiobookChapter]:
+    result = await db.execute(
+        select(AudiobookChapter)
+        .where(
+            AudiobookChapter.book_id == book_id,
+            or_(
+                AudiobookChapter.needs_reassembly.is_(True),
+                AudiobookChapter.audio_file_path.is_(None),
+                AudiobookChapter.smil_file_path.is_(None),
+            ),
+        )
         .order_by(AudiobookChapter.chapter_number)
     )
     return list(result.scalars().all())
@@ -261,6 +287,26 @@ async def update_sentence_audio(db: AsyncSession, sentence_id: int, audio_file_p
     await db.commit()
 
 
+async def mark_sentence_error(db: AsyncSession, sentence_id: int) -> None:
+    await db.execute(update(AudiobookSentence).where(AudiobookSentence.id == sentence_id).values(status="error"))
+    await db.commit()
+
+
+async def reset_error_sentences_for_book(db: AsyncSession, book_id: int) -> int:
+    chapter_ids = select(AudiobookChapter.id).where(AudiobookChapter.book_id == book_id)
+    result = await db.execute(
+        update(AudiobookSentence)
+        .where(
+            AudiobookSentence.chapter_id.in_(chapter_ids),
+            AudiobookSentence.status == "error",
+        )
+        .values(status="ready_for_audio", audio_file_path=None, audio_duration_ms=None)
+    )
+    await db.execute(update(AudiobookChapter).where(AudiobookChapter.book_id == book_id).values(needs_reassembly=True))
+    await db.commit()
+    return result.rowcount or 0
+
+
 async def update_sentence_speaker(
     db: AsyncSession, sentence_id: int, character_id: Optional[int], tagged_text: str
 ) -> Optional[AudiobookSentence]:
@@ -287,6 +333,49 @@ async def count_sentences_by_status(db: AsyncSession, book_id: int) -> dict[str,
         .group_by(AudiobookSentence.status)
     )
     return {row[0]: row[1] for row in result.all()}
+
+
+async def has_sentence_status(db: AsyncSession, book_id: int, statuses: str | list[str]) -> bool:
+    status_values = [statuses] if isinstance(statuses, str) else statuses
+    result = await db.execute(
+        select(func.count())
+        .select_from(AudiobookSentence)
+        .join(AudiobookChapter, AudiobookSentence.chapter_id == AudiobookChapter.id)
+        .where(
+            AudiobookChapter.book_id == book_id,
+            AudiobookSentence.status.in_(status_values),
+        )
+    )
+    return result.scalar_one() > 0
+
+
+async def get_book_pipeline_status(db: AsyncSession, book_id: int) -> Optional[str]:
+    result = await db.execute(select(Book.audiobook_pipeline_status).where(Book.id == book_id))
+    return result.scalar_one_or_none()
+
+
+async def infer_audiobook_resume_status(db: AsyncSession, book_id: int) -> str:
+    """Infer the earliest safe phase from durable chapter/sentence state."""
+    chapters = await get_chapters_for_book(db, book_id)
+    if not chapters:
+        return "ingesting"
+
+    characters = await get_characters_for_book(db, book_id)
+    if not characters:
+        return "roster_gen"
+
+    counts = await count_sentences_by_status(db, book_id)
+    if counts.get("pending_diarization", 0) > 0:
+        return "diarizing"
+    if counts.get("ready_for_audio", 0) > 0 or counts.get("error", 0) > 0:
+        return "audio_gen"
+
+    total = sum(counts.values())
+    if total > 0 and counts.get("audio_generated", 0) == total:
+        pending_chapters = await get_chapters_pending_assembly(db, book_id)
+        return "assembling" if pending_chapters else "complete"
+
+    return "ingesting"
 
 
 async def chapter_all_audio_generated(db: AsyncSession, chapter_id: int) -> bool:

--- a/backend/app/crud/audiobook.py
+++ b/backend/app/crud/audiobook.py
@@ -8,7 +8,14 @@ from typing import Optional
 from sqlalchemy import and_, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from ..models import AudiobookSettings, AudiobookChapter, AudiobookCharacter, AudiobookSentence, Book
+from ..models import (
+    AudiobookSettings,
+    AudiobookChapter,
+    AudiobookCharacter,
+    AudiobookSeriesCharacter,
+    AudiobookSentence,
+    Book,
+)
 
 # ---------------------------------------------------------------------------
 # Settings
@@ -283,6 +290,23 @@ async def flag_chapter_for_reassembly(db: AsyncSession, chapter_id: int) -> None
     await db.commit()
 
 
+async def set_chapter_preview_status(
+    db: AsyncSession,
+    chapter_id: int,
+    status: Optional[str],
+    error: Optional[str] = None,
+) -> None:
+    await db.execute(
+        update(AudiobookChapter).where(AudiobookChapter.id == chapter_id).values(preview_status=status, preview_error=error)
+    )
+    await db.commit()
+
+
+async def get_chapters_with_pending_previews(db: AsyncSession) -> list[AudiobookChapter]:
+    result = await db.execute(select(AudiobookChapter).where(AudiobookChapter.preview_status.in_(["queued", "generating"])))
+    return list(result.scalars().all())
+
+
 async def delete_chapters_for_book(db: AsyncSession, book_id: int) -> None:
     chapters = await get_chapters_for_book(db, book_id)
     for ch in chapters:
@@ -328,6 +352,140 @@ async def update_character(db: AsyncSession, char_id: int, data: dict) -> Option
     return char
 
 
+def _canonical_character_name(name: str) -> str:
+    return " ".join(name.casefold().split())
+
+
+async def get_series_characters(db: AsyncSession, series_name: str) -> list[AudiobookSeriesCharacter]:
+    result = await db.execute(
+        select(AudiobookSeriesCharacter)
+        .where(func.lower(AudiobookSeriesCharacter.series_name) == series_name.lower())
+        .order_by(AudiobookSeriesCharacter.is_narrator.desc(), AudiobookSeriesCharacter.name)
+    )
+    return list(result.scalars().all())
+
+
+def _copy_series_profile_to_book_character(
+    profile: AudiobookSeriesCharacter,
+    character: AudiobookCharacter,
+) -> None:
+    character.series_character_id = profile.id
+    character.name = profile.name
+    character.description = profile.description
+    character.voice_design_prompt = profile.voice_design_prompt
+    character.is_narrator = profile.is_narrator
+    character.aliases = profile.aliases or []
+    character.evidence = profile.evidence or []
+
+
+async def sync_book_roster_with_series(
+    db: AsyncSession,
+    book: Book,
+    characters: list[AudiobookCharacter],
+    *,
+    prefer_series: bool = True,
+) -> int:
+    """Link a book roster to durable series profiles without changing sentence IDs."""
+    if not book.series:
+        return 0
+
+    profiles = await get_series_characters(db, book.series)
+    by_name = {profile.canonical_name: profile for profile in profiles}
+    linked = 0
+    for character in characters:
+        canonical = _canonical_character_name(character.name)
+        profile = by_name.get(canonical)
+        if profile is None:
+            profile = AudiobookSeriesCharacter(
+                series_name=book.series,
+                canonical_name=canonical,
+                name=character.name,
+                description=character.description,
+                voice_design_prompt=character.voice_design_prompt,
+                is_narrator=character.is_narrator,
+                aliases=character.aliases or [],
+                evidence=character.evidence or [],
+            )
+            db.add(profile)
+            await db.flush()
+            by_name[canonical] = profile
+        elif prefer_series:
+            _copy_series_profile_to_book_character(profile, character)
+        character.series_character_id = profile.id
+        linked += 1
+
+    await db.commit()
+    return linked
+
+
+async def unlink_book_roster_from_series(db: AsyncSession, book_id: int) -> None:
+    """Detach book-local characters when a book is removed from a series."""
+    await db.execute(update(AudiobookCharacter).where(AudiobookCharacter.book_id == book_id).values(series_character_id=None))
+    await db.commit()
+
+
+async def propagate_character_profile_across_series(
+    db: AsyncSession,
+    character: AudiobookCharacter,
+) -> list[AudiobookCharacter]:
+    """Promote an edited character and update matching profiles in sibling books."""
+    book = await db.get(Book, character.book_id)
+    if book is None or not book.series:
+        return [character]
+
+    linked_profile = (
+        await db.get(AudiobookSeriesCharacter, character.series_character_id) if character.series_character_id else None
+    )
+    canonical = _canonical_character_name(character.name)
+    result = await db.execute(
+        select(AudiobookSeriesCharacter).where(
+            func.lower(AudiobookSeriesCharacter.series_name) == book.series.lower(),
+            AudiobookSeriesCharacter.canonical_name == canonical,
+        )
+    )
+    matching_profile = result.scalar_one_or_none()
+    profile = matching_profile or linked_profile
+    if matching_profile is not None and linked_profile is not None and matching_profile.id != linked_profile.id:
+        await db.execute(
+            update(AudiobookCharacter)
+            .where(AudiobookCharacter.series_character_id == linked_profile.id)
+            .values(series_character_id=matching_profile.id)
+        )
+        await db.delete(linked_profile)
+        await db.flush()
+    if profile is None:
+        profile = AudiobookSeriesCharacter(series_name=book.series, canonical_name=canonical, name=character.name)
+        db.add(profile)
+        await db.flush()
+
+    profile.canonical_name = canonical
+    profile.name = character.name
+    profile.description = character.description
+    profile.voice_design_prompt = character.voice_design_prompt
+    profile.is_narrator = character.is_narrator
+    profile.aliases = character.aliases or []
+    profile.evidence = character.evidence or []
+
+    result = await db.execute(
+        select(AudiobookCharacter)
+        .join(Book, Book.id == AudiobookCharacter.book_id)
+        .where(
+            func.lower(Book.series) == book.series.lower(),
+            or_(
+                AudiobookCharacter.series_character_id == profile.id,
+                func.lower(AudiobookCharacter.name) == character.name.lower(),
+            ),
+        )
+    )
+    matching = list(result.scalars().all())
+    if character not in matching:
+        matching.append(character)
+    for sibling in matching:
+        _copy_series_profile_to_book_character(profile, sibling)
+    await db.commit()
+    return matching
+
+
 async def cascade_voice_change(db: AsyncSession, char_id: int) -> None:
     """Reset audio for all sentences by this character and flag affected chapters."""
     await db.execute(
@@ -338,7 +496,11 @@ async def cascade_voice_change(db: AsyncSession, char_id: int) -> None:
     result = await db.execute(select(AudiobookSentence.chapter_id).where(AudiobookSentence.character_id == char_id).distinct())
     chapter_ids = [row[0] for row in result.all()]
     if chapter_ids:
-        await db.execute(update(AudiobookChapter).where(AudiobookChapter.id.in_(chapter_ids)).values(needs_reassembly=True))
+        await db.execute(
+            update(AudiobookChapter)
+            .where(AudiobookChapter.id.in_(chapter_ids))
+            .values(needs_reassembly=True, preview_status=None, preview_error=None)
+        )
     await db.commit()
 
 
@@ -372,6 +534,8 @@ async def reset_roster_and_diarization_for_book(db: AsyncSession, book_id: int) 
             summary=None,
             summary_updated_at=None,
             needs_reassembly=True,
+            preview_status=None,
+            preview_error=None,
         )
     )
     await db.commit()
@@ -543,7 +707,11 @@ async def update_sentence_speaker(
     sentence.status = "ready_for_audio"
     sentence.audio_file_path = None
     sentence.audio_duration_ms = None
-    await db.execute(update(AudiobookChapter).where(AudiobookChapter.id == sentence.chapter_id).values(needs_reassembly=True))
+    await db.execute(
+        update(AudiobookChapter)
+        .where(AudiobookChapter.id == sentence.chapter_id)
+        .values(needs_reassembly=True, preview_status=None, preview_error=None)
+    )
     await db.commit()
     await db.refresh(sentence)
     return sentence

--- a/backend/app/crud/audiobook.py
+++ b/backend/app/crud/audiobook.py
@@ -821,10 +821,7 @@ async def infer_audiobook_resume_status(db: AsyncSession, book_id: int) -> str:
     counts = await count_sentences_by_status(db, book_id)
     if counts.get("pending_diarization", 0) > 0:
         return "diarizing"
-    if any(
-        counts.get(status, 0) > 0
-        for status in ("ready_for_audio", "audio_queued", "audio_generating", "error")
-    ):
+    if any(counts.get(status, 0) > 0 for status in ("ready_for_audio", "audio_queued", "audio_generating", "error")):
         return "audio_gen"
 
     total = sum(counts.values())

--- a/backend/app/crud/audiobook.py
+++ b/backend/app/crud/audiobook.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Optional
 
-from sqlalchemy import func, or_, select, update
+from sqlalchemy import and_, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..models import AudiobookSettings, AudiobookChapter, AudiobookCharacter, AudiobookSentence, Book
@@ -38,7 +39,11 @@ async def upsert_audiobook_settings(db: AsyncSession, data: dict) -> AudiobookSe
 
 
 async def set_book_pipeline_status(db: AsyncSession, book_id: int, status: Optional[str]) -> None:
-    await db.execute(update(Book).where(Book.id == book_id).values(audiobook_pipeline_status=status))
+    await db.execute(
+        update(Book)
+        .where(Book.id == book_id)
+        .values(audiobook_pipeline_status=status, audiobook_pipeline_updated_at=datetime.now(timezone.utc))
+    )
     await db.commit()
 
 
@@ -48,6 +53,7 @@ async def configure_book_pipeline_run(
     *,
     status: str,
     stop_after_phase: Optional[str],
+    batch_limit: Optional[int] = None,
 ) -> None:
     """Start or resume a run and clear stale pause/error state atomically."""
     await db.execute(
@@ -58,6 +64,13 @@ async def configure_book_pipeline_run(
             audiobook_stop_after_phase=stop_after_phase,
             audiobook_pause_requested=False,
             audiobook_last_error=None,
+            audiobook_batch_limit=batch_limit,
+            audiobook_progress_current=0,
+            audiobook_progress_total=0,
+            audiobook_progress_detail=None,
+            audiobook_pipeline_started_at=datetime.now(timezone.utc),
+            audiobook_pipeline_updated_at=datetime.now(timezone.utc),
+            audiobook_llm_requests=0,
         )
     )
     await db.commit()
@@ -66,6 +79,62 @@ async def configure_book_pipeline_run(
 async def request_book_pipeline_pause(db: AsyncSession, book_id: int) -> None:
     await db.execute(update(Book).where(Book.id == book_id).values(audiobook_pause_requested=True))
     await db.commit()
+
+
+async def update_book_pipeline_progress(
+    db: AsyncSession,
+    book_id: int,
+    *,
+    current: int,
+    total: int,
+    detail: Optional[str],
+    llm_request_increment: int = 0,
+) -> None:
+    values = {
+        "audiobook_progress_current": max(0, current),
+        "audiobook_progress_total": max(0, total),
+        "audiobook_progress_detail": detail,
+        "audiobook_pipeline_updated_at": datetime.now(timezone.utc),
+    }
+    if llm_request_increment:
+        values["audiobook_llm_requests"] = Book.audiobook_llm_requests + llm_request_increment
+    await db.execute(update(Book).where(Book.id == book_id).values(**values))
+    await db.commit()
+
+
+async def set_book_audiobook_summary(db: AsyncSession, book_id: int, summary: Optional[str]) -> None:
+    await db.execute(
+        update(Book)
+        .where(Book.id == book_id)
+        .values(audiobook_summary=summary, audiobook_pipeline_updated_at=datetime.now(timezone.utc))
+    )
+    await db.commit()
+
+
+async def consume_book_batch_limit(db: AsyncSession, book_id: int) -> bool:
+    """Consume one durable work unit and pause when a one-batch run is exhausted."""
+    result = await db.execute(select(Book.audiobook_batch_limit).where(Book.id == book_id))
+    remaining = result.scalar_one_or_none()
+    if remaining is None:
+        return False
+    remaining -= 1
+    if remaining > 0:
+        await db.execute(update(Book).where(Book.id == book_id).values(audiobook_batch_limit=remaining))
+        await db.commit()
+        return False
+    await db.execute(
+        update(Book)
+        .where(Book.id == book_id)
+        .values(
+            audiobook_pipeline_status="paused",
+            audiobook_batch_limit=None,
+            audiobook_stop_after_phase=None,
+            audiobook_pause_requested=False,
+            audiobook_pipeline_updated_at=datetime.now(timezone.utc),
+        )
+    )
+    await db.commit()
+    return True
 
 
 async def pause_book_pipeline_if_requested(db: AsyncSession, book_id: int) -> bool:
@@ -80,6 +149,8 @@ async def pause_book_pipeline_if_requested(db: AsyncSession, book_id: int) -> bo
             audiobook_pipeline_status="paused",
             audiobook_pause_requested=False,
             audiobook_stop_after_phase=None,
+            audiobook_batch_limit=None,
+            audiobook_pipeline_updated_at=datetime.now(timezone.utc),
         )
     )
     await db.commit()
@@ -95,7 +166,14 @@ async def pause_book_pipeline_after_phase(db: AsyncSession, book_id: int, phase:
     if row is None or row.audiobook_stop_after_phase != phase or row.audiobook_pipeline_status == "complete":
         return False
     await db.execute(
-        update(Book).where(Book.id == book_id).values(audiobook_pipeline_status="paused", audiobook_stop_after_phase=None)
+        update(Book)
+        .where(Book.id == book_id)
+        .values(
+            audiobook_pipeline_status="paused",
+            audiobook_stop_after_phase=None,
+            audiobook_batch_limit=None,
+            audiobook_pipeline_updated_at=datetime.now(timezone.utc),
+        )
     )
     await db.commit()
     return True
@@ -109,6 +187,8 @@ async def set_book_pipeline_error(db: AsyncSession, book_id: int, message: str) 
             audiobook_pipeline_status="error",
             audiobook_pause_requested=False,
             audiobook_stop_after_phase=None,
+            audiobook_batch_limit=None,
+            audiobook_pipeline_updated_at=datetime.now(timezone.utc),
             audiobook_last_error=message,
         )
     )
@@ -189,6 +269,15 @@ async def update_chapter_assembly(
     await db.commit()
 
 
+async def update_chapter_summary(db: AsyncSession, chapter_id: int, summary: Optional[str]) -> None:
+    await db.execute(
+        update(AudiobookChapter)
+        .where(AudiobookChapter.id == chapter_id)
+        .values(summary=summary, summary_updated_at=datetime.now(timezone.utc))
+    )
+    await db.commit()
+
+
 async def flag_chapter_for_reassembly(db: AsyncSession, chapter_id: int) -> None:
     await db.execute(update(AudiobookChapter).where(AudiobookChapter.id == chapter_id).values(needs_reassembly=True))
     await db.commit()
@@ -260,6 +349,35 @@ async def delete_characters_for_book(db: AsyncSession, book_id: int) -> None:
     await db.commit()
 
 
+async def reset_roster_and_diarization_for_book(db: AsyncSession, book_id: int) -> None:
+    """Clear derived speaker analysis while preserving the expensive EPUB ingestion."""
+    chapter_ids = select(AudiobookChapter.id).where(AudiobookChapter.book_id == book_id)
+    await db.execute(
+        update(AudiobookSentence)
+        .where(AudiobookSentence.chapter_id.in_(chapter_ids))
+        .values(
+            character_id=None,
+            tagged_text=AudiobookSentence.original_text,
+            audio_file_path=None,
+            audio_duration_ms=None,
+            speaker_confidence=None,
+            speaker_reason=None,
+            status="pending_diarization",
+        )
+    )
+    await db.execute(
+        update(AudiobookChapter)
+        .where(AudiobookChapter.book_id == book_id)
+        .values(
+            summary=None,
+            summary_updated_at=None,
+            needs_reassembly=True,
+        )
+    )
+    await db.commit()
+    await delete_characters_for_book(db, book_id)
+
+
 # ---------------------------------------------------------------------------
 # Sentences
 # ---------------------------------------------------------------------------
@@ -285,6 +403,7 @@ async def get_sentences_paginated(
     page: int = 1,
     limit: int = 50,
     chapter_id: Optional[int] = None,
+    review_only: bool = False,
 ) -> tuple[list[AudiobookSentence], int]:
     base_query = (
         select(AudiobookSentence)
@@ -300,6 +419,17 @@ async def get_sentences_paginated(
     if chapter_id is not None:
         base_query = base_query.where(AudiobookSentence.chapter_id == chapter_id)
         count_query = count_query.where(AudiobookSentence.chapter_id == chapter_id)
+    if review_only:
+        review_filter = and_(
+            AudiobookSentence.status != "pending_diarization",
+            or_(
+                AudiobookSentence.character_id.is_(None),
+                AudiobookSentence.speaker_confidence.is_(None),
+                AudiobookSentence.speaker_confidence < 0.65,
+            ),
+        )
+        base_query = base_query.where(review_filter)
+        count_query = count_query.where(review_filter)
 
     total_result = await db.execute(count_query)
     total = total_result.scalar_one()
@@ -312,8 +442,13 @@ async def get_sentences_paginated(
     return list(result.scalars().all()), total
 
 
-async def get_sentences_pending_diarization(db: AsyncSession, book_id: int, limit: int = 50) -> list[AudiobookSentence]:
-    result = await db.execute(
+async def get_sentences_pending_diarization(
+    db: AsyncSession,
+    book_id: int,
+    limit: int = 50,
+    chapter_id: Optional[int] = None,
+) -> list[AudiobookSentence]:
+    query = (
         select(AudiobookSentence)
         .join(AudiobookChapter, AudiobookSentence.chapter_id == AudiobookChapter.id)
         .where(
@@ -323,6 +458,9 @@ async def get_sentences_pending_diarization(db: AsyncSession, book_id: int, limi
         .order_by(AudiobookChapter.chapter_number, AudiobookSentence.sequence_order)
         .limit(limit)
     )
+    if chapter_id is not None:
+        query = query.where(AudiobookSentence.chapter_id == chapter_id)
+    result = await db.execute(query)
     return list(result.scalars().all())
 
 
@@ -341,12 +479,23 @@ async def get_sentences_ready_for_audio(db: AsyncSession, book_id: int, limit: i
 
 
 async def update_sentence_diarization(
-    db: AsyncSession, sentence_id: int, character_id: Optional[int], tagged_text: str
+    db: AsyncSession,
+    sentence_id: int,
+    character_id: Optional[int],
+    tagged_text: str,
+    speaker_confidence: Optional[float] = None,
+    speaker_reason: Optional[str] = None,
 ) -> None:
     await db.execute(
         update(AudiobookSentence)
         .where(AudiobookSentence.id == sentence_id)
-        .values(character_id=character_id, tagged_text=tagged_text, status="ready_for_audio")
+        .values(
+            character_id=character_id,
+            tagged_text=tagged_text,
+            speaker_confidence=speaker_confidence,
+            speaker_reason=speaker_reason,
+            status="ready_for_audio",
+        )
     )
     await db.commit()
 
@@ -389,6 +538,8 @@ async def update_sentence_speaker(
         return None
     sentence.character_id = character_id
     sentence.tagged_text = tagged_text
+    sentence.speaker_confidence = 1.0
+    sentence.speaker_reason = "Manually assigned"
     sentence.status = "ready_for_audio"
     sentence.audio_file_path = None
     sentence.audio_duration_ms = None
@@ -406,6 +557,48 @@ async def count_sentences_by_status(db: AsyncSession, book_id: int) -> dict[str,
         .group_by(AudiobookSentence.status)
     )
     return {row[0]: row[1] for row in result.all()}
+
+
+async def count_sentence_review_flags(db: AsyncSession, book_id: int) -> dict[str, int]:
+    base = (
+        select(AudiobookSentence)
+        .join(AudiobookChapter, AudiobookSentence.chapter_id == AudiobookChapter.id)
+        .where(AudiobookChapter.book_id == book_id)
+        .subquery()
+    )
+    result = await db.execute(
+        select(
+            func.count().filter(base.c.character_id.is_(None)),
+            func.count().filter(base.c.speaker_confidence < 0.65),
+            func.count().filter(base.c.speaker_confidence.is_not(None)),
+        ).select_from(base)
+    )
+    unassigned, low_confidence, reviewed = result.one()
+    return {
+        "unassigned": unassigned or 0,
+        "low_confidence": low_confidence or 0,
+        "with_confidence": reviewed or 0,
+    }
+
+
+async def get_character_sentence_stats(db: AsyncSession, book_id: int) -> dict[int, dict[str, float | int | None]]:
+    result = await db.execute(
+        select(
+            AudiobookSentence.character_id,
+            func.count(),
+            func.avg(AudiobookSentence.speaker_confidence),
+        )
+        .join(AudiobookChapter, AudiobookSentence.chapter_id == AudiobookChapter.id)
+        .where(AudiobookChapter.book_id == book_id, AudiobookSentence.character_id.is_not(None))
+        .group_by(AudiobookSentence.character_id)
+    )
+    return {
+        character_id: {
+            "sentence_count": sentence_count,
+            "average_confidence": float(average_confidence) if average_confidence is not None else None,
+        }
+        for character_id, sentence_count, average_confidence in result.all()
+    }
 
 
 async def has_sentence_status(db: AsyncSession, book_id: int, statuses: str | list[str]) -> bool:

--- a/backend/app/crud/audiobook.py
+++ b/backend/app/crud/audiobook.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Optional
 
-from sqlalchemy import and_, func, or_, select, update
+from sqlalchemy import and_, delete, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..models import (
@@ -16,6 +16,8 @@ from ..models import (
     AudiobookSentence,
     Book,
 )
+
+ROSTER_REFRESH_STOP_MARKER = "roster_gen:refresh_series_metadata"
 
 # ---------------------------------------------------------------------------
 # Settings
@@ -170,7 +172,8 @@ async def pause_book_pipeline_after_phase(db: AsyncSession, book_id: int, phase:
         select(Book.audiobook_stop_after_phase, Book.audiobook_pipeline_status).where(Book.id == book_id)
     )
     row = result.one_or_none()
-    if row is None or row.audiobook_stop_after_phase != phase or row.audiobook_pipeline_status == "complete":
+    requested_phase = row.audiobook_stop_after_phase.split(":", 1)[0] if row and row.audiobook_stop_after_phase else None
+    if row is None or requested_phase != phase or row.audiobook_pipeline_status == "complete":
         return False
     await db.execute(
         update(Book)
@@ -369,6 +372,40 @@ async def get_series_characters(db: AsyncSession, series_name: str) -> list[Audi
     return list(result.scalars().all())
 
 
+async def get_sibling_series_characters(
+    db: AsyncSession, series_name: str, current_book_id: int
+) -> list[AudiobookSeriesCharacter]:
+    """Return profiles backed by another book, excluding current-book-only guesses."""
+    linked_profile_ids = select(AudiobookCharacter.series_character_id).where(
+        AudiobookCharacter.book_id != current_book_id,
+        AudiobookCharacter.series_character_id.is_not(None),
+    )
+    result = await db.execute(
+        select(AudiobookSeriesCharacter)
+        .where(
+            func.lower(AudiobookSeriesCharacter.series_name) == series_name.lower(),
+            AudiobookSeriesCharacter.id.in_(linked_profile_ids),
+        )
+        .order_by(AudiobookSeriesCharacter.is_narrator.desc(), AudiobookSeriesCharacter.name)
+    )
+    return list(result.scalars().all())
+
+
+async def delete_orphaned_series_characters(db: AsyncSession, series_name: str) -> int:
+    """Remove stale profiles left behind by an explicit roster refresh."""
+    linked_profile_ids = select(AudiobookCharacter.series_character_id).where(
+        AudiobookCharacter.series_character_id.is_not(None)
+    )
+    result = await db.execute(
+        delete(AudiobookSeriesCharacter).where(
+            func.lower(AudiobookSeriesCharacter.series_name) == series_name.lower(),
+            AudiobookSeriesCharacter.id.not_in(linked_profile_ids),
+        )
+    )
+    await db.commit()
+    return result.rowcount or 0
+
+
 def _copy_series_profile_to_book_character(
     profile: AudiobookSeriesCharacter,
     character: AudiobookCharacter,
@@ -395,6 +432,8 @@ async def sync_book_roster_with_series(
 
     profiles = await get_series_characters(db, book.series)
     by_name = {profile.canonical_name: profile for profile in profiles}
+    refreshed_profiles: dict[int, AudiobookSeriesCharacter] = {}
+    voice_changed_profiles: set[int] = set()
     linked = 0
     for character in characters:
         canonical = _canonical_character_name(character.name)
@@ -415,10 +454,37 @@ async def sync_book_roster_with_series(
             by_name[canonical] = profile
         elif prefer_series:
             _copy_series_profile_to_book_character(profile, character)
+        else:
+            # An explicit roster rebuild refreshes shared analysis while
+            # retaining the established cross-book voice unless it was empty.
+            profile.name = character.name
+            profile.description = character.description
+            profile.aliases = character.aliases or []
+            profile.evidence = character.evidence or []
+            profile.is_narrator = character.is_narrator
+            if character.voice_design_prompt and profile.voice_design_prompt != character.voice_design_prompt:
+                profile.voice_design_prompt = character.voice_design_prompt
+                voice_changed_profiles.add(profile.id)
+            refreshed_profiles[profile.id] = profile
         character.series_character_id = profile.id
         linked += 1
 
+    changed_voice_character_ids: list[int] = []
+    if refreshed_profiles:
+        result = await db.execute(
+            select(AudiobookCharacter).where(AudiobookCharacter.series_character_id.in_(list(refreshed_profiles)))
+        )
+        for linked_character in result.scalars().all():
+            _copy_series_profile_to_book_character(
+                refreshed_profiles[linked_character.series_character_id],
+                linked_character,
+            )
+            if linked_character.series_character_id in voice_changed_profiles:
+                changed_voice_character_ids.append(linked_character.id)
+
     await db.commit()
+    for character_id in changed_voice_character_ids:
+        await cascade_voice_change(db, character_id)
     return linked
 
 

--- a/backend/app/crud/audiobook.py
+++ b/backend/app/crud/audiobook.py
@@ -95,9 +95,7 @@ async def pause_book_pipeline_after_phase(db: AsyncSession, book_id: int, phase:
     if row is None or row.audiobook_stop_after_phase != phase or row.audiobook_pipeline_status == "complete":
         return False
     await db.execute(
-        update(Book)
-        .where(Book.id == book_id)
-        .values(audiobook_pipeline_status="paused", audiobook_stop_after_phase=None)
+        update(Book).where(Book.id == book_id).values(audiobook_pipeline_status="paused", audiobook_stop_after_phase=None)
     )
     await db.commit()
     return True

--- a/backend/app/crud/audiobook.py
+++ b/backend/app/crud/audiobook.py
@@ -286,7 +286,11 @@ async def update_chapter_summary(db: AsyncSession, chapter_id: int, summary: Opt
 
 
 async def flag_chapter_for_reassembly(db: AsyncSession, chapter_id: int) -> None:
-    await db.execute(update(AudiobookChapter).where(AudiobookChapter.id == chapter_id).values(needs_reassembly=True))
+    await db.execute(
+        update(AudiobookChapter)
+        .where(AudiobookChapter.id == chapter_id)
+        .values(needs_reassembly=True, preview_status=None, preview_error=None)
+    )
     await db.commit()
 
 
@@ -642,6 +646,22 @@ async def get_sentences_ready_for_audio(db: AsyncSession, book_id: int, limit: i
     return list(result.scalars().all())
 
 
+async def get_pending_sentence_audio_jobs(db: AsyncSession) -> list[tuple[int, int]]:
+    """Return durable manual sentence jobs as (book_id, sentence_id)."""
+    result = await db.execute(
+        select(AudiobookChapter.book_id, AudiobookSentence.id)
+        .join(AudiobookChapter, AudiobookSentence.chapter_id == AudiobookChapter.id)
+        .where(AudiobookSentence.status.in_(["audio_queued", "audio_generating"]))
+        .order_by(AudiobookSentence.id)
+    )
+    return [(book_id, sentence_id) for book_id, sentence_id in result.all()]
+
+
+async def set_sentence_status(db: AsyncSession, sentence_id: int, status: str) -> None:
+    await db.execute(update(AudiobookSentence).where(AudiobookSentence.id == sentence_id).values(status=status))
+    await db.commit()
+
+
 async def update_sentence_diarization(
     db: AsyncSession,
     sentence_id: int,
@@ -801,7 +821,10 @@ async def infer_audiobook_resume_status(db: AsyncSession, book_id: int) -> str:
     counts = await count_sentences_by_status(db, book_id)
     if counts.get("pending_diarization", 0) > 0:
         return "diarizing"
-    if counts.get("ready_for_audio", 0) > 0 or counts.get("error", 0) > 0:
+    if any(
+        counts.get(status, 0) > 0
+        for status in ("ready_for_audio", "audio_queued", "audio_generating", "error")
+    ):
         return "audio_gen"
 
     total = sum(counts.values())

--- a/backend/app/crud/audiobook.py
+++ b/backend/app/crud/audiobook.py
@@ -42,6 +42,81 @@ async def set_book_pipeline_status(db: AsyncSession, book_id: int, status: Optio
     await db.commit()
 
 
+async def configure_book_pipeline_run(
+    db: AsyncSession,
+    book_id: int,
+    *,
+    status: str,
+    stop_after_phase: Optional[str],
+) -> None:
+    """Start or resume a run and clear stale pause/error state atomically."""
+    await db.execute(
+        update(Book)
+        .where(Book.id == book_id)
+        .values(
+            audiobook_pipeline_status=status,
+            audiobook_stop_after_phase=stop_after_phase,
+            audiobook_pause_requested=False,
+            audiobook_last_error=None,
+        )
+    )
+    await db.commit()
+
+
+async def request_book_pipeline_pause(db: AsyncSession, book_id: int) -> None:
+    await db.execute(update(Book).where(Book.id == book_id).values(audiobook_pause_requested=True))
+    await db.commit()
+
+
+async def pause_book_pipeline_if_requested(db: AsyncSession, book_id: int) -> bool:
+    """Acknowledge a cooperative pause request at a durable work boundary."""
+    result = await db.execute(select(Book.audiobook_pause_requested).where(Book.id == book_id))
+    if not result.scalar_one_or_none():
+        return False
+    await db.execute(
+        update(Book)
+        .where(Book.id == book_id)
+        .values(
+            audiobook_pipeline_status="paused",
+            audiobook_pause_requested=False,
+            audiobook_stop_after_phase=None,
+        )
+    )
+    await db.commit()
+    return True
+
+
+async def pause_book_pipeline_after_phase(db: AsyncSession, book_id: int, phase: str) -> bool:
+    """Stop a single-stage run once its requested phase has committed."""
+    result = await db.execute(
+        select(Book.audiobook_stop_after_phase, Book.audiobook_pipeline_status).where(Book.id == book_id)
+    )
+    row = result.one_or_none()
+    if row is None or row.audiobook_stop_after_phase != phase or row.audiobook_pipeline_status == "complete":
+        return False
+    await db.execute(
+        update(Book)
+        .where(Book.id == book_id)
+        .values(audiobook_pipeline_status="paused", audiobook_stop_after_phase=None)
+    )
+    await db.commit()
+    return True
+
+
+async def set_book_pipeline_error(db: AsyncSession, book_id: int, message: str) -> None:
+    await db.execute(
+        update(Book)
+        .where(Book.id == book_id)
+        .values(
+            audiobook_pipeline_status="error",
+            audiobook_pause_requested=False,
+            audiobook_stop_after_phase=None,
+            audiobook_last_error=message,
+        )
+    )
+    await db.commit()
+
+
 async def get_in_progress_audiobook_books(db: AsyncSession) -> list[Book]:
     active_statuses = ["ingesting", "roster_gen", "diarizing", "audio_gen", "assembling"]
     result = await db.execute(

--- a/backend/app/crud/audiobook.py
+++ b/backend/app/crud/audiobook.py
@@ -9,7 +9,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..models import AudiobookSettings, AudiobookChapter, AudiobookCharacter, AudiobookSentence, Book
 
-
 # ---------------------------------------------------------------------------
 # Settings
 # ---------------------------------------------------------------------------
@@ -63,9 +62,7 @@ async def create_chapter(db: AsyncSession, book_id: int, chapter_number: int) ->
 
 async def get_chapters_for_book(db: AsyncSession, book_id: int) -> list[AudiobookChapter]:
     result = await db.execute(
-        select(AudiobookChapter)
-        .where(AudiobookChapter.book_id == book_id)
-        .order_by(AudiobookChapter.chapter_number)
+        select(AudiobookChapter).where(AudiobookChapter.book_id == book_id).order_by(AudiobookChapter.chapter_number)
     )
     return list(result.scalars().all())
 
@@ -94,9 +91,7 @@ async def update_chapter_assembly(
 
 
 async def flag_chapter_for_reassembly(db: AsyncSession, chapter_id: int) -> None:
-    await db.execute(
-        update(AudiobookChapter).where(AudiobookChapter.id == chapter_id).values(needs_reassembly=True)
-    )
+    await db.execute(update(AudiobookChapter).where(AudiobookChapter.id == chapter_id).values(needs_reassembly=True))
     await db.commit()
 
 
@@ -152,18 +147,10 @@ async def cascade_voice_change(db: AsyncSession, char_id: int) -> None:
         .where(AudiobookSentence.character_id == char_id)
         .values(status="ready_for_audio", audio_file_path=None, audio_duration_ms=None)
     )
-    result = await db.execute(
-        select(AudiobookSentence.chapter_id)
-        .where(AudiobookSentence.character_id == char_id)
-        .distinct()
-    )
+    result = await db.execute(select(AudiobookSentence.chapter_id).where(AudiobookSentence.character_id == char_id).distinct())
     chapter_ids = [row[0] for row in result.all()]
     if chapter_ids:
-        await db.execute(
-            update(AudiobookChapter)
-            .where(AudiobookChapter.id.in_(chapter_ids))
-            .values(needs_reassembly=True)
-        )
+        await db.execute(update(AudiobookChapter).where(AudiobookChapter.id.in_(chapter_ids)).values(needs_reassembly=True))
     await db.commit()
 
 
@@ -188,9 +175,7 @@ async def create_sentences_bulk(db: AsyncSession, chapter_id: int, sentences_dat
 
 async def get_sentences_for_chapter(db: AsyncSession, chapter_id: int) -> list[AudiobookSentence]:
     result = await db.execute(
-        select(AudiobookSentence)
-        .where(AudiobookSentence.chapter_id == chapter_id)
-        .order_by(AudiobookSentence.sequence_order)
+        select(AudiobookSentence).where(AudiobookSentence.chapter_id == chapter_id).order_by(AudiobookSentence.sequence_order)
     )
     return list(result.scalars().all())
 
@@ -221,17 +206,14 @@ async def get_sentences_paginated(
     total = total_result.scalar_one()
 
     result = await db.execute(
-        base_query
-        .order_by(AudiobookChapter.chapter_number, AudiobookSentence.sequence_order)
+        base_query.order_by(AudiobookChapter.chapter_number, AudiobookSentence.sequence_order)
         .offset((page - 1) * limit)
         .limit(limit)
     )
     return list(result.scalars().all()), total
 
 
-async def get_sentences_pending_diarization(
-    db: AsyncSession, book_id: int, limit: int = 50
-) -> list[AudiobookSentence]:
+async def get_sentences_pending_diarization(db: AsyncSession, book_id: int, limit: int = 50) -> list[AudiobookSentence]:
     result = await db.execute(
         select(AudiobookSentence)
         .join(AudiobookChapter, AudiobookSentence.chapter_id == AudiobookChapter.id)
@@ -245,9 +227,7 @@ async def get_sentences_pending_diarization(
     return list(result.scalars().all())
 
 
-async def get_sentences_ready_for_audio(
-    db: AsyncSession, book_id: int, limit: int = 20
-) -> list[AudiobookSentence]:
+async def get_sentences_ready_for_audio(db: AsyncSession, book_id: int, limit: int = 20) -> list[AudiobookSentence]:
     result = await db.execute(
         select(AudiobookSentence)
         .join(AudiobookChapter, AudiobookSentence.chapter_id == AudiobookChapter.id)
@@ -272,9 +252,7 @@ async def update_sentence_diarization(
     await db.commit()
 
 
-async def update_sentence_audio(
-    db: AsyncSession, sentence_id: int, audio_file_path: str, audio_duration_ms: int
-) -> None:
+async def update_sentence_audio(db: AsyncSession, sentence_id: int, audio_file_path: str, audio_duration_ms: int) -> None:
     await db.execute(
         update(AudiobookSentence)
         .where(AudiobookSentence.id == sentence_id)
@@ -295,11 +273,7 @@ async def update_sentence_speaker(
     sentence.status = "ready_for_audio"
     sentence.audio_file_path = None
     sentence.audio_duration_ms = None
-    await db.execute(
-        update(AudiobookChapter)
-        .where(AudiobookChapter.id == sentence.chapter_id)
-        .values(needs_reassembly=True)
-    )
+    await db.execute(update(AudiobookChapter).where(AudiobookChapter.id == sentence.chapter_id).values(needs_reassembly=True))
     await db.commit()
     await db.refresh(sentence)
     return sentence

--- a/backend/app/crud/audiobook.py
+++ b/backend/app/crud/audiobook.py
@@ -380,24 +380,20 @@ async def infer_audiobook_resume_status(db: AsyncSession, book_id: int) -> str:
 
 async def chapter_all_audio_generated(db: AsyncSession, chapter_id: int) -> bool:
     result = await db.execute(
-        select(func.count())
+        select(func.count(), func.count().filter(AudiobookSentence.status != "audio_generated"))
         .select_from(AudiobookSentence)
-        .where(
-            AudiobookSentence.chapter_id == chapter_id,
-            AudiobookSentence.status != "audio_generated",
-        )
+        .where(AudiobookSentence.chapter_id == chapter_id)
     )
-    return result.scalar_one() == 0
+    total, pending = result.one()
+    return total > 0 and pending == 0
 
 
 async def all_sentences_audio_generated(db: AsyncSession, book_id: int) -> bool:
     result = await db.execute(
-        select(func.count())
+        select(func.count(), func.count().filter(AudiobookSentence.status != "audio_generated"))
         .select_from(AudiobookSentence)
         .join(AudiobookChapter, AudiobookSentence.chapter_id == AudiobookChapter.id)
-        .where(
-            AudiobookChapter.book_id == book_id,
-            AudiobookSentence.status != "audio_generated",
-        )
+        .where(AudiobookChapter.book_id == book_id)
     )
-    return result.scalar_one() == 0
+    total, pending = result.one()
+    return total > 0 and pending == 0

--- a/backend/app/crud/books.py
+++ b/backend/app/crud/books.py
@@ -16,6 +16,7 @@ def _build_books_query(sort_by: str = "title", sort_order: str = "asc"):
         "series": models.Book.series,
         "word_count": models.Book.current_word_count,
         "updated_at": models.Book.updated_at,
+        "audiobook_enabled": models.Book.audiobook_enabled,
     }
     column = sort_columns.get(sort_by, models.Book.title)
     order = asc(column) if sort_order == "asc" else desc(column)

--- a/backend/app/crud/series.py
+++ b/backend/app/crud/series.py
@@ -148,6 +148,8 @@ async def rename_series(db: AsyncSession, old_name: str, new_name: str) -> int:
         else:
             old_metadata.series_name = new_name
 
+    await _merge_audiobook_series_rosters(db, old_name, new_name)
+
     await db.commit()
     return len(books)
 
@@ -170,8 +172,44 @@ async def merge_series(db: AsyncSession, source: str, target: str) -> int:
             )
             await db.delete(source_metadata)
 
+    await _merge_audiobook_series_rosters(db, source, target)
+
     await db.commit()
     return len(books)
+
+
+async def _merge_audiobook_series_rosters(db: AsyncSession, source: str, target: str) -> None:
+    """Move or merge shared character profiles when a library series changes."""
+    source_result = await db.execute(
+        select(models.AudiobookSeriesCharacter).where(
+            func.lower(models.AudiobookSeriesCharacter.series_name) == source.lower()
+        )
+    )
+    target_result = await db.execute(
+        select(models.AudiobookSeriesCharacter).where(
+            func.lower(models.AudiobookSeriesCharacter.series_name) == target.lower()
+        )
+    )
+    source_profiles = list(source_result.scalars().all())
+    target_profiles = {profile.canonical_name: profile for profile in target_result.scalars().all()}
+    for profile in source_profiles:
+        existing = target_profiles.get(profile.canonical_name)
+        if existing is None:
+            profile.series_name = target
+            target_profiles[profile.canonical_name] = profile
+            continue
+        await db.execute(
+            models.AudiobookCharacter.__table__.update()
+            .where(models.AudiobookCharacter.series_character_id == profile.id)
+            .values(series_character_id=existing.id)
+        )
+        existing.aliases = _normalize_tags([*(existing.aliases or []), *(profile.aliases or [])])
+        existing.evidence = [*(existing.evidence or []), *(profile.evidence or [])][:6]
+        if not existing.description:
+            existing.description = profile.description
+        if not existing.voice_design_prompt:
+            existing.voice_design_prompt = profile.voice_design_prompt
+        await db.delete(profile)
 
 
 def validate_genre_tags(tags: list[str]) -> None:
@@ -227,11 +265,11 @@ def compute_effective_series_genre_tags(
 
 
 async def cleanup_orphaned_series_metadata(db: AsyncSession) -> int:
-    """Delete SeriesMetadata records whose series_name has no matching books."""
+    """Delete series metadata and audiobook rosters with no matching books."""
     result = await db.execute(select(models.SeriesMetadata))
     all_metadata = result.scalars().all()
-    if not all_metadata:
-        return 0
+    roster_result = await db.execute(select(models.AudiobookSeriesCharacter))
+    all_roster_profiles = roster_result.scalars().all()
 
     active_result = await db.execute(select(func.lower(models.Book.series)).filter(models.Book.series.isnot(None)).distinct())
     active_series = {row[0] for row in active_result.all()}
@@ -240,6 +278,10 @@ async def cleanup_orphaned_series_metadata(db: AsyncSession) -> int:
     for metadata in all_metadata:
         if metadata.series_name.lower() not in active_series:
             await db.delete(metadata)
+            deleted += 1
+    for profile in all_roster_profiles:
+        if profile.series_name.lower() not in active_series:
+            await db.delete(profile)
             deleted += 1
 
     if deleted:

--- a/backend/app/epub_editor.py
+++ b/backend/app/epub_editor.py
@@ -259,8 +259,9 @@ async def apply_book_cleaning(book, db, force: bool = False, cleaning_configs: l
     selectors with the book's own settings, then rewrites current_path from
     immutable_path and updates current_word_count in the DB.
 
-    Books with no applicable rules are always skipped. If force=True, rewrites
-    even when the output would match the current file.
+    Books with no applicable rules are skipped unless force=True. A forced
+    rebuild must still restore current_path from immutable_path after the last
+    cleaning rule is removed.
     """
     from . import crud
 
@@ -276,8 +277,9 @@ async def apply_book_cleaning(book, db, force: bool = False, cleaning_configs: l
     normalize_prose_blocks = book.source_type == models.SourceType.web
     has_rules = bool(chapter_selectors or content_selectors or removed_chapters or normalize_prose_blocks)
 
-    # Nothing to do — skip the (potentially expensive) epub rewrite
-    if not has_rules:
+    # Nothing to do — skip the (potentially expensive) epub rewrite unless a
+    # forced rebuild needs to restore a stale current copy.
+    if not has_rules and not force:
         return False
 
     if not book.immutable_path or not book.current_path:
@@ -293,6 +295,9 @@ async def apply_book_cleaning(book, db, force: bool = False, cleaning_configs: l
     library_path = (Path(__file__).parent.resolve() / ".." / ".." / "library").resolve()
     immutable_path = library_path.parent / book.immutable_path
     current_path = library_path.parent / book.current_path
+
+    if not has_rules and _files_match(immutable_path, current_path):
+        return False
 
     try:
         word_count = process_epub(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -19,7 +19,20 @@ from .errors import install_error_handlers
 from .middleware import RequestIdMiddleware
 from .database import SessionLocal, get_db
 from .logging_config import setup_logging
-from .routers import api_keys, auth, audiobook, books, cleaning, covers, metadata, reader, scheduler, storage, upload, web_novels
+from .routers import (
+    api_keys,
+    auth,
+    audiobook,
+    books,
+    cleaning,
+    covers,
+    metadata,
+    reader,
+    scheduler,
+    storage,
+    upload,
+    web_novels,
+)
 from .services.audiobook_queue import get_audiobook_queue
 from .services.metadata_sync_queue import get_metadata_sync_queue
 from .services.refresh_queue import get_refresh_queue

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,7 +20,8 @@ from .errors import install_error_handlers
 from .middleware import RequestIdMiddleware
 from .database import SessionLocal, get_db
 from .logging_config import setup_logging
-from .routers import api_keys, auth, books, cleaning, covers, metadata, reader, scheduler, storage, upload, web_novels
+from .routers import api_keys, auth, audiobook, books, cleaning, covers, metadata, reader, scheduler, storage, upload, web_novels
+from .services.audiobook_queue import get_audiobook_queue
 from .services.metadata_sync_queue import get_metadata_sync_queue
 from .services.refresh_queue import get_refresh_queue
 from .services.update_scheduler import get_scheduler, schedule_next_metadata_recheck, schedule_next_web_novel_update
@@ -48,6 +49,7 @@ _scheduler = get_scheduler()
 _web_import_queue = get_web_import_queue()
 _refresh_queue = get_refresh_queue()
 _metadata_sync_queue = get_metadata_sync_queue()
+_audiobook_queue = get_audiobook_queue()
 
 
 @asynccontextmanager
@@ -65,11 +67,15 @@ async def lifespan(app: FastAPI):
         await crud.reset_stuck_update_tasks(db)
     await _web_import_queue.start()
     await _refresh_queue.start()
+    await _audiobook_queue.start()
     if not is_test_app:
         await _metadata_sync_queue.start()
     requeued = await _web_import_queue.requeue_pending_books()
     if requeued:
         logger.info("Re-queued %s pending web novel imports.", requeued)
+    audiobook_requeued = await _audiobook_queue.requeue_in_progress()
+    if audiobook_requeued:
+        logger.info("Re-queued %s in-flight audiobook pipeline jobs.", audiobook_requeued)
     refresh_requeued = await _refresh_queue.requeue_pending_books()
     if refresh_requeued:
         logger.info("Re-queued %s in-flight book refreshes.", refresh_requeued)
@@ -85,6 +91,7 @@ async def lifespan(app: FastAPI):
     yield
     await _web_import_queue.stop()
     await _refresh_queue.stop()
+    await _audiobook_queue.stop()
     if not is_test_app:
         await _metadata_sync_queue.stop()
     if _scheduler.running:
@@ -100,7 +107,15 @@ app.mount(
     RasterCoverStaticFiles(directory=str((LIBRARY_PATH / "covers").resolve()), check_dir=False),
     name="cover-files",
 )
+_AUDIOBOOK_DIR = LIBRARY_PATH / "audiobooks"
+_AUDIOBOOK_DIR.mkdir(parents=True, exist_ok=True)
+app.mount(
+    "/library/audiobooks",
+    StaticFiles(directory=str(_AUDIOBOOK_DIR.resolve()), check_dir=False),
+    name="audiobook-files",
+)
 
+app.include_router(audiobook.router)
 app.include_router(books.router)
 app.include_router(upload.router)
 app.include_router(web_novels.router)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,7 +20,20 @@ from .errors import install_error_handlers
 from .middleware import RequestIdMiddleware
 from .database import SessionLocal, get_db
 from .logging_config import setup_logging
-from .routers import api_keys, auth, audiobook, books, cleaning, covers, metadata, reader, scheduler, storage, upload, web_novels
+from .routers import (
+    api_keys,
+    auth,
+    audiobook,
+    books,
+    cleaning,
+    covers,
+    metadata,
+    reader,
+    scheduler,
+    storage,
+    upload,
+    web_novels,
+)
 from .services.audiobook_queue import get_audiobook_queue
 from .services.metadata_sync_queue import get_metadata_sync_queue
 from .services.refresh_queue import get_refresh_queue

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -19,7 +19,8 @@ from .errors import install_error_handlers
 from .middleware import RequestIdMiddleware
 from .database import SessionLocal, get_db
 from .logging_config import setup_logging
-from .routers import api_keys, auth, books, cleaning, covers, metadata, reader, scheduler, storage, upload, web_novels
+from .routers import api_keys, auth, audiobook, books, cleaning, covers, metadata, reader, scheduler, storage, upload, web_novels
+from .services.audiobook_queue import get_audiobook_queue
 from .services.metadata_sync_queue import get_metadata_sync_queue
 from .services.refresh_queue import get_refresh_queue
 from .services.update_scheduler import get_scheduler, schedule_next_metadata_recheck, schedule_next_web_novel_update
@@ -32,6 +33,7 @@ _scheduler = get_scheduler()
 _web_import_queue = get_web_import_queue()
 _refresh_queue = get_refresh_queue()
 _metadata_sync_queue = get_metadata_sync_queue()
+_audiobook_queue = get_audiobook_queue()
 
 
 @asynccontextmanager
@@ -48,11 +50,15 @@ async def lifespan(app: FastAPI):
         await crud.reset_stuck_update_tasks(db)
     await _web_import_queue.start()
     await _refresh_queue.start()
+    await _audiobook_queue.start()
     if not is_test_app:
         await _metadata_sync_queue.start()
     requeued = await _web_import_queue.requeue_pending_books()
     if requeued:
         logger.info("Re-queued %s pending web novel imports.", requeued)
+    audiobook_requeued = await _audiobook_queue.requeue_in_progress()
+    if audiobook_requeued:
+        logger.info("Re-queued %s in-flight audiobook pipeline jobs.", audiobook_requeued)
     refresh_requeued = await _refresh_queue.requeue_pending_books()
     if refresh_requeued:
         logger.info("Re-queued %s in-flight book refreshes.", refresh_requeued)
@@ -68,6 +74,7 @@ async def lifespan(app: FastAPI):
     yield
     await _web_import_queue.stop()
     await _refresh_queue.stop()
+    await _audiobook_queue.stop()
     if not is_test_app:
         await _metadata_sync_queue.stop()
     if _scheduler.running:
@@ -83,7 +90,15 @@ app.mount(
     StaticFiles(directory=str((LIBRARY_PATH / "covers").resolve()), check_dir=False),
     name="cover-files",
 )
+_AUDIOBOOK_DIR = LIBRARY_PATH / "audiobooks"
+_AUDIOBOOK_DIR.mkdir(parents=True, exist_ok=True)
+app.mount(
+    "/library/audiobooks",
+    StaticFiles(directory=str(_AUDIOBOOK_DIR.resolve()), check_dir=False),
+    name="audiobook-files",
+)
 
+app.include_router(audiobook.router)
 app.include_router(books.router)
 app.include_router(upload.router)
 app.include_router(web_novels.router)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, Enum, JSON, Numeric
+from sqlalchemy import Boolean, Column, Integer, String, DateTime, ForeignKey, Enum, JSON, Numeric, Text
 from sqlalchemy.sql import func
 from .database import Base
 import enum
@@ -38,6 +38,9 @@ class Book(Base):
     # Tracks the lifecycle of a "refresh from source" job independently from the
     # initial download state. Values: None (idle), "queued", "processing", "error".
     refresh_status = Column(String, nullable=True)
+    # Audiobook pipeline state. Values: None (idle), "ingesting", "roster_gen",
+    # "diarizing", "audio_gen", "assembling", "complete", "error", "paused".
+    audiobook_pipeline_status = Column(String, nullable=True)
 
     # Timestamps
     created_at = Column(DateTime(timezone=True), server_default=func.now())
@@ -160,3 +163,54 @@ class ApiKey(Base):
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     last_used_at = Column(DateTime(timezone=True), nullable=True)
     revoked_at = Column(DateTime(timezone=True), nullable=True)
+
+
+class AudiobookSettings(Base):
+    __tablename__ = "audiobook_settings"
+
+    id = Column(Integer, primary_key=True, index=True)
+    llm_provider = Column(String, nullable=True)
+    llm_api_key = Column(String, nullable=True)
+    llm_base_url = Column(String, nullable=True)
+    llm_model = Column(String, nullable=True)
+    omnivoice_endpoint = Column(String, nullable=True)
+    roster_prompt_template = Column(Text, nullable=True)
+    diarization_prompt_template = Column(Text, nullable=True)
+
+
+class AudiobookChapter(Base):
+    __tablename__ = "audiobook_chapters"
+
+    id = Column(Integer, primary_key=True, index=True)
+    book_id = Column(Integer, ForeignKey("books.id", ondelete="CASCADE"), nullable=False, index=True)
+    chapter_number = Column(Integer, nullable=False)
+    smil_file_path = Column(String, nullable=True)
+    audio_file_path = Column(String, nullable=True)
+    needs_reassembly = Column(Boolean, nullable=False, server_default="false")
+
+
+class AudiobookCharacter(Base):
+    __tablename__ = "audiobook_characters"
+
+    id = Column(Integer, primary_key=True, index=True)
+    book_id = Column(Integer, ForeignKey("books.id", ondelete="CASCADE"), nullable=False, index=True)
+    name = Column(String, nullable=False)
+    description = Column(Text, nullable=True)
+    voice_design_prompt = Column(String, nullable=True)
+    is_narrator = Column(Boolean, nullable=False, server_default="false")
+
+
+class AudiobookSentence(Base):
+    __tablename__ = "audiobook_sentences"
+
+    id = Column(Integer, primary_key=True, index=True)
+    chapter_id = Column(Integer, ForeignKey("audiobook_chapters.id", ondelete="CASCADE"), nullable=False, index=True)
+    character_id = Column(Integer, ForeignKey("audiobook_characters.id", ondelete="SET NULL"), nullable=True)
+    html_element_id = Column(String, nullable=False)
+    sequence_order = Column(Integer, nullable=False)
+    original_text = Column(Text, nullable=False)
+    tagged_text = Column(Text, nullable=True)
+    audio_file_path = Column(String, nullable=True)
+    audio_duration_ms = Column(Integer, nullable=True)
+    # Status values: pending_diarization, ready_for_audio, audio_generated, error
+    status = Column(String, nullable=False, server_default="pending_diarization")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Boolean, Column, Integer, String, DateTime, ForeignKey, Enum, JSON, Numeric, Text
+from sqlalchemy import Boolean, Column, Integer, String, DateTime, Float, ForeignKey, Enum, JSON, Numeric, Text
 from sqlalchemy.sql import func
 from .database import Base
 import enum
@@ -49,6 +49,14 @@ class Book(Base):
     audiobook_stop_after_phase = Column(String, nullable=True)
     audiobook_pause_requested = Column(Boolean, nullable=False, default=False, server_default="false")
     audiobook_last_error = Column(Text, nullable=True)
+    audiobook_summary = Column(Text, nullable=True)
+    audiobook_progress_current = Column(Integer, nullable=False, default=0, server_default="0")
+    audiobook_progress_total = Column(Integer, nullable=False, default=0, server_default="0")
+    audiobook_progress_detail = Column(String, nullable=True)
+    audiobook_pipeline_started_at = Column(DateTime(timezone=True), nullable=True)
+    audiobook_pipeline_updated_at = Column(DateTime(timezone=True), nullable=True)
+    audiobook_batch_limit = Column(Integer, nullable=True)
+    audiobook_llm_requests = Column(Integer, nullable=False, default=0, server_default="0")
 
     # Timestamps
     created_at = Column(DateTime(timezone=True), server_default=func.now())
@@ -196,6 +204,8 @@ class AudiobookChapter(Base):
     smil_file_path = Column(String, nullable=True)
     audio_file_path = Column(String, nullable=True)
     needs_reassembly = Column(Boolean, nullable=False, server_default="false")
+    summary = Column(Text, nullable=True)
+    summary_updated_at = Column(DateTime(timezone=True), nullable=True)
 
 
 class AudiobookCharacter(Base):
@@ -207,6 +217,8 @@ class AudiobookCharacter(Base):
     description = Column(Text, nullable=True)
     voice_design_prompt = Column(String, nullable=True)
     is_narrator = Column(Boolean, nullable=False, server_default="false")
+    aliases = Column(JSON, nullable=True)
+    evidence = Column(JSON, nullable=True)
 
 
 class AudiobookSentence(Base):
@@ -221,5 +233,7 @@ class AudiobookSentence(Base):
     tagged_text = Column(Text, nullable=True)
     audio_file_path = Column(String, nullable=True)
     audio_duration_ms = Column(Integer, nullable=True)
+    speaker_confidence = Column(Float, nullable=True)
+    speaker_reason = Column(Text, nullable=True)
     # Status values: pending_diarization, ready_for_audio, audio_generated, error
     status = Column(String, nullable=False, server_default="pending_diarization")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -38,6 +38,9 @@ class Book(Base):
     # Tracks the lifecycle of a "refresh from source" job independently from the
     # initial download state. Values: None (idle), "queued", "processing", "error".
     refresh_status = Column(String, nullable=True)
+    # Audiobook generation is opt-in per book. Keep it disabled by default so
+    # normal library books do not show or run the heavier pipeline.
+    audiobook_enabled = Column(Boolean, nullable=False, default=False, server_default="false")
     # Audiobook pipeline state. Values: None (idle), "ingesting", "roster_gen",
     # "diarizing", "audio_gen", "assembling", "complete", "error", "paused".
     audiobook_pipeline_status = Column(String, nullable=True)
@@ -184,6 +187,7 @@ class AudiobookChapter(Base):
     id = Column(Integer, primary_key=True, index=True)
     book_id = Column(Integer, ForeignKey("books.id", ondelete="CASCADE"), nullable=False, index=True)
     chapter_number = Column(Integer, nullable=False)
+    content_file_name = Column(String, nullable=True)
     smil_file_path = Column(String, nullable=True)
     audio_file_path = Column(String, nullable=True)
     needs_reassembly = Column(Boolean, nullable=False, server_default="false")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -44,6 +44,11 @@ class Book(Base):
     # Audiobook pipeline state. Values: None (idle), "ingesting", "roster_gen",
     # "diarizing", "audio_gen", "assembling", "complete", "error", "paused".
     audiobook_pipeline_status = Column(String, nullable=True)
+    # Cooperative control state is persisted so a restart cannot turn a
+    # single-stage/debug run into an unattended full-book run.
+    audiobook_stop_after_phase = Column(String, nullable=True)
+    audiobook_pause_requested = Column(Boolean, nullable=False, default=False, server_default="false")
+    audiobook_last_error = Column(Text, nullable=True)
 
     # Timestamps
     created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,4 +1,17 @@
-from sqlalchemy import Boolean, Column, Integer, String, DateTime, Float, ForeignKey, Enum, JSON, Numeric, Text
+from sqlalchemy import (
+    Boolean,
+    Column,
+    Integer,
+    String,
+    DateTime,
+    Float,
+    ForeignKey,
+    Enum,
+    JSON,
+    Numeric,
+    Text,
+    UniqueConstraint,
+)
 from sqlalchemy.sql import func
 from .database import Base
 import enum
@@ -206,6 +219,27 @@ class AudiobookChapter(Base):
     needs_reassembly = Column(Boolean, nullable=False, server_default="false")
     summary = Column(Text, nullable=True)
     summary_updated_at = Column(DateTime(timezone=True), nullable=True)
+    # Manual chapter previews are independent of the full-book pipeline.
+    # Values: None, queued, generating, ready, error.
+    preview_status = Column(String, nullable=True)
+    preview_error = Column(Text, nullable=True)
+
+
+class AudiobookSeriesCharacter(Base):
+    __tablename__ = "audiobook_series_characters"
+    __table_args__ = (UniqueConstraint("series_name", "canonical_name", name="uq_audiobook_series_character"),)
+
+    id = Column(Integer, primary_key=True, index=True)
+    series_name = Column(String, nullable=False, index=True)
+    canonical_name = Column(String, nullable=False)
+    name = Column(String, nullable=False)
+    description = Column(Text, nullable=True)
+    voice_design_prompt = Column(String, nullable=True)
+    is_narrator = Column(Boolean, nullable=False, server_default="false")
+    aliases = Column(JSON, nullable=True)
+    evidence = Column(JSON, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now(), nullable=True)
 
 
 class AudiobookCharacter(Base):
@@ -213,6 +247,12 @@ class AudiobookCharacter(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     book_id = Column(Integer, ForeignKey("books.id", ondelete="CASCADE"), nullable=False, index=True)
+    series_character_id = Column(
+        Integer,
+        ForeignKey("audiobook_series_characters.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
     name = Column(String, nullable=False)
     description = Column(Text, nullable=True)
     voice_design_prompt = Column(String, nullable=True)

--- a/backend/app/routers/audiobook.py
+++ b/backend/app/routers/audiobook.py
@@ -196,9 +196,7 @@ async def list_characters(book_id: int, db: AsyncSession = Depends(get_db)) -> l
 
 
 @router.put("/api/audiobook/characters/{char_id}", response_model=CharacterResponse)
-async def update_character(
-    char_id: int, body: CharacterUpdate, db: AsyncSession = Depends(get_db)
-) -> CharacterResponse:
+async def update_character(char_id: int, body: CharacterUpdate, db: AsyncSession = Depends(get_db)) -> CharacterResponse:
     data = body.model_dump(exclude_none=True)
     voice_changed = "voice_design_prompt" in data
 
@@ -240,9 +238,7 @@ async def list_sentences(
 
 
 @router.put("/api/audiobook/sentences/{sentence_id}", response_model=SentenceResponse)
-async def update_sentence(
-    sentence_id: int, body: SentenceUpdate, db: AsyncSession = Depends(get_db)
-) -> SentenceResponse:
+async def update_sentence(sentence_id: int, body: SentenceUpdate, db: AsyncSession = Depends(get_db)) -> SentenceResponse:
     sentence = await crud.audiobook.update_sentence_speaker(
         db,
         sentence_id=sentence_id,

--- a/backend/app/routers/audiobook.py
+++ b/backend/app/routers/audiobook.py
@@ -53,6 +53,8 @@ class AudiobookStatusResponse(BaseModel):
 class CharacterResponse(BaseModel):
     id: int
     book_id: int
+    series_character_id: Optional[int] = None
+    shared_series_name: Optional[str] = None
     name: str
     description: Optional[str]
     voice_design_prompt: Optional[str]
@@ -104,8 +106,11 @@ class ChapterResponse(BaseModel):
     needs_reassembly: bool
     summary: Optional[str]
     summary_updated_at: Optional[datetime]
+    preview_status: Optional[str]
+    preview_error: Optional[str]
     sentence_count: int = 0
     processed_sentence_count: int = 0
+    audio_generated_count: int = 0
     low_confidence_count: int = 0
 
     model_config = {"from_attributes": True}
@@ -319,13 +324,15 @@ async def get_pipeline_status(book_id: int, db: AsyncSession = Depends(get_db)) 
 
 @router.get("/api/books/{book_id}/audiobook/characters", response_model=list[CharacterResponse])
 async def list_characters(book_id: int, db: AsyncSession = Depends(get_db)) -> list[CharacterResponse]:
-    await _get_audiobook_book_or_404(book_id, db)
+    book = await _get_audiobook_book_or_404(book_id, db)
     chars = await crud.audiobook.get_characters_for_book(db, book_id)
     stats = await crud.audiobook.get_character_sentence_stats(db, book_id)
     return [
         CharacterResponse(
             id=character.id,
             book_id=character.book_id,
+            series_character_id=character.series_character_id,
+            shared_series_name=book.series if character.series_character_id else None,
             name=character.name,
             description=character.description,
             voice_design_prompt=character.voice_design_prompt,
@@ -350,15 +357,41 @@ async def update_character(char_id: int, body: CharacterUpdate, db: AsyncSession
     await _get_audiobook_book_or_404(existing.book_id, db)
 
     char = await crud.audiobook.update_character(db, char_id, data)
+    linked_characters = await crud.audiobook.propagate_character_profile_across_series(db, char)
 
     if voice_changed:
-        await crud.audiobook.cascade_voice_change(db, char_id)
-        # Re-enqueue for TTS phase
-        queue = get_audiobook_queue()
-        await crud.audiobook.set_book_pipeline_status(db, char.book_id, "audio_gen")
-        await queue.enqueue(char.book_id)
+        for linked_character in linked_characters:
+            await crud.audiobook.cascade_voice_change(db, linked_character.id)
 
     return CharacterResponse.model_validate(char)
+
+
+@router.post("/api/books/{book_id}/audiobook/roster/share-series")
+async def share_character_roster_with_series(
+    book_id: int,
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    book = await _get_audiobook_book_or_404(book_id, db)
+    if not book.series:
+        raise HTTPException(status_code=409, detail="Assign this book to a series before sharing its roster")
+    characters = await crud.audiobook.get_characters_for_book(db, book_id)
+    if not characters:
+        raise HTTPException(status_code=409, detail="Generate a character roster before sharing it")
+    linked = await crud.audiobook.sync_book_roster_with_series(
+        db,
+        book,
+        characters,
+        prefer_series=True,
+    )
+    affected_book_ids: set[int] = {book_id}
+    for character in characters:
+        siblings = await crud.audiobook.propagate_character_profile_across_series(db, character)
+        affected_book_ids.update(sibling.book_id for sibling in siblings)
+    return {
+        "series": book.series,
+        "profiles": linked,
+        "books_updated": len(affected_book_ids),
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -370,7 +403,7 @@ async def update_character(char_id: int, body: CharacterUpdate, db: AsyncSession
 async def list_sentences(
     book_id: int,
     page: int = Query(1, ge=1),
-    limit: int = Query(50, ge=1, le=200),
+    limit: int = Query(50, ge=1, le=1000),
     chapter_id: Optional[int] = Query(None),
     review_only: bool = Query(False),
     db: AsyncSession = Depends(get_db),
@@ -455,8 +488,11 @@ async def list_chapters(book_id: int, db: AsyncSession = Depends(get_db)) -> lis
                 needs_reassembly=chapter.needs_reassembly,
                 summary=chapter.summary,
                 summary_updated_at=chapter.summary_updated_at,
+                preview_status=chapter.preview_status,
+                preview_error=chapter.preview_error,
                 sentence_count=len(sentences),
                 processed_sentence_count=len(processed),
+                audio_generated_count=sum(1 for sentence in sentences if sentence.status == "audio_generated"),
                 low_confidence_count=sum(
                     1
                     for sentence in sentences
@@ -465,6 +501,36 @@ async def list_chapters(book_id: int, db: AsyncSession = Depends(get_db)) -> lis
             )
         )
     return response
+
+
+@router.post("/api/books/{book_id}/audiobook/chapters/{chapter_id}/preview-audio")
+async def generate_chapter_preview(
+    book_id: int,
+    chapter_id: int,
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    book = await _get_audiobook_book_or_404(book_id, db)
+    if book.audiobook_pipeline_status in ("ingesting", "roster_gen", "diarizing", "audio_gen", "assembling"):
+        raise HTTPException(status_code=409, detail="Pause the full-book pipeline before generating a preview")
+    chapter = await db.get(AudiobookChapter, chapter_id)
+    if chapter is None or chapter.book_id != book_id:
+        raise HTTPException(status_code=404, detail="Audiobook chapter not found")
+    sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter_id)
+    pending = sum(1 for sentence in sentences if sentence.status == "pending_diarization")
+    if not sentences or pending:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Finish speaker analysis for this chapter first ({pending} sentences remain)"
+                if pending
+                else "Chapter has no narratable sentences"
+            ),
+        )
+    if chapter.preview_status in ("queued", "generating"):
+        return {"status": chapter.preview_status, "queued": False}
+    await crud.audiobook.set_chapter_preview_status(db, chapter_id, "queued")
+    queued = await get_audiobook_queue().enqueue_preview(book_id, chapter_id)
+    return {"status": "queued", "queued": queued, "chapter_id": chapter_id}
 
 
 @router.get("/api/books/{book_id}/audiobook/chapters/{chapter_id}/audio")

--- a/backend/app/routers/audiobook.py
+++ b/backend/app/routers/audiobook.py
@@ -29,6 +29,10 @@ router = APIRouter()
 
 class AudiobookStatusResponse(BaseModel):
     pipeline_status: Optional[str]
+    next_phase: str
+    pause_requested: bool
+    stop_after_phase: Optional[str]
+    last_error: Optional[str]
     sentence_counts: dict[str, int]
 
 
@@ -155,10 +159,14 @@ async def start_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> di
 
     resume_status = await crud.audiobook.infer_audiobook_resume_status(db, book_id)
     if resume_status == "complete":
-        await crud.audiobook.set_book_pipeline_status(db, book_id, "complete")
+        await crud.audiobook.configure_book_pipeline_run(
+            db, book_id, status="complete", stop_after_phase=None
+        )
         return {"status": "complete", "queued": False}
 
-    await crud.audiobook.set_book_pipeline_status(db, book_id, resume_status)
+    await crud.audiobook.configure_book_pipeline_run(
+        db, book_id, status=resume_status, stop_after_phase=None
+    )
 
     queue = get_audiobook_queue()
     queued = await queue.enqueue(book_id)
@@ -166,11 +174,39 @@ async def start_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> di
     return {"status": current_status, "queued": queued}
 
 
+@router.post("/api/books/{book_id}/audiobook/step")
+async def step_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> dict[str, Any]:
+    """Run exactly the next recoverable phase, then stop for review."""
+    book = await _get_audiobook_book_or_404(book_id, db)
+    if book.audiobook_pipeline_status in ("ingesting", "roster_gen", "diarizing", "audio_gen", "assembling"):
+        return {"status": book.audiobook_pipeline_status, "queued": False}
+
+    if book.audiobook_pipeline_status == "error" and await crud.audiobook.has_sentence_status(db, book_id, "error"):
+        await crud.audiobook.reset_error_sentences_for_book(db, book_id)
+
+    next_phase = await crud.audiobook.infer_audiobook_resume_status(db, book_id)
+    if next_phase == "complete":
+        await crud.audiobook.configure_book_pipeline_run(
+            db, book_id, status="complete", stop_after_phase=None
+        )
+        return {"status": "complete", "queued": False}
+
+    await crud.audiobook.configure_book_pipeline_run(
+        db, book_id, status=next_phase, stop_after_phase=next_phase
+    )
+    queued = await get_audiobook_queue().enqueue(book_id)
+    return {"status": next_phase, "queued": queued, "stop_after_phase": next_phase}
+
+
 @router.post("/api/books/{book_id}/audiobook/pause")
 async def pause_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> dict[str, Any]:
-    await _get_audiobook_book_or_404(book_id, db)
-    await crud.audiobook.set_book_pipeline_status(db, book_id, "paused")
-    return {"status": "paused"}
+    book = await _get_audiobook_book_or_404(book_id, db)
+    active = book.audiobook_pipeline_status in ("ingesting", "roster_gen", "diarizing", "audio_gen", "assembling")
+    await crud.audiobook.request_book_pipeline_pause(db, book_id)
+    if active:
+        return {"status": book.audiobook_pipeline_status, "pause_requested": True}
+    await crud.audiobook.pause_book_pipeline_if_requested(db, book_id)
+    return {"status": "paused", "pause_requested": False}
 
 
 @router.post("/api/books/{book_id}/audiobook/rebuild")
@@ -179,7 +215,9 @@ async def rebuild_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> 
     # Delete existing pipeline data so ingestion runs fresh
     await crud.audiobook.delete_chapters_for_book(db, book_id)
     await crud.audiobook.delete_characters_for_book(db, book_id)
-    await crud.audiobook.set_book_pipeline_status(db, book_id, "ingesting")
+    await crud.audiobook.configure_book_pipeline_run(
+        db, book_id, status="ingesting", stop_after_phase=None
+    )
     queue = get_audiobook_queue()
     await queue.enqueue(book_id)
     return {"status": "ingesting", "queued": True}
@@ -189,8 +227,14 @@ async def rebuild_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> 
 async def get_pipeline_status(book_id: int, db: AsyncSession = Depends(get_db)) -> AudiobookStatusResponse:
     book = await _get_audiobook_book_or_404(book_id, db)
     counts = await crud.audiobook.count_sentences_by_status(db, book_id)
+    next_phase = await crud.audiobook.infer_audiobook_resume_status(db, book_id)
+    await db.refresh(book)
     return AudiobookStatusResponse(
         pipeline_status=book.audiobook_pipeline_status,
+        next_phase=next_phase,
+        pause_requested=book.audiobook_pause_requested,
+        stop_after_phase=book.audiobook_stop_after_phase,
+        last_error=book.audiobook_last_error,
         sentence_counts=counts,
     )
 

--- a/backend/app/routers/audiobook.py
+++ b/backend/app/routers/audiobook.py
@@ -441,13 +441,34 @@ async def update_sentence(sentence_id: int, body: SentenceUpdate, db: AsyncSessi
         tagged_text=body.tagged_text or "",
     )
 
-    # Re-enqueue for TTS
-    if chapter:
-        queue = get_audiobook_queue()
-        await crud.audiobook.set_book_pipeline_status(db, chapter.book_id, "audio_gen")
-        await queue.enqueue(chapter.book_id)
-
     return SentenceResponse.model_validate(sentence)
+
+
+@router.post("/api/books/{book_id}/audiobook/sentences/{sentence_id}/generate-audio")
+async def generate_sentence_audio(
+    book_id: int,
+    sentence_id: int,
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    book = await _get_audiobook_book_or_404(book_id, db)
+    if book.audiobook_pipeline_status in ("ingesting", "roster_gen", "diarizing", "audio_gen", "assembling"):
+        raise HTTPException(status_code=409, detail="Pause the full-book pipeline before generating sentence audio")
+    sentence = await db.get(AudiobookSentence, sentence_id)
+    if sentence is None:
+        raise HTTPException(status_code=404, detail="Audiobook sentence not found")
+    chapter = await db.get(AudiobookChapter, sentence.chapter_id)
+    if chapter is None or chapter.book_id != book_id:
+        raise HTTPException(status_code=404, detail="Audiobook sentence not found")
+    if sentence.status in ("audio_queued", "audio_generating"):
+        return {"status": sentence.status, "queued": False, "sentence_id": sentence_id}
+    if sentence.status not in ("ready_for_audio", "error"):
+        raise HTTPException(status_code=409, detail=f"Sentence is {sentence.status}, not ready for audio")
+    if sentence.character_id is None:
+        raise HTTPException(status_code=409, detail="Assign a speaker before generating sentence audio")
+
+    await crud.audiobook.set_sentence_status(db, sentence_id, "audio_queued")
+    queued = await get_audiobook_queue().enqueue_sentence_audio(book_id, sentence_id)
+    return {"status": "audio_queued", "queued": queued, "sentence_id": sentence_id}
 
 
 @router.get("/api/audiobook/sentences/{sentence_id}/audio")

--- a/backend/app/routers/audiobook.py
+++ b/backend/app/routers/audiobook.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional
 
@@ -16,6 +17,7 @@ from ..config import LIBRARY_PATH
 from ..database import get_db
 from ..models import AudiobookChapter, AudiobookSentence, Book
 from ..services.audiobook_queue import get_audiobook_queue
+from ..services import audiobook_llm
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +36,18 @@ class AudiobookStatusResponse(BaseModel):
     stop_after_phase: Optional[str]
     last_error: Optional[str]
     sentence_counts: dict[str, int]
+    review_counts: dict[str, int]
+    summary: Optional[str]
+    progress_current: int
+    progress_total: int
+    progress_percent: Optional[float]
+    progress_detail: Optional[str]
+    pipeline_started_at: Optional[datetime]
+    pipeline_updated_at: Optional[datetime]
+    batch_limit: Optional[int]
+    llm_requests: int
+    llm_provider: str
+    llm_model: Optional[str]
 
 
 class CharacterResponse(BaseModel):
@@ -43,6 +57,10 @@ class CharacterResponse(BaseModel):
     description: Optional[str]
     voice_design_prompt: Optional[str]
     is_narrator: bool
+    aliases: Optional[list[str]] = None
+    evidence: Optional[list[str]] = None
+    sentence_count: int = 0
+    average_confidence: Optional[float] = None
 
     model_config = {"from_attributes": True}
 
@@ -64,6 +82,8 @@ class SentenceResponse(BaseModel):
     tagged_text: Optional[str]
     audio_file_path: Optional[str]
     audio_duration_ms: Optional[int]
+    speaker_confidence: Optional[float]
+    speaker_reason: Optional[str]
     status: str
 
     model_config = {"from_attributes": True}
@@ -82,6 +102,11 @@ class ChapterResponse(BaseModel):
     smil_file_path: Optional[str]
     audio_file_path: Optional[str]
     needs_reassembly: bool
+    summary: Optional[str]
+    summary_updated_at: Optional[datetime]
+    sentence_count: int = 0
+    processed_sentence_count: int = 0
+    low_confidence_count: int = 0
 
     model_config = {"from_attributes": True}
 
@@ -190,6 +215,26 @@ async def step_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> dic
     return {"status": next_phase, "queued": queued, "stop_after_phase": next_phase}
 
 
+@router.post("/api/books/{book_id}/audiobook/run-batch")
+async def run_pipeline_batch(book_id: int, db: AsyncSession = Depends(get_db)) -> dict[str, Any]:
+    """Run one durable LLM/TTS/assembly work unit, then pause for review."""
+    book = await _get_audiobook_book_or_404(book_id, db)
+    if book.audiobook_pipeline_status in ("ingesting", "roster_gen", "diarizing", "audio_gen", "assembling"):
+        return {"status": book.audiobook_pipeline_status, "queued": False}
+    next_phase = await crud.audiobook.infer_audiobook_resume_status(db, book_id)
+    if next_phase not in ("diarizing", "audio_gen", "assembling"):
+        raise HTTPException(status_code=409, detail=f"{next_phase} is atomic; use Run Next Stage instead")
+    await crud.audiobook.configure_book_pipeline_run(
+        db,
+        book_id,
+        status=next_phase,
+        stop_after_phase=None,
+        batch_limit=1,
+    )
+    queued = await get_audiobook_queue().enqueue(book_id)
+    return {"status": next_phase, "queued": queued, "batch_limit": 1}
+
+
 @router.post("/api/books/{book_id}/audiobook/pause")
 async def pause_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> dict[str, Any]:
     book = await _get_audiobook_book_or_404(book_id, db)
@@ -207,18 +252,44 @@ async def rebuild_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> 
     # Delete existing pipeline data so ingestion runs fresh
     await crud.audiobook.delete_chapters_for_book(db, book_id)
     await crud.audiobook.delete_characters_for_book(db, book_id)
+    await crud.audiobook.set_book_audiobook_summary(db, book_id, None)
     await crud.audiobook.configure_book_pipeline_run(db, book_id, status="ingesting", stop_after_phase=None)
     queue = get_audiobook_queue()
     await queue.enqueue(book_id)
     return {"status": "ingesting", "queued": True}
 
 
+@router.post("/api/books/{book_id}/audiobook/roster/rebuild")
+async def rebuild_character_roster(book_id: int, db: AsyncSession = Depends(get_db)) -> dict[str, Any]:
+    """Re-run roster and diarization analysis without parsing the EPUB again."""
+    book = await _get_audiobook_book_or_404(book_id, db)
+    if book.audiobook_pipeline_status in ("ingesting", "roster_gen", "diarizing", "audio_gen", "assembling"):
+        raise HTTPException(status_code=409, detail="Pause the active pipeline before regenerating the roster")
+    chapters = await crud.audiobook.get_chapters_for_book(db, book_id)
+    if not chapters:
+        raise HTTPException(status_code=409, detail="Run ingestion before regenerating the roster")
+    await crud.audiobook.reset_roster_and_diarization_for_book(db, book_id)
+    await crud.audiobook.set_book_audiobook_summary(db, book_id, None)
+    await crud.audiobook.configure_book_pipeline_run(
+        db,
+        book_id,
+        status="roster_gen",
+        stop_after_phase="roster_gen",
+    )
+    queued = await get_audiobook_queue().enqueue(book_id)
+    return {"status": "roster_gen", "queued": queued, "stop_after_phase": "roster_gen"}
+
+
 @router.get("/api/books/{book_id}/audiobook/status", response_model=AudiobookStatusResponse)
 async def get_pipeline_status(book_id: int, db: AsyncSession = Depends(get_db)) -> AudiobookStatusResponse:
     book = await _get_audiobook_book_or_404(book_id, db)
     counts = await crud.audiobook.count_sentences_by_status(db, book_id)
+    review_counts = await crud.audiobook.count_sentence_review_flags(db, book_id)
     next_phase = await crud.audiobook.infer_audiobook_resume_status(db, book_id)
+    settings = await crud.audiobook.get_audiobook_settings(db)
     await db.refresh(book)
+    total = book.audiobook_progress_total or 0
+    percent = round((book.audiobook_progress_current or 0) * 100 / total, 1) if total else None
     return AudiobookStatusResponse(
         pipeline_status=book.audiobook_pipeline_status,
         next_phase=next_phase,
@@ -226,6 +297,18 @@ async def get_pipeline_status(book_id: int, db: AsyncSession = Depends(get_db)) 
         stop_after_phase=book.audiobook_stop_after_phase,
         last_error=book.audiobook_last_error,
         sentence_counts=counts,
+        review_counts=review_counts,
+        summary=book.audiobook_summary,
+        progress_current=book.audiobook_progress_current or 0,
+        progress_total=total,
+        progress_percent=percent,
+        progress_detail=book.audiobook_progress_detail,
+        pipeline_started_at=book.audiobook_pipeline_started_at,
+        pipeline_updated_at=book.audiobook_pipeline_updated_at,
+        batch_limit=book.audiobook_batch_limit,
+        llm_requests=book.audiobook_llm_requests or 0,
+        llm_provider=(settings.llm_provider or "stub") if settings else "stub",
+        llm_model=settings.llm_model if settings else None,
     )
 
 
@@ -238,7 +321,22 @@ async def get_pipeline_status(book_id: int, db: AsyncSession = Depends(get_db)) 
 async def list_characters(book_id: int, db: AsyncSession = Depends(get_db)) -> list[CharacterResponse]:
     await _get_audiobook_book_or_404(book_id, db)
     chars = await crud.audiobook.get_characters_for_book(db, book_id)
-    return [CharacterResponse.model_validate(c) for c in chars]
+    stats = await crud.audiobook.get_character_sentence_stats(db, book_id)
+    return [
+        CharacterResponse(
+            id=character.id,
+            book_id=character.book_id,
+            name=character.name,
+            description=character.description,
+            voice_design_prompt=character.voice_design_prompt,
+            is_narrator=character.is_narrator,
+            aliases=character.aliases or [],
+            evidence=character.evidence or [],
+            sentence_count=stats.get(character.id, {}).get("sentence_count", 0),
+            average_confidence=stats.get(character.id, {}).get("average_confidence"),
+        )
+        for character in chars
+    ]
 
 
 @router.put("/api/audiobook/characters/{char_id}", response_model=CharacterResponse)
@@ -274,10 +372,18 @@ async def list_sentences(
     page: int = Query(1, ge=1),
     limit: int = Query(50, ge=1, le=200),
     chapter_id: Optional[int] = Query(None),
+    review_only: bool = Query(False),
     db: AsyncSession = Depends(get_db),
 ) -> SentenceListResponse:
     await _get_audiobook_book_or_404(book_id, db)
-    sentences, total = await crud.audiobook.get_sentences_paginated(db, book_id, page=page, limit=limit, chapter_id=chapter_id)
+    sentences, total = await crud.audiobook.get_sentences_paginated(
+        db,
+        book_id,
+        page=page,
+        limit=limit,
+        chapter_id=chapter_id,
+        review_only=review_only,
+    )
     return SentenceListResponse(
         items=[SentenceResponse.model_validate(s) for s in sentences],
         total=total,
@@ -334,7 +440,31 @@ async def get_sentence_audio(sentence_id: int, db: AsyncSession = Depends(get_db
 async def list_chapters(book_id: int, db: AsyncSession = Depends(get_db)) -> list[ChapterResponse]:
     await _get_audiobook_book_or_404(book_id, db)
     chapters = await crud.audiobook.get_chapters_for_book(db, book_id)
-    return [ChapterResponse.model_validate(c) for c in chapters]
+    response = []
+    for chapter in chapters:
+        sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
+        processed = [sentence for sentence in sentences if sentence.status != "pending_diarization"]
+        response.append(
+            ChapterResponse(
+                id=chapter.id,
+                book_id=chapter.book_id,
+                chapter_number=chapter.chapter_number,
+                content_file_name=chapter.content_file_name,
+                smil_file_path=chapter.smil_file_path,
+                audio_file_path=chapter.audio_file_path,
+                needs_reassembly=chapter.needs_reassembly,
+                summary=chapter.summary,
+                summary_updated_at=chapter.summary_updated_at,
+                sentence_count=len(sentences),
+                processed_sentence_count=len(processed),
+                low_confidence_count=sum(
+                    1
+                    for sentence in sentences
+                    if sentence.speaker_confidence is not None and sentence.speaker_confidence < 0.65
+                ),
+            )
+        )
+    return response
 
 
 @router.get("/api/books/{book_id}/audiobook/chapters/{chapter_id}/audio")
@@ -406,3 +536,27 @@ async def update_settings(body: SettingsUpdate, db: AsyncSession = Depends(get_d
         roster_prompt_template=settings.roster_prompt_template,
         diarization_prompt_template=settings.diarization_prompt_template,
     )
+
+
+@router.post("/api/audiobook/settings/test-llm")
+async def test_llm_settings(db: AsyncSession = Depends(get_db)) -> dict[str, Any]:
+    settings = await crud.audiobook.get_audiobook_settings(db)
+    if settings is None or (settings.llm_provider or "stub").lower() == "stub":
+        return {"status": "ready", "provider": "stub", "model": None, "response": "local harness"}
+    schema = {
+        "type": "object",
+        "properties": {"status": {"type": "string"}},
+        "required": ["status"],
+    }
+    raw = await audiobook_llm._call_llm(
+        settings,
+        [{"role": "user", "content": "Return JSON with status set to ready."}],
+        response_schema=schema,
+    )
+    parsed = audiobook_llm._extract_json(raw)
+    return {
+        "status": parsed.get("status", "unknown") if isinstance(parsed, dict) else "unknown",
+        "provider": settings.llm_provider,
+        "model": settings.llm_model,
+        "response": parsed,
+    }

--- a/backend/app/routers/audiobook.py
+++ b/backend/app/routers/audiobook.py
@@ -159,14 +159,10 @@ async def start_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> di
 
     resume_status = await crud.audiobook.infer_audiobook_resume_status(db, book_id)
     if resume_status == "complete":
-        await crud.audiobook.configure_book_pipeline_run(
-            db, book_id, status="complete", stop_after_phase=None
-        )
+        await crud.audiobook.configure_book_pipeline_run(db, book_id, status="complete", stop_after_phase=None)
         return {"status": "complete", "queued": False}
 
-    await crud.audiobook.configure_book_pipeline_run(
-        db, book_id, status=resume_status, stop_after_phase=None
-    )
+    await crud.audiobook.configure_book_pipeline_run(db, book_id, status=resume_status, stop_after_phase=None)
 
     queue = get_audiobook_queue()
     queued = await queue.enqueue(book_id)
@@ -186,14 +182,10 @@ async def step_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> dic
 
     next_phase = await crud.audiobook.infer_audiobook_resume_status(db, book_id)
     if next_phase == "complete":
-        await crud.audiobook.configure_book_pipeline_run(
-            db, book_id, status="complete", stop_after_phase=None
-        )
+        await crud.audiobook.configure_book_pipeline_run(db, book_id, status="complete", stop_after_phase=None)
         return {"status": "complete", "queued": False}
 
-    await crud.audiobook.configure_book_pipeline_run(
-        db, book_id, status=next_phase, stop_after_phase=next_phase
-    )
+    await crud.audiobook.configure_book_pipeline_run(db, book_id, status=next_phase, stop_after_phase=next_phase)
     queued = await get_audiobook_queue().enqueue(book_id)
     return {"status": next_phase, "queued": queued, "stop_after_phase": next_phase}
 
@@ -215,9 +207,7 @@ async def rebuild_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> 
     # Delete existing pipeline data so ingestion runs fresh
     await crud.audiobook.delete_chapters_for_book(db, book_id)
     await crud.audiobook.delete_characters_for_book(db, book_id)
-    await crud.audiobook.configure_book_pipeline_run(
-        db, book_id, status="ingesting", stop_after_phase=None
-    )
+    await crud.audiobook.configure_book_pipeline_run(db, book_id, status="ingesting", stop_after_phase=None)
     queue = get_audiobook_queue()
     await queue.enqueue(book_id)
     return {"status": "ingesting", "queued": True}

--- a/backend/app/routers/audiobook.py
+++ b/backend/app/routers/audiobook.py
@@ -279,7 +279,7 @@ async def rebuild_character_roster(book_id: int, db: AsyncSession = Depends(get_
         db,
         book_id,
         status="roster_gen",
-        stop_after_phase="roster_gen",
+        stop_after_phase=crud.audiobook.ROSTER_REFRESH_STOP_MARKER,
     )
     queued = await get_audiobook_queue().enqueue(book_id)
     return {"status": "roster_gen", "queued": queued, "stop_after_phase": "roster_gen"}

--- a/backend/app/routers/audiobook.py
+++ b/backend/app/routers/audiobook.py
@@ -74,6 +74,7 @@ class ChapterResponse(BaseModel):
     id: int
     book_id: int
     chapter_number: int
+    content_file_name: Optional[str]
     smil_file_path: Optional[str]
     audio_file_path: Optional[str]
     needs_reassembly: bool
@@ -121,6 +122,13 @@ async def _get_book_or_404(book_id: int, db: AsyncSession) -> Book:
     return book
 
 
+async def _get_audiobook_book_or_404(book_id: int, db: AsyncSession) -> Book:
+    book = await _get_book_or_404(book_id, db)
+    if not book.audiobook_enabled:
+        raise HTTPException(status_code=403, detail="Audiobook pipeline is not enabled for this book")
+    return book
+
+
 def _resolve_path(relative_path: Optional[str]) -> Optional[Path]:
     if not relative_path:
         return None
@@ -134,19 +142,22 @@ def _resolve_path(relative_path: Optional[str]) -> Optional[Path]:
 
 @router.post("/api/books/{book_id}/audiobook/start")
 async def start_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> dict[str, Any]:
-    book = await _get_book_or_404(book_id, db)
+    book = await _get_audiobook_book_or_404(book_id, db)
     status = book.audiobook_pipeline_status
 
     if status in ("ingesting", "roster_gen", "diarizing", "audio_gen", "assembling"):
         # Already running; idempotent
         return {"status": status, "queued": False}
 
-    if status == "complete":
-        # Resume from audio_gen to re-generate only chapters with needs_reassembly
-        await crud.audiobook.set_book_pipeline_status(db, book_id, "audio_gen")
-    elif status != "paused":
-        # Fresh start or reset
-        await crud.audiobook.set_book_pipeline_status(db, book_id, "ingesting")
+    if status == "error" and await crud.audiobook.has_sentence_status(db, book_id, "error"):
+        await crud.audiobook.reset_error_sentences_for_book(db, book_id)
+
+    resume_status = await crud.audiobook.infer_audiobook_resume_status(db, book_id)
+    if resume_status == "complete":
+        await crud.audiobook.set_book_pipeline_status(db, book_id, "complete")
+        return {"status": "complete", "queued": False}
+
+    await crud.audiobook.set_book_pipeline_status(db, book_id, resume_status)
 
     queue = get_audiobook_queue()
     queued = await queue.enqueue(book_id)
@@ -156,14 +167,14 @@ async def start_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> di
 
 @router.post("/api/books/{book_id}/audiobook/pause")
 async def pause_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> dict[str, Any]:
-    await _get_book_or_404(book_id, db)
+    await _get_audiobook_book_or_404(book_id, db)
     await crud.audiobook.set_book_pipeline_status(db, book_id, "paused")
     return {"status": "paused"}
 
 
 @router.post("/api/books/{book_id}/audiobook/rebuild")
 async def rebuild_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> dict[str, Any]:
-    await _get_book_or_404(book_id, db)
+    await _get_audiobook_book_or_404(book_id, db)
     # Delete existing pipeline data so ingestion runs fresh
     await crud.audiobook.delete_chapters_for_book(db, book_id)
     await crud.audiobook.delete_characters_for_book(db, book_id)
@@ -175,7 +186,7 @@ async def rebuild_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> 
 
 @router.get("/api/books/{book_id}/audiobook/status", response_model=AudiobookStatusResponse)
 async def get_pipeline_status(book_id: int, db: AsyncSession = Depends(get_db)) -> AudiobookStatusResponse:
-    book = await _get_book_or_404(book_id, db)
+    book = await _get_audiobook_book_or_404(book_id, db)
     counts = await crud.audiobook.count_sentences_by_status(db, book_id)
     return AudiobookStatusResponse(
         pipeline_status=book.audiobook_pipeline_status,
@@ -190,7 +201,7 @@ async def get_pipeline_status(book_id: int, db: AsyncSession = Depends(get_db)) 
 
 @router.get("/api/books/{book_id}/audiobook/characters", response_model=list[CharacterResponse])
 async def list_characters(book_id: int, db: AsyncSession = Depends(get_db)) -> list[CharacterResponse]:
-    await _get_book_or_404(book_id, db)
+    await _get_audiobook_book_or_404(book_id, db)
     chars = await crud.audiobook.get_characters_for_book(db, book_id)
     return [CharacterResponse.model_validate(c) for c in chars]
 
@@ -200,9 +211,12 @@ async def update_character(char_id: int, body: CharacterUpdate, db: AsyncSession
     data = body.model_dump(exclude_none=True)
     voice_changed = "voice_design_prompt" in data
 
-    char = await crud.audiobook.update_character(db, char_id, data)
-    if char is None:
+    existing = await crud.audiobook.get_character(db, char_id)
+    if existing is None:
         raise HTTPException(status_code=404, detail="Character not found")
+    await _get_audiobook_book_or_404(existing.book_id, db)
+
+    char = await crud.audiobook.update_character(db, char_id, data)
 
     if voice_changed:
         await crud.audiobook.cascade_voice_change(db, char_id)
@@ -227,7 +241,7 @@ async def list_sentences(
     chapter_id: Optional[int] = Query(None),
     db: AsyncSession = Depends(get_db),
 ) -> SentenceListResponse:
-    await _get_book_or_404(book_id, db)
+    await _get_audiobook_book_or_404(book_id, db)
     sentences, total = await crud.audiobook.get_sentences_paginated(db, book_id, page=page, limit=limit, chapter_id=chapter_id)
     return SentenceListResponse(
         items=[SentenceResponse.model_validate(s) for s in sentences],
@@ -239,17 +253,21 @@ async def list_sentences(
 
 @router.put("/api/audiobook/sentences/{sentence_id}", response_model=SentenceResponse)
 async def update_sentence(sentence_id: int, body: SentenceUpdate, db: AsyncSession = Depends(get_db)) -> SentenceResponse:
+    existing = await db.get(AudiobookSentence, sentence_id)
+    if existing is None:
+        raise HTTPException(status_code=404, detail="Sentence not found")
+    chapter = await db.get(AudiobookChapter, existing.chapter_id)
+    if chapter:
+        await _get_audiobook_book_or_404(chapter.book_id, db)
+
     sentence = await crud.audiobook.update_sentence_speaker(
         db,
         sentence_id=sentence_id,
         character_id=body.character_id,
         tagged_text=body.tagged_text or "",
     )
-    if sentence is None:
-        raise HTTPException(status_code=404, detail="Sentence not found")
 
     # Re-enqueue for TTS
-    chapter = await db.get(AudiobookChapter, sentence.chapter_id)
     if chapter:
         queue = get_audiobook_queue()
         await crud.audiobook.set_book_pipeline_status(db, chapter.book_id, "audio_gen")
@@ -263,6 +281,9 @@ async def get_sentence_audio(sentence_id: int, db: AsyncSession = Depends(get_db
     sentence = await db.get(AudiobookSentence, sentence_id)
     if sentence is None or not sentence.audio_file_path:
         raise HTTPException(status_code=404, detail="Audio not available")
+    chapter = await db.get(AudiobookChapter, sentence.chapter_id)
+    if chapter:
+        await _get_audiobook_book_or_404(chapter.book_id, db)
     full_path = _resolve_path(sentence.audio_file_path)
     if not full_path or not full_path.exists():
         raise HTTPException(status_code=404, detail="Audio file not found on disk")
@@ -276,7 +297,7 @@ async def get_sentence_audio(sentence_id: int, db: AsyncSession = Depends(get_db
 
 @router.get("/api/books/{book_id}/audiobook/chapters", response_model=list[ChapterResponse])
 async def list_chapters(book_id: int, db: AsyncSession = Depends(get_db)) -> list[ChapterResponse]:
-    await _get_book_or_404(book_id, db)
+    await _get_audiobook_book_or_404(book_id, db)
     chapters = await crud.audiobook.get_chapters_for_book(db, book_id)
     return [ChapterResponse.model_validate(c) for c in chapters]
 
@@ -286,6 +307,7 @@ async def get_chapter_audio(book_id: int, chapter_id: int, db: AsyncSession = De
     chapter = await db.get(AudiobookChapter, chapter_id)
     if chapter is None or chapter.book_id != book_id or not chapter.audio_file_path:
         raise HTTPException(status_code=404, detail="Audio not available")
+    await _get_audiobook_book_or_404(book_id, db)
     full_path = _resolve_path(chapter.audio_file_path)
     if not full_path or not full_path.exists():
         raise HTTPException(status_code=404, detail="Audio file not found on disk")

--- a/backend/app/routers/audiobook.py
+++ b/backend/app/routers/audiobook.py
@@ -132,7 +132,8 @@ async def _get_audiobook_book_or_404(book_id: int, db: AsyncSession) -> Book:
 def _resolve_path(relative_path: Optional[str]) -> Optional[Path]:
     if not relative_path:
         return None
-    return (LIBRARY_PATH.parent / relative_path).resolve()
+    path = (LIBRARY_PATH.parent / relative_path).resolve()
+    return path if path.is_relative_to(LIBRARY_PATH.resolve()) else None
 
 
 # ---------------------------------------------------------------------------
@@ -312,6 +313,18 @@ async def get_chapter_audio(book_id: int, chapter_id: int, db: AsyncSession = De
     if not full_path or not full_path.exists():
         raise HTTPException(status_code=404, detail="Audio file not found on disk")
     return FileResponse(str(full_path), media_type="audio/mpeg")
+
+
+@router.get("/api/books/{book_id}/audiobook/download")
+async def download_audiobook(book_id: int, db: AsyncSession = Depends(get_db)) -> FileResponse:
+    book = await _get_audiobook_book_or_404(book_id, db)
+    if book.audiobook_pipeline_status != "complete":
+        raise HTTPException(status_code=409, detail="Audiobook generation is not complete")
+    full_path = (LIBRARY_PATH / "audiobooks" / str(book_id) / "audiobook.epub").resolve()
+    if not full_path.exists():
+        raise HTTPException(status_code=404, detail="Audiobook EPUB not found on disk")
+    filename = f"{book.title or 'audiobook'}-audiobook.epub"
+    return FileResponse(str(full_path), media_type="application/epub+zip", filename=filename)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/routers/audiobook.py
+++ b/backend/app/routers/audiobook.py
@@ -1,0 +1,343 @@
+"""Audiobook pipeline API endpoints."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import FileResponse
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import crud
+from ..config import LIBRARY_PATH
+from ..database import get_db
+from ..models import AudiobookChapter, AudiobookSentence, Book
+from ..services.audiobook_queue import get_audiobook_queue
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class AudiobookStatusResponse(BaseModel):
+    pipeline_status: Optional[str]
+    sentence_counts: dict[str, int]
+
+
+class CharacterResponse(BaseModel):
+    id: int
+    book_id: int
+    name: str
+    description: Optional[str]
+    voice_design_prompt: Optional[str]
+    is_narrator: bool
+
+    model_config = {"from_attributes": True}
+
+
+class CharacterUpdate(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
+    voice_design_prompt: Optional[str] = None
+    is_narrator: Optional[bool] = None
+
+
+class SentenceResponse(BaseModel):
+    id: int
+    chapter_id: int
+    character_id: Optional[int]
+    html_element_id: str
+    sequence_order: int
+    original_text: str
+    tagged_text: Optional[str]
+    audio_file_path: Optional[str]
+    audio_duration_ms: Optional[int]
+    status: str
+
+    model_config = {"from_attributes": True}
+
+
+class SentenceUpdate(BaseModel):
+    character_id: Optional[int] = None
+    tagged_text: Optional[str] = None
+
+
+class ChapterResponse(BaseModel):
+    id: int
+    book_id: int
+    chapter_number: int
+    smil_file_path: Optional[str]
+    audio_file_path: Optional[str]
+    needs_reassembly: bool
+
+    model_config = {"from_attributes": True}
+
+
+class SettingsResponse(BaseModel):
+    id: Optional[int]
+    llm_provider: Optional[str]
+    llm_api_key_set: bool
+    llm_base_url: Optional[str]
+    llm_model: Optional[str]
+    omnivoice_endpoint: Optional[str]
+    roster_prompt_template: Optional[str]
+    diarization_prompt_template: Optional[str]
+
+
+class SettingsUpdate(BaseModel):
+    llm_provider: Optional[str] = None
+    llm_api_key: Optional[str] = None
+    llm_base_url: Optional[str] = None
+    llm_model: Optional[str] = None
+    omnivoice_endpoint: Optional[str] = None
+    roster_prompt_template: Optional[str] = None
+    diarization_prompt_template: Optional[str] = None
+
+
+class SentenceListResponse(BaseModel):
+    items: list[SentenceResponse]
+    total: int
+    page: int
+    limit: int
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _get_book_or_404(book_id: int, db: AsyncSession) -> Book:
+    book = await db.get(Book, book_id)
+    if book is None:
+        raise HTTPException(status_code=404, detail="Book not found")
+    return book
+
+
+def _resolve_path(relative_path: Optional[str]) -> Optional[Path]:
+    if not relative_path:
+        return None
+    return (LIBRARY_PATH.parent / relative_path).resolve()
+
+
+# ---------------------------------------------------------------------------
+# Pipeline control
+# ---------------------------------------------------------------------------
+
+
+@router.post("/api/books/{book_id}/audiobook/start")
+async def start_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> dict[str, Any]:
+    book = await _get_book_or_404(book_id, db)
+    status = book.audiobook_pipeline_status
+
+    if status in ("ingesting", "roster_gen", "diarizing", "audio_gen", "assembling"):
+        # Already running; idempotent
+        return {"status": status, "queued": False}
+
+    if status == "complete":
+        # Resume from audio_gen to re-generate only chapters with needs_reassembly
+        await crud.audiobook.set_book_pipeline_status(db, book_id, "audio_gen")
+    elif status != "paused":
+        # Fresh start or reset
+        await crud.audiobook.set_book_pipeline_status(db, book_id, "ingesting")
+
+    queue = get_audiobook_queue()
+    queued = await queue.enqueue(book_id)
+    current_status = (await db.get(Book, book_id)).audiobook_pipeline_status
+    return {"status": current_status, "queued": queued}
+
+
+@router.post("/api/books/{book_id}/audiobook/pause")
+async def pause_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> dict[str, Any]:
+    await _get_book_or_404(book_id, db)
+    await crud.audiobook.set_book_pipeline_status(db, book_id, "paused")
+    return {"status": "paused"}
+
+
+@router.post("/api/books/{book_id}/audiobook/rebuild")
+async def rebuild_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> dict[str, Any]:
+    await _get_book_or_404(book_id, db)
+    # Delete existing pipeline data so ingestion runs fresh
+    await crud.audiobook.delete_chapters_for_book(db, book_id)
+    await crud.audiobook.delete_characters_for_book(db, book_id)
+    await crud.audiobook.set_book_pipeline_status(db, book_id, "ingesting")
+    queue = get_audiobook_queue()
+    await queue.enqueue(book_id)
+    return {"status": "ingesting", "queued": True}
+
+
+@router.get("/api/books/{book_id}/audiobook/status", response_model=AudiobookStatusResponse)
+async def get_pipeline_status(book_id: int, db: AsyncSession = Depends(get_db)) -> AudiobookStatusResponse:
+    book = await _get_book_or_404(book_id, db)
+    counts = await crud.audiobook.count_sentences_by_status(db, book_id)
+    return AudiobookStatusResponse(
+        pipeline_status=book.audiobook_pipeline_status,
+        sentence_counts=counts,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Characters
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/books/{book_id}/audiobook/characters", response_model=list[CharacterResponse])
+async def list_characters(book_id: int, db: AsyncSession = Depends(get_db)) -> list[CharacterResponse]:
+    await _get_book_or_404(book_id, db)
+    chars = await crud.audiobook.get_characters_for_book(db, book_id)
+    return [CharacterResponse.model_validate(c) for c in chars]
+
+
+@router.put("/api/audiobook/characters/{char_id}", response_model=CharacterResponse)
+async def update_character(
+    char_id: int, body: CharacterUpdate, db: AsyncSession = Depends(get_db)
+) -> CharacterResponse:
+    data = body.model_dump(exclude_none=True)
+    voice_changed = "voice_design_prompt" in data
+
+    char = await crud.audiobook.update_character(db, char_id, data)
+    if char is None:
+        raise HTTPException(status_code=404, detail="Character not found")
+
+    if voice_changed:
+        await crud.audiobook.cascade_voice_change(db, char_id)
+        # Re-enqueue for TTS phase
+        queue = get_audiobook_queue()
+        await crud.audiobook.set_book_pipeline_status(db, char.book_id, "audio_gen")
+        await queue.enqueue(char.book_id)
+
+    return CharacterResponse.model_validate(char)
+
+
+# ---------------------------------------------------------------------------
+# Sentences
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/books/{book_id}/audiobook/sentences", response_model=SentenceListResponse)
+async def list_sentences(
+    book_id: int,
+    page: int = Query(1, ge=1),
+    limit: int = Query(50, ge=1, le=200),
+    chapter_id: Optional[int] = Query(None),
+    db: AsyncSession = Depends(get_db),
+) -> SentenceListResponse:
+    await _get_book_or_404(book_id, db)
+    sentences, total = await crud.audiobook.get_sentences_paginated(db, book_id, page=page, limit=limit, chapter_id=chapter_id)
+    return SentenceListResponse(
+        items=[SentenceResponse.model_validate(s) for s in sentences],
+        total=total,
+        page=page,
+        limit=limit,
+    )
+
+
+@router.put("/api/audiobook/sentences/{sentence_id}", response_model=SentenceResponse)
+async def update_sentence(
+    sentence_id: int, body: SentenceUpdate, db: AsyncSession = Depends(get_db)
+) -> SentenceResponse:
+    sentence = await crud.audiobook.update_sentence_speaker(
+        db,
+        sentence_id=sentence_id,
+        character_id=body.character_id,
+        tagged_text=body.tagged_text or "",
+    )
+    if sentence is None:
+        raise HTTPException(status_code=404, detail="Sentence not found")
+
+    # Re-enqueue for TTS
+    chapter = await db.get(AudiobookChapter, sentence.chapter_id)
+    if chapter:
+        queue = get_audiobook_queue()
+        await crud.audiobook.set_book_pipeline_status(db, chapter.book_id, "audio_gen")
+        await queue.enqueue(chapter.book_id)
+
+    return SentenceResponse.model_validate(sentence)
+
+
+@router.get("/api/audiobook/sentences/{sentence_id}/audio")
+async def get_sentence_audio(sentence_id: int, db: AsyncSession = Depends(get_db)) -> FileResponse:
+    sentence = await db.get(AudiobookSentence, sentence_id)
+    if sentence is None or not sentence.audio_file_path:
+        raise HTTPException(status_code=404, detail="Audio not available")
+    full_path = _resolve_path(sentence.audio_file_path)
+    if not full_path or not full_path.exists():
+        raise HTTPException(status_code=404, detail="Audio file not found on disk")
+    return FileResponse(str(full_path), media_type="audio/mpeg")
+
+
+# ---------------------------------------------------------------------------
+# Chapters
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/books/{book_id}/audiobook/chapters", response_model=list[ChapterResponse])
+async def list_chapters(book_id: int, db: AsyncSession = Depends(get_db)) -> list[ChapterResponse]:
+    await _get_book_or_404(book_id, db)
+    chapters = await crud.audiobook.get_chapters_for_book(db, book_id)
+    return [ChapterResponse.model_validate(c) for c in chapters]
+
+
+@router.get("/api/books/{book_id}/audiobook/chapters/{chapter_id}/audio")
+async def get_chapter_audio(book_id: int, chapter_id: int, db: AsyncSession = Depends(get_db)) -> FileResponse:
+    chapter = await db.get(AudiobookChapter, chapter_id)
+    if chapter is None or chapter.book_id != book_id or not chapter.audio_file_path:
+        raise HTTPException(status_code=404, detail="Audio not available")
+    full_path = _resolve_path(chapter.audio_file_path)
+    if not full_path or not full_path.exists():
+        raise HTTPException(status_code=404, detail="Audio file not found on disk")
+    return FileResponse(str(full_path), media_type="audio/mpeg")
+
+
+# ---------------------------------------------------------------------------
+# Settings
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/audiobook/settings", response_model=SettingsResponse)
+async def get_settings(db: AsyncSession = Depends(get_db)) -> SettingsResponse:
+    settings = await crud.audiobook.get_audiobook_settings(db)
+    if settings is None:
+        return SettingsResponse(
+            id=None,
+            llm_provider=None,
+            llm_api_key_set=False,
+            llm_base_url=None,
+            llm_model=None,
+            omnivoice_endpoint=None,
+            roster_prompt_template=None,
+            diarization_prompt_template=None,
+        )
+    return SettingsResponse(
+        id=settings.id,
+        llm_provider=settings.llm_provider,
+        llm_api_key_set=bool(settings.llm_api_key),
+        llm_base_url=settings.llm_base_url,
+        llm_model=settings.llm_model,
+        omnivoice_endpoint=settings.omnivoice_endpoint,
+        roster_prompt_template=settings.roster_prompt_template,
+        diarization_prompt_template=settings.diarization_prompt_template,
+    )
+
+
+@router.put("/api/audiobook/settings", response_model=SettingsResponse)
+async def update_settings(body: SettingsUpdate, db: AsyncSession = Depends(get_db)) -> SettingsResponse:
+    data = body.model_dump(exclude_none=True)
+    settings = await crud.audiobook.upsert_audiobook_settings(db, data)
+    return SettingsResponse(
+        id=settings.id,
+        llm_provider=settings.llm_provider,
+        llm_api_key_set=bool(settings.llm_api_key),
+        llm_base_url=settings.llm_base_url,
+        llm_model=settings.llm_model,
+        omnivoice_endpoint=settings.omnivoice_endpoint,
+        roster_prompt_template=settings.roster_prompt_template,
+        diarization_prompt_template=settings.diarization_prompt_template,
+    )

--- a/backend/app/routers/books.py
+++ b/backend/app/routers/books.py
@@ -240,6 +240,16 @@ async def update_book_details(
     ):
         await queue_metadata_sync_job(db, trigger="book_update", book_ids=[updated_book.id])
     if updated_book.series != previous_series:
+        characters = await crud.audiobook.get_characters_for_book(db, updated_book.id)
+        if updated_book.series and characters:
+            await crud.audiobook.sync_book_roster_with_series(
+                db,
+                updated_book,
+                characters,
+                prefer_series=True,
+            )
+        elif not updated_book.series:
+            await crud.audiobook.unlink_book_roster_from_series(db, updated_book.id)
         await crud.cleanup_orphaned_series_metadata(db)
     return updated_book
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -31,6 +31,8 @@ class BookBase(BaseModel):
     notes: Optional[str] = None
     download_status: Optional[str] = None
     refresh_status: Optional[str] = None
+    audiobook_enabled: bool = False
+    audiobook_pipeline_status: Optional[str] = None
 
 
 # Pydantic model for creating a new book.
@@ -48,6 +50,7 @@ class BookUpdate(BaseModel):
     user_genre_tags: Optional[List[str]] = None
     source_tags: Optional[List[str]] = None
     metadata_remote_ids: Optional[dict] = None
+    audiobook_enabled: Optional[bool] = None
     removed_chapters: Optional[List[str]] = None
     content_selectors: Optional[List[str]] = None
     notes: Optional[str] = None
@@ -81,6 +84,8 @@ class BookCatalogEntry(BaseModel):
     updated_at: Optional[datetime] = None
     download_status: Optional[str] = None
     refresh_status: Optional[str] = None
+    audiobook_enabled: bool = False
+    audiobook_pipeline_status: Optional[str] = None
 
 
 # Pydantic model for creating a new book log.

--- a/backend/app/services/audiobook_assembly.py
+++ b/backend/app/services/audiobook_assembly.py
@@ -167,12 +167,25 @@ async def assemble_book(book_id: int, db: AsyncSession) -> None:
         await crud.audiobook.set_book_pipeline_status(db, book_id, "complete")
         return
 
-    for chapter in chapters:
+    await crud.audiobook.update_book_pipeline_progress(
+        db, book_id, current=0, total=len(chapters), detail=f"Preparing {len(chapters)} chapter assemblies"
+    )
+    for chapter_index, chapter in enumerate(chapters, start=1):
         if await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):
             logger.info("Book %s paused between chapter assemblies.", book_id)
             return
         sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
         await _assemble_chapter(book_id, chapter, sentences, output_dir, db)
+        await crud.audiobook.update_book_pipeline_progress(
+            db,
+            book_id,
+            current=chapter_index,
+            total=len(chapters),
+            detail=f"Assembled chapter {chapter_index} of {len(chapters)}",
+        )
+        if await crud.audiobook.consume_book_batch_limit(db, book_id):
+            logger.info("Book %s paused after one chapter assembly.", book_id)
+            return
 
     # Repackage the EPUB with updated media-overlay references
     working_epub_path = output_dir / "working.epub"

--- a/backend/app/services/audiobook_assembly.py
+++ b/backend/app/services/audiobook_assembly.py
@@ -27,8 +27,22 @@ def _ms_to_clock(ms: int) -> str:
     return f"{hours:02d}:{mins:02d}:{secs:02d}.{millis:03d}"
 
 
-def _build_smil(chapter_num: int, sentences: list, audio_filename: str) -> str:
+def _ensure_toc_link_ids(toc_items, prefix: str = "toc") -> None:
+    for index, item in enumerate(toc_items or []):
+        uid = f"{prefix}_{index}"
+        if isinstance(item, epub.Link) and not item.uid:
+            item.uid = uid
+        elif isinstance(item, (tuple, list)) and item:
+            section = item[0]
+            if isinstance(section, epub.Link) and not section.uid:
+                section.uid = uid
+            if len(item) > 1:
+                _ensure_toc_link_ids(item[1], uid)
+
+
+def _build_smil(chapter, sentences: list, audio_filename: str) -> str:
     """Generate EPUB 3 Media Overlay SMIL XML for a chapter."""
+    text_file_name = chapter.content_file_name or f"chapter{chapter.chapter_number:04d}.xhtml"
     root = ET.Element(
         "smil",
         {
@@ -38,7 +52,7 @@ def _build_smil(chapter_num: int, sentences: list, audio_filename: str) -> str:
         },
     )
     body = ET.SubElement(root, "body")
-    seq = ET.SubElement(body, "seq", {"epub:textref": f"chapter{chapter_num:04d}.xhtml", "epub:type": "chapter"})
+    seq = ET.SubElement(body, "seq", {"epub:textref": text_file_name, "epub:type": "chapter"})
 
     cumulative_ms = 0
     for sentence in sentences:
@@ -47,7 +61,7 @@ def _build_smil(chapter_num: int, sentences: list, audio_filename: str) -> str:
         ET.SubElement(
             par,
             "text",
-            {"src": f"chapter{chapter_num:04d}.xhtml#{sentence.html_element_id}"},
+            {"src": f"{text_file_name}#{sentence.html_element_id}"},
         )
         ET.SubElement(
             par,
@@ -74,15 +88,10 @@ async def _assemble_chapter(book_id: int, chapter, sentences: list, output_dir: 
     combined = AudioSegment.empty()
     for sentence in sentences:
         if not sentence.audio_file_path:
-            logger.warning("Sentence %s missing audio; inserting silence.", sentence.id)
-            duration_ms = sentence.audio_duration_ms or 500
-            combined += AudioSegment.silent(duration=duration_ms)
-            continue
+            raise RuntimeError(f"Sentence {sentence.id} is missing audio path during assembly.")
         snippet_full = LIBRARY_PATH.parent / sentence.audio_file_path
         if not snippet_full.exists():
-            logger.warning("Snippet file missing for sentence %s; inserting silence.", sentence.id)
-            combined += AudioSegment.silent(duration=sentence.audio_duration_ms or 500)
-            continue
+            raise RuntimeError(f"Snippet file missing for sentence {sentence.id}: {snippet_full}")
         combined += AudioSegment.from_mp3(str(snippet_full))
 
     audio_filename = f"ch{chapter.chapter_number:04d}.mp3"
@@ -90,7 +99,7 @@ async def _assemble_chapter(book_id: int, chapter, sentences: list, output_dir: 
     combined.export(str(audio_path), format="mp3")
     logger.info("Assembled chapter audio: %s (%d ms)", audio_path, len(combined))
 
-    smil_xml = _build_smil(chapter.chapter_number, sentences, audio_filename)
+    smil_xml = _build_smil(chapter, sentences, audio_filename)
     smil_filename = f"ch{chapter.chapter_number:04d}.smil"
     smil_path = output_dir / smil_filename
     smil_path.write_text(smil_xml, encoding="utf-8")
@@ -108,7 +117,19 @@ async def assemble_book(book_id: int, db: AsyncSession) -> None:
     output_dir = LIBRARY_PATH.parent / "library" / "audiobooks" / str(book_id)
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    chapters = await crud.audiobook.get_chapters_needing_reassembly(db, book_id)
+    if await crud.audiobook.get_book_pipeline_status(db, book_id) == "paused":
+        logger.info("Book %s paused before assembly.", book_id)
+        return
+
+    if await crud.audiobook.has_sentence_status(db, book_id, "error"):
+        await crud.audiobook.set_book_pipeline_status(db, book_id, "error")
+        raise RuntimeError(f"Cannot assemble book {book_id}: sentence audio generation has errors.")
+
+    if not await crud.audiobook.all_sentences_audio_generated(db, book_id):
+        await crud.audiobook.set_book_pipeline_status(db, book_id, "error")
+        raise RuntimeError(f"Cannot assemble book {book_id}: not all sentences have generated audio.")
+
+    chapters = await crud.audiobook.get_chapters_pending_assembly(db, book_id)
     if not chapters:
         logger.info("No chapters need reassembly for book %s.", book_id)
         await crud.audiobook.set_book_pipeline_status(db, book_id, "complete")
@@ -134,6 +155,18 @@ async def assemble_book(book_id: int, db: AsyncSession) -> None:
         smil_full = LIBRARY_PATH.parent / chapter.smil_file_path
         if not smil_full.exists():
             continue
+        audio_full = LIBRARY_PATH.parent / chapter.audio_file_path if chapter.audio_file_path else None
+        if audio_full is None or not audio_full.exists():
+            raise RuntimeError(f"Missing chapter audio for book {book_id}, chapter {chapter.id}.")
+
+        audio_item = epub.EpubItem(
+            uid=f"audio_ch{chapter.chapter_number:04d}",
+            file_name=f"ch{chapter.chapter_number:04d}.mp3",
+            media_type="audio/mpeg",
+            content=audio_full.read_bytes(),
+        )
+        ebook.add_item(audio_item)
+
         smil_item = epub.EpubSMIL(
             uid=f"smil_ch{chapter.chapter_number:04d}",
             file_name=f"ch{chapter.chapter_number:04d}.smil",
@@ -143,15 +176,17 @@ async def assemble_book(book_id: int, db: AsyncSession) -> None:
 
         # Attach media-overlay to the matching spine item
         for item in ebook.get_items_of_type(ebooklib.ITEM_DOCUMENT):
-            if f"chapter{chapter.chapter_number:04d}" in item.get_name():
+            if item.get_name() == chapter.content_file_name:
                 item.media_overlay = smil_item.id
                 break
 
     audiobook_epub_path = output_dir / "audiobook.epub"
+    _ensure_toc_link_ids(ebook.toc)
     epub.write_epub(str(audiobook_epub_path), ebook)
     logger.info("Repackaged audiobook EPUB: %s", audiobook_epub_path)
 
-    await crud.audiobook.set_book_pipeline_status(db, book_id, "complete")
+    if await crud.audiobook.get_book_pipeline_status(db, book_id) != "paused":
+        await crud.audiobook.set_book_pipeline_status(db, book_id, "complete")
     logger.info("Assembly complete for book %s.", book_id)
 
 

--- a/backend/app/services/audiobook_assembly.py
+++ b/backend/app/services/audiobook_assembly.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import crud
 from ..config import LIBRARY_PATH
+from ..models import AudiobookChapter
 
 logger = logging.getLogger(__name__)
 
@@ -142,6 +143,19 @@ async def _assemble_chapter(book_id: int, chapter, sentences: list, output_dir: 
         audio_file_path=_relative_path(audio_path),
         smil_file_path=_relative_path(smil_path),
     )
+
+
+async def assemble_chapter_preview(book_id: int, chapter_id: int, db: AsyncSession) -> None:
+    """Assemble one chapter without requiring the rest of the book to be ready."""
+    chapter = await db.get(AudiobookChapter, chapter_id)
+    if chapter is None or chapter.book_id != book_id:
+        raise RuntimeError("Audiobook chapter not found.")
+    sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter_id)
+    if not sentences or any(sentence.status != "audio_generated" for sentence in sentences):
+        raise RuntimeError("Every sentence in the chapter needs audio before preview assembly.")
+    output_dir = LIBRARY_PATH.parent / "library" / "audiobooks" / str(book_id)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    await _assemble_chapter(book_id, chapter, sentences, output_dir, db)
 
 
 async def assemble_book(book_id: int, db: AsyncSession) -> None:

--- a/backend/app/services/audiobook_assembly.py
+++ b/backend/app/services/audiobook_assembly.py
@@ -149,7 +149,7 @@ async def assemble_book(book_id: int, db: AsyncSession) -> None:
     output_dir = LIBRARY_PATH.parent / "library" / "audiobooks" / str(book_id)
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    if await crud.audiobook.get_book_pipeline_status(db, book_id) == "paused":
+    if await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):
         logger.info("Book %s paused before assembly.", book_id)
         return
 
@@ -168,6 +168,9 @@ async def assemble_book(book_id: int, db: AsyncSession) -> None:
         return
 
     for chapter in chapters:
+        if await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):
+            logger.info("Book %s paused between chapter assemblies.", book_id)
+            return
         sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
         await _assemble_chapter(book_id, chapter, sentences, output_dir, db)
 
@@ -217,7 +220,7 @@ async def assemble_book(book_id: int, db: AsyncSession) -> None:
     epub.write_epub(str(audiobook_epub_path), ebook)
     logger.info("Repackaged audiobook EPUB: %s", audiobook_epub_path)
 
-    if await crud.audiobook.get_book_pipeline_status(db, book_id) != "paused":
+    if not await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):
         await crud.audiobook.set_book_pipeline_status(db, book_id, "complete")
     logger.info("Assembly complete for book %s.", book_id)
 

--- a/backend/app/services/audiobook_assembly.py
+++ b/backend/app/services/audiobook_assembly.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from pathlib import Path
+import shutil
+import tempfile
 from xml.etree import ElementTree as ET
 
 from ebooklib import epub
@@ -79,25 +82,54 @@ def _build_smil(chapter, sentences: list, audio_filename: str) -> str:
 
 
 async def _assemble_chapter(book_id: int, chapter, sentences: list, output_dir: Path, db: AsyncSession) -> None:
-    from pydub import AudioSegment
-
     if not sentences:
         logger.warning("Chapter %s has no sentences with audio; skipping assembly.", chapter.id)
         return
 
-    combined = AudioSegment.empty()
+    snippet_paths: list[Path] = []
     for sentence in sentences:
         if not sentence.audio_file_path:
             raise RuntimeError(f"Sentence {sentence.id} is missing audio path during assembly.")
         snippet_full = LIBRARY_PATH.parent / sentence.audio_file_path
         if not snippet_full.exists():
             raise RuntimeError(f"Snippet file missing for sentence {sentence.id}: {snippet_full}")
-        combined += AudioSegment.from_mp3(str(snippet_full))
+        snippet_paths.append(snippet_full)
 
     audio_filename = f"ch{chapter.chapter_number:04d}.mp3"
     audio_path = output_dir / audio_filename
-    combined.export(str(audio_path), format="mp3")
-    logger.info("Assembled chapter audio: %s (%d ms)", audio_path, len(combined))
+    ffmpeg = shutil.which("ffmpeg")
+    if not ffmpeg:
+        raise RuntimeError("ffmpeg is required to assemble audiobook chapters.")
+    with tempfile.NamedTemporaryFile("w", suffix=".txt", dir=output_dir, encoding="utf-8") as manifest:
+        for snippet_path in snippet_paths:
+            escaped_path = str(snippet_path).replace("'", "'\\''")
+            manifest.write(f"file '{escaped_path}'\n")
+        manifest.flush()
+        process = await asyncio.create_subprocess_exec(
+            ffmpeg,
+            "-v",
+            "error",
+            "-f",
+            "concat",
+            "-safe",
+            "0",
+            "-i",
+            manifest.name,
+            "-codec:a",
+            "libmp3lame",
+            "-b:a",
+            "64k",
+            "-y",
+            str(audio_path),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        _, stderr = await process.communicate()
+        if process.returncode:
+            message = stderr.decode("utf-8", errors="replace")[:500]
+            raise RuntimeError(f"ffmpeg chapter assembly failed: {message}")
+    total_duration_ms = sum(sentence.audio_duration_ms or 0 for sentence in sentences)
+    logger.info("Assembled chapter audio: %s (%d ms)", audio_path, total_duration_ms)
 
     smil_xml = _build_smil(chapter, sentences, audio_filename)
     smil_filename = f"ch{chapter.chapter_number:04d}.smil"

--- a/backend/app/services/audiobook_assembly.py
+++ b/backend/app/services/audiobook_assembly.py
@@ -1,0 +1,159 @@
+"""Phase 5: MP3 concatenation, SMIL generation, and EPUB 3 Media Overlay packaging."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+from ebooklib import epub
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import crud
+from ..config import LIBRARY_PATH
+
+logger = logging.getLogger(__name__)
+
+
+def _relative_path(full_path: Path) -> str:
+    return str(full_path.relative_to(LIBRARY_PATH.parent))
+
+
+def _ms_to_clock(ms: int) -> str:
+    """Convert milliseconds to SMIL clock value hh:mm:ss.mmm."""
+    total_s, millis = divmod(ms, 1000)
+    total_m, secs = divmod(total_s, 60)
+    hours, mins = divmod(total_m, 60)
+    return f"{hours:02d}:{mins:02d}:{secs:02d}.{millis:03d}"
+
+
+def _build_smil(chapter_num: int, sentences: list, audio_filename: str) -> str:
+    """Generate EPUB 3 Media Overlay SMIL XML for a chapter."""
+    root = ET.Element(
+        "smil",
+        {
+            "xmlns": "http://www.w3.org/ns/SMIL",
+            "xmlns:epub": "http://www.idpf.org/2007/ops",
+            "version": "3.0",
+        },
+    )
+    body = ET.SubElement(root, "body")
+    seq = ET.SubElement(body, "seq", {"epub:textref": f"chapter{chapter_num:04d}.xhtml", "epub:type": "chapter"})
+
+    cumulative_ms = 0
+    for sentence in sentences:
+        duration_ms = sentence.audio_duration_ms or 0
+        par = ET.SubElement(seq, "par", {"id": f"par_{sentence.html_element_id}"})
+        ET.SubElement(
+            par,
+            "text",
+            {"src": f"chapter{chapter_num:04d}.xhtml#{sentence.html_element_id}"},
+        )
+        ET.SubElement(
+            par,
+            "audio",
+            {
+                "src": audio_filename,
+                "clipBegin": _ms_to_clock(cumulative_ms),
+                "clipEnd": _ms_to_clock(cumulative_ms + duration_ms),
+            },
+        )
+        cumulative_ms += duration_ms
+
+    ET.indent(root, space="  ")
+    return '<?xml version="1.0" encoding="UTF-8"?>\n' + ET.tostring(root, encoding="unicode")
+
+
+async def _assemble_chapter(book_id: int, chapter, sentences: list, output_dir: Path, db: AsyncSession) -> None:
+    from pydub import AudioSegment
+
+    if not sentences:
+        logger.warning("Chapter %s has no sentences with audio; skipping assembly.", chapter.id)
+        return
+
+    combined = AudioSegment.empty()
+    for sentence in sentences:
+        if not sentence.audio_file_path:
+            logger.warning("Sentence %s missing audio; inserting silence.", sentence.id)
+            duration_ms = sentence.audio_duration_ms or 500
+            combined += AudioSegment.silent(duration=duration_ms)
+            continue
+        snippet_full = LIBRARY_PATH.parent / sentence.audio_file_path
+        if not snippet_full.exists():
+            logger.warning("Snippet file missing for sentence %s; inserting silence.", sentence.id)
+            combined += AudioSegment.silent(duration=sentence.audio_duration_ms or 500)
+            continue
+        combined += AudioSegment.from_mp3(str(snippet_full))
+
+    audio_filename = f"ch{chapter.chapter_number:04d}.mp3"
+    audio_path = output_dir / audio_filename
+    combined.export(str(audio_path), format="mp3")
+    logger.info("Assembled chapter audio: %s (%d ms)", audio_path, len(combined))
+
+    smil_xml = _build_smil(chapter.chapter_number, sentences, audio_filename)
+    smil_filename = f"ch{chapter.chapter_number:04d}.smil"
+    smil_path = output_dir / smil_filename
+    smil_path.write_text(smil_xml, encoding="utf-8")
+
+    await crud.audiobook.update_chapter_assembly(
+        db,
+        chapter_id=chapter.id,
+        audio_file_path=_relative_path(audio_path),
+        smil_file_path=_relative_path(smil_path),
+    )
+
+
+async def assemble_book(book_id: int, db: AsyncSession) -> None:
+    """Phase 5: assemble all chapters that need reassembly and repackage the EPUB."""
+    output_dir = LIBRARY_PATH.parent / "library" / "audiobooks" / str(book_id)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    chapters = await crud.audiobook.get_chapters_needing_reassembly(db, book_id)
+    if not chapters:
+        logger.info("No chapters need reassembly for book %s.", book_id)
+        await crud.audiobook.set_book_pipeline_status(db, book_id, "complete")
+        return
+
+    for chapter in chapters:
+        sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
+        await _assemble_chapter(book_id, chapter, sentences, output_dir, db)
+
+    # Repackage the EPUB with updated media-overlay references
+    working_epub_path = output_dir / "working.epub"
+    if not working_epub_path.exists():
+        logger.warning("Working EPUB not found for book %s; skipping repackage.", book_id)
+        await crud.audiobook.set_book_pipeline_status(db, book_id, "complete")
+        return
+
+    ebook = epub.read_epub(str(working_epub_path))
+
+    all_chapters = await crud.audiobook.get_chapters_for_book(db, book_id)
+    for chapter in all_chapters:
+        if not chapter.smil_file_path:
+            continue
+        smil_full = LIBRARY_PATH.parent / chapter.smil_file_path
+        if not smil_full.exists():
+            continue
+        smil_item = epub.EpubSMIL(
+            uid=f"smil_ch{chapter.chapter_number:04d}",
+            file_name=f"ch{chapter.chapter_number:04d}.smil",
+            content=smil_full.read_bytes(),
+        )
+        ebook.add_item(smil_item)
+
+        # Attach media-overlay to the matching spine item
+        for item in ebook.get_items_of_type(ebooklib.ITEM_DOCUMENT):
+            if f"chapter{chapter.chapter_number:04d}" in item.get_name():
+                item.media_overlay = smil_item.id
+                break
+
+    audiobook_epub_path = output_dir / "audiobook.epub"
+    epub.write_epub(str(audiobook_epub_path), ebook)
+    logger.info("Repackaged audiobook EPUB: %s", audiobook_epub_path)
+
+    await crud.audiobook.set_book_pipeline_status(db, book_id, "complete")
+    logger.info("Assembly complete for book %s.", book_id)
+
+
+# ebooklib constant needed above
+import ebooklib  # noqa: E402

--- a/backend/app/services/audiobook_ingestion.py
+++ b/backend/app/services/audiobook_ingestion.py
@@ -23,6 +23,7 @@ def _get_nlp():
     global _NLP
     if _NLP is None:
         import spacy
+
         _NLP = spacy.load("en_core_web_sm", disable=["ner", "parser"])
         _NLP.add_pipe("sentencizer")
     return _NLP

--- a/backend/app/services/audiobook_ingestion.py
+++ b/backend/app/services/audiobook_ingestion.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 
 import ebooklib
 from ebooklib import epub

--- a/backend/app/services/audiobook_ingestion.py
+++ b/backend/app/services/audiobook_ingestion.py
@@ -24,8 +24,13 @@ def _get_nlp():
     if _NLP is None:
         import spacy
 
-        _NLP = spacy.load("en_core_web_sm", disable=["ner", "parser"])
-        _NLP.add_pipe("sentencizer")
+        try:
+            _NLP = spacy.load("en_core_web_sm", disable=["ner", "parser"])
+        except OSError:
+            logger.warning("spaCy model en_core_web_sm is unavailable; using the built-in English tokenizer.")
+            _NLP = spacy.blank("en")
+        if "sentencizer" not in _NLP.pipe_names:
+            _NLP.add_pipe("sentencizer")
     return _NLP
 
 
@@ -172,6 +177,7 @@ async def ingest_epub(book_id: int, db: AsyncSession) -> None:
     logger.info("Wrote span-injected EPUB to %s", working_epub_path)
 
     # Persist to database
+    persisted_chapters = 0
     for chapter_num, item, chapter_sentences in all_chapter_records:
         if not chapter_sentences:
             continue
@@ -182,8 +188,11 @@ async def ingest_epub(book_id: int, db: AsyncSession) -> None:
             content_file_name=item.get_name(),
         )
         await crud.audiobook.create_sentences_bulk(db, chapter_id=chapter.id, sentences_data=chapter_sentences)
+        persisted_chapters += 1
 
     await db.commit()
+    if persisted_chapters == 0:
+        raise RuntimeError(f"EPUB for book {book_id} contains no narratable text.")
     if await crud.audiobook.get_book_pipeline_status(db, book_id) != "paused":
         await crud.audiobook.set_book_pipeline_status(db, book_id, "roster_gen")
-    logger.info("Ingestion complete for book %s: %d chapters processed", book_id, len(all_chapter_records))
+    logger.info("Ingestion complete for book %s: %d chapters processed", book_id, persisted_chapters)

--- a/backend/app/services/audiobook_ingestion.py
+++ b/backend/app/services/audiobook_ingestion.py
@@ -1,0 +1,138 @@
+"""Phase 1: EPUB ingestion, sentence tokenization, and span ID injection."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import ebooklib
+from ebooklib import epub
+from bs4 import BeautifulSoup, NavigableString
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import crud
+from ..config import LIBRARY_PATH
+from ..models import Book
+
+logger = logging.getLogger(__name__)
+
+_NLP = None  # lazy-load spaCy model to avoid startup cost
+
+
+def _get_nlp():
+    global _NLP
+    if _NLP is None:
+        import spacy
+        _NLP = spacy.load("en_core_web_sm", disable=["ner", "parser"])
+        _NLP.add_pipe("sentencizer")
+    return _NLP
+
+
+def _tokenize_text(text: str) -> list[str]:
+    nlp = _get_nlp()
+    doc = nlp(text)
+    return [sent.text.strip() for sent in doc.sents if sent.text.strip()]
+
+
+def _inject_spans_into_element(element, chapter_num: int, start_seq: int) -> tuple[int, list[dict]]:
+    """Replace the text content of block elements with span-wrapped sentences.
+
+    Returns (next_sequence_number, list_of_sentence_dicts).
+    """
+    sentences_data = []
+    seq = start_seq
+
+    # Collect all text nodes that are direct or shallow children
+    raw_text = element.get_text(separator=" ", strip=True)
+    if not raw_text:
+        return seq, sentences_data
+
+    sentences = _tokenize_text(raw_text)
+    if not sentences:
+        return seq, sentences_data
+
+    # Clear existing children and re-build with span-wrapped sentences
+    element.clear()
+    for sent_text in sentences:
+        span_id = f"ch{chapter_num}_s{seq}"
+        span = BeautifulSoup(f'<span id="{span_id}"></span>', "html.parser").find("span")
+        span.string = sent_text
+        element.append(span)
+        element.append(NavigableString(" "))
+
+        sentences_data.append(
+            {
+                "html_element_id": span_id,
+                "sequence_order": seq,
+                "original_text": sent_text,
+                "tagged_text": sent_text,
+                "status": "pending_diarization",
+            }
+        )
+        seq += 1
+
+    return seq, sentences_data
+
+
+async def ingest_epub(book_id: int, db: AsyncSession) -> None:
+    """Parse the book's EPUB, inject span IDs, populate chapters and sentences tables."""
+    book: Book = await db.get(Book, book_id)
+    if book is None:
+        raise ValueError(f"Book {book_id} not found")
+
+    epub_path = (LIBRARY_PATH.parent / book.current_path).resolve()
+    logger.info("Ingesting EPUB for book %s from %s", book_id, epub_path)
+
+    output_dir = LIBRARY_PATH.parent / "library" / "audiobooks" / str(book_id)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    snippets_dir = output_dir / "snippets"
+    snippets_dir.mkdir(exist_ok=True)
+
+    ebook = epub.read_epub(str(epub_path))
+
+    # Collect spine items in order
+    spine_items = []
+    for item_id, _linear in ebook.spine:
+        item = ebook.get_item_with_id(item_id)
+        if item and item.get_type() == ebooklib.ITEM_DOCUMENT:
+            spine_items.append(item)
+
+    all_chapter_records = []
+
+    for chapter_num, item in enumerate(spine_items, start=1):
+        content = item.get_content()
+        soup = BeautifulSoup(content, "html.parser")
+
+        chapter_sentences: list[dict] = []
+        seq = 0
+
+        # Process block-level text elements
+        for tag in soup.find_all(["p", "div", "h1", "h2", "h3", "h4", "h5", "h6", "li"]):
+            # Skip elements with no direct text (only child elements)
+            if not tag.get_text(strip=True):
+                continue
+            # Skip if already contains span children from a previous run
+            if tag.find("span", id=True):
+                continue
+            seq, new_sentences = _inject_spans_into_element(tag, chapter_num, seq)
+            chapter_sentences.extend(new_sentences)
+
+        # Save modified XHTML back into the ebook item
+        item.set_content(str(soup).encode("utf-8"))
+        all_chapter_records.append((chapter_num, item, chapter_sentences))
+
+    # Write modified EPUB to working copy
+    working_epub_path = output_dir / "working.epub"
+    epub.write_epub(str(working_epub_path), ebook)
+    logger.info("Wrote span-injected EPUB to %s", working_epub_path)
+
+    # Persist to database
+    for chapter_num, _item, chapter_sentences in all_chapter_records:
+        if not chapter_sentences:
+            continue
+        chapter = await crud.audiobook.create_chapter(db, book_id=book_id, chapter_number=chapter_num)
+        await crud.audiobook.create_sentences_bulk(db, chapter_id=chapter.id, sentences_data=chapter_sentences)
+
+    await db.commit()
+    await crud.audiobook.set_book_pipeline_status(db, book_id, "roster_gen")
+    logger.info("Ingestion complete for book %s: %d chapters processed", book_id, len(all_chapter_records))

--- a/backend/app/services/audiobook_ingestion.py
+++ b/backend/app/services/audiobook_ingestion.py
@@ -178,6 +178,14 @@ async def ingest_epub(book_id: int, db: AsyncSession) -> None:
 
     # Persist to database
     persisted_chapters = 0
+    total_chapters = sum(1 for _chapter_num, _item, sentences in all_chapter_records if sentences)
+    await crud.audiobook.update_book_pipeline_progress(
+        db,
+        book_id,
+        current=0,
+        total=total_chapters,
+        detail=f"Tokenized EPUB; saving {total_chapters} narratable sections",
+    )
     for chapter_num, item, chapter_sentences in all_chapter_records:
         if not chapter_sentences:
             continue
@@ -189,6 +197,13 @@ async def ingest_epub(book_id: int, db: AsyncSession) -> None:
         )
         await crud.audiobook.create_sentences_bulk(db, chapter_id=chapter.id, sentences_data=chapter_sentences)
         persisted_chapters += 1
+        await crud.audiobook.update_book_pipeline_progress(
+            db,
+            book_id,
+            current=persisted_chapters,
+            total=total_chapters,
+            detail=f"Saved section {persisted_chapters} of {total_chapters}",
+        )
 
     await db.commit()
     if persisted_chapters == 0:

--- a/backend/app/services/audiobook_ingestion.py
+++ b/backend/app/services/audiobook_ingestion.py
@@ -16,6 +16,7 @@ from ..models import Book
 logger = logging.getLogger(__name__)
 
 _NLP = None  # lazy-load spaCy model to avoid startup cost
+_SKIP_TEXT_ANCESTORS = {"script", "style", "head", "title", "svg", "math", "audio", "video"}
 
 
 def _get_nlp():
@@ -34,31 +35,72 @@ def _tokenize_text(text: str) -> list[str]:
     return [sent.text.strip() for sent in doc.sents if sent.text.strip()]
 
 
-def _inject_spans_into_element(element, chapter_num: int, start_seq: int) -> tuple[int, list[dict]]:
-    """Replace the text content of block elements with span-wrapped sentences.
+def _span_for_sentence(span_id: str, text: str):
+    span = BeautifulSoup(f'<span id="{span_id}"></span>', "html.parser").find("span")
+    span.string = text
+    return span
+
+
+def _replace_text_node(text_node: NavigableString, replacement_nodes: list) -> None:
+    first, *rest = replacement_nodes
+    text_node.replace_with(first)
+    previous = first
+    for node in rest:
+        previous.insert_after(node)
+        previous = node
+
+
+def _should_skip_text_node(text_node: NavigableString) -> bool:
+    for parent in text_node.parents:
+        if parent.name in _SKIP_TEXT_ANCESTORS:
+            return True
+        if parent.name == "span" and parent.get("id"):
+            return True
+    return False
+
+
+def _ensure_toc_link_ids(toc_items, prefix: str = "toc") -> None:
+    for index, item in enumerate(toc_items or []):
+        uid = f"{prefix}_{index}"
+        if isinstance(item, epub.Link) and not item.uid:
+            item.uid = uid
+        elif isinstance(item, (tuple, list)) and item:
+            section = item[0]
+            if isinstance(section, epub.Link) and not section.uid:
+                section.uid = uid
+            if len(item) > 1:
+                _ensure_toc_link_ids(item[1], uid)
+
+
+def _inject_spans_into_text_node(text_node: NavigableString, chapter_num: int, start_seq: int) -> tuple[int, list[dict]]:
+    """Wrap one text node's sentences without disturbing surrounding markup.
 
     Returns (next_sequence_number, list_of_sentence_dicts).
     """
     sentences_data = []
     seq = start_seq
 
-    # Collect all text nodes that are direct or shallow children
-    raw_text = element.get_text(separator=" ", strip=True)
-    if not raw_text:
+    raw_text = str(text_node)
+    stripped = raw_text.strip()
+    if not stripped or _should_skip_text_node(text_node):
         return seq, sentences_data
 
-    sentences = _tokenize_text(raw_text)
+    sentences = _tokenize_text(stripped)
     if not sentences:
         return seq, sentences_data
 
-    # Clear existing children and re-build with span-wrapped sentences
-    element.clear()
-    for sent_text in sentences:
+    leading_whitespace = raw_text[: len(raw_text) - len(raw_text.lstrip())]
+    trailing_start = len(raw_text.rstrip())
+    trailing_whitespace = raw_text[trailing_start:]
+    replacement_nodes: list = []
+    if leading_whitespace:
+        replacement_nodes.append(NavigableString(leading_whitespace))
+
+    for index, sent_text in enumerate(sentences):
+        if index > 0:
+            replacement_nodes.append(NavigableString(" "))
         span_id = f"ch{chapter_num}_s{seq}"
-        span = BeautifulSoup(f'<span id="{span_id}"></span>', "html.parser").find("span")
-        span.string = sent_text
-        element.append(span)
-        element.append(NavigableString(" "))
+        replacement_nodes.append(_span_for_sentence(span_id, sent_text))
 
         sentences_data.append(
             {
@@ -71,6 +113,10 @@ def _inject_spans_into_element(element, chapter_num: int, start_seq: int) -> tup
         )
         seq += 1
 
+    if trailing_whitespace:
+        replacement_nodes.append(NavigableString(trailing_whitespace))
+
+    _replace_text_node(text_node, replacement_nodes)
     return seq, sentences_data
 
 
@@ -89,12 +135,14 @@ async def ingest_epub(book_id: int, db: AsyncSession) -> None:
     snippets_dir.mkdir(exist_ok=True)
 
     ebook = epub.read_epub(str(epub_path))
+    await crud.audiobook.delete_chapters_for_book(db, book_id)
+    await crud.audiobook.delete_characters_for_book(db, book_id)
 
     # Collect spine items in order
     spine_items = []
     for item_id, _linear in ebook.spine:
         item = ebook.get_item_with_id(item_id)
-        if item and item.get_type() == ebooklib.ITEM_DOCUMENT:
+        if item and item.get_type() == ebooklib.ITEM_DOCUMENT and not isinstance(item, epub.EpubNav):
             spine_items.append(item)
 
     all_chapter_records = []
@@ -106,15 +154,11 @@ async def ingest_epub(book_id: int, db: AsyncSession) -> None:
         chapter_sentences: list[dict] = []
         seq = 0
 
-        # Process block-level text elements
-        for tag in soup.find_all(["p", "div", "h1", "h2", "h3", "h4", "h5", "h6", "li"]):
-            # Skip elements with no direct text (only child elements)
-            if not tag.get_text(strip=True):
-                continue
-            # Skip if already contains span children from a previous run
-            if tag.find("span", id=True):
-                continue
-            seq, new_sentences = _inject_spans_into_element(tag, chapter_num, seq)
+        # Process text nodes in document order. This preserves existing block and
+        # inline structure while adding stable sentence-level anchors.
+        container = soup.body or soup
+        for text_node in list(container.find_all(string=True)):
+            seq, new_sentences = _inject_spans_into_text_node(text_node, chapter_num, seq)
             chapter_sentences.extend(new_sentences)
 
         # Save modified XHTML back into the ebook item
@@ -123,16 +167,23 @@ async def ingest_epub(book_id: int, db: AsyncSession) -> None:
 
     # Write modified EPUB to working copy
     working_epub_path = output_dir / "working.epub"
+    _ensure_toc_link_ids(ebook.toc)
     epub.write_epub(str(working_epub_path), ebook)
     logger.info("Wrote span-injected EPUB to %s", working_epub_path)
 
     # Persist to database
-    for chapter_num, _item, chapter_sentences in all_chapter_records:
+    for chapter_num, item, chapter_sentences in all_chapter_records:
         if not chapter_sentences:
             continue
-        chapter = await crud.audiobook.create_chapter(db, book_id=book_id, chapter_number=chapter_num)
+        chapter = await crud.audiobook.create_chapter(
+            db,
+            book_id=book_id,
+            chapter_number=chapter_num,
+            content_file_name=item.get_name(),
+        )
         await crud.audiobook.create_sentences_bulk(db, chapter_id=chapter.id, sentences_data=chapter_sentences)
 
     await db.commit()
-    await crud.audiobook.set_book_pipeline_status(db, book_id, "roster_gen")
+    if await crud.audiobook.get_book_pipeline_status(db, book_id) != "paused":
+        await crud.audiobook.set_book_pipeline_status(db, book_id, "roster_gen")
     logger.info("Ingestion complete for book %s: %d chapters processed", book_id, len(all_chapter_records))

--- a/backend/app/services/audiobook_ingestion.py
+++ b/backend/app/services/audiobook_ingestion.py
@@ -193,6 +193,6 @@ async def ingest_epub(book_id: int, db: AsyncSession) -> None:
     await db.commit()
     if persisted_chapters == 0:
         raise RuntimeError(f"EPUB for book {book_id} contains no narratable text.")
-    if await crud.audiobook.get_book_pipeline_status(db, book_id) != "paused":
+    if not await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):
         await crud.audiobook.set_book_pipeline_status(db, book_id, "roster_gen")
     logger.info("Ingestion complete for book %s: %d chapters processed", book_id, persisted_chapters)

--- a/backend/app/services/audiobook_llm.py
+++ b/backend/app/services/audiobook_llm.py
@@ -1,0 +1,215 @@
+"""Phases 2 & 3: LLM-based character roster generation and sentence diarization."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import httpx
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import crud
+from ..models import AudiobookSettings
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_ROSTER_PROMPT = """\
+You are a literary analyst. Analyze the following text excerpt from a book and extract a list of all named \
+characters (including the narrator if the text uses first person).
+
+For each character produce:
+- name: their name (use "Narrator" for first-person narrators)
+- description: a 1-2 sentence description of their personality and role
+- voice_design_prompt: an OmniVoice voice parameter string using ONLY these tokens:
+  [gender-{male|female|neutral}] [pitch-{low|medium|high}] [speed-{slow|normal|fast}]
+  Optional: [accent-{british|american|australian}] [age-{young|middle|old}]
+  Example: [gender-male][pitch-low][speed-normal][age-middle]
+- is_narrator: true only for the primary narrator
+
+Return ONLY a valid JSON array of objects. No markdown, no explanation.
+
+Text:
+{text}
+"""
+
+DEFAULT_DIARIZATION_PROMPT = """\
+You are a script editor. Assign each sentence to a speaker from the character roster and add non-verbal \
+expression tags where appropriate.
+
+Character roster (JSON):
+{roster_json}
+
+Previous context (last 5 sentences):
+{context}
+
+Sentences to process (JSON array with id and text):
+{sentences_json}
+
+For each sentence return:
+- id: the sentence id (integer)
+- character_id: the character id from the roster (use the narrator's id for narration; null if uncertain)
+- tagged_text: the sentence text with optional non-verbal tags like [laughter], [sigh], [whisper], [shout]
+
+Return ONLY a valid JSON array. No markdown, no explanation.
+"""
+
+
+async def _call_llm(settings: AudiobookSettings, messages: list[dict[str, Any]]) -> str:
+    """Route to the configured LLM provider and return the text response."""
+    if not settings.llm_api_key and not settings.llm_base_url:
+        raise RuntimeError("LLM not configured: set llm_api_key or llm_base_url in Audio Settings.")
+
+    provider = (settings.llm_provider or "openai").lower()
+    model = settings.llm_model or "gpt-4o"
+
+    headers = {"Content-Type": "application/json"}
+
+    if provider == "anthropic":
+        url = (settings.llm_base_url or "https://api.anthropic.com").rstrip("/") + "/v1/messages"
+        headers["x-api-key"] = settings.llm_api_key or ""
+        headers["anthropic-version"] = "2023-06-01"
+        payload: dict[str, Any] = {
+            "model": model,
+            "max_tokens": 4096,
+            "messages": messages,
+        }
+        async with httpx.AsyncClient(timeout=120.0) as client:
+            resp = await client.post(url, json=payload, headers=headers)
+            resp.raise_for_status()
+            data = resp.json()
+        return data["content"][0]["text"]
+
+    else:
+        # OpenAI-compatible (openai, custom, local)
+        base = settings.llm_base_url or "https://api.openai.com"
+        url = base.rstrip("/") + "/v1/chat/completions"
+        if settings.llm_api_key:
+            headers["Authorization"] = f"Bearer {settings.llm_api_key}"
+        payload = {
+            "model": model,
+            "messages": messages,
+            "temperature": 0.2,
+        }
+        async with httpx.AsyncClient(timeout=120.0) as client:
+            resp = await client.post(url, json=payload, headers=headers)
+            resp.raise_for_status()
+            data = resp.json()
+        return data["choices"][0]["message"]["content"]
+
+
+def _extract_json(raw: str) -> Any:
+    """Strip markdown code fences if present and parse JSON."""
+    text = raw.strip()
+    if text.startswith("```"):
+        lines = text.splitlines()
+        # Drop first and last fence lines
+        text = "\n".join(lines[1:-1] if lines[-1].strip() == "```" else lines[1:])
+    return json.loads(text)
+
+
+async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
+    """Phase 2: extract characters from book text and persist to audiobook_characters."""
+    settings = await crud.audiobook.get_audiobook_settings(db)
+    if settings is None:
+        raise RuntimeError("Audiobook settings not found.")
+
+    chapters = await crud.audiobook.get_chapters_for_book(db, book_id)
+    if not chapters:
+        logger.warning("No chapters found for book %s during roster generation.", book_id)
+        await crud.audiobook.set_book_pipeline_status(db, book_id, "diarizing")
+        return
+
+    # Collect text from up to 5 chapters (keeps prompt size manageable)
+    text_chunks: list[str] = []
+    for chapter in chapters[:5]:
+        sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
+        text_chunks.append(" ".join(s.original_text for s in sentences))
+    combined_text = "\n\n".join(text_chunks)[:12000]  # ~10k tokens safety cap
+
+    prompt_template = settings.roster_prompt_template or DEFAULT_ROSTER_PROMPT
+    prompt = prompt_template.format(text=combined_text)
+
+    logger.info("Calling LLM for character roster (book %s).", book_id)
+    raw = await _call_llm(settings, [{"role": "user", "content": prompt}])
+
+    try:
+        characters_data = _extract_json(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"LLM returned invalid JSON for roster: {exc}\nRaw: {raw[:500]}") from exc
+
+    if not isinstance(characters_data, list):
+        raise RuntimeError(f"Expected a JSON array from LLM, got: {type(characters_data)}")
+
+    # Normalise keys to match our model
+    normalised: list[dict] = []
+    for c in characters_data:
+        normalised.append(
+            {
+                "name": str(c.get("name", "Unknown")),
+                "description": c.get("description"),
+                "voice_design_prompt": c.get("voice_design_prompt"),
+                "is_narrator": bool(c.get("is_narrator", False)),
+            }
+        )
+
+    await crud.audiobook.create_characters_bulk(db, book_id=book_id, characters_data=normalised)
+    logger.info("Created %d characters for book %s.", len(normalised), book_id)
+    await crud.audiobook.set_book_pipeline_status(db, book_id, "diarizing")
+
+
+async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
+    """Phase 3: batch-assign speakers and expression tags to all pending sentences."""
+    settings = await crud.audiobook.get_audiobook_settings(db)
+    if settings is None:
+        raise RuntimeError("Audiobook settings not found.")
+
+    characters = await crud.audiobook.get_characters_for_book(db, book_id)
+    roster_json = json.dumps(
+        [
+            {"id": c.id, "name": c.name, "description": c.description, "is_narrator": c.is_narrator}
+            for c in characters
+        ],
+        ensure_ascii=False,
+    )
+
+    context_window: list[str] = []
+    batch_size = 50
+
+    while True:
+        batch = await crud.audiobook.get_sentences_pending_diarization(db, book_id, limit=batch_size)
+        if not batch:
+            break
+
+        sentences_json = json.dumps(
+            [{"id": s.id, "text": s.original_text} for s in batch],
+            ensure_ascii=False,
+        )
+        context_str = "\n".join(context_window[-5:]) if context_window else "(none)"
+
+        prompt_template = settings.diarization_prompt_template or DEFAULT_DIARIZATION_PROMPT
+        prompt = prompt_template.format(
+            roster_json=roster_json,
+            context=context_str,
+            sentences_json=sentences_json,
+        )
+
+        logger.debug("Diarizing %d sentences for book %s.", len(batch), book_id)
+        raw = await _call_llm(settings, [{"role": "user", "content": prompt}])
+
+        try:
+            results = _extract_json(raw)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"LLM returned invalid JSON for diarization: {exc}\nRaw: {raw[:500]}") from exc
+
+        result_map = {r["id"]: r for r in results if isinstance(r, dict)}
+
+        for sentence in batch:
+            result = result_map.get(sentence.id, {})
+            char_id = result.get("character_id")
+            tagged = result.get("tagged_text") or sentence.original_text
+            await crud.audiobook.update_sentence_diarization(db, sentence.id, char_id, tagged)
+            context_window.append(sentence.original_text)
+
+    logger.info("Diarization complete for book %s.", book_id)
+    await crud.audiobook.set_book_pipeline_status(db, book_id, "audio_gen")

--- a/backend/app/services/audiobook_llm.py
+++ b/backend/app/services/audiobook_llm.py
@@ -176,7 +176,7 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
 
     await crud.audiobook.create_characters_bulk(db, book_id=book_id, characters_data=normalised)
     logger.info("Created %d characters for book %s.", len(normalised), book_id)
-    if await crud.audiobook.get_book_pipeline_status(db, book_id) != "paused":
+    if not await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):
         await crud.audiobook.set_book_pipeline_status(db, book_id, "diarizing")
 
 
@@ -197,7 +197,7 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
     batch_size = 50
 
     while True:
-        if await crud.audiobook.get_book_pipeline_status(db, book_id) == "paused":
+        if await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):
             logger.info("Book %s paused during diarization.", book_id)
             return
 
@@ -244,5 +244,5 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
             context_window.append(sentence.original_text)
 
     logger.info("Diarization complete for book %s.", book_id)
-    if await crud.audiobook.get_book_pipeline_status(db, book_id) != "paused":
+    if not await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):
         await crud.audiobook.set_book_pipeline_status(db, book_id, "audio_gen")

--- a/backend/app/services/audiobook_llm.py
+++ b/backend/app/services/audiobook_llm.py
@@ -85,7 +85,8 @@ For each sentence return:
 - reason: a brief evidence-based reason, such as an adjacent dialogue tag or turn-taking context
   (12 words or fewer)
 
-Also return chapter_summary: an updated spoiler-light summary incorporating this batch and the prior summary.
+Also return chapter_summary: an updated spoiler-light summary incorporating this batch and the prior summary, using
+no more than 100 words.
 The roster descriptions are identity hints only and may be inaccurate. Ground the chapter summary exclusively in the
 sentence text and prior chapter summary; never import plot events, body changes, relationships, or backstory from a
 character description.
@@ -95,15 +96,21 @@ Return JSON with keys assignments and chapter_summary. No markdown or explanatio
 _ALLOWED_EXPRESSION_TAGS = {"laughter", "sigh", "whisper", "shout"}
 _BRACKET_TAG_RE = re.compile(r"\[([^\[\]]+)\]")
 _GENDERED_ATTRIBUTION_RE = re.compile(
-    r"\b(she|he)\s+(?:said|asked|replied|yelled|shouted|whispered|muttered|added|continued|answered|snapped)\b",
+    r"\b(she|he)\s+(?:said|asked|replied|yelled|shouted|whispered|muttered|added|continued|answered|snapped|"
+    r"repeated|remarked|responded|interrupted)\b",
+    re.IGNORECASE,
+)
+_FIRST_PERSON_ATTRIBUTION_RE = re.compile(
+    r"\bI\s+(?:said|asked|replied|yelled|shouted|whispered|muttered|added|continued|answered|snapped|reminded)\b",
     re.IGNORECASE,
 )
 _DIALOGUE_ATTRIBUTION_IN_SENTENCE_RE = re.compile(
     r"\b(?:said|asked|replied|yelled|shouted|whispered|muttered|added|continued|answered|snapped)\b" r"[^“\"]{0,80}[“\"]",
     re.IGNORECASE,
 )
-MAX_DIARIZATION_BATCH_SIZE = 40
+MAX_DIARIZATION_BATCH_SIZE = 10
 MIN_DIARIZATION_BATCH_SIZE = 5
+MIN_STORY_CHAPTER_SENTENCES = 40
 
 ROSTER_SCHEMA = {
     "type": "object",
@@ -156,12 +163,12 @@ DIARIZATION_SCHEMA = {
                     "character_id": {"type": ["integer", "null"]},
                     "tagged_text": {"type": ["string", "null"]},
                     "confidence": {"type": "number", "minimum": 0, "maximum": 1},
-                    "reason": {"type": "string"},
+                    "reason": {"type": "string", "maxLength": 160},
                 },
                 "required": ["id", "character_id", "tagged_text", "confidence", "reason"],
             },
         },
-        "chapter_summary": {"type": "string"},
+        "chapter_summary": {"type": "string", "maxLength": 1200},
     },
     "required": ["assignments", "chapter_summary"],
 }
@@ -348,26 +355,63 @@ def _apply_speaker_guardrails(
     next_text: str,
     character_id: int | None,
     narrator_id: int | None,
+    protagonist_id: int | None,
     minor_female_id: int | None,
     minor_male_id: int | None,
     reason: str,
 ) -> tuple[int | None, str, float | None]:
     """Correct two common local-model ID errors without inventing named speakers."""
     starts_with_quote = text.lstrip().startswith(("“", '"'))
+    has_quote = any(quote in text for quote in ("“", "”", '"'))
     has_dialogue = starts_with_quote or bool(_DIALOGUE_ATTRIBUTION_IN_SENTENCE_RE.search(text))
 
-    if character_id == narrator_id and has_dialogue:
-        attribution = _GENDERED_ATTRIBUTION_RE.search(f"{text} {next_text}")
-        if attribution:
-            gender = attribution.group(1).casefold()
-            fallback_id = minor_female_id if gender == "she" else minor_male_id
-            if fallback_id is not None:
-                return fallback_id, f"Deterministic {gender} dialogue attribution to minor voice", 0.98
+    current_first_person = _FIRST_PERSON_ATTRIBUTION_RE.search(text)
+    next_first_person = starts_with_quote and _FIRST_PERSON_ATTRIBUTION_RE.match(next_text.lstrip())
+    if protagonist_id is not None and has_quote and (current_first_person or next_first_person):
+        return protagonist_id, "Deterministic first-person dialogue attribution", 0.99
+
+    current_gender = _GENDERED_ATTRIBUTION_RE.search(text)
+    next_gender = starts_with_quote and _GENDERED_ATTRIBUTION_RE.match(next_text.lstrip())
+    attribution = current_gender or next_gender
+    if has_quote and attribution:
+        gender = attribution.group(1).casefold()
+        fallback_id = minor_female_id if gender == "she" else minor_male_id
+        if fallback_id is not None:
+            return fallback_id, f"Deterministic {gender} dialogue attribution to minor voice", 0.98
+
+    if character_id == narrator_id and starts_with_quote and protagonist_id is not None:
+        return protagonist_id, "Deterministic first-person dialogue fallback", 0.75
 
     if character_id != narrator_id and not has_dialogue:
         return narrator_id, "Deterministic prose/narration guardrail", 0.98
 
     return character_id, reason, None
+
+
+def _advance_open_dialogue_speaker(
+    text: str,
+    resolved_character_id: int | None,
+    *,
+    narrator_id: int | None,
+    minor_female_id: int | None,
+    minor_male_id: int | None,
+    current_open_speaker_id: int | None,
+) -> int | None:
+    """Track a curly-quoted utterance split across sentence records."""
+    opens = text.count("“")
+    closes = text.count("”")
+    if opens > closes:
+        prefix = text.rsplit("“", 1)[0]
+        pronouns = re.findall(r"\b(she|her|he|him)\b", prefix[-120:], re.IGNORECASE)
+        if pronouns:
+            gender = pronouns[-1].casefold()
+            return minor_female_id if gender in {"she", "her"} else minor_male_id
+        if resolved_character_id != narrator_id:
+            return resolved_character_id
+        return None
+    if closes > opens:
+        return None
+    return current_open_speaker_id
 
 
 async def _build_roster_excerpt(chapters, db: AsyncSession) -> str:
@@ -991,6 +1035,10 @@ async def generate_character_roster(
                 character["voice_design_prompt"] = _normalise_voice_prompt(
                     character.get("voice_design_prompt"), gender=first_person_gender
                 )
+                character["description"] = (
+                    "First-person protagonist; spoken dialogue voice is separate from the Narrator. "
+                    f"{character['description']}"
+                )
 
     def character_tokens(character: dict) -> set[str]:
         values = [character["name"], *character["aliases"]]
@@ -1128,6 +1176,14 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
     characters = await crud.audiobook.get_characters_for_book(db, book_id)
     character_ids = {character.id for character in characters}
     narrator_id = next((character.id for character in characters if character.is_narrator), None)
+    protagonist_id = next(
+        (
+            character.id
+            for character in characters
+            if "first-person protagonist" in str(character.description or "").casefold()
+        ),
+        None,
+    )
     minor_female_id = next((character.id for character in characters if character.name == "Minor Female Voice"), None)
     minor_male_id = next((character.id for character in characters if character.name == "Minor Male Voice"), None)
     roster_json = json.dumps(
@@ -1167,9 +1223,11 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
 
         # Treat short files before the first substantial chapter as front matter.
         # Once the story begins, retain short chapters and only skip tiny dividers.
-        if len(chapter_sentences) >= batch_size:
+        if len(chapter_sentences) >= MIN_STORY_CHAPTER_SENTENCES:
             story_started = True
-        is_front_matter = (not story_started and len(chapter_sentences) < batch_size) or len(chapter_sentences) < 20
+        is_front_matter = (not story_started and len(chapter_sentences) < MIN_STORY_CHAPTER_SENTENCES) or len(
+            chapter_sentences
+        ) < 20
         if is_front_matter:
             for sentence in pending:
                 await crud.audiobook.update_sentence_diarization(
@@ -1194,6 +1252,18 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
         context_window = [
             sentence.original_text for sentence in chapter_sentences if sentence.status != "pending_diarization"
         ][-8:]
+        open_dialogue_speaker_id = None
+        for previous_sentence in chapter_sentences:
+            if previous_sentence.status == "pending_diarization":
+                break
+            open_dialogue_speaker_id = _advance_open_dialogue_speaker(
+                previous_sentence.original_text,
+                previous_sentence.character_id,
+                narrator_id=narrator_id,
+                minor_female_id=minor_female_id,
+                minor_male_id=minor_male_id,
+                current_open_speaker_id=open_dialogue_speaker_id,
+            )
         while True:
             batch = await crud.audiobook.get_sentences_pending_diarization(
                 db, book_id, limit=batch_size, chapter_id=chapter.id
@@ -1334,12 +1404,25 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
                     next_text=next_text,
                     character_id=char_id,
                     narrator_id=narrator_id,
+                    protagonist_id=protagonist_id,
                     minor_female_id=minor_female_id,
                     minor_male_id=minor_male_id,
                     reason=reason,
                 )
                 if guardrail_confidence is not None:
                     confidence = guardrail_confidence
+                if open_dialogue_speaker_id is not None and char_id == narrator_id:
+                    char_id = open_dialogue_speaker_id
+                    reason = "Deterministic continuation of open quoted dialogue"
+                    confidence = 0.95
+                open_dialogue_speaker_id = _advance_open_dialogue_speaker(
+                    sentence.original_text,
+                    char_id,
+                    narrator_id=narrator_id,
+                    minor_female_id=minor_female_id,
+                    minor_male_id=minor_male_id,
+                    current_open_speaker_id=open_dialogue_speaker_id,
+                )
                 await crud.audiobook.update_sentence_diarization(
                     db,
                     sentence.id,
@@ -1350,7 +1433,7 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
                 )
                 context_window.append(sentence.original_text)
 
-            chapter_summary = str(batch_result.get("chapter_summary") or chapter.summary or "")[:4000]
+            chapter_summary = str(batch_result.get("chapter_summary") or chapter.summary or "")[:1200]
             await crud.audiobook.update_chapter_summary(db, chapter.id, chapter_summary or None)
             chapter.summary = chapter_summary or None
             processed += len(batch)

--- a/backend/app/services/audiobook_llm.py
+++ b/backend/app/services/audiobook_llm.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import logging
+import re
+from collections import Counter
 from typing import Any
 
 import httpx
@@ -17,21 +19,35 @@ logger = logging.getLogger(__name__)
 STUB_PROVIDER = "stub"
 
 DEFAULT_ROSTER_PROMPT = """\
-You are a literary analyst. Analyze the following text excerpt from a book and extract a list of all named \
-characters (including the narrator if the text uses first person).
+You are a literary analyst preparing a cast list for an audiobook. Analyze the sampled excerpts from across the \
+book and identify the primary narrator plus the major or recurring speaking characters. Merge aliases, titles, and \
+surname-only references into one character. Do not include authors, publishers, places, organizations, unnamed \
+crowds, or one-line background figures. Prefer people with repeated mentions across the book and omit one-scene \
+figures even if they appear in an excerpt. Return no more than 15 characters.
 
 For each character produce:
-- name: their name (use "Narrator" for first-person narrators)
-- description: a 1-2 sentence description of their personality and role
+- name: canonical full name; use "Narrator" for the narrative prose voice
+- aliases: other names, surnames, nicknames, ranks, or titles used for this person
+- description: a concise description of their personality, relationships, and role
+- evidence: 1-3 short quotations or explicit textual facts supporting the identification
 - voice_design_prompt: an OmniVoice voice parameter string using ONLY these tokens:
-  [gender-{male|female|neutral}] [pitch-{low|medium|high}] [speed-{slow|normal|fast}]
-  Optional: [accent-{british|american|australian}] [age-{young|middle|old}]
+  [gender-{{male|female|neutral}}] [pitch-{{low|medium|high}}] [speed-{{slow|normal|fast}}]
+  Optional: [accent-{{british|american|australian}}] [age-{{young|middle|old}}]
   Example: [gender-male][pitch-low][speed-normal][age-middle]
-- is_narrator: true only for the primary narrator
+- is_narrator: true only for an entry named exactly "Narrator". In first-person books, the protagonist must be a \
+  separate character with is_narrator false so their spoken dialogue has a distinct voice.
 
-Return ONLY a valid JSON array of objects. No markdown, no explanation.
+Also produce a spoiler-light 2-4 sentence book_summary grounded only in these excerpts.
+Return JSON with keys book_summary and characters. No markdown or explanation.
 
-Text:
+Candidate name frequency hints from the complete book (not ground truth; ignore non-people):
+{candidate_hints}
+
+Names with explicit dialogue-tag hits (for example, "Harry said") are confirmed speaking candidates. Include the
+highest-hit confirmed speakers unless the evidence clearly shows they are not a person. Do not substitute low-count
+cameos for them. If the story is first-person, also include the named protagonist separately from Narrator.
+
+Sampled excerpts:
 {text}
 """
 
@@ -39,10 +55,17 @@ DEFAULT_DIARIZATION_PROMPT = """\
 You are a script editor. Assign each sentence to a speaker from the character roster and add non-verbal \
 expression tags where appropriate.
 
+Assign quoted dialogue to the person speaking it, even when the attribution (for example, "she asked") is in an
+adjacent sentence. Keep attribution and action prose on Narrator. If an unnamed or one-scene speaker is absent from
+the recurring roster, use "Minor Female Voice" or "Minor Male Voice" when present instead of Narrator.
+
 Character roster (JSON):
 {roster_json}
 
-Previous context (last 5 sentences):
+Chapter summary so far:
+{chapter_summary}
+
+Previous context (last 8 sentences):
 {context}
 
 Sentences to process (JSON array with id and text):
@@ -51,21 +74,124 @@ Sentences to process (JSON array with id and text):
 For each sentence return:
 - id: the sentence id (integer)
 - character_id: the character id from the roster (use the narrator's id for narration; null if uncertain)
-- tagged_text: the sentence text with optional non-verbal tags like [laughter], [sigh], [whisper], [shout]
+- tagged_text: the sentence text with optional non-verbal tags like [laughter], [sigh], [whisper], [shout], or null
+  when no tag is needed (do not repeat unchanged text)
+- confidence: a number from 0 to 1 for the speaker assignment
+- reason: a brief evidence-based reason, such as an adjacent dialogue tag or turn-taking context
 
-Return ONLY a valid JSON array. No markdown, no explanation.
+Also return chapter_summary: an updated spoiler-light summary incorporating this batch and the prior summary.
+The roster descriptions are identity hints only and may be inaccurate. Ground the chapter summary exclusively in the
+sentence text and prior chapter summary; never import plot events, body changes, relationships, or backstory from a
+character description.
+Return JSON with keys assignments and chapter_summary. No markdown or explanation.
 """
 
+_ALLOWED_EXPRESSION_TAGS = {"laughter", "sigh", "whisper", "shout"}
+_BRACKET_TAG_RE = re.compile(r"\[([^\[\]]+)\]")
+_GENDERED_ATTRIBUTION_RE = re.compile(
+    r"\b(she|he)\s+(?:said|asked|replied|yelled|shouted|whispered|muttered|added|continued|answered|snapped)\b",
+    re.IGNORECASE,
+)
+_NARRATION_REASON_RE = re.compile(
+    r"\b(?:narrat(?:or|ion|ive)|internal|reflection|action description|monologue|observation|recounting)\b",
+    re.IGNORECASE,
+)
 
-async def _call_llm(settings: AudiobookSettings, messages: list[dict[str, Any]]) -> str:
+ROSTER_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "book_summary": {"type": "string"},
+        "characters": {
+            "type": "array",
+            "maxItems": 15,
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "aliases": {
+                        "type": "array",
+                        "maxItems": 10,
+                        "items": {"type": "string"},
+                    },
+                    "description": {"type": "string"},
+                    "evidence": {
+                        "type": "array",
+                        "maxItems": 3,
+                        "items": {"type": "string"},
+                    },
+                    "voice_design_prompt": {"type": "string"},
+                    "is_narrator": {"type": "boolean"},
+                },
+                "required": [
+                    "name",
+                    "aliases",
+                    "description",
+                    "evidence",
+                    "voice_design_prompt",
+                    "is_narrator",
+                ],
+            },
+        },
+    },
+    "required": ["book_summary", "characters"],
+}
+
+DIARIZATION_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "assignments": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "integer"},
+                    "character_id": {"type": ["integer", "null"]},
+                    "tagged_text": {"type": ["string", "null"]},
+                    "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+                    "reason": {"type": "string"},
+                },
+                "required": ["id", "character_id", "tagged_text", "confidence", "reason"],
+            },
+        },
+        "chapter_summary": {"type": "string"},
+    },
+    "required": ["assignments", "chapter_summary"],
+}
+
+
+async def _call_llm(
+    settings: AudiobookSettings,
+    messages: list[dict[str, Any]],
+    *,
+    response_schema: dict[str, Any] | None = None,
+) -> str:
     """Route to the configured LLM provider and return the text response."""
-    if not settings.llm_api_key and not settings.llm_base_url:
+    provider = (settings.llm_provider or "openai").lower()
+    if provider != "ollama" and not settings.llm_api_key and not settings.llm_base_url:
         raise RuntimeError("LLM not configured: set llm_api_key or llm_base_url in Audio Settings.")
 
-    provider = (settings.llm_provider or "openai").lower()
-    model = settings.llm_model or "gpt-4o"
+    model = settings.llm_model or ("qwen3.5:9b" if provider == "ollama" else "gpt-4o")
 
     headers = {"Content-Type": "application/json"}
+
+    if provider == "ollama":
+        url = (settings.llm_base_url or "http://127.0.0.1:11434").rstrip("/") + "/api/chat"
+        payload: dict[str, Any] = {
+            "model": model,
+            "messages": messages,
+            "stream": False,
+            "think": False,
+            "format": response_schema or "json",
+            "options": {"temperature": 0, "num_ctx": 32768, "num_predict": 4096},
+            "keep_alive": "30m",
+        }
+        timeout = httpx.Timeout(600.0, connect=10.0)
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.post(url, json=payload, headers=headers)
+            if resp.is_error:
+                raise RuntimeError(f"Ollama returned HTTP {resp.status_code}: {resp.text[:1000]}")
+            data = resp.json()
+        return data["message"]["content"]
 
     if provider == "anthropic":
         url = (settings.llm_base_url or "https://api.anthropic.com").rstrip("/") + "/v1/messages"
@@ -88,11 +214,16 @@ async def _call_llm(settings: AudiobookSettings, messages: list[dict[str, Any]])
         url = base.rstrip("/") + "/v1/chat/completions"
         if settings.llm_api_key:
             headers["Authorization"] = f"Bearer {settings.llm_api_key}"
-        payload = {
+        payload: dict[str, Any] = {
             "model": model,
             "messages": messages,
-            "temperature": 0.2,
+            "temperature": 0,
         }
+        if response_schema:
+            payload["response_format"] = {
+                "type": "json_schema",
+                "json_schema": {"name": "audiobook_analysis", "strict": True, "schema": response_schema},
+            }
         async with httpx.AsyncClient(timeout=120.0) as client:
             resp = await client.post(url, json=payload, headers=headers)
             resp.raise_for_status()
@@ -110,6 +241,216 @@ def _extract_json(raw: str) -> Any:
     return json.loads(text)
 
 
+def _sanitize_tagged_text(original: str, tagged: Any) -> str:
+    """Accept expression-tag insertion, but reject unsupported tags or prose rewrites."""
+    if not isinstance(tagged, str) or not tagged.strip():
+        return original
+
+    def remove_unknown(match: re.Match[str]) -> str:
+        token = match.group(1).strip().casefold()
+        if token in _ALLOWED_EXPRESSION_TAGS or match.group(0) in original:
+            return match.group(0)
+        return ""
+
+    cleaned = _BRACKET_TAG_RE.sub(remove_unknown, tagged).strip()
+    without_allowed = _BRACKET_TAG_RE.sub(
+        lambda match: "" if match.group(1).strip().casefold() in _ALLOWED_EXPRESSION_TAGS else match.group(0),
+        cleaned,
+    )
+    if " ".join(without_allowed.split()) != " ".join(original.split()):
+        return original
+    return cleaned
+
+
+def _apply_speaker_guardrails(
+    *,
+    text: str,
+    next_text: str,
+    character_id: int | None,
+    narrator_id: int | None,
+    minor_female_id: int | None,
+    minor_male_id: int | None,
+    reason: str,
+) -> tuple[int | None, str, float | None]:
+    """Correct two common local-model ID errors without inventing named speakers."""
+    has_closing_quote = "”" in text or ('"' in text and not text.rstrip().endswith('"'))
+    starts_with_quote = text.lstrip().startswith(("“", '"'))
+    has_dialogue = has_closing_quote or starts_with_quote
+
+    if character_id == narrator_id and has_dialogue:
+        attribution = _GENDERED_ATTRIBUTION_RE.search(f"{text} {next_text}")
+        if attribution:
+            gender = attribution.group(1).casefold()
+            fallback_id = minor_female_id if gender == "she" else minor_male_id
+            if fallback_id is not None:
+                return fallback_id, f"Deterministic {gender} dialogue attribution to minor voice", 0.98
+
+    if character_id != narrator_id and not has_dialogue and _NARRATION_REASON_RE.search(reason):
+        return narrator_id, "Deterministic prose/narration guardrail", 0.98
+
+    return character_id, reason, None
+
+
+async def _build_roster_excerpt(chapters, db: AsyncSession) -> str:
+    """Sample real story chapters across the book instead of front matter."""
+    candidates: list[tuple[Any, list[Any]]] = []
+    for chapter in chapters:
+        sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
+        if len(sentences) >= 40:
+            candidates.append((chapter, sentences))
+
+    if not candidates:
+        for chapter in chapters:
+            sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
+            if sentences:
+                candidates.append((chapter, sentences))
+
+    if len(candidates) > 8:
+        indexes = sorted({round(index * (len(candidates) - 1) / 7) for index in range(8)})
+        selected = [candidates[index] for index in indexes]
+    else:
+        selected = candidates
+
+    excerpts: list[str] = []
+    for chapter, sentences in selected:
+        chapter_text = " ".join(sentence.original_text for sentence in sentences)
+        excerpts.append(f"### Chapter {chapter.chapter_number}\n{chapter_text[:4000]}")
+    return "\n\n".join(excerpts)[:32000]
+
+
+_CANDIDATE_TOKEN_RE = re.compile(r"\b[A-Z][a-z]{2,}\b")
+_DIALOGUE_TAG_RE = re.compile(
+    r"\b([A-Z][a-z]{2,})\s+(?:said|asked|replied|yelled|shouted|whispered|added|continued|noted|answered|"
+    r"snapped|muttered|called|agreed|insisted)\b|\b(?:said|asked|replied|yelled|shouted|whispered|added|"
+    r"continued|noted|answered|snapped|muttered|called|agreed|insisted)\s+([A-Z][a-z]{2,})\b"
+)
+_CANDIDATE_STOP_WORDS = {
+    "About",
+    "After",
+    "Again",
+    "And",
+    "Are",
+    "Before",
+    "But",
+    "Chapter",
+    "Copyright",
+    "Could",
+    "Did",
+    "Does",
+    "Earth",
+    "For",
+    "From",
+    "Had",
+    "Has",
+    "Have",
+    "Here",
+    "How",
+    "However",
+    "Into",
+    "Just",
+    "Like",
+    "Maybe",
+    "More",
+    "Much",
+    "Neither",
+    "Never",
+    "Next",
+    "None",
+    "Nothing",
+    "Now",
+    "One",
+    "Only",
+    "Other",
+    "Our",
+    "Part",
+    "Right",
+    "She",
+    "Since",
+    "Some",
+    "Something",
+    "Still",
+    "That",
+    "The",
+    "Then",
+    "There",
+    "These",
+    "They",
+    "This",
+    "Those",
+    "Through",
+    "Very",
+    "Was",
+    "We",
+    "Well",
+    "What",
+    "When",
+    "Where",
+    "Which",
+    "While",
+    "Who",
+    "Why",
+    "With",
+    "Would",
+    "Yes",
+    "You",
+    "Your",
+}
+
+
+async def _build_character_candidate_analysis(chapters, db: AsyncSession) -> tuple[str, list[dict[str, Any]]]:
+    """Provide whole-book evidence so sampled cameos do not crowd out recurring cast."""
+    counts: Counter[str] = Counter()
+    contextual_counts: Counter[str] = Counter()
+    dialogue_counts: Counter[str] = Counter()
+    dialogue_examples: dict[str, str] = {}
+    for chapter in chapters:
+        for sentence in await crud.audiobook.get_sentences_for_chapter(db, chapter.id):
+            for match in _CANDIDATE_TOKEN_RE.finditer(sentence.original_text):
+                token = match.group(0)
+                if token in _CANDIDATE_STOP_WORDS:
+                    continue
+                counts[token] += 1
+                if match.start() > 0:
+                    contextual_counts[token] += 1
+            for match in _DIALOGUE_TAG_RE.finditer(sentence.original_text):
+                name = match.group(1) or match.group(2)
+                if name in _CANDIDATE_STOP_WORDS:
+                    continue
+                dialogue_counts[name] += 1
+                dialogue_examples.setdefault(name, sentence.original_text[:220])
+
+    candidates = [
+        (name, count, contextual_counts[name], dialogue_counts[name])
+        for name, count in counts.items()
+        if contextual_counts[name] >= 2 or count >= 8
+    ]
+    candidates.sort(key=lambda item: (item[3], item[2], item[1], item[0]), reverse=True)
+    lines = []
+    for name, count, _, dialogue_count in candidates[:50]:
+        line = f"- {name}: {count} mentions; {dialogue_count} explicit dialogue tags"
+        if dialogue_count and name in dialogue_examples:
+            line += f'; example: "{dialogue_examples[name]}"'
+        lines.append(line)
+    confirmed = [
+        {
+            "name": name,
+            "mention_count": count,
+            "dialogue_count": dialogue_count,
+            "evidence": dialogue_examples.get(name),
+        }
+        for name, count, _, dialogue_count in candidates
+        if dialogue_count >= 5
+    ]
+    required_names = ", ".join(candidate["name"] for candidate in confirmed[:12])
+    heading = f"REQUIRED confirmed speakers (include all): {required_names}\n" if required_names else ""
+    return heading + ("\n".join(lines) or "(none)"), confirmed
+
+
+async def _build_character_candidate_hints(chapters, db: AsyncSession) -> str:
+    hints, _ = await _build_character_candidate_analysis(chapters, db)
+    return hints
+
+
 async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
     """Phase 2: extract characters from book text and persist to audiobook_characters."""
     settings = await crud.audiobook.get_audiobook_settings(db)
@@ -119,32 +460,53 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
     if not chapters:
         raise RuntimeError(f"No narratable chapters found for book {book_id} during roster generation.")
 
-    # Collect text from up to 5 chapters (keeps prompt size manageable)
-    text_chunks: list[str] = []
-    for chapter in chapters[:5]:
-        sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
-        text_chunks.append(" ".join(s.original_text for s in sentences))
-    combined_text = "\n\n".join(text_chunks)[:12000]  # ~10k tokens safety cap
+    combined_text = await _build_roster_excerpt(chapters, db)
+    candidate_hints, confirmed_speakers = await _build_character_candidate_analysis(chapters, db)
+    await crud.audiobook.update_book_pipeline_progress(
+        db, book_id, current=0, total=1, detail="Analyzing story excerpts for recurring characters"
+    )
 
     if provider == STUB_PROVIDER:
-        characters_data = [
-            {
-                "name": "Narrator",
-                "description": "Deterministic local harness narrator.",
-                "voice_design_prompt": "[gender-neutral][pitch-medium][speed-normal]",
-                "is_narrator": True,
-            }
-        ]
+        roster_result = {
+            "book_summary": "Deterministic local harness analysis.",
+            "characters": [
+                {
+                    "name": "Narrator",
+                    "aliases": [],
+                    "description": "Deterministic local harness narrator.",
+                    "evidence": [],
+                    "voice_design_prompt": "[gender-neutral][pitch-medium][speed-normal]",
+                    "is_narrator": True,
+                }
+            ],
+        }
     else:
         prompt_template = settings.roster_prompt_template or DEFAULT_ROSTER_PROMPT
-        prompt = prompt_template.format(text=combined_text)
+        prompt = prompt_template.format(text=combined_text, candidate_hints=candidate_hints)
         logger.info("Calling LLM for character roster (book %s).", book_id)
-        raw = await _call_llm(settings, [{"role": "user", "content": prompt}])
+        await crud.audiobook.update_book_pipeline_progress(
+            db,
+            book_id,
+            current=0,
+            total=1,
+            detail=f"Waiting for {settings.llm_model or provider} roster analysis",
+            llm_request_increment=1,
+        )
+        raw = await _call_llm(
+            settings,
+            [{"role": "user", "content": prompt}],
+            response_schema=ROSTER_SCHEMA,
+        )
         try:
-            characters_data = _extract_json(raw)
+            roster_result = _extract_json(raw)
         except json.JSONDecodeError as exc:
             raise RuntimeError(f"LLM returned invalid JSON for roster: {exc}\nRaw: {raw[:500]}") from exc
 
+    if isinstance(roster_result, list):
+        roster_result = {"book_summary": None, "characters": roster_result}
+    if not isinstance(roster_result, dict):
+        raise RuntimeError(f"Expected a JSON object from LLM, got: {type(roster_result)}")
+    characters_data = roster_result.get("characters")
     if not isinstance(characters_data, list):
         raise RuntimeError(f"Expected a JSON array from LLM, got: {type(characters_data)}")
 
@@ -156,25 +518,136 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
         normalised.append(
             {
                 "name": str(c.get("name", "Unknown")),
+                "aliases": [str(alias) for alias in c.get("aliases", []) if alias],
                 "description": c.get("description"),
+                "evidence": [str(item) for item in c.get("evidence", []) if item][:3],
                 "voice_design_prompt": c.get("voice_design_prompt"),
-                "is_narrator": bool(c.get("is_narrator", False)),
+                "is_narrator": str(c.get("name", "")).strip().casefold() == "narrator",
             }
         )
     if not normalised:
         raise RuntimeError("LLM returned an empty character roster.")
+    existing_names = {character["name"].strip().casefold() for character in normalised}
+    promoted_protagonists: list[dict] = []
+    for character in normalised:
+        if not character["is_narrator"]:
+            continue
+        retained_aliases = []
+        for alias in character["aliases"]:
+            canonical = alias.strip().casefold()
+            if canonical in {"narrator", "narrative voice", "storyteller"}:
+                continue
+            if " " in alias.strip() and canonical not in existing_names:
+                promoted_protagonists.append(
+                    {
+                        "name": alias.strip(),
+                        "aliases": [],
+                        "description": "First-person protagonist, kept separate from the narrative prose voice.",
+                        "evidence": character["evidence"],
+                        "voice_design_prompt": "[gender-male][pitch-medium][speed-normal]",
+                        "is_narrator": False,
+                    }
+                )
+                existing_names.add(canonical)
+            else:
+                retained_aliases.append(alias)
+        character["aliases"] = retained_aliases
+    for character in normalised:
+        if not character["is_narrator"]:
+            character["aliases"] = [alias for alias in character["aliases"] if alias.strip().casefold() != "narrator"]
     if not any(character["is_narrator"] for character in normalised):
         normalised.insert(
             0,
             {
                 "name": "Narrator",
+                "aliases": [],
                 "description": "Primary narrative voice.",
+                "evidence": [],
                 "voice_design_prompt": "[gender-neutral][pitch-medium][speed-normal]",
                 "is_narrator": True,
             },
         )
+    if promoted_protagonists:
+        narrator_index = next(index for index, character in enumerate(normalised) if character["is_narrator"])
+        for offset, protagonist in enumerate(promoted_protagonists, start=1):
+            normalised.insert(narrator_index + offset, protagonist)
 
-    await crud.audiobook.create_characters_bulk(db, book_id=book_id, characters_data=normalised)
+    def character_tokens(character: dict) -> set[str]:
+        values = [character["name"], *character["aliases"]]
+        return {token.casefold() for value in values for token in _CANDIDATE_TOKEN_RE.findall(value)}
+
+    represented_tokens = set().union(*(character_tokens(character) for character in normalised))
+    for candidate in confirmed_speakers[:12]:
+        canonical = candidate["name"].casefold()
+        if canonical in represented_tokens:
+            continue
+        normalised.append(
+            {
+                "name": candidate["name"],
+                "aliases": [],
+                "description": (
+                    f"Recurring speaking character identified from {candidate['dialogue_count']} explicit "
+                    "dialogue attributions across the book."
+                ),
+                "evidence": [candidate["evidence"]] if candidate["evidence"] else [],
+                "voice_design_prompt": "[gender-neutral][pitch-medium][speed-normal]",
+                "is_narrator": False,
+            }
+        )
+        represented_tokens.add(canonical)
+
+    protagonist_names = {character["name"].strip().casefold() for character in promoted_protagonists}
+    if protagonist_names:
+        for character in normalised:
+            if character["name"].strip().casefold() in protagonist_names:
+                continue
+            character["aliases"] = [
+                alias for alias in character["aliases"] if alias.strip().casefold() not in protagonist_names
+            ]
+
+    dialogue_scores = {candidate["name"].casefold(): candidate["dialogue_count"] for candidate in confirmed_speakers}
+
+    def roster_priority(character: dict) -> tuple[int, int, str]:
+        if character["is_narrator"]:
+            return (3, 0, character["name"])
+        if "protagonist" in str(character.get("description") or "").casefold():
+            return (2, 0, character["name"])
+        score = max((dialogue_scores.get(token, 0) for token in character_tokens(character)), default=0)
+        return (1, score, character["name"])
+
+    normalised.sort(key=roster_priority, reverse=True)
+
+    if provider != STUB_PROVIDER:
+        # Reserve stable voices for one-scene and unnamed dialogue without
+        # allowing hundreds of cameos to crowd recurring characters out.
+        normalised = normalised[:13]
+        normalised.extend(
+            [
+                {
+                    "name": "Minor Female Voice",
+                    "aliases": ["Unnamed female speaker"],
+                    "description": "Fallback voice for unnamed or one-scene female dialogue.",
+                    "evidence": [],
+                    "voice_design_prompt": "[gender-female][pitch-medium][speed-normal]",
+                    "is_narrator": False,
+                },
+                {
+                    "name": "Minor Male Voice",
+                    "aliases": ["Unnamed male speaker"],
+                    "description": "Fallback voice for unnamed or one-scene male dialogue.",
+                    "evidence": [],
+                    "voice_design_prompt": "[gender-male][pitch-medium][speed-normal]",
+                    "is_narrator": False,
+                },
+            ]
+        )
+
+    await crud.audiobook.delete_characters_for_book(db, book_id)
+    await crud.audiobook.create_characters_bulk(db, book_id=book_id, characters_data=normalised[:15])
+    await crud.audiobook.set_book_audiobook_summary(db, book_id, roster_result.get("book_summary"))
+    await crud.audiobook.update_book_pipeline_progress(
+        db, book_id, current=1, total=1, detail=f"Created {len(normalised[:15])} character profiles"
+    )
     logger.info("Created %d characters for book %s.", len(normalised), book_id)
     if not await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):
         await crud.audiobook.set_book_pipeline_status(db, book_id, "diarizing")
@@ -188,60 +661,182 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
     characters = await crud.audiobook.get_characters_for_book(db, book_id)
     character_ids = {character.id for character in characters}
     narrator_id = next((character.id for character in characters if character.is_narrator), None)
+    minor_female_id = next((character.id for character in characters if character.name == "Minor Female Voice"), None)
+    minor_male_id = next((character.id for character in characters if character.name == "Minor Male Voice"), None)
     roster_json = json.dumps(
         [{"id": c.id, "name": c.name, "description": c.description, "is_narrator": c.is_narrator} for c in characters],
         ensure_ascii=False,
     )
 
-    context_window: list[str] = []
-    batch_size = 50
+    chapters = await crud.audiobook.get_chapters_for_book(db, book_id)
+    counts = await crud.audiobook.count_sentences_by_status(db, book_id)
+    total = sum(counts.values())
+    processed = total - counts.get("pending_diarization", 0)
+    batch_size = 40
+    await crud.audiobook.update_book_pipeline_progress(
+        db, book_id, current=processed, total=total, detail="Preparing dialogue attribution"
+    )
 
-    while True:
+    story_started = False
+    for chapter_index, chapter in enumerate(chapters, start=1):
         if await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):
             logger.info("Book %s paused during diarization.", book_id)
             return
 
-        batch = await crud.audiobook.get_sentences_pending_diarization(db, book_id, limit=batch_size)
-        if not batch:
-            break
+        chapter_sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
+        pending = [sentence for sentence in chapter_sentences if sentence.status == "pending_diarization"]
+        if not pending:
+            continue
 
-        sentences_json = json.dumps(
-            [{"id": s.id, "text": s.original_text} for s in batch],
-            ensure_ascii=False,
-        )
-        context_str = "\n".join(context_window[-5:]) if context_window else "(none)"
-
-        if provider == STUB_PROVIDER:
-            results = [
-                {"id": sentence.id, "character_id": narrator_id, "tagged_text": sentence.original_text} for sentence in batch
-            ]
-        else:
-            prompt_template = settings.diarization_prompt_template or DEFAULT_DIARIZATION_PROMPT
-            prompt = prompt_template.format(
-                roster_json=roster_json,
-                context=context_str,
-                sentences_json=sentences_json,
+        # Treat short files before the first substantial chapter as front matter.
+        # Once the story begins, retain short chapters and only skip tiny dividers.
+        if len(chapter_sentences) >= batch_size:
+            story_started = True
+        is_front_matter = (not story_started and len(chapter_sentences) < batch_size) or len(chapter_sentences) < 20
+        if is_front_matter:
+            for sentence in pending:
+                await crud.audiobook.update_sentence_diarization(
+                    db,
+                    sentence.id,
+                    narrator_id,
+                    sentence.original_text,
+                    speaker_confidence=0.99,
+                    speaker_reason="Front matter narration",
+                )
+            processed += len(pending)
+            await crud.audiobook.update_chapter_summary(db, chapter.id, "Front matter or section divider.")
+            await crud.audiobook.update_book_pipeline_progress(
+                db,
+                book_id,
+                current=processed,
+                total=total,
+                detail=f"Skipped front matter; next is chapter {chapter.chapter_number}",
             )
-            logger.debug("Diarizing %d sentences for book %s.", len(batch), book_id)
-            raw = await _call_llm(settings, [{"role": "user", "content": prompt}])
-            try:
-                results = _extract_json(raw)
-            except json.JSONDecodeError as exc:
-                raise RuntimeError(f"LLM returned invalid JSON for diarization: {exc}\nRaw: {raw[:500]}") from exc
+            continue
 
-        if not isinstance(results, list):
-            raise RuntimeError(f"Expected a JSON array from diarization, got: {type(results)}")
+        context_window = [
+            sentence.original_text for sentence in chapter_sentences if sentence.status != "pending_diarization"
+        ][-8:]
+        while True:
+            batch = await crud.audiobook.get_sentences_pending_diarization(
+                db, book_id, limit=batch_size, chapter_id=chapter.id
+            )
+            if not batch:
+                break
 
-        result_map = {r["id"]: r for r in results if isinstance(r, dict) and isinstance(r.get("id"), int)}
+            sentences_json = json.dumps(
+                [{"id": s.id, "text": s.original_text} for s in batch],
+                ensure_ascii=False,
+            )
+            context_str = "\n".join(context_window[-8:]) if context_window else "(none)"
 
-        for sentence in batch:
-            result = result_map.get(sentence.id, {})
-            char_id = result.get("character_id")
-            if char_id not in character_ids:
-                char_id = narrator_id
-            tagged = result.get("tagged_text") or sentence.original_text
-            await crud.audiobook.update_sentence_diarization(db, sentence.id, char_id, tagged)
-            context_window.append(sentence.original_text)
+            await crud.audiobook.update_book_pipeline_progress(
+                db,
+                book_id,
+                current=processed,
+                total=total,
+                detail=(
+                    f"Chapter {chapter.chapter_number} ({chapter_index}/{len(chapters)}): "
+                    f"attributing {len(batch)} sentences"
+                ),
+            )
+            if provider == STUB_PROVIDER:
+                batch_result = {
+                    "assignments": [
+                        {
+                            "id": sentence.id,
+                            "character_id": narrator_id,
+                            "tagged_text": sentence.original_text,
+                            "confidence": 1.0,
+                            "reason": "Deterministic local harness",
+                        }
+                        for sentence in batch
+                    ],
+                    "chapter_summary": "Deterministic local harness chapter summary.",
+                }
+            else:
+                prompt_template = settings.diarization_prompt_template or DEFAULT_DIARIZATION_PROMPT
+                prompt = prompt_template.format(
+                    roster_json=roster_json,
+                    chapter_summary=chapter.summary or "(none yet)",
+                    context=context_str,
+                    sentences_json=sentences_json,
+                )
+                logger.debug("Diarizing %d sentences for book %s.", len(batch), book_id)
+                await crud.audiobook.update_book_pipeline_progress(
+                    db,
+                    book_id,
+                    current=processed,
+                    total=total,
+                    detail=f"Waiting for {settings.llm_model or provider}: chapter {chapter.chapter_number}",
+                    llm_request_increment=1,
+                )
+                raw = await _call_llm(
+                    settings,
+                    [{"role": "user", "content": prompt}],
+                    response_schema=DIARIZATION_SCHEMA,
+                )
+                try:
+                    batch_result = _extract_json(raw)
+                except json.JSONDecodeError as exc:
+                    raise RuntimeError(f"LLM returned invalid JSON for diarization: {exc}\nRaw: {raw[:500]}") from exc
+
+            if isinstance(batch_result, list):
+                batch_result = {"assignments": batch_result, "chapter_summary": chapter.summary}
+            if not isinstance(batch_result, dict) or not isinstance(batch_result.get("assignments"), list):
+                raise RuntimeError(f"Expected a JSON object from diarization, got: {type(batch_result)}")
+            results = batch_result["assignments"]
+
+            result_map = {r["id"]: r for r in results if isinstance(r, dict) and isinstance(r.get("id"), int)}
+
+            for sentence_index, sentence in enumerate(batch):
+                result = result_map.get(sentence.id, {})
+                char_id = result.get("character_id")
+                if char_id not in character_ids:
+                    char_id = narrator_id
+                tagged = _sanitize_tagged_text(sentence.original_text, result.get("tagged_text"))
+                confidence = result.get("confidence")
+                try:
+                    confidence = max(0.0, min(1.0, float(confidence)))
+                except (TypeError, ValueError):
+                    confidence = 0.0
+                reason = str(result.get("reason") or "No model rationale returned")[:500]
+                next_text = batch[sentence_index + 1].original_text if sentence_index + 1 < len(batch) else ""
+                char_id, reason, guardrail_confidence = _apply_speaker_guardrails(
+                    text=sentence.original_text,
+                    next_text=next_text,
+                    character_id=char_id,
+                    narrator_id=narrator_id,
+                    minor_female_id=minor_female_id,
+                    minor_male_id=minor_male_id,
+                    reason=reason,
+                )
+                if guardrail_confidence is not None:
+                    confidence = guardrail_confidence
+                await crud.audiobook.update_sentence_diarization(
+                    db,
+                    sentence.id,
+                    char_id,
+                    tagged,
+                    speaker_confidence=confidence,
+                    speaker_reason=reason,
+                )
+                context_window.append(sentence.original_text)
+
+            chapter_summary = str(batch_result.get("chapter_summary") or chapter.summary or "")[:4000]
+            await crud.audiobook.update_chapter_summary(db, chapter.id, chapter_summary or None)
+            chapter.summary = chapter_summary or None
+            processed += len(batch)
+            await crud.audiobook.update_book_pipeline_progress(
+                db,
+                book_id,
+                current=processed,
+                total=total,
+                detail=f"Chapter {chapter.chapter_number}: attributed {processed} of {total} sentences",
+            )
+            if await crud.audiobook.consume_book_batch_limit(db, book_id):
+                logger.info("Book %s paused after one diarization batch.", book_id)
+                return
 
     logger.info("Diarization complete for book %s.", book_id)
     if not await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):

--- a/backend/app/services/audiobook_llm.py
+++ b/backend/app/services/audiobook_llm.py
@@ -417,6 +417,11 @@ def _apply_speaker_guardrails(
         if last_dialogue_speaker_id is not None:
             return last_dialogue_speaker_id, "Deterministic recurring role dialogue attribution", 0.9
 
+    if has_quote and re.match(r'^\s*[“"]?Paragraph\s+(?:one|two|three|four|five|six|\d+)\b', text, re.I):
+        recruiter_id = role_speaker_ids.get("recruiter")
+        if recruiter_id is not None:
+            return recruiter_id, "Deterministic grounded recruiter enumeration", 0.98
+
     if (
         starts_with_quote
         and protagonist_id is not None
@@ -1564,7 +1569,11 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
                 )
                 if guardrail_confidence is not None:
                     confidence = guardrail_confidence
-                if open_dialogue_speaker_id is not None and char_id != open_dialogue_speaker_id:
+                if (
+                    open_dialogue_speaker_id is not None
+                    and char_id != open_dialogue_speaker_id
+                    and (guardrail_confidence is None or guardrail_confidence < 0.9)
+                ):
                     char_id = open_dialogue_speaker_id
                     reason = "Deterministic continuation of open quoted dialogue"
                     confidence = 0.95

--- a/backend/app/services/audiobook_llm.py
+++ b/backend/app/services/audiobook_llm.py
@@ -23,17 +23,19 @@ You are a literary analyst preparing a cast list for an audiobook. Analyze the s
 book and identify the primary narrator plus the major or recurring speaking characters. Merge aliases, titles, and \
 surname-only references into one character. Do not include authors, publishers, places, organizations, unnamed \
 crowds, or one-line background figures. Prefer people with repeated mentions across the book and omit one-scene \
-figures even if they appear in an excerpt. Return no more than 15 characters.
+figures even if they appear in an excerpt. Return no more than 18 characters.
 
 For each character produce:
 - name: canonical full name; use "Narrator" for the narrative prose voice
 - aliases: other names, surnames, nicknames, ranks, or titles used for this person
 - description: a concise description of their personality, relationships, and role
-- evidence: 1-3 short quotations or explicit textual facts supporting the identification
+- evidence: 1-3 short exact quotations from the supplied text supporting the identification
 - voice_design_prompt: an OmniVoice voice parameter string using ONLY these tokens:
   [gender-{{male|female|neutral}}] [pitch-{{low|medium|high}}] [speed-{{slow|normal|fast}}]
   Optional: [accent-{{british|american|australian}}] [age-{{young|middle|old}}]
   Example: [gender-male][pitch-low][speed-normal][age-middle]
+  Always include gender, pitch, speed, and age. Use the textual evidence to make recurring characters distinct;
+  do not give every character the same generic profile. Add an accent only when the text supports it.
 - is_narrator: true only for an entry named exactly "Narrator". In first-person books, the protagonist must be a \
   separate character with is_narrator false so their spoken dialogue has a distinct voice.
 
@@ -81,6 +83,7 @@ For each sentence return:
   when no tag is needed (do not repeat unchanged text)
 - confidence: a number from 0 to 1 for the speaker assignment
 - reason: a brief evidence-based reason, such as an adjacent dialogue tag or turn-taking context
+  (12 words or fewer)
 
 Also return chapter_summary: an updated spoiler-light summary incorporating this batch and the prior summary.
 The roster descriptions are identity hints only and may be inaccurate. Ground the chapter summary exclusively in the
@@ -95,10 +98,12 @@ _GENDERED_ATTRIBUTION_RE = re.compile(
     r"\b(she|he)\s+(?:said|asked|replied|yelled|shouted|whispered|muttered|added|continued|answered|snapped)\b",
     re.IGNORECASE,
 )
-_NARRATION_REASON_RE = re.compile(
-    r"\b(?:narrat(?:or|ion|ive)|internal|reflection|action description|monologue|observation|recounting)\b",
+_DIALOGUE_ATTRIBUTION_IN_SENTENCE_RE = re.compile(
+    r"\b(?:said|asked|replied|yelled|shouted|whispered|muttered|added|continued|answered|snapped)\b" r"[^“\"]{0,80}[“\"]",
     re.IGNORECASE,
 )
+MAX_DIARIZATION_BATCH_SIZE = 40
+MIN_DIARIZATION_BATCH_SIZE = 5
 
 ROSTER_SCHEMA = {
     "type": "object",
@@ -106,7 +111,7 @@ ROSTER_SCHEMA = {
         "book_summary": {"type": "string"},
         "characters": {
             "type": "array",
-            "maxItems": 15,
+            "maxItems": 18,
             "items": {
                 "type": "object",
                 "properties": {
@@ -185,7 +190,7 @@ async def _call_llm(
             "stream": False,
             "think": False,
             "format": response_schema or "json",
-            "options": {"temperature": 0, "num_ctx": 32768, "num_predict": 4096},
+            "options": {"temperature": 0, "num_ctx": 32768, "num_predict": 8192},
             "keep_alive": "30m",
         }
         timeout = httpx.Timeout(600.0, connect=10.0)
@@ -234,14 +239,86 @@ async def _call_llm(
         return data["choices"][0]["message"]["content"]
 
 
-def _extract_json(raw: str) -> Any:
-    """Strip markdown code fences if present and parse JSON."""
+def _strip_json_fence(raw: str) -> str:
     text = raw.strip()
     if text.startswith("```"):
         lines = text.splitlines()
         # Drop first and last fence lines
         text = "\n".join(lines[1:-1] if lines[-1].strip() == "```" else lines[1:])
-    return json.loads(text)
+    return text
+
+
+def _remove_trailing_json_commas(text: str) -> str:
+    """Remove commas immediately before ] or } without changing JSON strings."""
+    output: list[str] = []
+    in_string = False
+    escaped = False
+    for char in text:
+        if in_string:
+            output.append(char)
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            continue
+        if char == '"':
+            in_string = True
+            output.append(char)
+            continue
+        if char in "]}":
+            previous = len(output) - 1
+            while previous >= 0 and output[previous].isspace():
+                previous -= 1
+            if previous >= 0 and output[previous] == ",":
+                del output[previous]
+        output.append(char)
+    return "".join(output)
+
+
+def _extract_json(raw: str) -> Any:
+    """Parse structured output and repair common local-model trailing commas."""
+    text = _strip_json_fence(raw)
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as original_error:
+        repaired = _remove_trailing_json_commas(text)
+        if repaired == text:
+            raise
+        try:
+            return json.loads(repaired)
+        except json.JSONDecodeError:
+            raise original_error
+
+
+def _normalise_diarization_result(batch_result: Any, expected_ids: set[int]) -> dict[str, Any]:
+    """Require exactly one assignment for every requested sentence."""
+    if isinstance(batch_result, list):
+        batch_result = {"assignments": batch_result, "chapter_summary": None}
+    if not isinstance(batch_result, dict) or not isinstance(batch_result.get("assignments"), list):
+        raise ValueError(f"Expected a JSON object with assignments, got {type(batch_result).__name__}")
+
+    result_ids = [
+        result.get("id")
+        for result in batch_result["assignments"]
+        if isinstance(result, dict) and isinstance(result.get("id"), int)
+    ]
+    result_id_set = set(result_ids)
+    missing = sorted(expected_ids - result_id_set)
+    unexpected = sorted(result_id_set - expected_ids)
+    duplicates = sorted(
+        sentence_id for sentence_id, count in Counter(result_ids).items() if sentence_id in expected_ids and count > 1
+    )
+    if missing or duplicates or len(result_ids) != len(batch_result["assignments"]):
+        raise ValueError(
+            "Invalid assignment coverage: "
+            f"missing={missing[:10]}, unexpected={unexpected[:10]}, duplicates={duplicates[:10]}"
+        )
+    if unexpected:
+        logger.warning("Ignoring %d unsolicited diarization assignments: %s", len(unexpected), unexpected[:10])
+        batch_result["assignments"] = [result for result in batch_result["assignments"] if result.get("id") in expected_ids]
+    return batch_result
 
 
 def _sanitize_tagged_text(original: str, tagged: Any) -> str:
@@ -276,9 +353,8 @@ def _apply_speaker_guardrails(
     reason: str,
 ) -> tuple[int | None, str, float | None]:
     """Correct two common local-model ID errors without inventing named speakers."""
-    has_closing_quote = "”" in text or ('"' in text and not text.rstrip().endswith('"'))
     starts_with_quote = text.lstrip().startswith(("“", '"'))
-    has_dialogue = has_closing_quote or starts_with_quote
+    has_dialogue = starts_with_quote or bool(_DIALOGUE_ATTRIBUTION_IN_SENTENCE_RE.search(text))
 
     if character_id == narrator_id and has_dialogue:
         attribution = _GENDERED_ATTRIBUTION_RE.search(f"{text} {next_text}")
@@ -288,7 +364,7 @@ def _apply_speaker_guardrails(
             if fallback_id is not None:
                 return fallback_id, f"Deterministic {gender} dialogue attribution to minor voice", 0.98
 
-    if character_id != narrator_id and not has_dialogue and _NARRATION_REASON_RE.search(reason):
+    if character_id != narrator_id and not has_dialogue:
         return narrator_id, "Deterministic prose/narration guardrail", 0.98
 
     return character_id, reason, None
@@ -299,12 +375,16 @@ async def _build_roster_excerpt(chapters, db: AsyncSession) -> str:
     candidates: list[tuple[Any, list[Any]]] = []
     for chapter in chapters:
         sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
+        if _starts_back_matter(sentences):
+            break
         if len(sentences) >= 40:
             candidates.append((chapter, sentences))
 
     if not candidates:
         for chapter in chapters:
             sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
+            if _starts_back_matter(sentences):
+                break
             if sentences:
                 candidates.append((chapter, sentences))
 
@@ -322,6 +402,7 @@ async def _build_roster_excerpt(chapters, db: AsyncSession) -> str:
 
 
 _CANDIDATE_TOKEN_RE = re.compile(r"\b[A-Z][a-z]{2,}\b")
+_FULL_NAME_RE = re.compile(r"\b([A-Z][a-z]{2,})\s+([A-Z][a-z]{2,})\b")
 _DIALOGUE_TAG_RE = re.compile(
     r"\b([A-Z][a-z]{2,})\s+(?:said|asked|replied|yelled|shouted|whispered|added|continued|noted|answered|"
     r"snapped|muttered|called|agreed|insisted)\b|\b(?:said|asked|replied|yelled|shouted|whispered|added|"
@@ -398,6 +479,111 @@ _CANDIDATE_STOP_WORDS = {
     "You",
     "Your",
 }
+_NAME_TITLE_WORDS = {
+    "Administrator",
+    "Admiral",
+    "Captain",
+    "Colonel",
+    "Corporal",
+    "Doctor",
+    "Doubtful",
+    "General",
+    "Lieutenant",
+    "Major",
+    "Master",
+    "Mister",
+    "Private",
+    "Professor",
+    "Sergeant",
+}
+_BACK_MATTER_HEADINGS = (
+    "ACKNOWLEDGMENTS",
+    "ACKNOWLEDGEMENTS",
+    "ABOUT THE AUTHOR",
+    "ALSO BY ",
+    "EXCERPT FROM",
+    "THIS IS A WORK OF FICTION",
+    "TOR BOOKS BY ",
+)
+_FIRST_PERSON_GENDER_RE = re.compile(
+    r"\bI(?:'m| am| was)\s+(?:an?\s+)?(?:old\s+|young\s+)?(man|male|widower|woman|female|widow)\b",
+    re.IGNORECASE,
+)
+
+
+def _starts_back_matter(sentences: list[Any]) -> bool:
+    if not sentences:
+        return False
+    heading = " ".join(str(sentences[0].original_text).split()).upper()
+    return any(heading.startswith(marker) for marker in _BACK_MATTER_HEADINGS)
+
+
+async def _infer_first_person_gender(chapters, db: AsyncSession) -> str | None:
+    counts: Counter[str] = Counter()
+    for chapter in chapters:
+        sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
+        if _starts_back_matter(sentences):
+            break
+        for sentence in sentences:
+            for match in _FIRST_PERSON_GENDER_RE.finditer(sentence.original_text):
+                token = match.group(1).casefold()
+                counts["male" if token in {"man", "male", "widower"} else "female"] += 1
+    if counts["male"] >= 1 and counts["male"] >= counts["female"] * 2:
+        return "male"
+    if counts["female"] >= 1 and counts["female"] >= counts["male"] * 2:
+        return "female"
+    return None
+
+
+def _infer_candidate_gender(texts: list[str], names: set[str]) -> str | None:
+    """Infer gender only when repeated, local pronoun evidence is decisive."""
+    pronouns: Counter[str] = Counter()
+    patterns = [re.compile(rf"\b{re.escape(name)}\b", re.IGNORECASE) for name in names if name]
+    self_intro_patterns = [
+        re.compile(
+            rf"^\s*[“\"]?{re.escape(name)}\s*[,.”\"]+\s*(she|he)\s+" r"(?:said|replied|answered)\b",
+            re.IGNORECASE,
+        )
+        for name in names
+        if " " in name
+    ]
+    for text in texts:
+        for pattern in self_intro_patterns:
+            match = pattern.search(text)
+            if match:
+                return "female" if match.group(1).casefold() == "she" else "male"
+        if not any(pattern.search(text) for pattern in patterns):
+            continue
+        pronouns.update(token.casefold() for token in re.findall(r"\b(?:he|him|his|she|her|hers)\b", text, re.I))
+    male = sum(pronouns[token] for token in ("he", "him", "his"))
+    female = sum(pronouns[token] for token in ("she", "her", "hers"))
+    if male >= 3 and male >= female * 2:
+        return "male"
+    if female >= 3 and female >= male * 2:
+        return "female"
+    return None
+
+
+def _normalise_voice_prompt(value: Any, *, gender: str | None = None) -> str:
+    """Keep OmniVoice parameters valid and apply evidence-backed gender."""
+    text = str(value or "")
+
+    def token(kind: str, allowed: set[str], default: str) -> str:
+        match = re.search(rf"\[{kind}-([^\]]+)\]", text, re.IGNORECASE)
+        candidate = match.group(1).casefold() if match else default
+        return candidate if candidate in allowed else default
+
+    selected_gender = gender or token("gender", {"male", "female", "neutral"}, "neutral")
+    parts = [
+        f"[gender-{selected_gender}]",
+        f"[pitch-{token('pitch', {'low', 'medium', 'high'}, 'medium')}]",
+        f"[speed-{token('speed', {'slow', 'normal', 'fast'}, 'normal')}]",
+    ]
+    accent = token("accent", {"british", "american", "australian"}, "")
+    if accent:
+        parts.append(f"[accent-{accent}]")
+    parts.append(f"[age-{token('age', {'young', 'middle', 'old'}, 'middle')}]")
+    return "".join(parts)
 
 
 async def _build_character_candidate_analysis(chapters, db: AsyncSession) -> tuple[str, list[dict[str, Any]]]:
@@ -406,21 +592,32 @@ async def _build_character_candidate_analysis(chapters, db: AsyncSession) -> tup
     contextual_counts: Counter[str] = Counter()
     dialogue_counts: Counter[str] = Counter()
     dialogue_examples: dict[str, str] = {}
+    full_name_counts: Counter[str] = Counter()
+    all_texts: list[str] = []
     for chapter in chapters:
-        for sentence in await crud.audiobook.get_sentences_for_chapter(db, chapter.id):
-            for match in _CANDIDATE_TOKEN_RE.finditer(sentence.original_text):
+        chapter_sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
+        if _starts_back_matter(chapter_sentences):
+            break
+        for sentence in chapter_sentences:
+            text = sentence.original_text
+            all_texts.append(text)
+            for match in _CANDIDATE_TOKEN_RE.finditer(text):
                 token = match.group(0)
                 if token in _CANDIDATE_STOP_WORDS:
                     continue
                 counts[token] += 1
                 if match.start() > 0:
                     contextual_counts[token] += 1
-            for match in _DIALOGUE_TAG_RE.finditer(sentence.original_text):
+            for match in _FULL_NAME_RE.finditer(text):
+                first, last = match.groups()
+                if first not in _CANDIDATE_STOP_WORDS and last not in _CANDIDATE_STOP_WORDS and first not in _NAME_TITLE_WORDS:
+                    full_name_counts[f"{first} {last}"] += 1
+            for match in _DIALOGUE_TAG_RE.finditer(text):
                 name = match.group(1) or match.group(2)
                 if name in _CANDIDATE_STOP_WORDS:
                     continue
                 dialogue_counts[name] += 1
-                dialogue_examples.setdefault(name, sentence.original_text[:220])
+                dialogue_examples.setdefault(name, text[:220])
 
     candidates = [
         (name, count, contextual_counts[name], dialogue_counts[name])
@@ -434,17 +631,60 @@ async def _build_character_candidate_analysis(chapters, db: AsyncSession) -> tup
         if dialogue_count and name in dialogue_examples:
             line += f'; example: "{dialogue_examples[name]}"'
         lines.append(line)
-    confirmed = [
-        {
-            "name": name,
-            "mention_count": count,
-            "dialogue_count": dialogue_count,
-            "evidence": dialogue_examples.get(name),
-        }
-        for name, count, _, dialogue_count in candidates
-        if dialogue_count >= 5
-    ]
-    required_names = ", ".join(candidate["name"] for candidate in confirmed[:12])
+    confirmed = []
+    for name, count, _, dialogue_count in candidates:
+        if dialogue_count < 5:
+            continue
+        surname_matches = [
+            (full_name, full_count) for full_name, full_count in full_name_counts.items() if full_name.split()[-1] == name
+        ]
+        first_name_matches = [
+            (full_name, full_count) for full_name, full_count in full_name_counts.items() if full_name.split()[0] == name
+        ]
+        matches = surname_matches or first_name_matches
+        canonical_name = max(matches, key=lambda item: (item[1], item[0]))[0] if matches else name
+        identity_names = {canonical_name} if " " in canonical_name else {name}
+        confirmed.append(
+            {
+                "name": name,
+                "canonical_name": canonical_name,
+                "mention_count": count,
+                "dialogue_count": dialogue_count,
+                "evidence": dialogue_examples.get(name),
+                "gender": _infer_candidate_gender(all_texts, identity_names),
+                "required": True,
+            }
+        )
+
+    # Full names are useful for validating an LLM-produced protagonist even
+    # when a first-person book rarely uses their name in dialogue tags. They
+    # are identity metadata only and are not promoted into the roster by
+    # themselves.
+    known_canonical_names = {candidate["canonical_name"].casefold() for candidate in confirmed}
+    for full_name, full_count in full_name_counts.most_common():
+        if full_count < 3 or full_name.casefold() in known_canonical_names:
+            continue
+        first, last = full_name.split()
+        if max(counts[first], counts[last]) < 8:
+            continue
+        confirmed.append(
+            {
+                "name": full_name,
+                "canonical_name": full_name,
+                "mention_count": full_count,
+                "dialogue_count": 0,
+                "evidence": next(
+                    (text[:220] for text in all_texts if re.search(rf"\b{re.escape(full_name)}\b", text)),
+                    None,
+                ),
+                "gender": _infer_candidate_gender(all_texts, {full_name}),
+                "required": False,
+            }
+        )
+        known_canonical_names.add(full_name.casefold())
+
+    required = [candidate for candidate in confirmed if candidate["required"]]
+    required_names = ", ".join(dict.fromkeys(candidate["canonical_name"] for candidate in required[:16]))
     heading = f"REQUIRED confirmed speakers (include all): {required_names}\n" if required_names else ""
     return heading + ("\n".join(lines) or "(none)"), confirmed
 
@@ -454,7 +694,102 @@ async def _build_character_candidate_hints(chapters, db: AsyncSession) -> str:
     return hints
 
 
-async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
+def _canonicalize_roster_characters(
+    characters: list[dict[str, Any]],
+    candidates: list[dict[str, Any]],
+    grounding_corpus: str,
+) -> list[dict[str, Any]]:
+    """Merge split identities and replace speculative biographies with facts."""
+    stats_by_canonical: dict[str, dict[str, Any]] = {}
+    identity_lookup: dict[str, str] = {}
+    for candidate in candidates:
+        canonical_name = str(candidate.get("canonical_name") or candidate["name"]).strip()
+        canonical_key = canonical_name.casefold()
+        stats = stats_by_canonical.setdefault(
+            canonical_key,
+            {
+                "canonical_name": canonical_name,
+                "names": set(),
+                "mention_count": 0,
+                "dialogue_count": 0,
+                "gender": None,
+                "gender_score": -1,
+                "required": False,
+            },
+        )
+        original_name = str(candidate["name"]).strip()
+        stats["names"].update({original_name, canonical_name})
+        stats["mention_count"] = max(stats["mention_count"], int(candidate.get("mention_count") or 0))
+        stats["dialogue_count"] = max(stats["dialogue_count"], int(candidate.get("dialogue_count") or 0))
+        stats["required"] = stats["required"] or bool(candidate.get("required", True))
+        gender = candidate.get("gender")
+        gender_score = int(candidate.get("dialogue_count") or 0) + int(candidate.get("mention_count") or 0)
+        if gender and gender_score > stats["gender_score"]:
+            stats["gender"] = gender
+            stats["gender_score"] = gender_score
+        identity_lookup[original_name.casefold()] = canonical_key
+        identity_lookup[canonical_key] = canonical_key
+
+    merged: dict[str, dict[str, Any]] = {}
+    for character in characters:
+        character = dict(character)
+        original_name = str(character["name"]).strip()
+        lookup_keys = [original_name.casefold(), *(str(alias).strip().casefold() for alias in character["aliases"])]
+        canonical_key = next((identity_lookup[key] for key in lookup_keys if key in identity_lookup), None)
+        stats = stats_by_canonical.get(canonical_key or "")
+        allowed_identity_names: set[str] = set()
+        if stats and not character["is_narrator"]:
+            character["name"] = stats["canonical_name"]
+            allowed_identity_names = {name.casefold() for name in stats["names"]}
+            character["aliases"] = [
+                *character["aliases"],
+                *(name for name in sorted(stats["names"]) if name.casefold() != character["name"].casefold()),
+            ]
+            if original_name.casefold() != character["name"].casefold():
+                character["aliases"] = [*character["aliases"], original_name]
+            dialogue_count = stats["dialogue_count"]
+            mention_count = stats["mention_count"]
+            if dialogue_count:
+                character["description"] = (
+                    f"Recurring speaking character identified from {dialogue_count} explicit dialogue "
+                    f"attributions and {mention_count} name mentions."
+                )
+            else:
+                character["description"] = f"Character identity grounded by {mention_count} full-name mentions."
+            evidence_gender = stats["gender"] or ("neutral" if stats["required"] else None)
+            character["voice_design_prompt"] = _normalise_voice_prompt(
+                character.get("voice_design_prompt"), gender=evidence_gender
+            )
+        elif not character["is_narrator"]:
+            character["description"] = "Speaking character identified from supplied story excerpts."
+            character["voice_design_prompt"] = _normalise_voice_prompt(character.get("voice_design_prompt"))
+
+        grounded_aliases = []
+        for alias in character["aliases"]:
+            value = " ".join(str(alias).split()).strip()
+            if not value or value.casefold() == character["name"].casefold():
+                continue
+            if value.casefold() in allowed_identity_names or value.casefold() in grounding_corpus:
+                grounded_aliases.append(value)
+        character["aliases"] = list(dict.fromkeys(grounded_aliases))[:10]
+
+        merge_key = character["name"].strip().casefold()
+        existing = merged.get(merge_key)
+        if existing is None:
+            merged[merge_key] = character
+            continue
+        existing["aliases"] = list(dict.fromkeys([*existing["aliases"], *character["aliases"]]))[:10]
+        existing["evidence"] = list(dict.fromkeys([*existing["evidence"], *character["evidence"]]))[:3]
+
+    return list(merged.values())
+
+
+async def generate_character_roster(
+    book_id: int,
+    db: AsyncSession,
+    *,
+    refresh_series_metadata: bool = False,
+) -> None:
     """Phase 2: extract characters from book text and persist to audiobook_characters."""
     settings = await crud.audiobook.get_audiobook_settings(db)
     provider = (settings.llm_provider or STUB_PROVIDER).lower() if settings else STUB_PROVIDER
@@ -481,6 +816,10 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
 
     combined_text = await _build_roster_excerpt(context_chapters, db)
     candidate_hints, confirmed_speakers = await _build_character_candidate_analysis(context_chapters, db)
+    first_person_gender = await _infer_first_person_gender(context_chapters, db)
+    prompt_series_profiles = series_profiles
+    if refresh_series_metadata and book.series:
+        prompt_series_profiles = await crud.audiobook.get_sibling_series_characters(db, book.series, book_id)
     series_roster = (
         json.dumps(
             [
@@ -490,11 +829,11 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
                     "description": profile.description,
                     "voice_design_prompt": profile.voice_design_prompt,
                 }
-                for profile in series_profiles
+                for profile in prompt_series_profiles
             ],
             ensure_ascii=False,
         )
-        if series_profiles
+        if prompt_series_profiles
         else "(none yet)"
     )
     await crud.audiobook.update_book_pipeline_progress(
@@ -557,19 +896,36 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
     if not isinstance(characters_data, list):
         raise RuntimeError(f"Expected a JSON array from LLM, got: {type(characters_data)}")
 
+    grounding_corpus = " ".join(combined_text.split()).casefold()
+    grounding_corpus += " " + " ".join(
+        " ".join(str(candidate.get("evidence") or "").split()).casefold() for candidate in confirmed_speakers
+    )
+
+    def grounded_evidence(items: Any) -> list[str]:
+        if not isinstance(items, list):
+            return []
+        grounded = []
+        for item in items:
+            value = " ".join(str(item).split()).strip(' "“”')
+            if len(value) >= 8 and value.casefold() in grounding_corpus:
+                grounded.append(value)
+        return grounded[:3]
+
     # Normalise keys to match our model
     normalised: list[dict] = []
     for c in characters_data:
         if not isinstance(c, dict):
             continue
+        description = c.get("description")
         normalised.append(
             {
                 "name": str(c.get("name", "Unknown")),
                 "aliases": [str(alias) for alias in c.get("aliases", []) if alias],
-                "description": c.get("description"),
-                "evidence": [str(item) for item in c.get("evidence", []) if item][:3],
+                "description": description,
+                "evidence": grounded_evidence(c.get("evidence")),
                 "voice_design_prompt": c.get("voice_design_prompt"),
                 "is_narrator": str(c.get("name", "")).strip().casefold() == "narrator",
+                "_is_protagonist": bool(re.search(r"\b(?:protagonist|first-person)\b", str(description or ""), re.IGNORECASE)),
             }
         )
     if not normalised:
@@ -593,6 +949,7 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
                         "evidence": character["evidence"],
                         "voice_design_prompt": "[gender-male][pitch-medium][speed-normal]",
                         "is_narrator": False,
+                        "_is_protagonist": True,
                     }
                 )
                 existing_names.add(canonical)
@@ -612,36 +969,57 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
                 "evidence": [],
                 "voice_design_prompt": "[gender-neutral][pitch-medium][speed-normal]",
                 "is_narrator": True,
+                "_is_protagonist": False,
             },
         )
+    for character in normalised:
+        if character["is_narrator"]:
+            character["name"] = "Narrator"
+            character["aliases"] = []
+            character["description"] = "Primary narrative voice for prose; not a story character."
+            character["evidence"] = []
+            character["_is_protagonist"] = False
     if promoted_protagonists:
         narrator_index = next(index for index, character in enumerate(normalised) if character["is_narrator"])
         for offset, protagonist in enumerate(promoted_protagonists, start=1):
             normalised.insert(narrator_index + offset, protagonist)
 
+    normalised = _canonicalize_roster_characters(normalised, confirmed_speakers, grounding_corpus)
+    if first_person_gender:
+        for character in normalised:
+            if character.get("_is_protagonist"):
+                character["voice_design_prompt"] = _normalise_voice_prompt(
+                    character.get("voice_design_prompt"), gender=first_person_gender
+                )
+
     def character_tokens(character: dict) -> set[str]:
         values = [character["name"], *character["aliases"]]
         return {token.casefold() for value in values for token in _CANDIDATE_TOKEN_RE.findall(value)}
 
-    represented_tokens = set().union(*(character_tokens(character) for character in normalised))
-    for candidate in confirmed_speakers[:12]:
-        canonical = candidate["name"].casefold()
-        if canonical in represented_tokens:
+    represented_names = {
+        value.strip().casefold() for character in normalised for value in [character["name"], *character["aliases"]]
+    }
+    required_speakers = [candidate for candidate in confirmed_speakers if candidate.get("required", True)][:16]
+    for candidate in required_speakers:
+        candidate_name = str(candidate.get("canonical_name") or candidate["name"])
+        canonical = candidate_name.casefold()
+        if canonical in represented_names:
             continue
         normalised.append(
             {
-                "name": candidate["name"],
-                "aliases": [],
+                "name": candidate_name,
+                "aliases": [candidate["name"]] if candidate["name"].casefold() != canonical else [],
                 "description": (
                     f"Recurring speaking character identified from {candidate['dialogue_count']} explicit "
-                    "dialogue attributions across the book."
+                    f"dialogue attributions and {candidate['mention_count']} name mentions."
                 ),
                 "evidence": [candidate["evidence"]] if candidate["evidence"] else [],
-                "voice_design_prompt": "[gender-neutral][pitch-medium][speed-normal]",
+                "voice_design_prompt": _normalise_voice_prompt(None, gender=candidate.get("gender") or "neutral"),
                 "is_narrator": False,
+                "_is_protagonist": False,
             }
         )
-        represented_tokens.add(canonical)
+        represented_names.update({canonical, candidate["name"].casefold()})
 
     protagonist_names = {character["name"].strip().casefold() for character in promoted_protagonists}
     if protagonist_names:
@@ -652,12 +1030,16 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
                 alias for alias in character["aliases"] if alias.strip().casefold() not in protagonist_names
             ]
 
-    dialogue_scores = {candidate["name"].casefold(): candidate["dialogue_count"] for candidate in confirmed_speakers}
+    dialogue_scores = {
+        name.casefold(): candidate["dialogue_count"]
+        for candidate in confirmed_speakers
+        for name in {candidate["name"], candidate.get("canonical_name") or candidate["name"]}
+    }
 
     def roster_priority(character: dict) -> tuple[int, int, str]:
         if character["is_narrator"]:
             return (3, 0, character["name"])
-        if "protagonist" in str(character.get("description") or "").casefold():
+        if character.get("_is_protagonist"):
             return (2, 0, character["name"])
         score = max((dialogue_scores.get(token, 0) for token in character_tokens(character)), default=0)
         return (1, score, character["name"])
@@ -667,7 +1049,7 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
     if provider != STUB_PROVIDER:
         # Reserve stable voices for one-scene and unnamed dialogue without
         # allowing hundreds of cameos to crowd recurring characters out.
-        normalised = normalised[:13]
+        normalised = normalised[:18]
         normalised.extend(
             [
                 {
@@ -677,6 +1059,7 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
                     "evidence": [],
                     "voice_design_prompt": "[gender-female][pitch-medium][speed-normal]",
                     "is_narrator": False,
+                    "_is_protagonist": False,
                 },
                 {
                     "name": "Minor Male Voice",
@@ -685,6 +1068,7 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
                     "evidence": [],
                     "voice_design_prompt": "[gender-male][pitch-medium][speed-normal]",
                     "is_narrator": False,
+                    "_is_protagonist": False,
                 },
             ]
         )
@@ -694,34 +1078,42 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
         profile = shared_by_name.get(" ".join(character["name"].casefold().split()))
         if profile is None:
             continue
-        character.update(
-            {
-                "series_character_id": profile.id,
-                "name": profile.name,
-                "description": profile.description,
-                "voice_design_prompt": profile.voice_design_prompt,
-                "is_narrator": profile.is_narrator,
-                "aliases": profile.aliases or [],
-                "evidence": profile.evidence or [],
-            }
-        )
+        if refresh_series_metadata:
+            character["series_character_id"] = profile.id
+        else:
+            character.update(
+                {
+                    "series_character_id": profile.id,
+                    "name": profile.name,
+                    "description": profile.description,
+                    "voice_design_prompt": profile.voice_design_prompt,
+                    "is_narrator": profile.is_narrator,
+                    "aliases": profile.aliases or [],
+                    "evidence": profile.evidence or [],
+                }
+            )
+
+    for character in normalised:
+        character.pop("_is_protagonist", None)
 
     await crud.audiobook.delete_characters_for_book(db, book_id)
     created_characters = await crud.audiobook.create_characters_bulk(
         db,
         book_id=book_id,
-        characters_data=normalised[:15],
+        characters_data=normalised[:20],
     )
     if book.series:
         await crud.audiobook.sync_book_roster_with_series(
             db,
             book,
             created_characters,
-            prefer_series=True,
+            prefer_series=not refresh_series_metadata,
         )
+        if refresh_series_metadata:
+            await crud.audiobook.delete_orphaned_series_characters(db, book.series)
     await crud.audiobook.set_book_audiobook_summary(db, book_id, roster_result.get("book_summary"))
     await crud.audiobook.update_book_pipeline_progress(
-        db, book_id, current=1, total=1, detail=f"Created {len(normalised[:15])} character profiles"
+        db, book_id, current=1, total=1, detail=f"Created {len(normalised[:20])} character profiles"
     )
     logger.info("Created %d characters for book %s.", len(normalised), book_id)
     if not await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):
@@ -739,7 +1131,16 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
     minor_female_id = next((character.id for character in characters if character.name == "Minor Female Voice"), None)
     minor_male_id = next((character.id for character in characters if character.name == "Minor Male Voice"), None)
     roster_json = json.dumps(
-        [{"id": c.id, "name": c.name, "description": c.description, "is_narrator": c.is_narrator} for c in characters],
+        [
+            {
+                "id": c.id,
+                "name": c.name,
+                "aliases": c.aliases or [],
+                "description": c.description,
+                "is_narrator": c.is_narrator,
+            }
+            for c in characters
+        ],
         ensure_ascii=False,
     )
 
@@ -747,7 +1148,8 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
     counts = await crud.audiobook.count_sentences_by_status(db, book_id)
     total = sum(counts.values())
     processed = total - counts.get("pending_diarization", 0)
-    batch_size = 40
+    batch_size = MAX_DIARIZATION_BATCH_SIZE
+    smaller_batch_successes = 0
     await crud.audiobook.update_book_pipeline_progress(
         db, book_id, current=processed, total=total, detail="Preparing dialogue attribution"
     )
@@ -854,12 +1256,62 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
                 try:
                     batch_result = _extract_json(raw)
                 except json.JSONDecodeError as exc:
-                    raise RuntimeError(f"LLM returned invalid JSON for diarization: {exc}\nRaw: {raw[:500]}") from exc
+                    if batch_size > MIN_DIARIZATION_BATCH_SIZE:
+                        smaller_batch_size = max(MIN_DIARIZATION_BATCH_SIZE, batch_size // 2)
+                        logger.warning(
+                            "Invalid diarization JSON for book %s at batch size %s; retrying %s sentences: %s",
+                            book_id,
+                            batch_size,
+                            smaller_batch_size,
+                            exc,
+                        )
+                        batch_size = smaller_batch_size
+                        smaller_batch_successes = 0
+                        await crud.audiobook.update_book_pipeline_progress(
+                            db,
+                            book_id,
+                            current=processed,
+                            total=total,
+                            detail=f"Retrying malformed model output with {batch_size} sentences",
+                        )
+                        continue
+                    raw_excerpt = f"{raw[:500]}\n...\n{raw[-500:]}" if len(raw) > 1000 else raw
+                    raise RuntimeError(
+                        f"LLM returned invalid JSON for diarization after smaller-batch retries: {exc}\n" f"Raw: {raw_excerpt}"
+                    ) from exc
 
-            if isinstance(batch_result, list):
-                batch_result = {"assignments": batch_result, "chapter_summary": chapter.summary}
-            if not isinstance(batch_result, dict) or not isinstance(batch_result.get("assignments"), list):
-                raise RuntimeError(f"Expected a JSON object from diarization, got: {type(batch_result)}")
+            try:
+                batch_result = _normalise_diarization_result(
+                    batch_result,
+                    {sentence.id for sentence in batch},
+                )
+            except ValueError as exc:
+                if provider != STUB_PROVIDER and batch_size > MIN_DIARIZATION_BATCH_SIZE:
+                    smaller_batch_size = max(MIN_DIARIZATION_BATCH_SIZE, batch_size // 2)
+                    logger.warning(
+                        "Incomplete diarization response for book %s at batch size %s; retrying %s sentences: %s",
+                        book_id,
+                        batch_size,
+                        smaller_batch_size,
+                        exc,
+                    )
+                    batch_size = smaller_batch_size
+                    smaller_batch_successes = 0
+                    await crud.audiobook.update_book_pipeline_progress(
+                        db,
+                        book_id,
+                        current=processed,
+                        total=total,
+                        detail=f"Retrying incomplete model output with {batch_size} sentences",
+                    )
+                    continue
+                raise RuntimeError(f"Invalid diarization response: {exc}") from exc
+
+            if batch_size < MAX_DIARIZATION_BATCH_SIZE:
+                smaller_batch_successes += 1
+                if smaller_batch_successes >= 2:
+                    batch_size = min(MAX_DIARIZATION_BATCH_SIZE, batch_size * 2)
+                    smaller_batch_successes = 0
             results = batch_result["assignments"]
 
             result_map = {r["id"]: r for r in results if isinstance(r, dict) and isinstance(r.get("id"), int)}

--- a/backend/app/services/audiobook_llm.py
+++ b/backend/app/services/audiobook_llm.py
@@ -117,7 +117,8 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
     chapters = await crud.audiobook.get_chapters_for_book(db, book_id)
     if not chapters:
         logger.warning("No chapters found for book %s during roster generation.", book_id)
-        await crud.audiobook.set_book_pipeline_status(db, book_id, "diarizing")
+        if await crud.audiobook.get_book_pipeline_status(db, book_id) != "paused":
+            await crud.audiobook.set_book_pipeline_status(db, book_id, "diarizing")
         return
 
     # Collect text from up to 5 chapters (keeps prompt size manageable)
@@ -155,7 +156,8 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
 
     await crud.audiobook.create_characters_bulk(db, book_id=book_id, characters_data=normalised)
     logger.info("Created %d characters for book %s.", len(normalised), book_id)
-    await crud.audiobook.set_book_pipeline_status(db, book_id, "diarizing")
+    if await crud.audiobook.get_book_pipeline_status(db, book_id) != "paused":
+        await crud.audiobook.set_book_pipeline_status(db, book_id, "diarizing")
 
 
 async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
@@ -174,6 +176,10 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
     batch_size = 50
 
     while True:
+        if await crud.audiobook.get_book_pipeline_status(db, book_id) == "paused":
+            logger.info("Book %s paused during diarization.", book_id)
+            return
+
         batch = await crud.audiobook.get_sentences_pending_diarization(db, book_id, limit=batch_size)
         if not batch:
             break
@@ -209,4 +215,5 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
             context_window.append(sentence.original_text)
 
     logger.info("Diarization complete for book %s.", book_id)
-    await crud.audiobook.set_book_pipeline_status(db, book_id, "audio_gen")
+    if await crud.audiobook.get_book_pipeline_status(db, book_id) != "paused":
+        await crud.audiobook.set_book_pipeline_status(db, book_id, "audio_gen")

--- a/backend/app/services/audiobook_llm.py
+++ b/backend/app/services/audiobook_llm.py
@@ -12,7 +12,7 @@ import httpx
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import crud
-from ..models import AudiobookSettings
+from ..models import AudiobookSettings, Book
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +42,9 @@ Return JSON with keys book_summary and characters. No markdown or explanation.
 
 Candidate name frequency hints from the complete book (not ground truth; ignore non-people):
 {candidate_hints}
+
+Existing shared roster for this series (reuse these canonical identities and voice profiles when they appear):
+{series_roster}
 
 Names with explicit dialogue-tag hits (for example, "Harry said") are confirmed speaking candidates. Include the
 highest-hit confirmed speakers unless the evidence clearly shows they are not a person. Do not substitute low-count
@@ -456,14 +459,54 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
     settings = await crud.audiobook.get_audiobook_settings(db)
     provider = (settings.llm_provider or STUB_PROVIDER).lower() if settings else STUB_PROVIDER
 
+    book = await db.get(Book, book_id)
+    if book is None:
+        raise RuntimeError(f"Book {book_id} was deleted during roster generation.")
+
     chapters = await crud.audiobook.get_chapters_for_book(db, book_id)
     if not chapters:
         raise RuntimeError(f"No narratable chapters found for book {book_id} during roster generation.")
 
-    combined_text = await _build_roster_excerpt(chapters, db)
-    candidate_hints, confirmed_speakers = await _build_character_candidate_analysis(chapters, db)
+    context_chapters = list(chapters)
+    series_profiles = []
+    series_book_count = 1
+    if book.series:
+        series_profiles = await crud.audiobook.get_series_characters(db, book.series)
+        sibling_books = await crud.get_books_by_series(db, book.series, skip=0, limit=1000)
+        series_book_count = len(sibling_books)
+        for sibling in sibling_books:
+            if sibling.id == book_id:
+                continue
+            context_chapters.extend(await crud.audiobook.get_chapters_for_book(db, sibling.id))
+
+    combined_text = await _build_roster_excerpt(context_chapters, db)
+    candidate_hints, confirmed_speakers = await _build_character_candidate_analysis(context_chapters, db)
+    series_roster = (
+        json.dumps(
+            [
+                {
+                    "name": profile.name,
+                    "aliases": profile.aliases or [],
+                    "description": profile.description,
+                    "voice_design_prompt": profile.voice_design_prompt,
+                }
+                for profile in series_profiles
+            ],
+            ensure_ascii=False,
+        )
+        if series_profiles
+        else "(none yet)"
+    )
     await crud.audiobook.update_book_pipeline_progress(
-        db, book_id, current=0, total=1, detail="Analyzing story excerpts for recurring characters"
+        db,
+        book_id,
+        current=0,
+        total=1,
+        detail=(
+            f"Analyzing recurring characters across {series_book_count} series books"
+            if book.series and series_book_count > 1
+            else "Analyzing story excerpts for recurring characters"
+        ),
     )
 
     if provider == STUB_PROVIDER:
@@ -482,7 +525,11 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
         }
     else:
         prompt_template = settings.roster_prompt_template or DEFAULT_ROSTER_PROMPT
-        prompt = prompt_template.format(text=combined_text, candidate_hints=candidate_hints)
+        prompt = prompt_template.format(
+            text=combined_text,
+            candidate_hints=candidate_hints,
+            series_roster=series_roster,
+        )
         logger.info("Calling LLM for character roster (book %s).", book_id)
         await crud.audiobook.update_book_pipeline_progress(
             db,
@@ -642,8 +689,36 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
             ]
         )
 
+    shared_by_name = {profile.canonical_name: profile for profile in series_profiles}
+    for character in normalised:
+        profile = shared_by_name.get(" ".join(character["name"].casefold().split()))
+        if profile is None:
+            continue
+        character.update(
+            {
+                "series_character_id": profile.id,
+                "name": profile.name,
+                "description": profile.description,
+                "voice_design_prompt": profile.voice_design_prompt,
+                "is_narrator": profile.is_narrator,
+                "aliases": profile.aliases or [],
+                "evidence": profile.evidence or [],
+            }
+        )
+
     await crud.audiobook.delete_characters_for_book(db, book_id)
-    await crud.audiobook.create_characters_bulk(db, book_id=book_id, characters_data=normalised[:15])
+    created_characters = await crud.audiobook.create_characters_bulk(
+        db,
+        book_id=book_id,
+        characters_data=normalised[:15],
+    )
+    if book.series:
+        await crud.audiobook.sync_book_roster_with_series(
+            db,
+            book,
+            created_characters,
+            prefer_series=True,
+        )
     await crud.audiobook.set_book_audiobook_summary(db, book_id, roster_result.get("book_summary"))
     await crud.audiobook.update_book_pipeline_progress(
         db, book_id, current=1, total=1, detail=f"Created {len(normalised[:15])} character profiles"

--- a/backend/app/services/audiobook_llm.py
+++ b/backend/app/services/audiobook_llm.py
@@ -108,6 +108,15 @@ _DIALOGUE_ATTRIBUTION_IN_SENTENCE_RE = re.compile(
     r"\b(?:said|asked|replied|yelled|shouted|whispered|muttered|added|continued|answered|snapped)\b" r"[^“\"]{0,80}[“\"]",
     re.IGNORECASE,
 )
+_ATTRIBUTION_VERBS = (
+    "said|asked|replied|yelled|shouted|whispered|muttered|added|continued|answered|snapped|reminded|"
+    "repeated|remarked|responded|interrupted"
+)
+_GENERIC_SPEAKER_ROLES = ("recruiter", "doctor", "nurse", "clerk", "manager", "officer", "soldier", "guard", "pilot")
+_GENERIC_ROLE_ATTRIBUTION_RE = re.compile(
+    rf"\b(?:the\s+)?(?P<role>{'|'.join(_GENERIC_SPEAKER_ROLES)})\s+(?:{_ATTRIBUTION_VERBS})\b",
+    re.IGNORECASE,
+)
 MAX_DIARIZATION_BATCH_SIZE = 10
 MIN_DIARIZATION_BATCH_SIZE = 5
 MIN_STORY_CHAPTER_SENTENCES = 40
@@ -197,7 +206,11 @@ async def _call_llm(
             "stream": False,
             "think": False,
             "format": response_schema or "json",
-            "options": {"temperature": 0, "num_ctx": 32768, "num_predict": 8192},
+            "options": {
+                "temperature": 0,
+                "num_ctx": 32768,
+                "num_predict": 8192 if response_schema is ROSTER_SCHEMA else 2048,
+            },
             "keep_alive": "30m",
         }
         timeout = httpx.Timeout(600.0, connect=10.0)
@@ -356,6 +369,9 @@ def _apply_speaker_guardrails(
     character_id: int | None,
     narrator_id: int | None,
     protagonist_id: int | None,
+    character_name_ids: dict[str, int],
+    role_speaker_ids: dict[str, int],
+    last_dialogue_speaker_id: int | None,
     minor_female_id: int | None,
     minor_male_id: int | None,
     reason: str,
@@ -364,6 +380,16 @@ def _apply_speaker_guardrails(
     starts_with_quote = text.lstrip().startswith(("“", '"'))
     has_quote = any(quote in text for quote in ("“", "”", '"'))
     has_dialogue = starts_with_quote or bool(_DIALOGUE_ATTRIBUTION_IN_SENTENCE_RE.search(text))
+
+    attribution_context = f"{text} {next_text if starts_with_quote else ''}"
+    for name, attributed_character_id in character_name_ids.items():
+        escaped_name = re.escape(name)
+        if re.search(
+            rf"(?:\b{escaped_name}\s+(?:{_ATTRIBUTION_VERBS})\b|\b(?:{_ATTRIBUTION_VERBS})\s+{escaped_name}\b)",
+            attribution_context,
+            re.IGNORECASE,
+        ):
+            return attributed_character_id, f"Deterministic named dialogue attribution to {name}", 0.99
 
     current_first_person = _FIRST_PERSON_ATTRIBUTION_RE.search(text)
     next_first_person = starts_with_quote and _FIRST_PERSON_ATTRIBUTION_RE.match(next_text.lstrip())
@@ -378,6 +404,14 @@ def _apply_speaker_guardrails(
         fallback_id = minor_female_id if gender == "she" else minor_male_id
         if fallback_id is not None:
             return fallback_id, f"Deterministic {gender} dialogue attribution to minor voice", 0.98
+
+    role_attribution = _GENERIC_ROLE_ATTRIBUTION_RE.search(attribution_context) if has_quote else None
+    if role_attribution:
+        role_speaker_id = role_speaker_ids.get(role_attribution.group("role").casefold())
+        if role_speaker_id is not None:
+            return role_speaker_id, "Deterministic grounded role dialogue attribution", 0.98
+        if last_dialogue_speaker_id is not None:
+            return last_dialogue_speaker_id, "Deterministic recurring role dialogue attribution", 0.9
 
     if character_id == narrator_id and starts_with_quote and protagonist_id is not None:
         return protagonist_id, "Deterministic first-person dialogue fallback", 0.75
@@ -412,6 +446,25 @@ def _advance_open_dialogue_speaker(
     if closes > opens:
         return None
     return current_open_speaker_id
+
+
+def _infer_role_speaker_ids(sentences: list[Any], minor_female_id: int | None, minor_male_id: int | None) -> dict[str, int]:
+    """Ground recurring unnamed roles in repeated chapter-local pronouns."""
+    result: dict[str, int] = {}
+    for role in _GENERIC_SPEAKER_ROLES:
+        pronouns: Counter[str] = Counter()
+        role_pattern = re.compile(rf"\b{re.escape(role)}\b", re.IGNORECASE)
+        for sentence in sentences:
+            text = sentence.original_text
+            if role_pattern.search(text):
+                pronouns.update(token.casefold() for token in re.findall(r"\b(?:she|her|he|him|his)\b", text, re.I))
+        female = pronouns["she"] + pronouns["her"]
+        male = pronouns["he"] + pronouns["him"] + pronouns["his"]
+        if minor_female_id is not None and female >= 1 and female >= male * 2:
+            result[role] = minor_female_id
+        elif minor_male_id is not None and male >= 1 and male >= female * 2:
+            result[role] = minor_male_id
+    return result
 
 
 async def _build_roster_excerpt(chapters, db: AsyncSession) -> str:
@@ -1186,6 +1239,13 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
     )
     minor_female_id = next((character.id for character in characters if character.name == "Minor Female Voice"), None)
     minor_male_id = next((character.id for character in characters if character.name == "Minor Male Voice"), None)
+    character_name_ids = {
+        name.casefold(): character.id
+        for character in characters
+        if not character.is_narrator and character.id not in {minor_female_id, minor_male_id}
+        for name in sorted([character.name, *(character.aliases or [])], key=len, reverse=True)
+        if len(name.strip()) >= 3
+    }
     roster_json = json.dumps(
         [
             {
@@ -1217,6 +1277,7 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
             return
 
         chapter_sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
+        role_speaker_ids = _infer_role_speaker_ids(chapter_sentences, minor_female_id, minor_male_id)
         pending = [sentence for sentence in chapter_sentences if sentence.status == "pending_diarization"]
         if not pending:
             continue
@@ -1253,9 +1314,15 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
             sentence.original_text for sentence in chapter_sentences if sentence.status != "pending_diarization"
         ][-8:]
         open_dialogue_speaker_id = None
+        last_dialogue_speaker_id = None
         for previous_sentence in chapter_sentences:
             if previous_sentence.status == "pending_diarization":
                 break
+            was_open_dialogue = open_dialogue_speaker_id is not None
+            if previous_sentence.character_id != narrator_id and (
+                was_open_dialogue or any(quote in previous_sentence.original_text for quote in ("“", "”", '"'))
+            ):
+                last_dialogue_speaker_id = previous_sentence.character_id
             open_dialogue_speaker_id = _advance_open_dialogue_speaker(
                 previous_sentence.original_text,
                 previous_sentence.character_id,
@@ -1270,6 +1337,39 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
             )
             if not batch:
                 break
+
+            # Quote-free prose cannot be a spoken character line. Commit the
+            # unambiguous prefix before asking the local model about the next
+            # dialogue span; long prose should never inflate a dialogue call.
+            deterministic_prefix = []
+            if open_dialogue_speaker_id is None:
+                for sentence in batch:
+                    if any(quote in sentence.original_text for quote in ("“", "”", '"')):
+                        break
+                    deterministic_prefix.append(sentence)
+            if deterministic_prefix:
+                for sentence in deterministic_prefix:
+                    await crud.audiobook.update_sentence_diarization(
+                        db,
+                        sentence.id,
+                        narrator_id,
+                        sentence.original_text,
+                        speaker_confidence=0.99,
+                        speaker_reason="Deterministic quote-free narration",
+                    )
+                    context_window.append(sentence.original_text)
+                processed += len(deterministic_prefix)
+                await crud.audiobook.update_book_pipeline_progress(
+                    db,
+                    book_id,
+                    current=processed,
+                    total=total,
+                    detail=f"Chapter {chapter.chapter_number}: short-circuited quote-free prose",
+                )
+                if await crud.audiobook.consume_book_batch_limit(db, book_id):
+                    logger.info("Book %s paused after one deterministic narration batch.", book_id)
+                    return
+                continue
 
             sentences_json = json.dumps(
                 [{"id": s.id, "text": s.original_text} for s in batch],
@@ -1405,6 +1505,9 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
                     character_id=char_id,
                     narrator_id=narrator_id,
                     protagonist_id=protagonist_id,
+                    character_name_ids=character_name_ids,
+                    role_speaker_ids=role_speaker_ids,
+                    last_dialogue_speaker_id=last_dialogue_speaker_id,
                     minor_female_id=minor_female_id,
                     minor_male_id=minor_male_id,
                     reason=reason,
@@ -1415,6 +1518,10 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
                     char_id = open_dialogue_speaker_id
                     reason = "Deterministic continuation of open quoted dialogue"
                     confidence = 0.95
+                if char_id != narrator_id and (
+                    open_dialogue_speaker_id is not None or any(quote in sentence.original_text for quote in ("“", "”", '"'))
+                ):
+                    last_dialogue_speaker_id = char_id
                 open_dialogue_speaker_id = _advance_open_dialogue_speaker(
                     sentence.original_text,
                     char_id,

--- a/backend/app/services/audiobook_llm.py
+++ b/backend/app/services/audiobook_llm.py
@@ -382,14 +382,19 @@ def _apply_speaker_guardrails(
     has_dialogue = starts_with_quote or bool(_DIALOGUE_ATTRIBUTION_IN_SENTENCE_RE.search(text))
 
     attribution_context = f"{text} {next_text if starts_with_quote else ''}"
-    for name, attributed_character_id in character_name_ids.items():
-        escaped_name = re.escape(name)
-        if re.search(
-            rf"(?:\b{escaped_name}\s+(?:{_ATTRIBUTION_VERBS})\b|\b(?:{_ATTRIBUTION_VERBS})\s+{escaped_name}\b)",
-            attribution_context,
-            re.IGNORECASE,
-        ):
-            return attributed_character_id, f"Deterministic named dialogue attribution to {name}", 0.99
+    named_contexts = [text]
+    if starts_with_quote and next_text:
+        named_contexts.append(next_text)
+    for named_context in named_contexts:
+        for name, attributed_character_id in character_name_ids.items():
+            escaped_name = re.escape(name)
+            if re.search(
+                rf"(?:\b{escaped_name}\s+(?:{_ATTRIBUTION_VERBS})\b|"
+                rf"\b(?:{_ATTRIBUTION_VERBS})\s+{escaped_name}\b)",
+                named_context,
+                re.IGNORECASE,
+            ):
+                return attributed_character_id, f"Deterministic named dialogue attribution to {name}", 0.99
 
     current_first_person = _FIRST_PERSON_ATTRIBUTION_RE.search(text)
     next_first_person = starts_with_quote and _FIRST_PERSON_ATTRIBUTION_RE.match(next_text.lstrip())
@@ -413,6 +418,14 @@ def _apply_speaker_guardrails(
         if last_dialogue_speaker_id is not None:
             return last_dialogue_speaker_id, "Deterministic recurring role dialogue attribution", 0.9
 
+    if (
+        starts_with_quote
+        and protagonist_id is not None
+        and character_id != protagonist_id
+        and last_dialogue_speaker_id in {minor_female_id, minor_male_id}
+    ):
+        return protagonist_id, "Deterministic first-person turn-taking fallback", 0.8
+
     if character_id == narrator_id and starts_with_quote and protagonist_id is not None:
         return protagonist_id, "Deterministic first-person dialogue fallback", 0.75
 
@@ -431,21 +444,44 @@ def _advance_open_dialogue_speaker(
     minor_male_id: int | None,
     current_open_speaker_id: int | None,
 ) -> int | None:
-    """Track a curly-quoted utterance split across sentence records."""
-    opens = text.count("“")
-    closes = text.count("”")
-    if opens > closes:
-        prefix = text.rsplit("“", 1)[0]
-        pronouns = re.findall(r"\b(she|her|he|him)\b", prefix[-120:], re.IGNORECASE)
+    """Track quoted speech in source order, including close-then-reopen lines."""
+    open_speaker_id = current_open_speaker_id
+    for quote in re.finditer("[“”]", text):
+        if quote.group(0) == "”":
+            open_speaker_id = None
+            continue
+
+        # A repeated opening quote while a speaker is already active is the
+        # conventional marker for a new paragraph in the same long speech.
+        if open_speaker_id is not None:
+            continue
+
+        prefix = text[max(0, quote.start() - 120):quote.start()]
+        pronouns = re.findall(r"\b(she|her|he|him)\b", prefix, re.IGNORECASE)
         if pronouns:
             gender = pronouns[-1].casefold()
-            return minor_female_id if gender in {"she", "her"} else minor_male_id
-        if resolved_character_id != narrator_id:
-            return resolved_character_id
-        return None
-    if closes > opens:
-        return None
-    return current_open_speaker_id
+            open_speaker_id = minor_female_id if gender in {"she", "her"} else minor_male_id
+        elif resolved_character_id != narrator_id:
+            open_speaker_id = resolved_character_id
+    return open_speaker_id
+
+
+def _fallback_open_dialogue_speaker(
+    text: str,
+    inferred_open_speaker_id: int | None,
+    *,
+    protagonist_id: int | None,
+    last_dialogue_speaker_id: int | None,
+    last_other_dialogue_speaker_id: int | None,
+) -> int | None:
+    """Resolve an unattributed opening quote from established turn-taking."""
+    if inferred_open_speaker_id is not None or text.count("“") <= text.count("”"):
+        return inferred_open_speaker_id
+    if last_dialogue_speaker_id == protagonist_id and last_other_dialogue_speaker_id is not None:
+        return last_other_dialogue_speaker_id
+    if protagonist_id is not None and last_dialogue_speaker_id not in {None, protagonist_id}:
+        return protagonist_id
+    return None
 
 
 def _infer_role_speaker_ids(sentences: list[Any], minor_female_id: int | None, minor_male_id: int | None) -> dict[str, int]:
@@ -1315,6 +1351,7 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
         ][-8:]
         open_dialogue_speaker_id = None
         last_dialogue_speaker_id = None
+        last_other_dialogue_speaker_id = None
         for previous_sentence in chapter_sentences:
             if previous_sentence.status == "pending_diarization":
                 break
@@ -1323,13 +1360,22 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
                 was_open_dialogue or any(quote in previous_sentence.original_text for quote in ("“", "”", '"'))
             ):
                 last_dialogue_speaker_id = previous_sentence.character_id
-            open_dialogue_speaker_id = _advance_open_dialogue_speaker(
+                if previous_sentence.character_id != protagonist_id:
+                    last_other_dialogue_speaker_id = previous_sentence.character_id
+            inferred_open_speaker_id = _advance_open_dialogue_speaker(
                 previous_sentence.original_text,
                 previous_sentence.character_id,
                 narrator_id=narrator_id,
                 minor_female_id=minor_female_id,
                 minor_male_id=minor_male_id,
                 current_open_speaker_id=open_dialogue_speaker_id,
+            )
+            open_dialogue_speaker_id = _fallback_open_dialogue_speaker(
+                previous_sentence.original_text,
+                inferred_open_speaker_id,
+                protagonist_id=protagonist_id,
+                last_dialogue_speaker_id=last_dialogue_speaker_id,
+                last_other_dialogue_speaker_id=last_other_dialogue_speaker_id,
             )
         while True:
             batch = await crud.audiobook.get_sentences_pending_diarization(
@@ -1366,6 +1412,9 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
                     total=total,
                     detail=f"Chapter {chapter.chapter_number}: short-circuited quote-free prose",
                 )
+                if await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):
+                    logger.info("Book %s paused after a deterministic narration batch.", book_id)
+                    return
                 if await crud.audiobook.consume_book_batch_limit(db, book_id):
                     logger.info("Book %s paused after one deterministic narration batch.", book_id)
                     return
@@ -1514,7 +1563,7 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
                 )
                 if guardrail_confidence is not None:
                     confidence = guardrail_confidence
-                if open_dialogue_speaker_id is not None and char_id == narrator_id:
+                if open_dialogue_speaker_id is not None and char_id != open_dialogue_speaker_id:
                     char_id = open_dialogue_speaker_id
                     reason = "Deterministic continuation of open quoted dialogue"
                     confidence = 0.95
@@ -1522,13 +1571,22 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
                     open_dialogue_speaker_id is not None or any(quote in sentence.original_text for quote in ("“", "”", '"'))
                 ):
                     last_dialogue_speaker_id = char_id
-                open_dialogue_speaker_id = _advance_open_dialogue_speaker(
+                    if char_id != protagonist_id:
+                        last_other_dialogue_speaker_id = char_id
+                inferred_open_speaker_id = _advance_open_dialogue_speaker(
                     sentence.original_text,
                     char_id,
                     narrator_id=narrator_id,
                     minor_female_id=minor_female_id,
                     minor_male_id=minor_male_id,
                     current_open_speaker_id=open_dialogue_speaker_id,
+                )
+                open_dialogue_speaker_id = _fallback_open_dialogue_speaker(
+                    sentence.original_text,
+                    inferred_open_speaker_id,
+                    protagonist_id=protagonist_id,
+                    last_dialogue_speaker_id=last_dialogue_speaker_id,
+                    last_other_dialogue_speaker_id=last_other_dialogue_speaker_id,
                 )
                 await crud.audiobook.update_sentence_diarization(
                     db,
@@ -1551,6 +1609,9 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
                 total=total,
                 detail=f"Chapter {chapter.chapter_number}: attributed {processed} of {total} sentences",
             )
+            if await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):
+                logger.info("Book %s paused after a diarization batch.", book_id)
+                return
             if await crud.audiobook.consume_book_batch_limit(db, book_id):
                 logger.info("Book %s paused after one diarization batch.", book_id)
                 return

--- a/backend/app/services/audiobook_llm.py
+++ b/backend/app/services/audiobook_llm.py
@@ -166,10 +166,7 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
 
     characters = await crud.audiobook.get_characters_for_book(db, book_id)
     roster_json = json.dumps(
-        [
-            {"id": c.id, "name": c.name, "description": c.description, "is_narrator": c.is_narrator}
-            for c in characters
-        ],
+        [{"id": c.id, "name": c.name, "description": c.description, "is_narrator": c.is_narrator} for c in characters],
         ensure_ascii=False,
     )
 

--- a/backend/app/services/audiobook_llm.py
+++ b/backend/app/services/audiobook_llm.py
@@ -389,8 +389,7 @@ def _apply_speaker_guardrails(
         for name, attributed_character_id in character_name_ids.items():
             escaped_name = re.escape(name)
             if re.search(
-                rf"(?:\b{escaped_name}\s+(?:{_ATTRIBUTION_VERBS})\b|"
-                rf"\b(?:{_ATTRIBUTION_VERBS})\s+{escaped_name}\b)",
+                rf"(?:\b{escaped_name}\s+(?:{_ATTRIBUTION_VERBS})\b|" rf"\b(?:{_ATTRIBUTION_VERBS})\s+{escaped_name}\b)",
                 named_context,
                 re.IGNORECASE,
             ):
@@ -456,7 +455,9 @@ def _advance_open_dialogue_speaker(
         if open_speaker_id is not None:
             continue
 
-        prefix = text[max(0, quote.start() - 120):quote.start()]
+        prefix_end = quote.start()
+        prefix_start = max(0, prefix_end - 120)
+        prefix = text[prefix_start:prefix_end]
         pronouns = re.findall(r"\b(she|her|he|him)\b", prefix, re.IGNORECASE)
         if pronouns:
             gender = pronouns[-1].casefold()

--- a/backend/app/services/audiobook_llm.py
+++ b/backend/app/services/audiobook_llm.py
@@ -14,6 +14,8 @@ from ..models import AudiobookSettings
 
 logger = logging.getLogger(__name__)
 
+STUB_PROVIDER = "stub"
+
 DEFAULT_ROSTER_PROMPT = """\
 You are a literary analyst. Analyze the following text excerpt from a book and extract a list of all named \
 characters (including the narrator if the text uses first person).
@@ -111,15 +113,11 @@ def _extract_json(raw: str) -> Any:
 async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
     """Phase 2: extract characters from book text and persist to audiobook_characters."""
     settings = await crud.audiobook.get_audiobook_settings(db)
-    if settings is None:
-        raise RuntimeError("Audiobook settings not found.")
+    provider = (settings.llm_provider or STUB_PROVIDER).lower() if settings else STUB_PROVIDER
 
     chapters = await crud.audiobook.get_chapters_for_book(db, book_id)
     if not chapters:
-        logger.warning("No chapters found for book %s during roster generation.", book_id)
-        if await crud.audiobook.get_book_pipeline_status(db, book_id) != "paused":
-            await crud.audiobook.set_book_pipeline_status(db, book_id, "diarizing")
-        return
+        raise RuntimeError(f"No narratable chapters found for book {book_id} during roster generation.")
 
     # Collect text from up to 5 chapters (keeps prompt size manageable)
     text_chunks: list[str] = []
@@ -128,16 +126,24 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
         text_chunks.append(" ".join(s.original_text for s in sentences))
     combined_text = "\n\n".join(text_chunks)[:12000]  # ~10k tokens safety cap
 
-    prompt_template = settings.roster_prompt_template or DEFAULT_ROSTER_PROMPT
-    prompt = prompt_template.format(text=combined_text)
-
-    logger.info("Calling LLM for character roster (book %s).", book_id)
-    raw = await _call_llm(settings, [{"role": "user", "content": prompt}])
-
-    try:
-        characters_data = _extract_json(raw)
-    except json.JSONDecodeError as exc:
-        raise RuntimeError(f"LLM returned invalid JSON for roster: {exc}\nRaw: {raw[:500]}") from exc
+    if provider == STUB_PROVIDER:
+        characters_data = [
+            {
+                "name": "Narrator",
+                "description": "Deterministic local harness narrator.",
+                "voice_design_prompt": "[gender-neutral][pitch-medium][speed-normal]",
+                "is_narrator": True,
+            }
+        ]
+    else:
+        prompt_template = settings.roster_prompt_template or DEFAULT_ROSTER_PROMPT
+        prompt = prompt_template.format(text=combined_text)
+        logger.info("Calling LLM for character roster (book %s).", book_id)
+        raw = await _call_llm(settings, [{"role": "user", "content": prompt}])
+        try:
+            characters_data = _extract_json(raw)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"LLM returned invalid JSON for roster: {exc}\nRaw: {raw[:500]}") from exc
 
     if not isinstance(characters_data, list):
         raise RuntimeError(f"Expected a JSON array from LLM, got: {type(characters_data)}")
@@ -145,6 +151,8 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
     # Normalise keys to match our model
     normalised: list[dict] = []
     for c in characters_data:
+        if not isinstance(c, dict):
+            continue
         normalised.append(
             {
                 "name": str(c.get("name", "Unknown")),
@@ -152,6 +160,18 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
                 "voice_design_prompt": c.get("voice_design_prompt"),
                 "is_narrator": bool(c.get("is_narrator", False)),
             }
+        )
+    if not normalised:
+        raise RuntimeError("LLM returned an empty character roster.")
+    if not any(character["is_narrator"] for character in normalised):
+        normalised.insert(
+            0,
+            {
+                "name": "Narrator",
+                "description": "Primary narrative voice.",
+                "voice_design_prompt": "[gender-neutral][pitch-medium][speed-normal]",
+                "is_narrator": True,
+            },
         )
 
     await crud.audiobook.create_characters_bulk(db, book_id=book_id, characters_data=normalised)
@@ -163,10 +183,11 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
 async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
     """Phase 3: batch-assign speakers and expression tags to all pending sentences."""
     settings = await crud.audiobook.get_audiobook_settings(db)
-    if settings is None:
-        raise RuntimeError("Audiobook settings not found.")
+    provider = (settings.llm_provider or STUB_PROVIDER).lower() if settings else STUB_PROVIDER
 
     characters = await crud.audiobook.get_characters_for_book(db, book_id)
+    character_ids = {character.id for character in characters}
+    narrator_id = next((character.id for character in characters if character.is_narrator), None)
     roster_json = json.dumps(
         [{"id": c.id, "name": c.name, "description": c.description, "is_narrator": c.is_narrator} for c in characters],
         ensure_ascii=False,
@@ -190,26 +211,34 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
         )
         context_str = "\n".join(context_window[-5:]) if context_window else "(none)"
 
-        prompt_template = settings.diarization_prompt_template or DEFAULT_DIARIZATION_PROMPT
-        prompt = prompt_template.format(
-            roster_json=roster_json,
-            context=context_str,
-            sentences_json=sentences_json,
-        )
+        if provider == STUB_PROVIDER:
+            results = [
+                {"id": sentence.id, "character_id": narrator_id, "tagged_text": sentence.original_text} for sentence in batch
+            ]
+        else:
+            prompt_template = settings.diarization_prompt_template or DEFAULT_DIARIZATION_PROMPT
+            prompt = prompt_template.format(
+                roster_json=roster_json,
+                context=context_str,
+                sentences_json=sentences_json,
+            )
+            logger.debug("Diarizing %d sentences for book %s.", len(batch), book_id)
+            raw = await _call_llm(settings, [{"role": "user", "content": prompt}])
+            try:
+                results = _extract_json(raw)
+            except json.JSONDecodeError as exc:
+                raise RuntimeError(f"LLM returned invalid JSON for diarization: {exc}\nRaw: {raw[:500]}") from exc
 
-        logger.debug("Diarizing %d sentences for book %s.", len(batch), book_id)
-        raw = await _call_llm(settings, [{"role": "user", "content": prompt}])
+        if not isinstance(results, list):
+            raise RuntimeError(f"Expected a JSON array from diarization, got: {type(results)}")
 
-        try:
-            results = _extract_json(raw)
-        except json.JSONDecodeError as exc:
-            raise RuntimeError(f"LLM returned invalid JSON for diarization: {exc}\nRaw: {raw[:500]}") from exc
-
-        result_map = {r["id"]: r for r in results if isinstance(r, dict)}
+        result_map = {r["id"]: r for r in results if isinstance(r, dict) and isinstance(r.get("id"), int)}
 
         for sentence in batch:
             result = result_map.get(sentence.id, {})
             char_id = result.get("character_id")
+            if char_id not in character_ids:
+                char_id = narrator_id
             tagged = result.get("tagged_text") or sentence.original_text
             await crud.audiobook.update_sentence_diarization(db, sentence.id, char_id, tagged)
             context_window.append(sentence.original_text)

--- a/backend/app/services/audiobook_queue.py
+++ b/backend/app/services/audiobook_queue.py
@@ -1,0 +1,134 @@
+"""Single-worker queue for the audiobook pipeline."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Optional
+
+from .. import crud
+from ..database import SessionLocal
+from .audiobook_ingestion import ingest_epub
+from .audiobook_llm import generate_character_roster, diarize_sentences
+from .audiobook_tts import generate_audio_for_book
+from .audiobook_assembly import assemble_book
+
+logger = logging.getLogger(__name__)
+
+# Ordered pipeline phases; the worker resumes from wherever the book's status is.
+_PHASE_ORDER = [
+    "ingesting",
+    "roster_gen",
+    "diarizing",
+    "audio_gen",
+    "assembling",
+]
+
+
+class AudiobookQueue:
+    """App-scoped queue that processes one audiobook pipeline job at a time."""
+
+    def __init__(self) -> None:
+        self._queue: asyncio.Queue[Optional[int]] = asyncio.Queue()
+        self._queued_book_ids: set[int] = set()
+        self._worker_task: Optional[asyncio.Task[None]] = None
+
+    async def start(self) -> None:
+        if self._worker_task and not self._worker_task.done():
+            return
+        self._worker_task = asyncio.create_task(self._run(), name="audiobook-worker")
+
+    async def stop(self) -> None:
+        if not self._worker_task:
+            return
+        await self._queue.put(None)
+        await self._worker_task
+        self._worker_task = None
+        self._queued_book_ids.clear()
+
+    async def enqueue(self, book_id: int) -> bool:
+        if book_id in self._queued_book_ids:
+            return False
+        self._queued_book_ids.add(book_id)
+        await self._queue.put(book_id)
+        return True
+
+    async def requeue_in_progress(self) -> int:
+        async with SessionLocal() as db:
+            books = await crud.audiobook.get_in_progress_audiobook_books(db)
+        queued = 0
+        for book in books:
+            if await self.enqueue(book.id):
+                queued += 1
+        return queued
+
+    async def _run(self) -> None:
+        while True:
+            item = await self._queue.get()
+            try:
+                if item is None:
+                    return
+                book_id = item
+                try:
+                    await self._process(book_id)
+                except Exception:
+                    logger.exception("Unhandled exception in audiobook pipeline for book %s.", book_id)
+                    async with SessionLocal() as db:
+                        await crud.audiobook.set_book_pipeline_status(db, book_id, "error")
+                finally:
+                    self._queued_book_ids.discard(book_id)
+            finally:
+                self._queue.task_done()
+
+    async def _process(self, book_id: int) -> None:
+        """Run the pipeline from the book's current status to completion."""
+        async with SessionLocal() as db:
+            from ..models import Book
+            book = await db.get(Book, book_id)
+            if book is None:
+                logger.warning("Book %s not found; skipping pipeline.", book_id)
+                return
+            current_status = book.audiobook_pipeline_status
+
+        if current_status == "paused":
+            logger.info("Book %s is paused; skipping pipeline.", book_id)
+            return
+
+        if current_status not in _PHASE_ORDER and current_status != "ingesting":
+            # Default: start from the beginning
+            current_status = "ingesting"
+            async with SessionLocal() as db:
+                await crud.audiobook.set_book_pipeline_status(db, book_id, "ingesting")
+
+        start_idx = _PHASE_ORDER.index(current_status) if current_status in _PHASE_ORDER else 0
+
+        for phase in _PHASE_ORDER[start_idx:]:
+            logger.info("Book %s: running phase '%s'.", book_id, phase)
+            async with SessionLocal() as db:
+                if phase == "ingesting":
+                    await ingest_epub(book_id, db)
+                elif phase == "roster_gen":
+                    await generate_character_roster(book_id, db)
+                elif phase == "diarizing":
+                    await diarize_sentences(book_id, db)
+                elif phase == "audio_gen":
+                    await generate_audio_for_book(book_id, db)
+                elif phase == "assembling":
+                    await assemble_book(book_id, db)
+
+            # Check if the book was paused mid-pipeline
+            async with SessionLocal() as db:
+                from ..models import Book
+                book = await db.get(Book, book_id)
+                if book and book.audiobook_pipeline_status == "paused":
+                    logger.info("Book %s paused after phase '%s'.", book_id, phase)
+                    return
+
+        logger.info("Audiobook pipeline complete for book %s.", book_id)
+
+
+_audiobook_queue = AudiobookQueue()
+
+
+def get_audiobook_queue() -> AudiobookQueue:
+    return _audiobook_queue

--- a/backend/app/services/audiobook_queue.py
+++ b/backend/app/services/audiobook_queue.py
@@ -84,6 +84,7 @@ class AudiobookQueue:
         """Run the pipeline from the book's current status to completion."""
         async with SessionLocal() as db:
             from ..models import Book
+
             book = await db.get(Book, book_id)
             if book is None:
                 logger.warning("Book %s not found; skipping pipeline.", book_id)
@@ -119,6 +120,7 @@ class AudiobookQueue:
             # Check if the book was paused mid-pipeline
             async with SessionLocal() as db:
                 from ..models import Book
+
                 book = await db.get(Book, book_id)
                 if book and book.audiobook_pipeline_status == "paused":
                     logger.info("Book %s paused after phase '%s'.", book_id, phase)

--- a/backend/app/services/audiobook_queue.py
+++ b/backend/app/services/audiobook_queue.py
@@ -77,10 +77,10 @@ class AudiobookQueue:
                 book_id = item
                 try:
                     await self._process(book_id)
-                except Exception:
+                except Exception as exc:
                     logger.exception("Unhandled exception in audiobook pipeline for book %s.", book_id)
                     async with SessionLocal() as db:
-                        await crud.audiobook.set_book_pipeline_status(db, book_id, "error")
+                        await crud.audiobook.set_book_pipeline_error(db, book_id, str(exc))
                 finally:
                     self._queued_book_ids.discard(book_id)
                     if book_id in self._rerun_book_ids:
@@ -126,13 +126,20 @@ class AudiobookQueue:
                 elif phase == "assembling":
                     await assemble_book(book_id, db)
 
-            # Check if the book was paused mid-pipeline
+            # Stop only at durable boundaries. Mid-phase services also check
+            # cooperative pause requests between batches/items.
             async with SessionLocal() as db:
                 from ..models import Book
 
                 book = await db.get(Book, book_id)
                 if book and book.audiobook_pipeline_status == "paused":
                     logger.info("Book %s paused after phase '%s'.", book_id, phase)
+                    return
+                if await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):
+                    logger.info("Book %s acknowledged pause after phase '%s'.", book_id, phase)
+                    return
+                if await crud.audiobook.pause_book_pipeline_after_phase(db, book_id, phase):
+                    logger.info("Book %s stopped for review after phase '%s'.", book_id, phase)
                     return
 
         logger.info("Audiobook pipeline complete for book %s.", book_id)

--- a/backend/app/services/audiobook_queue.py
+++ b/backend/app/services/audiobook_queue.py
@@ -31,6 +31,10 @@ class AudiobookQueue:
     def __init__(self) -> None:
         self._queue: asyncio.Queue[Optional[int]] = asyncio.Queue()
         self._queued_book_ids: set[int] = set()
+        # A pipeline mutation may arrive while a book is already running. Keep
+        # one follow-up job so the mutation is not lost when the current worker
+        # finishes.
+        self._rerun_book_ids: set[int] = set()
         self._worker_task: Optional[asyncio.Task[None]] = None
 
     async def start(self) -> None:
@@ -45,9 +49,11 @@ class AudiobookQueue:
         await self._worker_task
         self._worker_task = None
         self._queued_book_ids.clear()
+        self._rerun_book_ids.clear()
 
     async def enqueue(self, book_id: int) -> bool:
         if book_id in self._queued_book_ids:
+            self._rerun_book_ids.add(book_id)
             return False
         self._queued_book_ids.add(book_id)
         await self._queue.put(book_id)
@@ -77,6 +83,9 @@ class AudiobookQueue:
                         await crud.audiobook.set_book_pipeline_status(db, book_id, "error")
                 finally:
                     self._queued_book_ids.discard(book_id)
+                    if book_id in self._rerun_book_ids:
+                        self._rerun_book_ids.discard(book_id)
+                        await self.enqueue(book_id)
             finally:
                 self._queue.task_done()
 

--- a/backend/app/services/audiobook_queue.py
+++ b/backend/app/services/audiobook_queue.py
@@ -11,7 +11,8 @@ from ..database import SessionLocal
 from .audiobook_ingestion import ingest_epub
 from .audiobook_llm import generate_character_roster, diarize_sentences
 from .audiobook_tts import generate_audio_for_book
-from .audiobook_assembly import assemble_book
+from .audiobook_tts import generate_audio_for_chapter_preview
+from .audiobook_assembly import assemble_book, assemble_chapter_preview
 
 logger = logging.getLogger(__name__)
 
@@ -29,12 +30,13 @@ class AudiobookQueue:
     """App-scoped queue that processes one audiobook pipeline job at a time."""
 
     def __init__(self) -> None:
-        self._queue: asyncio.Queue[Optional[int]] = asyncio.Queue()
+        self._queue: asyncio.Queue[Optional[int | tuple[int, int]]] = asyncio.Queue()
         self._queued_book_ids: set[int] = set()
         # A pipeline mutation may arrive while a book is already running. Keep
         # one follow-up job so the mutation is not lost when the current worker
         # finishes.
         self._rerun_book_ids: set[int] = set()
+        self._queued_preview_ids: set[int] = set()
         self._worker_task: Optional[asyncio.Task[None]] = None
 
     async def start(self) -> None:
@@ -50,6 +52,7 @@ class AudiobookQueue:
         self._worker_task = None
         self._queued_book_ids.clear()
         self._rerun_book_ids.clear()
+        self._queued_preview_ids.clear()
 
     async def enqueue(self, book_id: int) -> bool:
         if book_id in self._queued_book_ids:
@@ -59,12 +62,26 @@ class AudiobookQueue:
         await self._queue.put(book_id)
         return True
 
+    async def enqueue_preview(self, book_id: int, chapter_id: int) -> bool:
+        if chapter_id in self._queued_preview_ids:
+            return False
+        self._queued_preview_ids.add(chapter_id)
+        await self._queue.put((book_id, chapter_id))
+        return True
+
     async def requeue_in_progress(self) -> int:
         async with SessionLocal() as db:
             books = await crud.audiobook.get_in_progress_audiobook_books(db)
         queued = 0
         for book in books:
             if await self.enqueue(book.id):
+                queued += 1
+        async with SessionLocal() as db:
+            preview_chapters = await crud.audiobook.get_chapters_with_pending_previews(db)
+            for chapter in preview_chapters:
+                await crud.audiobook.set_chapter_preview_status(db, chapter.id, "queued")
+        for chapter in preview_chapters:
+            if await self.enqueue_preview(chapter.book_id, chapter.id):
                 queued += 1
         return queued
 
@@ -74,6 +91,17 @@ class AudiobookQueue:
             try:
                 if item is None:
                     return
+                if isinstance(item, tuple):
+                    book_id, chapter_id = item
+                    try:
+                        await self._process_preview(book_id, chapter_id)
+                    except Exception as exc:
+                        logger.exception("Chapter preview failed for chapter %s.", chapter_id)
+                        async with SessionLocal() as db:
+                            await crud.audiobook.set_chapter_preview_status(db, chapter_id, "error", str(exc))
+                    finally:
+                        self._queued_preview_ids.discard(chapter_id)
+                    continue
                 book_id = item
                 try:
                     await self._process(book_id)
@@ -88,6 +116,13 @@ class AudiobookQueue:
                         await self.enqueue(book_id)
             finally:
                 self._queue.task_done()
+
+    async def _process_preview(self, book_id: int, chapter_id: int) -> None:
+        async with SessionLocal() as db:
+            await crud.audiobook.set_chapter_preview_status(db, chapter_id, "generating")
+            await generate_audio_for_chapter_preview(book_id, chapter_id, db)
+            await assemble_chapter_preview(book_id, chapter_id, db)
+            await crud.audiobook.set_chapter_preview_status(db, chapter_id, "ready")
 
     async def _process(self, book_id: int) -> None:
         """Run the pipeline from the book's current status to completion."""

--- a/backend/app/services/audiobook_queue.py
+++ b/backend/app/services/audiobook_queue.py
@@ -48,9 +48,18 @@ class AudiobookQueue:
     async def stop(self) -> None:
         if not self._worker_task:
             return
-        await self._queue.put(None)
-        await self._worker_task
+        self._worker_task.cancel()
+        try:
+            await self._worker_task
+        except asyncio.CancelledError:
+            logger.info("Audiobook worker cancelled at its durable checkpoint.")
         self._worker_task = None
+        while not self._queue.empty():
+            try:
+                self._queue.get_nowait()
+                self._queue.task_done()
+            except asyncio.QueueEmpty:
+                break
         self._queued_book_ids.clear()
         self._rerun_book_ids.clear()
         self._queued_preview_ids.clear()
@@ -184,7 +193,15 @@ class AudiobookQueue:
                 if phase == "ingesting":
                     await ingest_epub(book_id, db)
                 elif phase == "roster_gen":
-                    await generate_character_roster(book_id, db)
+                    book = await db.get(Book, book_id)
+                    refresh_series_metadata = bool(
+                        book and book.audiobook_stop_after_phase == crud.audiobook.ROSTER_REFRESH_STOP_MARKER
+                    )
+                    await generate_character_roster(
+                        book_id,
+                        db,
+                        refresh_series_metadata=refresh_series_metadata,
+                    )
                 elif phase == "diarizing":
                     await diarize_sentences(book_id, db)
                 elif phase == "audio_gen":

--- a/backend/app/services/audiobook_queue.py
+++ b/backend/app/services/audiobook_queue.py
@@ -10,7 +10,7 @@ from .. import crud
 from ..database import SessionLocal
 from .audiobook_ingestion import ingest_epub
 from .audiobook_llm import generate_character_roster, diarize_sentences
-from .audiobook_tts import generate_audio_for_book
+from .audiobook_tts import generate_audio_for_book, generate_audio_for_sentence
 from .audiobook_tts import generate_audio_for_chapter_preview
 from .audiobook_assembly import assemble_book, assemble_chapter_preview
 
@@ -30,13 +30,14 @@ class AudiobookQueue:
     """App-scoped queue that processes one audiobook pipeline job at a time."""
 
     def __init__(self) -> None:
-        self._queue: asyncio.Queue[Optional[int | tuple[int, int]]] = asyncio.Queue()
+        self._queue: asyncio.Queue[Optional[int | tuple[str, int, int]]] = asyncio.Queue()
         self._queued_book_ids: set[int] = set()
         # A pipeline mutation may arrive while a book is already running. Keep
         # one follow-up job so the mutation is not lost when the current worker
         # finishes.
         self._rerun_book_ids: set[int] = set()
         self._queued_preview_ids: set[int] = set()
+        self._queued_sentence_ids: set[int] = set()
         self._worker_task: Optional[asyncio.Task[None]] = None
 
     async def start(self) -> None:
@@ -53,6 +54,7 @@ class AudiobookQueue:
         self._queued_book_ids.clear()
         self._rerun_book_ids.clear()
         self._queued_preview_ids.clear()
+        self._queued_sentence_ids.clear()
 
     async def enqueue(self, book_id: int) -> bool:
         if book_id in self._queued_book_ids:
@@ -66,7 +68,14 @@ class AudiobookQueue:
         if chapter_id in self._queued_preview_ids:
             return False
         self._queued_preview_ids.add(chapter_id)
-        await self._queue.put((book_id, chapter_id))
+        await self._queue.put(("preview", book_id, chapter_id))
+        return True
+
+    async def enqueue_sentence_audio(self, book_id: int, sentence_id: int) -> bool:
+        if sentence_id in self._queued_sentence_ids:
+            return False
+        self._queued_sentence_ids.add(sentence_id)
+        await self._queue.put(("sentence", book_id, sentence_id))
         return True
 
     async def requeue_in_progress(self) -> int:
@@ -83,6 +92,13 @@ class AudiobookQueue:
         for chapter in preview_chapters:
             if await self.enqueue_preview(chapter.book_id, chapter.id):
                 queued += 1
+        async with SessionLocal() as db:
+            sentence_jobs = await crud.audiobook.get_pending_sentence_audio_jobs(db)
+            for _book_id, sentence_id in sentence_jobs:
+                await crud.audiobook.set_sentence_status(db, sentence_id, "audio_queued")
+        for book_id, sentence_id in sentence_jobs:
+            if await self.enqueue_sentence_audio(book_id, sentence_id):
+                queued += 1
         return queued
 
     async def _run(self) -> None:
@@ -92,15 +108,25 @@ class AudiobookQueue:
                 if item is None:
                     return
                 if isinstance(item, tuple):
-                    book_id, chapter_id = item
-                    try:
-                        await self._process_preview(book_id, chapter_id)
-                    except Exception as exc:
-                        logger.exception("Chapter preview failed for chapter %s.", chapter_id)
-                        async with SessionLocal() as db:
-                            await crud.audiobook.set_chapter_preview_status(db, chapter_id, "error", str(exc))
-                    finally:
-                        self._queued_preview_ids.discard(chapter_id)
+                    job_type, book_id, record_id = item
+                    if job_type == "preview":
+                        try:
+                            await self._process_preview(book_id, record_id)
+                        except Exception as exc:
+                            logger.exception("Chapter preview failed for chapter %s.", record_id)
+                            async with SessionLocal() as db:
+                                await crud.audiobook.set_chapter_preview_status(db, record_id, "error", str(exc))
+                        finally:
+                            self._queued_preview_ids.discard(record_id)
+                    elif job_type == "sentence":
+                        try:
+                            await self._process_sentence_audio(book_id, record_id)
+                        except Exception:
+                            logger.exception("Sentence audio failed for sentence %s.", record_id)
+                            async with SessionLocal() as db:
+                                await crud.audiobook.mark_sentence_error(db, record_id)
+                        finally:
+                            self._queued_sentence_ids.discard(record_id)
                     continue
                 book_id = item
                 try:
@@ -123,6 +149,11 @@ class AudiobookQueue:
             await generate_audio_for_chapter_preview(book_id, chapter_id, db)
             await assemble_chapter_preview(book_id, chapter_id, db)
             await crud.audiobook.set_chapter_preview_status(db, chapter_id, "ready")
+
+    async def _process_sentence_audio(self, book_id: int, sentence_id: int) -> None:
+        async with SessionLocal() as db:
+            await crud.audiobook.set_sentence_status(db, sentence_id, "audio_generating")
+            await generate_audio_for_sentence(book_id, sentence_id, db)
 
     async def _process(self, book_id: int) -> None:
         """Run the pipeline from the book's current status to completion."""

--- a/backend/app/services/audiobook_tts.py
+++ b/backend/app/services/audiobook_tts.py
@@ -95,6 +95,11 @@ async def generate_audio_for_book(book_id: int, db: AsyncSession) -> None:
 
     processed = 0
     failed = 0
+    counts = await crud.audiobook.count_sentences_by_status(db, book_id)
+    total = counts.get("ready_for_audio", 0)
+    await crud.audiobook.update_book_pipeline_progress(
+        db, book_id, current=0, total=total, detail=f"Preparing speech for {total} sentences"
+    )
     while True:
         if await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):
             logger.info("Book %s paused during TTS generation.", book_id)
@@ -148,10 +153,20 @@ async def generate_audio_for_book(book_id: int, db: AsyncSession) -> None:
 
             await crud.audiobook.update_sentence_audio(db, sentence.id, _relative_path(out_path), duration_ms)
             processed += 1
+            await crud.audiobook.update_book_pipeline_progress(
+                db,
+                book_id,
+                current=processed,
+                total=total,
+                detail=f"Generated speech for {processed} of {total} sentences",
+            )
 
             # Flag chapter for reassembly if all its sentences are done
             if await crud.audiobook.chapter_all_audio_generated(db, sentence.chapter_id):
                 await crud.audiobook.flag_chapter_for_reassembly(db, sentence.chapter_id)
+            if await crud.audiobook.consume_book_batch_limit(db, book_id):
+                logger.info("Book %s paused after one TTS sentence.", book_id)
+                return
 
     if failed or await crud.audiobook.has_sentence_status(db, book_id, "error"):
         await crud.audiobook.set_book_pipeline_status(db, book_id, "error")

--- a/backend/app/services/audiobook_tts.py
+++ b/backend/app/services/audiobook_tts.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import crud
 from ..config import LIBRARY_PATH
-from ..models import AudiobookChapter, AudiobookCharacter
+from ..models import AudiobookChapter, AudiobookCharacter, AudiobookSentence
 
 logger = logging.getLogger(__name__)
 
@@ -80,14 +80,68 @@ async def _call_omnivoice(endpoint: str, voice_prompt: str, tagged_text: str) ->
     return resp.content
 
 
-async def generate_audio_for_book(book_id: int, db: AsyncSession) -> None:
-    """Phase 4: iterate ready_for_audio sentences and call OmniVoice for each."""
+async def _get_tts_endpoint(db: AsyncSession) -> str:
     settings = await crud.audiobook.get_audiobook_settings(db)
     endpoint = settings.omnivoice_endpoint if settings else None
     if not endpoint and (settings is None or (settings.llm_provider or "stub").lower() == "stub"):
         endpoint = "stub://local"
     if not endpoint:
         raise RuntimeError("OmniVoice endpoint not configured. Set it in Audio Settings.")
+    return endpoint
+
+
+async def _generate_sentence_clip(
+    endpoint: str,
+    book_id: int,
+    sentence: AudiobookSentence,
+    db: AsyncSession,
+) -> None:
+    voice_prompt = DEFAULT_VOICE_PROMPT
+    if sentence.character_id is not None:
+        char = await db.get(AudiobookCharacter, sentence.character_id)
+        if char and char.voice_design_prompt:
+            voice_prompt = char.voice_design_prompt
+
+    audio_bytes = await _call_omnivoice(
+        endpoint,
+        voice_prompt,
+        sentence.tagged_text or sentence.original_text,
+    )
+    out_path = _snippet_path(book_id, sentence.id)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_bytes(audio_bytes)
+    duration_ms = _get_mp3_duration_ms(out_path)
+    await crud.audiobook.update_sentence_audio(
+        db,
+        sentence.id,
+        _relative_path(out_path),
+        duration_ms,
+    )
+
+
+async def generate_audio_for_sentence(
+    book_id: int,
+    sentence_id: int,
+    db: AsyncSession,
+) -> None:
+    """Generate one manually requested sentence without advancing the book pipeline."""
+    sentence = await db.get(AudiobookSentence, sentence_id)
+    if sentence is None:
+        raise RuntimeError("Audiobook sentence not found.")
+    chapter = await db.get(AudiobookChapter, sentence.chapter_id)
+    if chapter is None or chapter.book_id != book_id:
+        raise RuntimeError("Audiobook sentence does not belong to this book.")
+    if sentence.character_id is None:
+        raise RuntimeError("Assign a speaker before generating sentence audio.")
+
+    endpoint = await _get_tts_endpoint(db)
+    await _generate_sentence_clip(endpoint, book_id, sentence, db)
+    await crud.audiobook.flag_chapter_for_reassembly(db, chapter.id)
+
+
+async def generate_audio_for_book(book_id: int, db: AsyncSession) -> None:
+    """Phase 4: iterate ready_for_audio sentences and call OmniVoice for each."""
+    endpoint = await _get_tts_endpoint(db)
 
     # Ensure snippets directory exists
     snippets_dir = LIBRARY_PATH.parent / "library" / "audiobooks" / str(book_id) / "snippets"
@@ -114,22 +168,9 @@ async def generate_audio_for_book(book_id: int, db: AsyncSession) -> None:
                 logger.info("Book %s paused during TTS generation.", book_id)
                 return
 
-            # Resolve voice prompt from the assigned character
-            voice_prompt = DEFAULT_VOICE_PROMPT
-            if sentence.character_id is not None:
-                char = await db.get(AudiobookCharacter, sentence.character_id)
-                if char and char.voice_design_prompt:
-                    voice_prompt = char.voice_design_prompt
-
-            text_to_speak = sentence.tagged_text or sentence.original_text
-
             logger.debug("Generating audio for sentence %s (book %s).", sentence.id, book_id)
             try:
-                audio_bytes = await _call_omnivoice(endpoint, voice_prompt, text_to_speak)
-                out_path = _snippet_path(book_id, sentence.id)
-                out_path.write_bytes(audio_bytes)
-
-                duration_ms = _get_mp3_duration_ms(out_path)
+                await _generate_sentence_clip(endpoint, book_id, sentence, db)
             except httpx.HTTPStatusError as exc:
                 response_text = exc.response.text[:200] if exc.response is not None else ""
                 logger.error(
@@ -151,7 +192,6 @@ async def generate_audio_for_book(book_id: int, db: AsyncSession) -> None:
                 failed += 1
                 continue
 
-            await crud.audiobook.update_sentence_audio(db, sentence.id, _relative_path(out_path), duration_ms)
             processed += 1
             await crud.audiobook.update_book_pipeline_progress(
                 db,
@@ -202,12 +242,7 @@ async def generate_audio_for_chapter_preview(
     if any(sentence.character_id is None for sentence in sentences):
         raise RuntimeError("Assign a speaker to every chapter sentence before generating a preview.")
 
-    settings = await crud.audiobook.get_audiobook_settings(db)
-    endpoint = settings.omnivoice_endpoint if settings else None
-    if not endpoint and (settings is None or (settings.llm_provider or "stub").lower() == "stub"):
-        endpoint = "stub://local"
-    if not endpoint:
-        raise RuntimeError("OmniVoice endpoint not configured. Set it in Audio Settings.")
+    endpoint = await _get_tts_endpoint(db)
 
     snippets_dir = LIBRARY_PATH.parent / "library" / "audiobooks" / str(book_id) / "snippets"
     snippets_dir.mkdir(parents=True, exist_ok=True)
@@ -225,25 +260,11 @@ async def generate_audio_for_chapter_preview(
             completed += 1
             continue
 
-        voice_prompt = DEFAULT_VOICE_PROMPT
-        char = await db.get(AudiobookCharacter, sentence.character_id)
-        if char and char.voice_design_prompt:
-            voice_prompt = char.voice_design_prompt
-        text_to_speak = sentence.tagged_text or sentence.original_text
         try:
-            audio_bytes = await _call_omnivoice(endpoint, voice_prompt, text_to_speak)
-            out_path = _snippet_path(book_id, sentence.id)
-            out_path.write_bytes(audio_bytes)
-            duration_ms = _get_mp3_duration_ms(out_path)
+            await _generate_sentence_clip(endpoint, book_id, sentence, db)
         except Exception:
             await crud.audiobook.mark_sentence_error(db, sentence.id)
             raise
-        await crud.audiobook.update_sentence_audio(
-            db,
-            sentence.id,
-            _relative_path(out_path),
-            duration_ms,
-        )
         completed += 1
         await crud.audiobook.update_book_pipeline_progress(
             db,

--- a/backend/app/services/audiobook_tts.py
+++ b/backend/app/services/audiobook_tts.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import crud
 from ..config import LIBRARY_PATH
-from ..models import AudiobookCharacter
+from ..models import AudiobookChapter, AudiobookCharacter
 
 logger = logging.getLogger(__name__)
 
@@ -182,3 +182,73 @@ async def generate_audio_for_book(book_id: int, db: AsyncSession) -> None:
 
     logger.info("TTS complete for book %s: %d sentences generated.", book_id, processed)
     await crud.audiobook.set_book_pipeline_status(db, book_id, "assembling")
+
+
+async def generate_audio_for_chapter_preview(
+    book_id: int,
+    chapter_id: int,
+    db: AsyncSession,
+) -> None:
+    """Generate/reuse sentence clips for one fully diarized chapter only."""
+    chapter = await db.get(AudiobookChapter, chapter_id)
+    if chapter is None or chapter.book_id != book_id:
+        raise RuntimeError("Audiobook chapter not found.")
+    sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter_id)
+    if not sentences:
+        raise RuntimeError("Chapter has no narratable sentences.")
+    pending = [sentence for sentence in sentences if sentence.status == "pending_diarization"]
+    if pending:
+        raise RuntimeError(f"Finish speaker analysis for this chapter first ({len(pending)} sentences remain).")
+    if any(sentence.character_id is None for sentence in sentences):
+        raise RuntimeError("Assign a speaker to every chapter sentence before generating a preview.")
+
+    settings = await crud.audiobook.get_audiobook_settings(db)
+    endpoint = settings.omnivoice_endpoint if settings else None
+    if not endpoint and (settings is None or (settings.llm_provider or "stub").lower() == "stub"):
+        endpoint = "stub://local"
+    if not endpoint:
+        raise RuntimeError("OmniVoice endpoint not configured. Set it in Audio Settings.")
+
+    snippets_dir = LIBRARY_PATH.parent / "library" / "audiobooks" / str(book_id) / "snippets"
+    snippets_dir.mkdir(parents=True, exist_ok=True)
+    completed = 0
+    await crud.audiobook.update_book_pipeline_progress(
+        db,
+        book_id,
+        current=0,
+        total=len(sentences),
+        detail=f"Generating manual preview for chapter {chapter.chapter_number}",
+    )
+    for sentence in sentences:
+        existing_path = LIBRARY_PATH.parent / sentence.audio_file_path if sentence.audio_file_path else None
+        if sentence.status == "audio_generated" and existing_path and existing_path.exists():
+            completed += 1
+            continue
+
+        voice_prompt = DEFAULT_VOICE_PROMPT
+        char = await db.get(AudiobookCharacter, sentence.character_id)
+        if char and char.voice_design_prompt:
+            voice_prompt = char.voice_design_prompt
+        text_to_speak = sentence.tagged_text or sentence.original_text
+        try:
+            audio_bytes = await _call_omnivoice(endpoint, voice_prompt, text_to_speak)
+            out_path = _snippet_path(book_id, sentence.id)
+            out_path.write_bytes(audio_bytes)
+            duration_ms = _get_mp3_duration_ms(out_path)
+        except Exception:
+            await crud.audiobook.mark_sentence_error(db, sentence.id)
+            raise
+        await crud.audiobook.update_sentence_audio(
+            db,
+            sentence.id,
+            _relative_path(out_path),
+            duration_ms,
+        )
+        completed += 1
+        await crud.audiobook.update_book_pipeline_progress(
+            db,
+            book_id,
+            current=completed,
+            total=len(sentences),
+            detail=(f"Chapter {chapter.chapter_number} preview: " f"generated {completed} of {len(sentences)} sentences"),
+        )

--- a/backend/app/services/audiobook_tts.py
+++ b/backend/app/services/audiobook_tts.py
@@ -1,0 +1,110 @@
+"""Phase 4: OmniVoice TTS — generate a per-sentence MP3 snippet."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import httpx
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import crud
+from ..config import LIBRARY_PATH
+from ..models import AudiobookCharacter, AudiobookSentence
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_VOICE_PROMPT = "[gender-neutral][pitch-medium][speed-normal]"
+
+
+def _snippet_path(book_id: int, sentence_id: int) -> Path:
+    return LIBRARY_PATH.parent / "library" / "audiobooks" / str(book_id) / "snippets" / f"{sentence_id}.mp3"
+
+
+def _relative_path(full_path: Path) -> str:
+    return str(full_path.relative_to(LIBRARY_PATH.parent))
+
+
+def _get_mp3_duration_ms(path: Path) -> int:
+    from mutagen.mp3 import MP3
+    audio = MP3(str(path))
+    return int(audio.info.length * 1000)
+
+
+async def _call_omnivoice(endpoint: str, voice_prompt: str, tagged_text: str) -> bytes:
+    url = endpoint.rstrip("/") + "/generate"
+    async with httpx.AsyncClient(timeout=120.0) as client:
+        resp = await client.post(
+            url,
+            json={"voice": voice_prompt, "text": tagged_text},
+            headers={"Accept": "audio/mpeg"},
+        )
+        resp.raise_for_status()
+    return resp.content
+
+
+async def generate_audio_for_book(book_id: int, db: AsyncSession) -> None:
+    """Phase 4: iterate ready_for_audio sentences and call OmniVoice for each."""
+    settings = await crud.audiobook.get_audiobook_settings(db)
+    if not settings or not settings.omnivoice_endpoint:
+        raise RuntimeError("OmniVoice endpoint not configured. Set it in Audio Settings.")
+
+    endpoint = settings.omnivoice_endpoint
+
+    # Ensure snippets directory exists
+    snippets_dir = LIBRARY_PATH.parent / "library" / "audiobooks" / str(book_id) / "snippets"
+    snippets_dir.mkdir(parents=True, exist_ok=True)
+
+    processed = 0
+    while True:
+        batch = await crud.audiobook.get_sentences_ready_for_audio(db, book_id, limit=20)
+        if not batch:
+            break
+
+        for sentence in batch:
+            # Resolve voice prompt from the assigned character
+            voice_prompt = DEFAULT_VOICE_PROMPT
+            if sentence.character_id is not None:
+                char = await db.get(AudiobookCharacter, sentence.character_id)
+                if char and char.voice_design_prompt:
+                    voice_prompt = char.voice_design_prompt
+
+            text_to_speak = sentence.tagged_text or sentence.original_text
+
+            logger.debug("Generating audio for sentence %s (book %s).", sentence.id, book_id)
+            try:
+                audio_bytes = await _call_omnivoice(endpoint, voice_prompt, text_to_speak)
+            except httpx.HTTPStatusError as exc:
+                logger.error(
+                    "OmniVoice error for sentence %s: %s %s",
+                    sentence.id,
+                    exc.response.status_code,
+                    exc.response.text[:200],
+                )
+                # Mark as error but continue with remaining sentences
+                from sqlalchemy import update
+                from ..database import SessionLocal
+                async with SessionLocal() as err_db:
+                    await err_db.execute(
+                        update(AudiobookSentence)
+                        .where(AudiobookSentence.id == sentence.id)
+                        .values(status="error")
+                    )
+                    await err_db.commit()
+                continue
+
+            out_path = _snippet_path(book_id, sentence.id)
+            out_path.write_bytes(audio_bytes)
+
+            duration_ms = _get_mp3_duration_ms(out_path)
+            await crud.audiobook.update_sentence_audio(
+                db, sentence.id, _relative_path(out_path), duration_ms
+            )
+            processed += 1
+
+            # Flag chapter for reassembly if all its sentences are done
+            if await crud.audiobook.chapter_all_audio_generated(db, sentence.chapter_id):
+                await crud.audiobook.flag_chapter_for_reassembly(db, sentence.chapter_id)
+
+    logger.info("TTS complete for book %s: %d sentences generated.", book_id, processed)
+    await crud.audiobook.set_book_pipeline_status(db, book_id, "assembling")

--- a/backend/app/services/audiobook_tts.py
+++ b/backend/app/services/audiobook_tts.py
@@ -93,7 +93,7 @@ async def generate_audio_for_book(book_id: int, db: AsyncSession) -> None:
     processed = 0
     failed = 0
     while True:
-        if await crud.audiobook.get_book_pipeline_status(db, book_id) == "paused":
+        if await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):
             logger.info("Book %s paused during TTS generation.", book_id)
             return
 
@@ -102,7 +102,7 @@ async def generate_audio_for_book(book_id: int, db: AsyncSession) -> None:
             break
 
         for sentence in batch:
-            if await crud.audiobook.get_book_pipeline_status(db, book_id) == "paused":
+            if await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):
                 logger.info("Book %s paused during TTS generation.", book_id)
                 return
 
@@ -158,7 +158,7 @@ async def generate_audio_for_book(book_id: int, db: AsyncSession) -> None:
         await crud.audiobook.set_book_pipeline_status(db, book_id, "error")
         raise RuntimeError(f"TTS finished before all sentences had audio for book {book_id}.")
 
-    if await crud.audiobook.get_book_pipeline_status(db, book_id) == "paused":
+    if await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):
         logger.info("Book %s paused after TTS generation.", book_id)
         return
 

--- a/backend/app/services/audiobook_tts.py
+++ b/backend/app/services/audiobook_tts.py
@@ -27,6 +27,7 @@ def _relative_path(full_path: Path) -> str:
 
 def _get_mp3_duration_ms(path: Path) -> int:
     from mutagen.mp3 import MP3
+
     audio = MP3(str(path))
     return int(audio.info.length * 1000)
 
@@ -84,11 +85,10 @@ async def generate_audio_for_book(book_id: int, db: AsyncSession) -> None:
                 # Mark as error but continue with remaining sentences
                 from sqlalchemy import update
                 from ..database import SessionLocal
+
                 async with SessionLocal() as err_db:
                     await err_db.execute(
-                        update(AudiobookSentence)
-                        .where(AudiobookSentence.id == sentence.id)
-                        .values(status="error")
+                        update(AudiobookSentence).where(AudiobookSentence.id == sentence.id).values(status="error")
                     )
                     await err_db.commit()
                 continue
@@ -97,9 +97,7 @@ async def generate_audio_for_book(book_id: int, db: AsyncSession) -> None:
             out_path.write_bytes(audio_bytes)
 
             duration_ms = _get_mp3_duration_ms(out_path)
-            await crud.audiobook.update_sentence_audio(
-                db, sentence.id, _relative_path(out_path), duration_ms
-            )
+            await crud.audiobook.update_sentence_audio(db, sentence.id, _relative_path(out_path), duration_ms)
             processed += 1
 
             # Flag chapter for reassembly if all its sentences are done

--- a/backend/app/services/audiobook_tts.py
+++ b/backend/app/services/audiobook_tts.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from pathlib import Path
+import shutil
 
 import httpx
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -33,6 +35,37 @@ def _get_mp3_duration_ms(path: Path) -> int:
 
 
 async def _call_omnivoice(endpoint: str, voice_prompt: str, tagged_text: str) -> bytes:
+    if endpoint.startswith("stub://"):
+        duration_ms = max(350, min(5000, len(tagged_text.split()) * 260))
+        ffmpeg = shutil.which("ffmpeg")
+        if not ffmpeg:
+            raise RuntimeError("ffmpeg is required by the local audiobook TTS harness.")
+        process = await asyncio.create_subprocess_exec(
+            ffmpeg,
+            "-v",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "anullsrc=r=22050:cl=mono",
+            "-t",
+            f"{duration_ms / 1000:.3f}",
+            "-codec:a",
+            "libmp3lame",
+            "-b:a",
+            "64k",
+            "-f",
+            "mp3",
+            "pipe:1",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await process.communicate()
+        if process.returncode:
+            message = stderr.decode("utf-8", errors="replace")[:500]
+            raise RuntimeError(f"Local TTS harness failed: {message}")
+        return stdout
+
     url = endpoint.rstrip("/") + "/generate"
     async with httpx.AsyncClient(timeout=120.0) as client:
         resp = await client.post(
@@ -47,10 +80,11 @@ async def _call_omnivoice(endpoint: str, voice_prompt: str, tagged_text: str) ->
 async def generate_audio_for_book(book_id: int, db: AsyncSession) -> None:
     """Phase 4: iterate ready_for_audio sentences and call OmniVoice for each."""
     settings = await crud.audiobook.get_audiobook_settings(db)
-    if not settings or not settings.omnivoice_endpoint:
+    endpoint = settings.omnivoice_endpoint if settings else None
+    if not endpoint and (settings is None or (settings.llm_provider or "stub").lower() == "stub"):
+        endpoint = "stub://local"
+    if not endpoint:
         raise RuntimeError("OmniVoice endpoint not configured. Set it in Audio Settings.")
-
-    endpoint = settings.omnivoice_endpoint
 
     # Ensure snippets directory exists
     snippets_dir = LIBRARY_PATH.parent / "library" / "audiobooks" / str(book_id) / "snippets"

--- a/backend/app/services/audiobook_tts.py
+++ b/backend/app/services/audiobook_tts.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import crud
 from ..config import LIBRARY_PATH
-from ..models import AudiobookCharacter, AudiobookSentence
+from ..models import AudiobookCharacter
 
 logger = logging.getLogger(__name__)
 
@@ -57,12 +57,21 @@ async def generate_audio_for_book(book_id: int, db: AsyncSession) -> None:
     snippets_dir.mkdir(parents=True, exist_ok=True)
 
     processed = 0
+    failed = 0
     while True:
+        if await crud.audiobook.get_book_pipeline_status(db, book_id) == "paused":
+            logger.info("Book %s paused during TTS generation.", book_id)
+            return
+
         batch = await crud.audiobook.get_sentences_ready_for_audio(db, book_id, limit=20)
         if not batch:
             break
 
         for sentence in batch:
+            if await crud.audiobook.get_book_pipeline_status(db, book_id) == "paused":
+                logger.info("Book %s paused during TTS generation.", book_id)
+                return
+
             # Resolve voice prompt from the assigned character
             voice_prompt = DEFAULT_VOICE_PROMPT
             if sentence.character_id is not None:
@@ -75,34 +84,49 @@ async def generate_audio_for_book(book_id: int, db: AsyncSession) -> None:
             logger.debug("Generating audio for sentence %s (book %s).", sentence.id, book_id)
             try:
                 audio_bytes = await _call_omnivoice(endpoint, voice_prompt, text_to_speak)
+                out_path = _snippet_path(book_id, sentence.id)
+                out_path.write_bytes(audio_bytes)
+
+                duration_ms = _get_mp3_duration_ms(out_path)
             except httpx.HTTPStatusError as exc:
+                response_text = exc.response.text[:200] if exc.response is not None else ""
                 logger.error(
                     "OmniVoice error for sentence %s: %s %s",
                     sentence.id,
-                    exc.response.status_code,
-                    exc.response.text[:200],
+                    exc.response.status_code if exc.response is not None else "unknown",
+                    response_text,
                 )
-                # Mark as error but continue with remaining sentences
-                from sqlalchemy import update
-                from ..database import SessionLocal
-
-                async with SessionLocal() as err_db:
-                    await err_db.execute(
-                        update(AudiobookSentence).where(AudiobookSentence.id == sentence.id).values(status="error")
-                    )
-                    await err_db.commit()
+                await crud.audiobook.mark_sentence_error(db, sentence.id)
+                failed += 1
+                continue
+            except Exception as exc:
+                logger.exception(
+                    "Unable to generate or inspect audio for sentence %s: %s",
+                    sentence.id,
+                    exc,
+                )
+                await crud.audiobook.mark_sentence_error(db, sentence.id)
+                failed += 1
                 continue
 
-            out_path = _snippet_path(book_id, sentence.id)
-            out_path.write_bytes(audio_bytes)
-
-            duration_ms = _get_mp3_duration_ms(out_path)
             await crud.audiobook.update_sentence_audio(db, sentence.id, _relative_path(out_path), duration_ms)
             processed += 1
 
             # Flag chapter for reassembly if all its sentences are done
             if await crud.audiobook.chapter_all_audio_generated(db, sentence.chapter_id):
                 await crud.audiobook.flag_chapter_for_reassembly(db, sentence.chapter_id)
+
+    if failed or await crud.audiobook.has_sentence_status(db, book_id, "error"):
+        await crud.audiobook.set_book_pipeline_status(db, book_id, "error")
+        raise RuntimeError(f"TTS failed for {failed} sentence(s) in book {book_id}.")
+
+    if not await crud.audiobook.all_sentences_audio_generated(db, book_id):
+        await crud.audiobook.set_book_pipeline_status(db, book_id, "error")
+        raise RuntimeError(f"TTS finished before all sentences had audio for book {book_id}.")
+
+    if await crud.audiobook.get_book_pipeline_status(db, book_id) == "paused":
+        logger.info("Book %s paused after TTS generation.", book_id)
+        return
 
     logger.info("TTS complete for book %s: %d sentences generated.", book_id, processed)
     await crud.audiobook.set_book_pipeline_status(db, book_id, "assembling")

--- a/backend/app/services/audiobook_tts.py
+++ b/backend/app/services/audiobook_tts.py
@@ -67,7 +67,10 @@ async def _call_omnivoice(endpoint: str, voice_prompt: str, tagged_text: str) ->
         return stdout
 
     url = endpoint.rstrip("/") + "/generate"
-    async with httpx.AsyncClient(timeout=120.0) as client:
+    # Local neural TTS can take longer on the first MPS/CPU request while
+    # kernels warm up. Keep connection failures fast but allow inference time.
+    timeout = httpx.Timeout(600.0, connect=10.0)
+    async with httpx.AsyncClient(timeout=timeout) as client:
         resp = await client.post(
             url,
             json={"voice": voice_prompt, "text": tagged_text},

--- a/backend/app/services/audiobook_tts.py
+++ b/backend/app/services/audiobook_tts.py
@@ -34,7 +34,13 @@ def _get_mp3_duration_ms(path: Path) -> int:
     return int(audio.info.length * 1000)
 
 
-async def _call_omnivoice(endpoint: str, voice_prompt: str, tagged_text: str) -> bytes:
+async def _call_omnivoice(
+    endpoint: str,
+    voice_prompt: str,
+    tagged_text: str,
+    *,
+    voice_id: str | None = None,
+) -> bytes:
     if endpoint.startswith("stub://"):
         duration_ms = max(350, min(5000, len(tagged_text.split()) * 260))
         ffmpeg = shutil.which("ffmpeg")
@@ -71,9 +77,12 @@ async def _call_omnivoice(endpoint: str, voice_prompt: str, tagged_text: str) ->
     # kernels warm up. Keep connection failures fast but allow inference time.
     timeout = httpx.Timeout(600.0, connect=10.0)
     async with httpx.AsyncClient(timeout=timeout) as client:
+        request_body = {"voice": voice_prompt, "text": tagged_text}
+        if voice_id:
+            request_body["voice_id"] = voice_id
         resp = await client.post(
             url,
-            json={"voice": voice_prompt, "text": tagged_text},
+            json=request_body,
             headers={"Accept": "audio/mpeg"},
         )
         resp.raise_for_status()
@@ -97,15 +106,23 @@ async def _generate_sentence_clip(
     db: AsyncSession,
 ) -> None:
     voice_prompt = DEFAULT_VOICE_PROMPT
+    voice_id = None
     if sentence.character_id is not None:
         char = await db.get(AudiobookCharacter, sentence.character_id)
-        if char and char.voice_design_prompt:
-            voice_prompt = char.voice_design_prompt
+        if char:
+            if char.voice_design_prompt:
+                voice_prompt = char.voice_design_prompt
+            voice_id = (
+                f"series-character:{char.series_character_id}"
+                if char.series_character_id is not None
+                else f"book:{book_id}:character:{char.id}"
+            )
 
     audio_bytes = await _call_omnivoice(
         endpoint,
         voice_prompt,
         sentence.tagged_text or sentence.original_text,
+        voice_id=voice_id,
     )
     out_path = _snippet_path(book_id, sentence.id)
     out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/backend/tests/test_audiobook_pipeline.py
+++ b/backend/tests/test_audiobook_pipeline.py
@@ -1,0 +1,254 @@
+from pathlib import Path
+
+import httpx
+import pytest
+from bs4 import BeautifulSoup
+from ebooklib import epub
+
+from backend.app import crud, models
+from backend.app.routers import audiobook as audiobook_router
+from backend.app.services import audiobook_assembly, audiobook_ingestion, audiobook_tts
+
+
+async def _make_book(db, **overrides):
+    title = overrides.get("title", "Audio Book")
+    slug = title.lower().replace(" ", "-")
+    payload = {
+        "title": title,
+        "author": "Reader",
+        "source_type": models.SourceType.epub,
+        "immutable_path": f"library/{slug}-immutable.epub",
+        "current_path": f"library/{slug}.epub",
+    }
+    payload.update(overrides)
+    book = models.Book(**payload)
+    db.add(book)
+    await db.commit()
+    await db.refresh(book)
+    return book
+
+
+async def _seed_audio_chapter(db, book_id: int, *, sentence_status: str = "ready_for_audio"):
+    chapter = await crud.audiobook.create_chapter(
+        db,
+        book_id=book_id,
+        chapter_number=1,
+        content_file_name="Text/chapter_1.xhtml",
+    )
+    characters = await crud.audiobook.create_characters_bulk(
+        db,
+        book_id=book_id,
+        characters_data=[
+            {
+                "name": "Narrator",
+                "description": "Primary narrator",
+                "voice_design_prompt": "[gender-neutral][pitch-medium][speed-normal]",
+                "is_narrator": True,
+            }
+        ],
+    )
+    await crud.audiobook.create_sentences_bulk(
+        db,
+        chapter_id=chapter.id,
+        sentences_data=[
+            {
+                "html_element_id": "ch1_s0",
+                "sequence_order": 0,
+                "original_text": "One sentence.",
+                "tagged_text": "One sentence.",
+                "character_id": characters[0].id,
+                "status": sentence_status,
+            }
+        ],
+    )
+    sentence = (await crud.audiobook.get_sentences_for_chapter(db, chapter.id))[0]
+    return chapter, characters[0], sentence
+
+
+class _FakeQueue:
+    def __init__(self):
+        self.enqueued: list[int] = []
+
+    async def enqueue(self, book_id: int) -> bool:
+        self.enqueued.append(book_id)
+        return True
+
+
+@pytest.mark.asyncio
+async def test_books_default_audiobook_pipeline_disabled(db, monkeypatch):
+    book = await _make_book(db)
+    queue = _FakeQueue()
+    monkeypatch.setattr(audiobook_router, "get_audiobook_queue", lambda: queue)
+
+    with pytest.raises(audiobook_router.HTTPException) as exc_info:
+        await audiobook_router.start_pipeline(book.id, db)
+
+    await db.refresh(book)
+    assert book.audiobook_enabled is False
+    assert exc_info.value.status_code == 403
+    assert queue.enqueued == []
+
+
+@pytest.mark.asyncio
+async def test_requeue_candidates_only_include_enabled_audiobooks(db):
+    disabled = await _make_book(db)
+    disabled.audiobook_pipeline_status = "audio_gen"
+    enabled = await _make_book(db, title="Enabled Audio", audiobook_enabled=True)
+    enabled.audiobook_pipeline_status = "audio_gen"
+    await db.commit()
+
+    pending = await crud.audiobook.get_in_progress_audiobook_books(db)
+
+    assert [book.id for book in pending] == [enabled.id]
+
+
+@pytest.mark.asyncio
+async def test_paused_pipeline_resumes_from_persisted_audio_state(db, monkeypatch):
+    book = await _make_book(db, audiobook_enabled=True)
+    await _seed_audio_chapter(db, book.id, sentence_status="ready_for_audio")
+    await crud.audiobook.set_book_pipeline_status(db, book.id, "paused")
+    queue = _FakeQueue()
+    monkeypatch.setattr(audiobook_router, "get_audiobook_queue", lambda: queue)
+
+    response = await audiobook_router.start_pipeline(book.id, db)
+
+    await db.refresh(book)
+    assert response == {"status": "audio_gen", "queued": True}
+    assert book.audiobook_pipeline_status == "audio_gen"
+    assert queue.enqueued == [book.id]
+
+
+@pytest.mark.asyncio
+async def test_error_pipeline_resets_failed_sentences_before_retry(db, monkeypatch):
+    book = await _make_book(db, audiobook_enabled=True)
+    chapter, _character, sentence = await _seed_audio_chapter(db, book.id, sentence_status="error")
+    await crud.audiobook.set_book_pipeline_status(db, book.id, "error")
+    queue = _FakeQueue()
+    monkeypatch.setattr(audiobook_router, "get_audiobook_queue", lambda: queue)
+
+    response = await audiobook_router.start_pipeline(book.id, db)
+
+    await db.refresh(book)
+    await db.refresh(chapter)
+    await db.refresh(sentence)
+    assert response == {"status": "audio_gen", "queued": True}
+    assert book.audiobook_pipeline_status == "audio_gen"
+    assert sentence.status == "ready_for_audio"
+    assert sentence.audio_file_path is None
+    assert chapter.needs_reassembly is True
+
+
+@pytest.mark.asyncio
+async def test_tts_failure_marks_book_error_instead_of_advancing_to_assembly(db, monkeypatch):
+    book = await _make_book(db)
+    chapter, _character, _sentence = await _seed_audio_chapter(db, book.id, sentence_status="ready_for_audio")
+    settings = models.AudiobookSettings(omnivoice_endpoint="http://tts.example.test")
+    db.add(settings)
+    await db.commit()
+
+    async def fail_omnivoice(endpoint, voice_prompt, tagged_text):
+        request = httpx.Request("POST", endpoint)
+        raise httpx.ConnectError("connection failed", request=request)
+
+    monkeypatch.setattr(audiobook_tts, "_call_omnivoice", fail_omnivoice)
+
+    with pytest.raises(RuntimeError, match="TTS failed"):
+        await audiobook_tts.generate_audio_for_book(book.id, db)
+
+    sentence = (await crud.audiobook.get_sentences_for_chapter(db, chapter.id))[0]
+    await db.refresh(book)
+    await db.refresh(sentence)
+    assert book.audiobook_pipeline_status == "error"
+    assert sentence.status == "error"
+    assert sentence.audio_file_path is None
+
+
+def test_smil_uses_real_epub_content_file_name():
+    chapter = models.AudiobookChapter(
+        chapter_number=1,
+        content_file_name="Text/real_chapter.xhtml",
+    )
+    sentence = models.AudiobookSentence(
+        html_element_id="ch1_s0",
+        audio_duration_ms=1250,
+    )
+
+    smil = audiobook_assembly._build_smil(chapter, [sentence], "ch0001.mp3")
+
+    assert 'epub:textref="Text/real_chapter.xhtml"' in smil
+    assert 'src="Text/real_chapter.xhtml#ch1_s0"' in smil
+    assert 'src="ch0001.mp3"' in smil
+    assert 'clipEnd="00:00:01.250"' in smil
+
+
+def _write_nested_epub(path: Path) -> None:
+    book = epub.EpubBook()
+    book.set_identifier("nested-test")
+    book.set_title("Nested")
+    book.set_language("en")
+    book.add_author("Author")
+    chapter = epub.EpubHtml(title="One", file_name="Text/chapter_1.xhtml", lang="en")
+    chapter.content = """
+    <html xmlns="http://www.w3.org/1999/xhtml">
+      <body>
+        <div class="chapter">
+          <h1>Chapter One</h1>
+          <p>First sentence. <em>Second sentence.</em></p>
+          <p><a href="next.xhtml">Linked sentence.</a></p>
+        </div>
+      </body>
+    </html>
+    """
+    chapter_two = epub.EpubHtml(title="Two", file_name="Text/chapter_2.xhtml", lang="en")
+    chapter_two.content = "<p>Third sentence.</p>"
+    book.add_item(chapter)
+    book.add_item(chapter_two)
+    book.add_item(epub.EpubNcx())
+    book.add_item(epub.EpubNav())
+    book.spine = ["nav", chapter, chapter_two]
+    book.toc = (
+        epub.Link("Text/chapter_1.xhtml", "One", "one"),
+        epub.Link("Text/chapter_2.xhtml", "Two", "two"),
+    )
+    epub.write_epub(path, book, {})
+
+
+def _simple_sentence_split(text: str) -> list[str]:
+    if "." not in text:
+        return [text.strip()]
+    return [f"{chunk.strip()}." for chunk in text.split(".") if chunk.strip()]
+
+
+@pytest.mark.asyncio
+async def test_ingestion_preserves_nested_markup_and_records_spine_file(db, tmp_path, monkeypatch):
+    library_path = tmp_path / "library"
+    library_path.mkdir()
+    epub_path = library_path / "nested.epub"
+    _write_nested_epub(epub_path)
+    book = await _make_book(
+        db,
+        immutable_path=str(epub_path.relative_to(library_path.parent)),
+        current_path=str(epub_path.relative_to(library_path.parent)),
+    )
+    monkeypatch.setattr(audiobook_ingestion, "LIBRARY_PATH", library_path)
+    monkeypatch.setattr(audiobook_ingestion, "_tokenize_text", _simple_sentence_split)
+
+    await audiobook_ingestion.ingest_epub(book.id, db)
+
+    chapters = await crud.audiobook.get_chapters_for_book(db, book.id)
+    assert [chapter.content_file_name for chapter in chapters] == [
+        "Text/chapter_1.xhtml",
+        "Text/chapter_2.xhtml",
+    ]
+
+    working_epub = library_path / "audiobooks" / str(book.id) / "working.epub"
+    parsed = epub.read_epub(str(working_epub))
+    item = parsed.get_item_with_href("Text/chapter_1.xhtml")
+    soup = BeautifulSoup(item.get_content(), "html.parser")
+
+    assert soup.find("div", class_="chapter") is not None
+    assert soup.find("p") is not None
+    assert soup.find("em") is not None
+    assert soup.find("a", href="next.xhtml") is not None
+    assert soup.find("span", id="ch1_s0") is not None
+    assert soup.find("span", id="ch1_s1") is not None

--- a/backend/tests/test_audiobook_pipeline.py
+++ b/backend/tests/test_audiobook_pipeline.py
@@ -264,6 +264,19 @@ def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
         minor_male_id=40,
         reason="Model followed the next sentence's speaker.",
     )
+    recruiter_enumeration = audiobook_llm._apply_speaker_guardrails(
+        text="“Paragraph two: I understand that I am volunteering.”",
+        next_text="",
+        character_id=20,
+        narrator_id=10,
+        protagonist_id=20,
+        character_name_ids={"harry": 50},
+        role_speaker_ids={"recruiter": 30},
+        last_dialogue_speaker_id=30,
+        minor_female_id=30,
+        minor_male_id=40,
+        reason="Model selected the protagonist.",
+    )
     turn_taking_dialogue = audiobook_llm._apply_speaker_guardrails(
         text="“Does that bother you?”",
         next_text="“No,” she said.",
@@ -300,6 +313,7 @@ def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
     assert role_dialogue == (30, "Deterministic grounded role dialogue attribution", 0.98)
     assert named_dialogue == (50, "Deterministic named dialogue attribution to harry", 0.99)
     assert current_named_dialogue == (60, "Deterministic named dialogue attribution to jesse", 0.99)
+    assert recruiter_enumeration == (30, "Deterministic grounded recruiter enumeration", 0.98)
     assert turn_taking_dialogue == (20, "Deterministic first-person turn-taking fallback", 0.8)
     assert setup == (10, "Narration setting up dialogue.", None)
 

--- a/backend/tests/test_audiobook_pipeline.py
+++ b/backend/tests/test_audiobook_pipeline.py
@@ -74,9 +74,14 @@ async def _seed_audio_chapter(db, book_id: int, *, sentence_status: str = "ready
 class _FakeQueue:
     def __init__(self):
         self.enqueued: list[int] = []
+        self.preview_enqueued: list[tuple[int, int]] = []
 
     async def enqueue(self, book_id: int) -> bool:
         self.enqueued.append(book_id)
+        return True
+
+    async def enqueue_preview(self, book_id: int, chapter_id: int) -> bool:
+        self.preview_enqueued.append((book_id, chapter_id))
         return True
 
 
@@ -84,6 +89,7 @@ def test_default_roster_prompt_formats_voice_token_examples():
     prompt = audiobook_llm.DEFAULT_ROSTER_PROMPT.format(
         text="A story excerpt.",
         candidate_hints="- Harry: 12 mentions",
+        series_roster="(none yet)",
     )
 
     assert "[gender-{male|female|neutral}]" in prompt
@@ -698,6 +704,122 @@ async def test_roster_keeps_first_person_protagonist_separate_from_narrator(db, 
     assert characters[2].aliases == []
     assert "40 explicit dialogue attributions" in characters[1].description
     assert "Harry: 40 mentions" in captured["prompt"]
+
+
+@pytest.mark.asyncio
+async def test_series_roster_reuses_and_propagates_voice_profiles(db):
+    first = await _make_book(db, title="Saga One", series="Shared Saga", audiobook_enabled=True)
+    second = await _make_book(db, title="Saga Two", series="Shared Saga", audiobook_enabled=True)
+    first_character = (
+        await crud.audiobook.create_characters_bulk(
+            db,
+            first.id,
+            [
+                {
+                    "name": "Captain Vale",
+                    "description": "Series captain.",
+                    "voice_design_prompt": "[gender-female][pitch-low][speed-normal]",
+                    "is_narrator": False,
+                    "aliases": ["Vale"],
+                    "evidence": [],
+                }
+            ],
+        )
+    )[0]
+    second_character = (
+        await crud.audiobook.create_characters_bulk(
+            db,
+            second.id,
+            [
+                {
+                    "name": "Captain Vale",
+                    "description": "Book-specific guess.",
+                    "voice_design_prompt": "[gender-neutral][pitch-high][speed-fast]",
+                    "is_narrator": False,
+                    "aliases": [],
+                    "evidence": [],
+                }
+            ],
+        )
+    )[0]
+
+    await crud.audiobook.sync_book_roster_with_series(db, first, [first_character])
+    await crud.audiobook.sync_book_roster_with_series(db, second, [second_character])
+    await db.refresh(second_character)
+
+    assert second_character.series_character_id == first_character.series_character_id
+    assert second_character.voice_design_prompt == "[gender-female][pitch-low][speed-normal]"
+
+    first_character.voice_design_prompt = "[gender-female][pitch-medium][speed-slow]"
+    await db.commit()
+    linked = await crud.audiobook.propagate_character_profile_across_series(db, first_character)
+    await db.refresh(second_character)
+
+    assert {character.book_id for character in linked} == {first.id, second.id}
+    assert second_character.voice_design_prompt == "[gender-female][pitch-medium][speed-slow]"
+
+    # Renaming onto an existing canonical identity merges the shared profiles
+    # instead of violating the series/name uniqueness constraint.
+    other_character = (
+        await crud.audiobook.create_characters_bulk(
+            db,
+            first.id,
+            [
+                {
+                    "name": "Commander Vale",
+                    "voice_design_prompt": "[gender-female][pitch-high][speed-normal]",
+                    "is_narrator": False,
+                }
+            ],
+        )
+    )[0]
+    await crud.audiobook.sync_book_roster_with_series(db, first, [other_character])
+    other_character.name = "Captain Vale"
+    await db.commit()
+    await crud.audiobook.propagate_character_profile_across_series(db, other_character)
+    await db.refresh(other_character)
+    assert other_character.series_character_id == first_character.series_character_id
+
+
+@pytest.mark.asyncio
+async def test_manual_chapter_preview_requires_analysis_and_queues_work(db, monkeypatch):
+    book = await _make_book(db, audiobook_enabled=True, audiobook_pipeline_status="paused")
+    chapter, _character, sentence = await _seed_audio_chapter(db, book.id)
+    queue = _FakeQueue()
+    monkeypatch.setattr(audiobook_router, "get_audiobook_queue", lambda: queue)
+
+    response = await audiobook_router.generate_chapter_preview(book.id, chapter.id, db)
+    await db.refresh(chapter)
+
+    assert response == {"status": "queued", "queued": True, "chapter_id": chapter.id}
+    assert queue.preview_enqueued == [(book.id, chapter.id)]
+    assert chapter.preview_status == "queued"
+
+    sentence.status = "pending_diarization"
+    chapter.preview_status = None
+    await db.commit()
+    with pytest.raises(audiobook_router.HTTPException) as exc_info:
+        await audiobook_router.generate_chapter_preview(book.id, chapter.id, db)
+    assert exc_info.value.status_code == 409
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg is required for MP3 assembly")
+async def test_manual_chapter_preview_generates_playable_audio(db, tmp_path, monkeypatch):
+    library_path = tmp_path / "library"
+    library_path.mkdir()
+    book = await _make_book(db, audiobook_enabled=True, audiobook_pipeline_status="paused")
+    chapter, _character, _sentence = await _seed_audio_chapter(db, book.id)
+    monkeypatch.setattr(audiobook_tts, "LIBRARY_PATH", library_path)
+    monkeypatch.setattr(audiobook_assembly, "LIBRARY_PATH", library_path)
+
+    await audiobook_tts.generate_audio_for_chapter_preview(book.id, chapter.id, db)
+    await audiobook_assembly.assemble_chapter_preview(book.id, chapter.id, db)
+    await db.refresh(chapter)
+
+    assert chapter.audio_file_path
+    assert (library_path.parent / chapter.audio_file_path).exists()
+    assert chapter.smil_file_path
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_audiobook_pipeline.py
+++ b/backend/tests/test_audiobook_pipeline.py
@@ -11,6 +11,7 @@ from ebooklib import epub
 from backend.app import crud, models
 from backend.app.routers import audiobook as audiobook_router
 from backend.app.services import audiobook_assembly, audiobook_ingestion, audiobook_llm, audiobook_tts
+from backend.app.services import audiobook_queue
 from backend.app.services.audiobook_queue import AudiobookQueue
 
 
@@ -108,6 +109,32 @@ async def test_queue_schedules_one_rerun_for_changes_during_processing(monkeypat
 
 
 @pytest.mark.asyncio
+async def test_queue_persists_actionable_pipeline_error(db, sqlite_sessionmaker, monkeypatch):
+    book = await _make_book(
+        db,
+        audiobook_enabled=True,
+        audiobook_pipeline_status="ingesting",
+    )
+    queue = AudiobookQueue()
+
+    async def fail(_book_id):
+        raise RuntimeError("EPUB contains no narratable text")
+
+    monkeypatch.setattr(audiobook_queue, "SessionLocal", sqlite_sessionmaker)
+    monkeypatch.setattr(queue, "_process", fail)
+    await queue.start()
+    try:
+        await queue.enqueue(book.id)
+        await queue._queue.join()
+    finally:
+        await queue.stop()
+
+    await db.refresh(book)
+    assert book.audiobook_pipeline_status == "error"
+    assert book.audiobook_last_error == "EPUB contains no narratable text"
+
+
+@pytest.mark.asyncio
 async def test_books_default_audiobook_pipeline_disabled(db, monkeypatch):
     book = await _make_book(db)
     queue = _FakeQueue()
@@ -176,6 +203,80 @@ async def test_error_pipeline_resets_failed_sentences_before_retry(db, monkeypat
     assert sentence.status == "ready_for_audio"
     assert sentence.audio_file_path is None
     assert chapter.needs_reassembly is True
+
+
+@pytest.mark.asyncio
+async def test_step_pipeline_runs_only_next_recoverable_phase(db, monkeypatch):
+    book = await _make_book(db, audiobook_enabled=True)
+    queue = _FakeQueue()
+    monkeypatch.setattr(audiobook_router, "get_audiobook_queue", lambda: queue)
+
+    response = await audiobook_router.step_pipeline(book.id, db)
+
+    await db.refresh(book)
+    assert response == {
+        "status": "ingesting",
+        "queued": True,
+        "stop_after_phase": "ingesting",
+    }
+    assert book.audiobook_pipeline_status == "ingesting"
+    assert book.audiobook_stop_after_phase == "ingesting"
+    assert book.audiobook_last_error is None
+    assert queue.enqueued == [book.id]
+
+
+@pytest.mark.asyncio
+async def test_queue_stops_for_review_after_requested_phase(db, sqlite_sessionmaker, monkeypatch):
+    book = await _make_book(
+        db,
+        audiobook_enabled=True,
+        audiobook_pipeline_status="ingesting",
+        audiobook_stop_after_phase="ingesting",
+    )
+    phases: list[str] = []
+
+    async def ingest(book_id, phase_db):
+        phases.append("ingesting")
+        await crud.audiobook.set_book_pipeline_status(phase_db, book_id, "roster_gen")
+
+    async def unexpected(*_args):
+        phases.append("unexpected")
+
+    monkeypatch.setattr(audiobook_queue, "SessionLocal", sqlite_sessionmaker)
+    monkeypatch.setattr(audiobook_queue, "ingest_epub", ingest)
+    monkeypatch.setattr(audiobook_queue, "generate_character_roster", unexpected)
+
+    await AudiobookQueue()._process(book.id)
+
+    await db.refresh(book)
+    assert phases == ["ingesting"]
+    assert book.audiobook_pipeline_status == "paused"
+    assert book.audiobook_stop_after_phase is None
+
+
+@pytest.mark.asyncio
+async def test_pause_is_cooperative_and_status_exposes_error_context(db):
+    book = await _make_book(
+        db,
+        audiobook_enabled=True,
+        audiobook_pipeline_status="audio_gen",
+        audiobook_last_error="Previous failure",
+    )
+
+    response = await audiobook_router.pause_pipeline(book.id, db)
+    await db.refresh(book)
+
+    assert response == {"status": "audio_gen", "pause_requested": True}
+    assert book.audiobook_pipeline_status == "audio_gen"
+    assert book.audiobook_pause_requested is True
+
+    await crud.audiobook.pause_book_pipeline_if_requested(db, book.id)
+    status = await audiobook_router.get_pipeline_status(book.id, db)
+
+    assert status.pipeline_status == "paused"
+    assert status.pause_requested is False
+    assert status.next_phase == "ingesting"
+    assert status.last_error == "Previous failure"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_audiobook_pipeline.py
+++ b/backend/tests/test_audiobook_pipeline.py
@@ -101,6 +101,40 @@ def test_default_roster_prompt_formats_voice_token_examples():
     assert "A story excerpt." in prompt
 
 
+def test_json_extraction_repairs_trailing_commas_from_local_models():
+    raw = """{
+      "assignments": [
+        {"id": 4, "character_id": 1, "tagged_text": null, "confidence": 1.0, "reason": "Narration",},
+      ],
+      "chapter_summary": "A summary",
+    }"""
+
+    result = audiobook_llm._extract_json(raw)
+
+    assert result["assignments"][0]["id"] == 4
+    assert result["chapter_summary"] == "A summary"
+
+
+def test_diarization_result_requires_complete_unique_sentence_coverage():
+    incomplete = {
+        "assignments": [
+            {"id": 1},
+            {"id": 1},
+        ],
+        "chapter_summary": "Summary",
+    }
+
+    with pytest.raises(ValueError, match="missing=\\[2\\].*duplicates=\\[1\\]"):
+        audiobook_llm._normalise_diarization_result(incomplete, {1, 2})
+
+    with_extras = {
+        "assignments": [{"id": 1}, {"id": 2}, {"id": 999}],
+        "chapter_summary": "Summary",
+    }
+    normalised = audiobook_llm._normalise_diarization_result(with_extras, {1, 2})
+    assert [result["id"] for result in normalised["assignments"]] == [1, 2]
+
+
 def test_tagged_text_sanitizer_only_accepts_supported_insertions():
     original = "Take your time, I said."
 
@@ -120,6 +154,24 @@ def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
         minor_female_id=30,
         minor_male_id=40,
         reason="Action description by the protagonist.",
+    )
+    emotional_prose = audiobook_llm._apply_speaker_guardrails(
+        text="I hated visiting the cemetery.",
+        next_text="",
+        character_id=20,
+        narrator_id=10,
+        minor_female_id=30,
+        minor_male_id=40,
+        reason="Expressing deep grief.",
+    )
+    embedded_quote = audiobook_llm._apply_speaker_guardrails(
+        text="I remembered her last words: “Where is the vanilla?”",
+        next_text="",
+        character_id=20,
+        narrator_id=10,
+        minor_female_id=30,
+        minor_male_id=40,
+        reason="Recalling her final words.",
     )
     dialogue = audiobook_llm._apply_speaker_guardrails(
         text="“You coming or going?”",
@@ -141,6 +193,8 @@ def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
     )
 
     assert prose == (10, "Deterministic prose/narration guardrail", 0.98)
+    assert emotional_prose == (10, "Deterministic prose/narration guardrail", 0.98)
+    assert embedded_quote == (10, "Deterministic prose/narration guardrail", 0.98)
     assert dialogue == (30, "Deterministic she dialogue attribution to minor voice", 0.98)
     assert setup == (10, "Narration setting up dialogue.", None)
 
@@ -195,6 +249,126 @@ async def test_ollama_call_requests_schema_constrained_non_thinking_json(monkeyp
     assert payload["think"] is False
     assert payload["format"] == schema
     assert payload["options"]["temperature"] == 0
+    assert payload["options"]["num_predict"] == 8192
+
+
+@pytest.mark.asyncio
+async def test_omnivoice_request_includes_durable_character_identity(monkeypatch):
+    captured = {}
+
+    class FakeResponse:
+        content = b"mp3"
+
+        def raise_for_status(self):
+            return None
+
+    class FakeClient:
+        def __init__(self, **_kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def post(self, url, **kwargs):
+            captured["url"] = url
+            captured["request"] = kwargs
+            return FakeResponse()
+
+    monkeypatch.setattr(audiobook_tts.httpx, "AsyncClient", FakeClient)
+
+    result = await audiobook_tts._call_omnivoice(
+        "http://127.0.0.1:8001",
+        "[gender-male][pitch-low][speed-normal][age-middle]",
+        "A spoken line.",
+        voice_id="series-character:7",
+    )
+
+    assert result == b"mp3"
+    assert captured["url"] == "http://127.0.0.1:8001/generate"
+    assert captured["request"]["json"]["voice_id"] == "series-character:7"
+
+
+@pytest.mark.asyncio
+async def test_diarization_retries_malformed_output_in_smaller_batches(db, monkeypatch):
+    book = await _make_book(db, audiobook_enabled=True, audiobook_pipeline_status="diarizing")
+    settings = models.AudiobookSettings(
+        llm_provider="ollama",
+        llm_base_url="http://127.0.0.1:11434",
+        llm_model="local-test",
+    )
+    db.add(settings)
+    await db.commit()
+    chapter = await crud.audiobook.create_chapter(
+        db,
+        book_id=book.id,
+        chapter_number=1,
+        content_file_name="Text/chapter_1.xhtml",
+    )
+    narrator = (
+        await crud.audiobook.create_characters_bulk(
+            db,
+            book_id=book.id,
+            characters_data=[
+                {
+                    "name": "Narrator",
+                    "voice_design_prompt": "[gender-neutral][pitch-medium][speed-normal][age-middle]",
+                    "is_narrator": True,
+                }
+            ],
+        )
+    )[0]
+    await crud.audiobook.create_sentences_bulk(
+        db,
+        chapter_id=chapter.id,
+        sentences_data=[
+            {
+                "html_element_id": f"sentence-{index}",
+                "sequence_order": index,
+                "original_text": f"Sentence {index} has enough text for analysis.",
+                "status": "pending_diarization",
+            }
+            for index in range(45)
+        ],
+    )
+    request_sizes = []
+
+    async def fake_llm(_settings, messages, **_kwargs):
+        prompt = messages[0]["content"]
+        serialized = prompt.split("Sentences to process (JSON array with id and text):\n", 1)[1].split(
+            "\n\nFor each sentence return:", 1
+        )[0]
+        sentences = json.loads(serialized)
+        request_sizes.append(len(sentences))
+        if len(request_sizes) == 1:
+            return '{"assignments": ['
+        return json.dumps(
+            {
+                "assignments": [
+                    {
+                        "id": sentence["id"],
+                        "character_id": narrator.id,
+                        "tagged_text": None,
+                        "confidence": 1.0,
+                        "reason": "Narrative prose",
+                    }
+                    for sentence in sentences
+                ],
+                "chapter_summary": "A complete test chapter.",
+            }
+        )
+
+    monkeypatch.setattr(audiobook_llm, "_call_llm", fake_llm)
+
+    await audiobook_llm.diarize_sentences(book.id, db)
+
+    counts = await crud.audiobook.count_sentences_by_status(db, book.id)
+    await db.refresh(book)
+    assert request_sizes == [40, 20, 20, 5]
+    assert counts == {"ready_for_audio": 45}
+    assert book.audiobook_pipeline_status == "audio_gen"
 
 
 @pytest.mark.asyncio
@@ -224,6 +398,31 @@ async def test_queue_schedules_one_rerun_for_changes_during_processing(monkeypat
         assert processed == [42, 42]
     finally:
         await queue.stop()
+
+
+@pytest.mark.asyncio
+async def test_queue_stop_cancels_an_in_flight_book_without_waiting(monkeypatch):
+    queue = AudiobookQueue()
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def process(_book_id: int) -> None:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    monkeypatch.setattr(queue, "_process", process)
+    await queue.start()
+    await queue.enqueue(42)
+    await started.wait()
+
+    await asyncio.wait_for(queue.stop(), timeout=1)
+
+    assert cancelled.is_set()
+    assert queue._worker_task is None
 
 
 @pytest.mark.asyncio
@@ -431,6 +630,7 @@ async def test_roster_rebuild_preserves_ingestion_and_clears_derived_analysis(db
         "stop_after_phase": "roster_gen",
     }
     assert book.audiobook_pipeline_status == "roster_gen"
+    assert book.audiobook_stop_after_phase == crud.audiobook.ROSTER_REFRESH_STOP_MARKER
     assert sentence.status == "pending_diarization"
     assert sentence.character_id is None
     assert sentence.speaker_confidence is None
@@ -502,7 +702,7 @@ async def test_tts_failure_marks_book_error_instead_of_advancing_to_assembly(db,
     db.add(settings)
     await db.commit()
 
-    async def fail_omnivoice(endpoint, voice_prompt, tagged_text):
+    async def fail_omnivoice(endpoint, voice_prompt, tagged_text, **_kwargs):
         request = httpx.Request("POST", endpoint)
         raise httpx.ConnectError("connection failed", request=request)
 
@@ -640,6 +840,20 @@ async def test_roster_excerpt_skips_short_front_matter(db):
             for index in range(40)
         ],
     )
+    back_matter = await crud.audiobook.create_chapter(db, book.id, 3, "ads.xhtml")
+    await crud.audiobook.create_sentences_bulk(
+        db,
+        back_matter.id,
+        [
+            {
+                "html_element_id": f"ads_{index}",
+                "sequence_order": index,
+                "original_text": "ACKNOWLEDGMENTS" if index == 0 else f"Advertisement person Thomas Stein {index}.",
+                "status": "pending_diarization",
+            }
+            for index in range(40)
+        ],
+    )
 
     excerpt = await audiobook_llm._build_roster_excerpt(
         await crud.audiobook.get_chapters_for_book(db, book.id),
@@ -649,6 +863,119 @@ async def test_roster_excerpt_skips_short_front_matter(db):
     assert "Copyright page only" not in excerpt
     assert "John and Kathy continue the story" in excerpt
     assert "### Chapter 2" in excerpt
+    assert "Thomas Stein" not in excerpt
+
+
+@pytest.mark.asyncio
+async def test_first_person_gender_uses_explicit_self_identification_and_stops_at_back_matter(db):
+    book = await _make_book(db, audiobook_enabled=True)
+    story = await crud.audiobook.create_chapter(db, book.id, 1, "story.xhtml")
+    await crud.audiobook.create_sentences_bulk(
+        db,
+        story.id,
+        [
+            {
+                "html_element_id": "story_0",
+                "sequence_order": 0,
+                "original_text": "I was a widower and he was a bachelor.",
+                "status": "pending_diarization",
+            }
+        ],
+    )
+    ads = await crud.audiobook.create_chapter(db, book.id, 2, "ads.xhtml")
+    await crud.audiobook.create_sentences_bulk(
+        db,
+        ads.id,
+        [
+            {
+                "html_element_id": "ads_0",
+                "sequence_order": 0,
+                "original_text": "ACKNOWLEDGMENTS",
+                "status": "pending_diarization",
+            },
+            {
+                "html_element_id": "ads_1",
+                "sequence_order": 1,
+                "original_text": "I'm a woman in this unrelated advertisement.",
+                "status": "pending_diarization",
+            },
+        ],
+    )
+
+    assert (
+        await audiobook_llm._infer_first_person_gender(await crud.audiobook.get_chapters_for_book(db, book.id), db) == "male"
+    )
+
+
+def test_roster_canonicalization_merges_full_names_and_removes_speculation():
+    characters = [
+        {
+            "name": "Jane",
+            "aliases": [],
+            "description": "Invented biography.",
+            "evidence": ["Thomas Jane said hello."],
+            "voice_design_prompt": "[gender-female][pitch-high][speed-fast]",
+            "is_narrator": False,
+        },
+        {
+            "name": "Thomas",
+            "aliases": [],
+            "description": "Another invented biography.",
+            "evidence": [],
+            "voice_design_prompt": "[gender-neutral][pitch-low][speed-normal]",
+            "is_narrator": False,
+        },
+        {
+            "name": "Sagan",
+            "aliases": [],
+            "description": "Invented biography.",
+            "evidence": ["Jane Sagan replied."],
+            "voice_design_prompt": "[gender-male][pitch-medium][speed-normal]",
+            "is_narrator": False,
+        },
+    ]
+    candidates = [
+        {
+            "name": "Jane",
+            "canonical_name": "Thomas Jane",
+            "mention_count": 70,
+            "dialogue_count": 30,
+            "gender": "male",
+        },
+        {
+            "name": "Thomas",
+            "canonical_name": "Thomas Jane",
+            "mention_count": 50,
+            "dialogue_count": 20,
+            "gender": "male",
+        },
+        {
+            "name": "Sagan",
+            "canonical_name": "Jane Sagan",
+            "mention_count": 40,
+            "dialogue_count": 25,
+            "gender": "female",
+        },
+    ]
+
+    result = audiobook_llm._canonicalize_roster_characters(
+        characters,
+        candidates,
+        "thomas jane said hello. jane sagan replied.",
+    )
+
+    assert [character["name"] for character in result] == ["Thomas Jane", "Jane Sagan"]
+    assert result[0]["aliases"] == ["Jane", "Thomas"]
+    assert "30 explicit dialogue attributions" in result[0]["description"]
+    assert result[0]["voice_design_prompt"].startswith("[gender-male]")
+    assert result[1]["voice_design_prompt"].startswith("[gender-female]")
+    assert "Invented biography" not in " ".join(character["description"] for character in result)
+
+
+def test_voice_prompt_normalization_adds_required_tokens():
+    assert audiobook_llm._normalise_voice_prompt("[gender-female][pitch-high]", gender="male") == (
+        "[gender-male][pitch-high][speed-normal][age-middle]"
+    )
 
 
 @pytest.mark.asyncio
@@ -755,6 +1082,23 @@ async def test_series_roster_reuses_and_propagates_voice_profiles(db):
     assert second_character.series_character_id == first_character.series_character_id
     assert second_character.voice_design_prompt == "[gender-female][pitch-low][speed-normal]"
 
+    second_character.description = "Fresh grounded series analysis."
+    second_character.voice_design_prompt = "[gender-neutral][pitch-high][speed-fast]"
+    await db.commit()
+    await crud.audiobook.sync_book_roster_with_series(
+        db,
+        second,
+        [second_character],
+        prefer_series=False,
+    )
+    await db.refresh(first_character)
+    await db.refresh(second_character)
+
+    assert first_character.description == "Fresh grounded series analysis."
+    assert second_character.description == "Fresh grounded series analysis."
+    assert first_character.voice_design_prompt == "[gender-neutral][pitch-high][speed-fast]"
+    assert second_character.voice_design_prompt == "[gender-neutral][pitch-high][speed-fast]"
+
     first_character.voice_design_prompt = "[gender-female][pitch-medium][speed-slow]"
     await db.commit()
     linked = await crud.audiobook.propagate_character_profile_across_series(db, first_character)
@@ -784,6 +1128,20 @@ async def test_series_roster_reuses_and_propagates_voice_profiles(db):
     await crud.audiobook.propagate_character_profile_across_series(db, other_character)
     await db.refresh(other_character)
     assert other_character.series_character_id == first_character.series_character_id
+
+    orphan = models.AudiobookSeriesCharacter(
+        series_name="Shared Saga",
+        canonical_name="stale guess",
+        name="Stale Guess",
+    )
+    db.add(orphan)
+    await db.commit()
+    orphan_id = orphan.id
+
+    sibling_profiles = await crud.audiobook.get_sibling_series_characters(db, "Shared Saga", first.id)
+    assert {profile.name for profile in sibling_profiles} == {"Captain Vale"}
+    assert await crud.audiobook.delete_orphaned_series_characters(db, "Shared Saga") == 1
+    assert await db.get(models.AudiobookSeriesCharacter, orphan_id) is None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_audiobook_pipeline.py
+++ b/backend/tests/test_audiobook_pipeline.py
@@ -151,6 +151,7 @@ def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
         next_text="",
         character_id=20,
         narrator_id=10,
+        protagonist_id=20,
         minor_female_id=30,
         minor_male_id=40,
         reason="Action description by the protagonist.",
@@ -160,6 +161,7 @@ def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
         next_text="",
         character_id=20,
         narrator_id=10,
+        protagonist_id=20,
         minor_female_id=30,
         minor_male_id=40,
         reason="Expressing deep grief.",
@@ -169,6 +171,7 @@ def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
         next_text="",
         character_id=20,
         narrator_id=10,
+        protagonist_id=20,
         minor_female_id=30,
         minor_male_id=40,
         reason="Recalling her final words.",
@@ -178,15 +181,37 @@ def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
         next_text="she asked without looking up.",
         character_id=10,
         narrator_id=10,
+        protagonist_id=20,
         minor_female_id=30,
         minor_male_id=40,
         reason="Dialogue attributed to the unnamed recruiter.",
+    )
+    first_person_dialogue = audiobook_llm._apply_speaker_guardrails(
+        text="“I could be lonely,” I said.",
+        next_text="“We do not get many,” she said.",
+        character_id=30,
+        narrator_id=10,
+        protagonist_id=20,
+        minor_female_id=30,
+        minor_male_id=40,
+        reason="Model confused the adjacent speaker.",
+    )
+    repeated_dialogue = audiobook_llm._apply_speaker_guardrails(
+        text="“Coming or going,” she repeated. “",
+        next_text="",
+        character_id=50,
+        narrator_id=10,
+        protagonist_id=20,
+        minor_female_id=30,
+        minor_male_id=40,
+        reason="Model selected an unrelated named character.",
     )
     setup = audiobook_llm._apply_speaker_guardrails(
         text="The recruiter looked up. “",
         next_text="Hello,” she said.",
         character_id=10,
         narrator_id=10,
+        protagonist_id=20,
         minor_female_id=30,
         minor_male_id=40,
         reason="Narration setting up dialogue.",
@@ -196,7 +221,43 @@ def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
     assert emotional_prose == (10, "Deterministic prose/narration guardrail", 0.98)
     assert embedded_quote == (10, "Deterministic prose/narration guardrail", 0.98)
     assert dialogue == (30, "Deterministic she dialogue attribution to minor voice", 0.98)
+    assert first_person_dialogue == (20, "Deterministic first-person dialogue attribution", 0.99)
+    assert repeated_dialogue == (30, "Deterministic she dialogue attribution to minor voice", 0.98)
     assert setup == (10, "Narration setting up dialogue.", None)
+
+
+def test_open_dialogue_state_tracks_split_quote_speaker():
+    open_speaker = audiobook_llm._advance_open_dialogue_speaker(
+        "“Take your time,” I said. “",
+        20,
+        narrator_id=10,
+        minor_female_id=30,
+        minor_male_id=40,
+        current_open_speaker_id=None,
+    )
+    assert open_speaker == 20
+    assert (
+        audiobook_llm._advance_open_dialogue_speaker(
+            "I know the place is packed.”",
+            20,
+            narrator_id=10,
+            minor_female_id=30,
+            minor_male_id=40,
+            current_open_speaker_id=open_speaker,
+        )
+        is None
+    )
+    assert (
+        audiobook_llm._advance_open_dialogue_speaker(
+            "She looked back to her computer. “",
+            10,
+            narrator_id=10,
+            minor_female_id=30,
+            minor_male_id=40,
+            current_open_speaker_id=None,
+        )
+        == 30
+    )
 
 
 @pytest.mark.asyncio
@@ -366,7 +427,7 @@ async def test_diarization_retries_malformed_output_in_smaller_batches(db, monke
 
     counts = await crud.audiobook.count_sentences_by_status(db, book.id)
     await db.refresh(book)
-    assert request_sizes == [40, 20, 20, 5]
+    assert request_sizes == [10, 5, 5, 10, 10, 10, 5]
     assert counts == {"ready_for_audio": 45}
     assert book.audiobook_pipeline_status == "audio_gen"
 

--- a/backend/tests/test_audiobook_pipeline.py
+++ b/backend/tests/test_audiobook_pipeline.py
@@ -75,6 +75,7 @@ class _FakeQueue:
     def __init__(self):
         self.enqueued: list[int] = []
         self.preview_enqueued: list[tuple[int, int]] = []
+        self.sentence_enqueued: list[tuple[int, int]] = []
 
     async def enqueue(self, book_id: int) -> bool:
         self.enqueued.append(book_id)
@@ -82,6 +83,10 @@ class _FakeQueue:
 
     async def enqueue_preview(self, book_id: int, chapter_id: int) -> bool:
         self.preview_enqueued.append((book_id, chapter_id))
+        return True
+
+    async def enqueue_sentence_audio(self, book_id: int, sentence_id: int) -> bool:
+        self.sentence_enqueued.append((book_id, sentence_id))
         return True
 
 
@@ -801,6 +806,42 @@ async def test_manual_chapter_preview_requires_analysis_and_queues_work(db, monk
     with pytest.raises(audiobook_router.HTTPException) as exc_info:
         await audiobook_router.generate_chapter_preview(book.id, chapter.id, db)
     assert exc_info.value.status_code == 409
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg is required for MP3 generation")
+async def test_manual_sentence_audio_queues_and_generates_only_that_sentence(db, tmp_path, monkeypatch):
+    library_path = tmp_path / "library"
+    library_path.mkdir()
+    book = await _make_book(db, audiobook_enabled=True, audiobook_pipeline_status="paused")
+    chapter, _character, sentence = await _seed_audio_chapter(db, book.id)
+    chapter.preview_status = "ready"
+    chapter.audio_file_path = "library/audiobooks/old-preview.mp3"
+    await db.commit()
+    queue = _FakeQueue()
+    monkeypatch.setattr(audiobook_router, "get_audiobook_queue", lambda: queue)
+    monkeypatch.setattr(audiobook_tts, "LIBRARY_PATH", library_path)
+
+    response = await audiobook_router.generate_sentence_audio(book.id, sentence.id, db)
+    await db.refresh(sentence)
+
+    assert response == {
+        "status": "audio_queued",
+        "queued": True,
+        "sentence_id": sentence.id,
+    }
+    assert sentence.status == "audio_queued"
+    assert queue.sentence_enqueued == [(book.id, sentence.id)]
+
+    await audiobook_tts.generate_audio_for_sentence(book.id, sentence.id, db)
+    await db.refresh(sentence)
+    await db.refresh(chapter)
+
+    assert sentence.status == "audio_generated"
+    assert sentence.audio_file_path
+    assert (library_path.parent / sentence.audio_file_path).exists()
+    assert chapter.needs_reassembly is True
+    assert chapter.preview_status is None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_audiobook_pipeline.py
+++ b/backend/tests/test_audiobook_pipeline.py
@@ -3,6 +3,7 @@ import json
 import shutil
 import zipfile
 from pathlib import Path
+from types import SimpleNamespace
 
 import httpx
 import pytest
@@ -152,6 +153,9 @@ def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
         character_id=20,
         narrator_id=10,
         protagonist_id=20,
+        character_name_ids={"harry": 50},
+        role_speaker_ids={"recruiter": 30},
+        last_dialogue_speaker_id=None,
         minor_female_id=30,
         minor_male_id=40,
         reason="Action description by the protagonist.",
@@ -162,6 +166,9 @@ def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
         character_id=20,
         narrator_id=10,
         protagonist_id=20,
+        character_name_ids={"harry": 50},
+        role_speaker_ids={"recruiter": 30},
+        last_dialogue_speaker_id=None,
         minor_female_id=30,
         minor_male_id=40,
         reason="Expressing deep grief.",
@@ -172,6 +179,9 @@ def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
         character_id=20,
         narrator_id=10,
         protagonist_id=20,
+        character_name_ids={"harry": 50},
+        role_speaker_ids={"recruiter": 30},
+        last_dialogue_speaker_id=None,
         minor_female_id=30,
         minor_male_id=40,
         reason="Recalling her final words.",
@@ -182,6 +192,9 @@ def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
         character_id=10,
         narrator_id=10,
         protagonist_id=20,
+        character_name_ids={"harry": 50},
+        role_speaker_ids={"recruiter": 30},
+        last_dialogue_speaker_id=None,
         minor_female_id=30,
         minor_male_id=40,
         reason="Dialogue attributed to the unnamed recruiter.",
@@ -192,6 +205,9 @@ def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
         character_id=30,
         narrator_id=10,
         protagonist_id=20,
+        character_name_ids={"harry": 50},
+        role_speaker_ids={"recruiter": 30},
+        last_dialogue_speaker_id=None,
         minor_female_id=30,
         minor_male_id=40,
         reason="Model confused the adjacent speaker.",
@@ -202,9 +218,38 @@ def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
         character_id=50,
         narrator_id=10,
         protagonist_id=20,
+        character_name_ids={"harry": 50},
+        role_speaker_ids={"recruiter": 30},
+        last_dialogue_speaker_id=30,
         minor_female_id=30,
         minor_male_id=40,
         reason="Model selected an unrelated named character.",
+    )
+    role_dialogue = audiobook_llm._apply_speaker_guardrails(
+        text="“Final paragraph,” the recruiter said. “",
+        next_text="",
+        character_id=20,
+        narrator_id=10,
+        protagonist_id=20,
+        character_name_ids={"harry": 50},
+        role_speaker_ids={"recruiter": 30},
+        last_dialogue_speaker_id=30,
+        minor_female_id=30,
+        minor_male_id=40,
+        reason="Model selected the protagonist.",
+    )
+    named_dialogue = audiobook_llm._apply_speaker_guardrails(
+        text="“Physics is lovely,” Harry said.",
+        next_text="",
+        character_id=10,
+        narrator_id=10,
+        protagonist_id=20,
+        character_name_ids={"harry": 50},
+        role_speaker_ids={"recruiter": 30},
+        last_dialogue_speaker_id=20,
+        minor_female_id=30,
+        minor_male_id=40,
+        reason="Model selected narration.",
     )
     setup = audiobook_llm._apply_speaker_guardrails(
         text="The recruiter looked up. “",
@@ -212,6 +257,9 @@ def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
         character_id=10,
         narrator_id=10,
         protagonist_id=20,
+        character_name_ids={"harry": 50},
+        role_speaker_ids={"recruiter": 30},
+        last_dialogue_speaker_id=None,
         minor_female_id=30,
         minor_male_id=40,
         reason="Narration setting up dialogue.",
@@ -223,6 +271,8 @@ def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
     assert dialogue == (30, "Deterministic she dialogue attribution to minor voice", 0.98)
     assert first_person_dialogue == (20, "Deterministic first-person dialogue attribution", 0.99)
     assert repeated_dialogue == (30, "Deterministic she dialogue attribution to minor voice", 0.98)
+    assert role_dialogue == (30, "Deterministic grounded role dialogue attribution", 0.98)
+    assert named_dialogue == (50, "Deterministic named dialogue attribution to harry", 0.99)
     assert setup == (10, "Narration setting up dialogue.", None)
 
 
@@ -258,6 +308,15 @@ def test_open_dialogue_state_tracks_split_quote_speaker():
         )
         == 30
     )
+
+
+def test_role_speaker_grounding_uses_chapter_local_pronouns():
+    sentences = [
+        SimpleNamespace(original_text="I waited for the recruiter while she finished typing."),
+        SimpleNamespace(original_text="“Final paragraph,” the recruiter said."),
+    ]
+
+    assert audiobook_llm._infer_role_speaker_ids(sentences, 30, 40)["recruiter"] == 30
 
 
 @pytest.mark.asyncio
@@ -310,7 +369,7 @@ async def test_ollama_call_requests_schema_constrained_non_thinking_json(monkeyp
     assert payload["think"] is False
     assert payload["format"] == schema
     assert payload["options"]["temperature"] == 0
-    assert payload["options"]["num_predict"] == 8192
+    assert payload["options"]["num_predict"] == 2048
 
 
 @pytest.mark.asyncio
@@ -388,7 +447,7 @@ async def test_diarization_retries_malformed_output_in_smaller_batches(db, monke
             {
                 "html_element_id": f"sentence-{index}",
                 "sequence_order": index,
-                "original_text": f"Sentence {index} has enough text for analysis.",
+                "original_text": f"“Sentence {index} has enough dialogue for analysis.”",
                 "status": "pending_diarization",
             }
             for index in range(45)
@@ -430,6 +489,56 @@ async def test_diarization_retries_malformed_output_in_smaller_batches(db, monke
     assert request_sizes == [10, 5, 5, 10, 10, 10, 5]
     assert counts == {"ready_for_audio": 45}
     assert book.audiobook_pipeline_status == "audio_gen"
+
+
+@pytest.mark.asyncio
+async def test_diarization_short_circuits_quote_free_prose_without_llm(db, monkeypatch):
+    book = await _make_book(db, audiobook_enabled=True, audiobook_pipeline_status="diarizing")
+    settings = models.AudiobookSettings(
+        llm_provider="ollama",
+        llm_base_url="http://127.0.0.1:11434",
+        llm_model="local-test",
+    )
+    db.add(settings)
+    chapter = await crud.audiobook.create_chapter(db, book.id, 1, "Text/prose.xhtml")
+    narrator = (
+        await crud.audiobook.create_characters_bulk(
+            db,
+            book.id,
+            [
+                {
+                    "name": "Narrator",
+                    "voice_design_prompt": "[gender-neutral][pitch-medium][speed-normal][age-middle]",
+                    "is_narrator": True,
+                }
+            ],
+        )
+    )[0]
+    await crud.audiobook.create_sentences_bulk(
+        db,
+        chapter.id,
+        [
+            {
+                "html_element_id": f"prose-{index}",
+                "sequence_order": index,
+                "original_text": f"Narrative sentence {index} contains no dialogue.",
+                "status": "pending_diarization",
+            }
+            for index in range(40)
+        ],
+    )
+
+    async def unexpected_llm(*_args, **_kwargs):
+        raise AssertionError("Quote-free narration should not call the LLM")
+
+    monkeypatch.setattr(audiobook_llm, "_call_llm", unexpected_llm)
+
+    await audiobook_llm.diarize_sentences(book.id, db)
+
+    sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
+    assert {sentence.character_id for sentence in sentences} == {narrator.id}
+    assert {sentence.speaker_reason for sentence in sentences} == {"Deterministic quote-free narration"}
+    assert await crud.audiobook.count_sentences_by_status(db, book.id) == {"ready_for_audio": 40}
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_audiobook_pipeline.py
+++ b/backend/tests/test_audiobook_pipeline.py
@@ -1,3 +1,4 @@
+import asyncio
 from pathlib import Path
 
 import httpx
@@ -8,6 +9,7 @@ from ebooklib import epub
 from backend.app import crud, models
 from backend.app.routers import audiobook as audiobook_router
 from backend.app.services import audiobook_assembly, audiobook_ingestion, audiobook_tts
+from backend.app.services.audiobook_queue import AudiobookQueue
 
 
 async def _make_book(db, **overrides):
@@ -72,6 +74,35 @@ class _FakeQueue:
     async def enqueue(self, book_id: int) -> bool:
         self.enqueued.append(book_id)
         return True
+
+
+@pytest.mark.asyncio
+async def test_queue_schedules_one_rerun_for_changes_during_processing(monkeypatch):
+    queue = AudiobookQueue()
+    processed: list[int] = []
+    first_run_started = asyncio.Event()
+    release_first_run = asyncio.Event()
+
+    async def process(book_id: int) -> None:
+        processed.append(book_id)
+        if len(processed) == 1:
+            first_run_started.set()
+            await release_first_run.wait()
+
+    monkeypatch.setattr(queue, "_process", process)
+    await queue.start()
+    try:
+        assert await queue.enqueue(42) is True
+        await first_run_started.wait()
+
+        assert await queue.enqueue(42) is False
+        assert await queue.enqueue(42) is False
+        release_first_run.set()
+        await queue._queue.join()
+
+        assert processed == [42, 42]
+    finally:
+        await queue.stop()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_audiobook_pipeline.py
+++ b/backend/tests/test_audiobook_pipeline.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import shutil
 import zipfile
 from pathlib import Path
@@ -77,6 +78,112 @@ class _FakeQueue:
     async def enqueue(self, book_id: int) -> bool:
         self.enqueued.append(book_id)
         return True
+
+
+def test_default_roster_prompt_formats_voice_token_examples():
+    prompt = audiobook_llm.DEFAULT_ROSTER_PROMPT.format(
+        text="A story excerpt.",
+        candidate_hints="- Harry: 12 mentions",
+    )
+
+    assert "[gender-{male|female|neutral}]" in prompt
+    assert "A story excerpt." in prompt
+
+
+def test_tagged_text_sanitizer_only_accepts_supported_insertions():
+    original = "Take your time, I said."
+
+    assert audiobook_llm._sanitize_tagged_text(original, "[whisper] Take your time, I said.") == (
+        "[whisper] Take your time, I said."
+    )
+    assert audiobook_llm._sanitize_tagged_text(original, "[fade in] Take your time, I said.") == original
+    assert audiobook_llm._sanitize_tagged_text(original, "I completely rewrote this sentence.") == original
+
+
+def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
+    prose = audiobook_llm._apply_speaker_guardrails(
+        text="I sat down and waited.",
+        next_text="",
+        character_id=20,
+        narrator_id=10,
+        minor_female_id=30,
+        minor_male_id=40,
+        reason="Action description by the protagonist.",
+    )
+    dialogue = audiobook_llm._apply_speaker_guardrails(
+        text="“You coming or going?”",
+        next_text="she asked without looking up.",
+        character_id=10,
+        narrator_id=10,
+        minor_female_id=30,
+        minor_male_id=40,
+        reason="Dialogue attributed to the unnamed recruiter.",
+    )
+    setup = audiobook_llm._apply_speaker_guardrails(
+        text="The recruiter looked up. “",
+        next_text="Hello,” she said.",
+        character_id=10,
+        narrator_id=10,
+        minor_female_id=30,
+        minor_male_id=40,
+        reason="Narration setting up dialogue.",
+    )
+
+    assert prose == (10, "Deterministic prose/narration guardrail", 0.98)
+    assert dialogue == (30, "Deterministic she dialogue attribution to minor voice", 0.98)
+    assert setup == (10, "Narration setting up dialogue.", None)
+
+
+@pytest.mark.asyncio
+async def test_ollama_call_requests_schema_constrained_non_thinking_json(monkeypatch):
+    captured = {}
+
+    class FakeResponse:
+        is_error = False
+
+        def json(self):
+            return {"message": {"content": json.dumps({"status": "ready"})}}
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            captured["client"] = kwargs
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def post(self, url, **kwargs):
+            captured["url"] = url
+            captured["request"] = kwargs
+            return FakeResponse()
+
+    monkeypatch.setattr(audiobook_llm.httpx, "AsyncClient", FakeClient)
+    settings = models.AudiobookSettings(
+        llm_provider="ollama",
+        llm_base_url="http://127.0.0.1:11434",
+        llm_model="qwen3.5:27b",
+    )
+    schema = {
+        "type": "object",
+        "properties": {"status": {"type": "string"}},
+        "required": ["status"],
+    }
+
+    raw = await audiobook_llm._call_llm(
+        settings,
+        [{"role": "user", "content": "ready?"}],
+        response_schema=schema,
+    )
+
+    assert json.loads(raw) == {"status": "ready"}
+    assert captured["url"] == "http://127.0.0.1:11434/api/chat"
+    payload = captured["request"]["json"]
+    assert payload["model"] == "qwen3.5:27b"
+    assert payload["think"] is False
+    assert payload["format"] == schema
+    assert payload["options"]["temperature"] == 0
 
 
 @pytest.mark.asyncio
@@ -222,6 +329,103 @@ async def test_step_pipeline_runs_only_next_recoverable_phase(db, monkeypatch):
     assert book.audiobook_pipeline_status == "ingesting"
     assert book.audiobook_stop_after_phase == "ingesting"
     assert book.audiobook_last_error is None
+    assert queue.enqueued == [book.id]
+
+
+@pytest.mark.asyncio
+async def test_run_batch_persists_one_unit_limit(db, monkeypatch):
+    book = await _make_book(db, audiobook_enabled=True, audiobook_pipeline_status="paused")
+    await _seed_audio_chapter(db, book.id, sentence_status="ready_for_audio")
+    queue = _FakeQueue()
+    monkeypatch.setattr(audiobook_router, "get_audiobook_queue", lambda: queue)
+
+    response = await audiobook_router.run_pipeline_batch(book.id, db)
+
+    await db.refresh(book)
+    assert response == {
+        "status": "audio_gen",
+        "queued": True,
+        "batch_limit": 1,
+    }
+    assert book.audiobook_pipeline_status == "audio_gen"
+    assert book.audiobook_batch_limit == 1
+    assert queue.enqueued == [book.id]
+
+
+@pytest.mark.asyncio
+async def test_review_filter_excludes_pending_and_keeps_uncertain_assignments(db):
+    book = await _make_book(db, audiobook_enabled=True)
+    chapter, character, sentence = await _seed_audio_chapter(
+        db,
+        book.id,
+        sentence_status="ready_for_audio",
+    )
+    sentence.speaker_confidence = 0.4
+    sentence.speaker_reason = "Ambiguous dialogue turn"
+    await crud.audiobook.create_sentences_bulk(
+        db,
+        chapter_id=chapter.id,
+        sentences_data=[
+            {
+                "html_element_id": "ch1_s1",
+                "sequence_order": 1,
+                "original_text": "Pending.",
+                "status": "pending_diarization",
+            },
+            {
+                "html_element_id": "ch1_s2",
+                "sequence_order": 2,
+                "original_text": "Certain.",
+                "tagged_text": "Certain.",
+                "character_id": character.id,
+                "speaker_confidence": 0.95,
+                "status": "ready_for_audio",
+            },
+        ],
+    )
+
+    review, total = await crud.audiobook.get_sentences_paginated(
+        db,
+        book.id,
+        review_only=True,
+    )
+
+    assert total == 1
+    assert [item.original_text for item in review] == ["One sentence."]
+
+
+@pytest.mark.asyncio
+async def test_roster_rebuild_preserves_ingestion_and_clears_derived_analysis(db, monkeypatch):
+    book = await _make_book(db, audiobook_enabled=True, audiobook_pipeline_status="paused")
+    chapter, _character, sentence = await _seed_audio_chapter(
+        db,
+        book.id,
+        sentence_status="audio_generated",
+    )
+    chapter.summary = "Old summary"
+    sentence.speaker_confidence = 0.9
+    sentence.audio_file_path = "library/audiobooks/1/snippets/1.mp3"
+    await db.commit()
+    queue = _FakeQueue()
+    monkeypatch.setattr(audiobook_router, "get_audiobook_queue", lambda: queue)
+
+    response = await audiobook_router.rebuild_character_roster(book.id, db)
+
+    await db.refresh(book)
+    await db.refresh(chapter)
+    await db.refresh(sentence)
+    assert response == {
+        "status": "roster_gen",
+        "queued": True,
+        "stop_after_phase": "roster_gen",
+    }
+    assert book.audiobook_pipeline_status == "roster_gen"
+    assert sentence.status == "pending_diarization"
+    assert sentence.character_id is None
+    assert sentence.speaker_confidence is None
+    assert sentence.audio_file_path is None
+    assert chapter.summary is None
+    assert await crud.audiobook.get_characters_for_book(db, book.id) == []
     assert queue.enqueued == [book.id]
 
 
@@ -393,6 +597,107 @@ async def test_ingestion_preserves_nested_markup_and_records_spine_file(db, tmp_
     assert soup.find("a", href="next.xhtml") is not None
     assert soup.find("span", id="ch1_s0") is not None
     assert soup.find("span", id="ch1_s1") is not None
+
+
+@pytest.mark.asyncio
+async def test_roster_excerpt_skips_short_front_matter(db):
+    book = await _make_book(db, audiobook_enabled=True)
+    front = await crud.audiobook.create_chapter(db, book.id, 1, "front.xhtml")
+    await crud.audiobook.create_sentences_bulk(
+        db,
+        front.id,
+        [
+            {
+                "html_element_id": "front_0",
+                "sequence_order": 0,
+                "original_text": "Copyright page only.",
+                "status": "pending_diarization",
+            }
+        ],
+    )
+    story = await crud.audiobook.create_chapter(db, book.id, 2, "story.xhtml")
+    await crud.audiobook.create_sentences_bulk(
+        db,
+        story.id,
+        [
+            {
+                "html_element_id": f"story_{index}",
+                "sequence_order": index,
+                "original_text": f"John and Kathy continue the story in sentence {index}.",
+                "status": "pending_diarization",
+            }
+            for index in range(40)
+        ],
+    )
+
+    excerpt = await audiobook_llm._build_roster_excerpt(
+        await crud.audiobook.get_chapters_for_book(db, book.id),
+        db,
+    )
+
+    assert "Copyright page only" not in excerpt
+    assert "John and Kathy continue the story" in excerpt
+    assert "### Chapter 2" in excerpt
+
+
+@pytest.mark.asyncio
+async def test_roster_keeps_first_person_protagonist_separate_from_narrator(db, monkeypatch):
+    book = await _make_book(db, audiobook_enabled=True)
+    settings = models.AudiobookSettings(
+        llm_provider="ollama",
+        llm_base_url="http://ollama.test",
+        llm_model="qwen-test",
+    )
+    db.add(settings)
+    chapter = await crud.audiobook.create_chapter(db, book.id, 1, "story.xhtml")
+    await crud.audiobook.create_sentences_bulk(
+        db,
+        chapter.id,
+        [
+            {
+                "html_element_id": f"story_{index}",
+                "sequence_order": index,
+                "original_text": f'Harry said, "John, sentence {index}."',
+                "status": "pending_diarization",
+            }
+            for index in range(40)
+        ],
+    )
+    captured = {}
+
+    async def fake_call(_settings, messages, **_kwargs):
+        captured["prompt"] = messages[0]["content"]
+        return json.dumps(
+            {
+                "book_summary": "John tells a story.",
+                "characters": [
+                    {
+                        "name": "John Perry",
+                        "aliases": ["Narrator"],
+                        "description": "First-person protagonist.",
+                        "evidence": ["John speaks."],
+                        "voice_design_prompt": "[gender-male][pitch-medium][speed-normal]",
+                        "is_narrator": True,
+                    }
+                ],
+            }
+        )
+
+    monkeypatch.setattr(audiobook_llm, "_call_llm", fake_call)
+
+    await audiobook_llm.generate_character_roster(book.id, db)
+
+    characters = await crud.audiobook.get_characters_for_book(db, book.id)
+    assert [(character.name, character.is_narrator) for character in characters] == [
+        ("Narrator", True),
+        ("Harry", False),
+        ("John Perry", False),
+        ("Minor Female Voice", False),
+        ("Minor Male Voice", False),
+    ]
+    assert characters[2].aliases == []
+    assert "40 explicit dialogue attributions" in characters[1].description
+    assert "Harry: 40 mentions" in captured["prompt"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_audiobook_pipeline.py
+++ b/backend/tests/test_audiobook_pipeline.py
@@ -251,6 +251,32 @@ def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
         minor_male_id=40,
         reason="Model selected narration.",
     )
+    current_named_dialogue = audiobook_llm._apply_speaker_guardrails(
+        text="“I dislike that,” Jesse said.",
+        next_text="“It may be harmless,” Harry said.",
+        character_id=50,
+        narrator_id=10,
+        protagonist_id=20,
+        character_name_ids={"harry": 50, "jesse": 60},
+        role_speaker_ids={"recruiter": 30},
+        last_dialogue_speaker_id=50,
+        minor_female_id=30,
+        minor_male_id=40,
+        reason="Model followed the next sentence's speaker.",
+    )
+    turn_taking_dialogue = audiobook_llm._apply_speaker_guardrails(
+        text="“Does that bother you?”",
+        next_text="“No,” she said.",
+        character_id=50,
+        narrator_id=10,
+        protagonist_id=20,
+        character_name_ids={"harry": 50},
+        role_speaker_ids={"recruiter": 30},
+        last_dialogue_speaker_id=30,
+        minor_female_id=30,
+        minor_male_id=40,
+        reason="Model selected an unrelated named character.",
+    )
     setup = audiobook_llm._apply_speaker_guardrails(
         text="The recruiter looked up. “",
         next_text="Hello,” she said.",
@@ -273,6 +299,8 @@ def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
     assert repeated_dialogue == (30, "Deterministic she dialogue attribution to minor voice", 0.98)
     assert role_dialogue == (30, "Deterministic grounded role dialogue attribution", 0.98)
     assert named_dialogue == (50, "Deterministic named dialogue attribution to harry", 0.99)
+    assert current_named_dialogue == (60, "Deterministic named dialogue attribution to jesse", 0.99)
+    assert turn_taking_dialogue == (20, "Deterministic first-person turn-taking fallback", 0.8)
     assert setup == (10, "Narration setting up dialogue.", None)
 
 
@@ -309,6 +337,29 @@ def test_open_dialogue_state_tracks_split_quote_speaker():
         == 30
     )
 
+    # A close followed by a new opening in one sentence starts another
+    # paragraph of the same resolved speaker's utterance.
+    reopened = audiobook_llm._advance_open_dialogue_speaker(
+        "You were sent refresher materials,” she said. “",
+        30,
+        narrator_id=10,
+        minor_female_id=30,
+        minor_male_id=40,
+        current_open_speaker_id=30,
+    )
+    assert reopened == 30
+    assert (
+        audiobook_llm._advance_open_dialogue_speaker(
+            "Additionally, you have been reminded of your obligations.",
+            30,
+            narrator_id=10,
+            minor_female_id=30,
+            minor_male_id=40,
+            current_open_speaker_id=reopened,
+        )
+        == 30
+    )
+
 
 def test_role_speaker_grounding_uses_chapter_local_pronouns():
     sentences = [
@@ -317,6 +368,19 @@ def test_role_speaker_grounding_uses_chapter_local_pronouns():
     ]
 
     assert audiobook_llm._infer_role_speaker_ids(sentences, 30, 40)["recruiter"] == 30
+
+
+def test_unattributed_open_quote_uses_established_other_speaker():
+    assert (
+        audiobook_llm._fallback_open_dialogue_speaker(
+            "I nodded. “",
+            None,
+            protagonist_id=20,
+            last_dialogue_speaker_id=20,
+            last_other_dialogue_speaker_id=30,
+        )
+        == 30
+    )
 
 
 @pytest.mark.asyncio
@@ -539,6 +603,78 @@ async def test_diarization_short_circuits_quote_free_prose_without_llm(db, monke
     assert {sentence.character_id for sentence in sentences} == {narrator.id}
     assert {sentence.speaker_reason for sentence in sentences} == {"Deterministic quote-free narration"}
     assert await crud.audiobook.count_sentences_by_status(db, book.id) == {"ready_for_audio": 40}
+
+
+@pytest.mark.asyncio
+async def test_diarization_honors_pause_after_current_durable_batch(db, monkeypatch):
+    book = await _make_book(db, audiobook_enabled=True, audiobook_pipeline_status="diarizing")
+    db.add(
+        models.AudiobookSettings(
+            llm_provider="ollama",
+            llm_base_url="http://127.0.0.1:11434",
+            llm_model="local-test",
+        )
+    )
+    chapter = await crud.audiobook.create_chapter(db, book.id, 1, "Text/dialogue.xhtml")
+    narrator = (
+        await crud.audiobook.create_characters_bulk(
+            db,
+            book.id,
+            [
+                {
+                    "name": "Narrator",
+                    "voice_design_prompt": "[gender-neutral][pitch-medium][speed-normal][age-middle]",
+                    "is_narrator": True,
+                }
+            ],
+        )
+    )[0]
+    await crud.audiobook.create_sentences_bulk(
+        db,
+        chapter.id,
+        [
+            {
+                "html_element_id": f"dialogue-{index}",
+                "sequence_order": index,
+                "original_text": f"“Dialogue sentence {index}.”",
+                "status": "pending_diarization",
+            }
+            for index in range(40)
+        ],
+    )
+
+    async def fake_llm(_settings, messages, **_kwargs):
+        serialized = messages[0]["content"].split(
+            "Sentences to process (JSON array with id and text):\n", 1
+        )[1].split("\n\nFor each sentence return:", 1)[0]
+        sentences = json.loads(serialized)
+        await crud.audiobook.request_book_pipeline_pause(db, book.id)
+        return json.dumps(
+            {
+                "assignments": [
+                    {
+                        "id": sentence["id"],
+                        "character_id": narrator.id,
+                        "tagged_text": None,
+                        "confidence": 1.0,
+                        "reason": "Test attribution",
+                    }
+                    for sentence in sentences
+                ]
+            }
+        )
+
+    monkeypatch.setattr(audiobook_llm, "_call_llm", fake_llm)
+
+    await audiobook_llm.diarize_sentences(book.id, db)
+
+    await db.refresh(book)
+    assert await crud.audiobook.count_sentences_by_status(db, book.id) == {
+        "pending_diarization": 30,
+        "ready_for_audio": 10,
+    }
+    assert book.audiobook_pipeline_status == "paused"
+    assert book.audiobook_pause_requested is False
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_audiobook_pipeline.py
+++ b/backend/tests/test_audiobook_pipeline.py
@@ -644,9 +644,11 @@ async def test_diarization_honors_pause_after_current_durable_batch(db, monkeypa
     )
 
     async def fake_llm(_settings, messages, **_kwargs):
-        serialized = messages[0]["content"].split(
-            "Sentences to process (JSON array with id and text):\n", 1
-        )[1].split("\n\nFor each sentence return:", 1)[0]
+        serialized = (
+            messages[0]["content"]
+            .split("Sentences to process (JSON array with id and text):\n", 1)[1]
+            .split("\n\nFor each sentence return:", 1)[0]
+        )
         sentences = json.loads(serialized)
         await crud.audiobook.request_book_pipeline_pause(db, book.id)
         return json.dumps(

--- a/backend/tests/test_audiobook_pipeline.py
+++ b/backend/tests/test_audiobook_pipeline.py
@@ -1,4 +1,6 @@
 import asyncio
+import shutil
+import zipfile
 from pathlib import Path
 
 import httpx
@@ -8,7 +10,7 @@ from ebooklib import epub
 
 from backend.app import crud, models
 from backend.app.routers import audiobook as audiobook_router
-from backend.app.services import audiobook_assembly, audiobook_ingestion, audiobook_tts
+from backend.app.services import audiobook_assembly, audiobook_ingestion, audiobook_llm, audiobook_tts
 from backend.app.services.audiobook_queue import AudiobookQueue
 
 
@@ -131,6 +133,13 @@ async def test_requeue_candidates_only_include_enabled_audiobooks(db):
     pending = await crud.audiobook.get_in_progress_audiobook_books(db)
 
     assert [book.id for book in pending] == [enabled.id]
+
+
+@pytest.mark.asyncio
+async def test_empty_audio_state_is_not_considered_complete(db):
+    book = await _make_book(db, audiobook_enabled=True)
+
+    assert await crud.audiobook.all_sentences_audio_generated(db, book.id) is False
 
 
 @pytest.mark.asyncio
@@ -283,3 +292,49 @@ async def test_ingestion_preserves_nested_markup_and_records_spine_file(db, tmp_
     assert soup.find("a", href="next.xhtml") is not None
     assert soup.find("span", id="ch1_s0") is not None
     assert soup.find("span", id="ch1_s1") is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg is required for MP3 assembly")
+async def test_offline_harness_builds_downloadable_media_overlay_epub(db, tmp_path, monkeypatch):
+    library_path = tmp_path / "library"
+    library_path.mkdir()
+    epub_path = library_path / "offline.epub"
+    _write_nested_epub(epub_path)
+    book = await _make_book(
+        db,
+        audiobook_enabled=True,
+        immutable_path=str(epub_path.relative_to(library_path.parent)),
+        current_path=str(epub_path.relative_to(library_path.parent)),
+    )
+    for module in (audiobook_ingestion, audiobook_tts, audiobook_assembly):
+        monkeypatch.setattr(module, "LIBRARY_PATH", library_path)
+    monkeypatch.setattr(audiobook_ingestion, "_tokenize_text", _simple_sentence_split)
+
+    await audiobook_ingestion.ingest_epub(book.id, db)
+    await audiobook_llm.generate_character_roster(book.id, db)
+    await audiobook_llm.diarize_sentences(book.id, db)
+    await audiobook_tts.generate_audio_for_book(book.id, db)
+    await audiobook_assembly.assemble_book(book.id, db)
+
+    await db.refresh(book)
+    characters = await crud.audiobook.get_characters_for_book(db, book.id)
+    counts = await crud.audiobook.count_sentences_by_status(db, book.id)
+    output_path = library_path / "audiobooks" / str(book.id) / "audiobook.epub"
+
+    assert book.audiobook_pipeline_status == "complete"
+    assert [(character.name, character.is_narrator) for character in characters] == [("Narrator", True)]
+    assert counts == {"audio_generated": 5}
+    assert output_path.exists()
+    with zipfile.ZipFile(output_path) as archive:
+        names = archive.namelist()
+        assert "EPUB/ch0001.mp3" in names
+        assert "EPUB/ch0001.smil" in names
+        package = archive.read("EPUB/content.opf").decode("utf-8")
+        assert 'media-type="application/smil+xml"' in package
+        assert 'media-overlay="smil_ch0001"' in package
+
+    monkeypatch.setattr(audiobook_router, "LIBRARY_PATH", library_path)
+    response = await audiobook_router.download_audiobook(book.id, db)
+    assert Path(response.path) == output_path
+    assert response.media_type == "application/epub+zip"

--- a/backend/tests/test_epub_editor.py
+++ b/backend/tests/test_epub_editor.py
@@ -1,10 +1,11 @@
 import zipfile
 from pathlib import Path
 
+import pytest
 from bs4 import BeautifulSoup
 from ebooklib import epub
 
-from backend.app import epub_editor
+from backend.app import epub_editor, models
 from backend.app.services.epub_utils import PROSE_BLOCK_MAX_CHARS
 
 
@@ -51,3 +52,34 @@ def test_process_epub_normalizes_oversized_prose_blocks(tmp_path):
     assert word_count is not None
     assert len(paragraphs) == 3
     assert all(len(p.get_text(" ", strip=True)) <= PROSE_BLOCK_MAX_CHARS for p in paragraphs)
+
+
+@pytest.mark.asyncio
+async def test_forced_cleaning_rebuild_restores_epub_after_last_rule_is_removed(db, monkeypatch):
+    book = models.Book(
+        title="Restored",
+        author="Reader",
+        source_type=models.SourceType.epub,
+        immutable_path="library/restored-immutable.epub",
+        current_path="library/restored.epub",
+        removed_chapters=[],
+        content_selectors=[],
+        current_word_count=0,
+    )
+    db.add(book)
+    await db.commit()
+    await db.refresh(book)
+    calls = []
+
+    def process(*args, **kwargs):
+        calls.append((args, kwargs))
+        return 3
+
+    monkeypatch.setattr(epub_editor, "process_epub", process)
+
+    changed = await epub_editor.apply_book_cleaning(book, db, force=True)
+
+    assert changed is True
+    assert len(calls) == 1
+    assert calls[0][0][2:4] == ([], [])
+    assert book.current_word_count == 3

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -97,6 +97,38 @@ async def test_get_book_catalog_returns_minimal_entries(db_session):
 
 
 @pytest.mark.asyncio
+async def test_book_catalog_sorts_audiobook_enabled_first(db_session):
+    async with AsyncTestingSessionLocal() as session:
+        enabled = await crud.create_book(
+            session,
+            schemas.BookCreate(
+                title="Audio Book",
+                author="Catalog Author",
+                immutable_path="audio-sort-enabled-source.epub",
+                current_path="audio-sort-enabled.epub",
+                source_type=models.SourceType.epub,
+            ),
+        )
+        enabled.audiobook_enabled = True
+        await crud.create_book(
+            session,
+            schemas.BookCreate(
+                title="Text Book",
+                author="Catalog Author",
+                immutable_path="audio-sort-disabled-source.epub",
+                current_path="audio-sort-disabled.epub",
+                source_type=models.SourceType.epub,
+            ),
+        )
+        await session.commit()
+
+    response = client.get("/api/books/catalog?sort_by=audiobook_enabled&sort_order=desc")
+
+    assert response.status_code == 200
+    assert [book["title"] for book in response.json()] == ["Audio Book", "Text Book"]
+
+
+@pytest.mark.asyncio
 async def test_get_book_catalog_includes_series_and_effective_genre_tags(db_session):
     async with AsyncTestingSessionLocal() as session:
         await crud.create_book(

--- a/backend/tests/test_omnivoice_adapter.py
+++ b/backend/tests/test_omnivoice_adapter.py
@@ -1,0 +1,32 @@
+from services.omnivoice.prompt import translate_generation_prompt
+
+
+def test_translates_legacy_voice_profile_to_official_omnivoice_attributes():
+    prompt = translate_generation_prompt(
+        "[gender-female][pitch-low][speed-fast][age-middle][accent-british]",
+        "A line of dialogue.",
+    )
+
+    assert prompt.text == "A line of dialogue."
+    assert prompt.instruct == "female, low pitch, middle-aged, british accent"
+    assert prompt.speed == 1.15
+
+
+def test_preserves_supported_audio_tags_and_removes_unsupported_tags():
+    prompt = translate_generation_prompt(
+        "[gender-neutral][pitch-medium][speed-normal]",
+        "[whisper] Quietly. [laughter] [shout] Loudly.",
+    )
+
+    assert prompt.text == "Quietly. [laughter] Loudly."
+    assert prompt.instruct == "moderate pitch, whisper"
+    assert prompt.speed == 1.0
+
+
+def test_accepts_native_omnivoice_instruction():
+    prompt = translate_generation_prompt(
+        "male, elderly, low pitch, american accent",
+        "Hello.",
+    )
+
+    assert prompt.instruct == "male, elderly, low pitch, american accent"

--- a/docs/AUDIOBOOK_PIPELINE.md
+++ b/docs/AUDIOBOOK_PIPELINE.md
@@ -82,11 +82,12 @@ Changes propagate via cascades without requiring full rebuilds.
 **Character voice profile updated:**
 ```
 PUT /api/audiobook/characters/{id}
+  → promote the profile into the series roster and update matching sibling-book characters
   → UPDATE sentences SET status="ready_for_audio", audio_file_path=NULL
       WHERE character_id = {id}
   → UPDATE chapters SET needs_reassembly=TRUE
       WHERE id IN (SELECT chapter_id FROM audiobook_sentences WHERE character_id = {id})
-  → Re-enqueue book starting at "audio_gen" phase
+  → wait for an explicit chapter preview or full pipeline run
 ```
 
 **Sentence speaker or tags changed:**
@@ -94,7 +95,7 @@ PUT /api/audiobook/characters/{id}
 PUT /api/audiobook/sentences/{id}
   → UPDATE sentence: character_id, tagged_text, status="ready_for_audio", audio_file_path=NULL
   → UPDATE chapter SET needs_reassembly=TRUE WHERE id = sentence.chapter_id
-  → Re-enqueue book starting at "audio_gen" phase
+  → wait for an explicit chapter preview or full pipeline run
 ```
 
 ---
@@ -125,16 +126,25 @@ PUT /api/audiobook/sentences/{id}
 | smil_file_path | String | Relative path to generated `.smil` |
 | audio_file_path | String | Relative path to concatenated chapter MP3 |
 | needs_reassembly | Boolean | Worker polls for `True` |
+| preview_status | String | `queued`, `generating`, `ready`, or `error` for a manual preview |
+| preview_error | Text | Last preview-generation error |
 
 **`audiobook_characters`**
 | Column | Type | Notes |
 |---|---|---|
 | id | Integer PK | |
 | book_id | FK → books CASCADE | |
+| series_character_id | FK → audiobook_series_characters SET NULL | Shared series voice/profile link |
 | name | String | |
 | description | Text | LLM-generated summary |
 | voice_design_prompt | String | OmniVoice params e.g. `[gender-male][pitch-low]` |
 | is_narrator | Boolean | |
+
+**`audiobook_series_characters`** (migration 0021) — the canonical character and voice profile roster shared by
+all audiobook-enabled books in a named series. Book-specific character rows remain stable for sentence assignments,
+while edits to a linked voice profile propagate to matching sibling-book characters and invalidate only their derived
+audio. Roster generation includes previously identified series characters as context and reuses their profiles when
+the same character appears in a later book.
 
 **`audiobook_sentences`** — the state engine
 | Column | Type | Notes |
@@ -167,7 +177,8 @@ Values: `None` (idle), `ingesting`, `roster_gen`, `diarizing`, `audio_gen`, `ass
 - `audiobook_llm_requests` — model calls made during the current run
 
 Migration `0020_audiobook_observability.py` also adds chapter summaries, character aliases/evidence, and sentence
-confidence/rationales.
+confidence/rationales. Migration `0021_series_roster_and_chapter_previews.py` adds the shared series roster links and
+durable manual chapter-preview state.
 
 ---
 
@@ -276,8 +287,26 @@ stale message; failed sentence audio is reset to `ready_for_audio` before TTS re
 
 The Characters tab also offers **Regenerate Character Roster**. It preserves the parsed EPUB and sentence IDs while
 clearing roster, diarization, summaries, and derived audio state. Roster generation samples real story chapters
-across the book and supplements those excerpts with whole-book capitalized-name frequency hints, reducing the chance
-that front matter or a one-scene cameo displaces a recurring speaker.
+across the book and sibling books in the same series. It supplements those excerpts with capitalized-name frequency
+hints and any existing series roster, reducing the chance that front matter or a one-scene cameo displaces a recurring
+speaker. **Sync Series Roster** can promote an already-generated standalone book roster after its series metadata is
+assigned.
+
+## Manual Voice Evaluation
+
+Voice-profile edits deliberately do not start a potentially expensive full-book TTS run. In **Chapter Assembly**, a
+fully diarized chapter exposes **Generate Preview** (or **Rebuild Preview** after a voice change). The preview job runs
+through the same serial worker as the full pipeline, generates or reuses only that chapter's sentence clips, assembles
+its MP3 and SMIL, and leaves the full-book pipeline paused. A partially analyzed chapter shows its analyzed sentence
+count and keeps the action disabled, preventing audio from being generated against incomplete speaker assignments.
+
+Ready previews appear in **Listen & Read**, which provides chapter navigation, a seekable audio player, the chapter
+summary, and the chapter transcript with speaker names available as sentence tooltips. This supports early voice
+evaluation without pretending the final voice roster is complete; after refining a series profile, rebuild the chosen
+chapter explicitly to compare it.
+
+The library catalog shows a headphone badge on audiobook-enabled books and a count on series rows. The Audiobook
+filter can show only enabled or non-enabled books, and the main sort control can order enabled books first.
 
 ---
 
@@ -311,6 +340,8 @@ All paths stored in the database as relative to `LIBRARY_PATH.parent`, matching 
 | POST | `/api/books/{id}/audiobook/pause` | Request a cooperative pause at the next durable boundary |
 | POST | `/api/books/{id}/audiobook/rebuild` | Force full rebuild |
 | POST | `/api/books/{id}/audiobook/roster/rebuild` | Preserve ingestion and regenerate roster/speaker analysis |
+| POST | `/api/books/{id}/audiobook/roster/share-series` | Link/promote the book roster into its series roster |
+| POST | `/api/books/{id}/audiobook/chapters/{cid}/preview-audio` | Queue an explicit single-chapter audio preview |
 | GET | `/api/books/{id}/audiobook/status` | Status, model, progress, summary, review flags, and sentence counts |
 | GET | `/api/books/{id}/audiobook/characters` | List characters |
 | PUT | `/api/audiobook/characters/{char_id}` | Update voice profile (triggers cascade) |
@@ -334,6 +365,7 @@ All paths stored in the database as relative to `LIBRARY_PATH.parent`, matching 
 | `backend/alembic/versions/0018_audiobook_pipeline.py` | Core audiobook schema migration |
 | `backend/alembic/versions/0019_audiobook_pipeline_controls.py` | Review, pause, and error-state migration |
 | `backend/alembic/versions/0020_audiobook_observability.py` | Progress, summaries, evidence, confidence, and batch controls |
+| `backend/alembic/versions/0021_series_roster_and_chapter_previews.py` | Shared series profiles and chapter-preview state |
 | `backend/app/crud/audiobook.py` | DB queries for all new tables |
 | `backend/app/services/audiobook_ingestion.py` | Phase 1: EPUB parse + span injection |
 | `backend/app/services/audiobook_llm.py` | Phases 2 & 3: character roster + diarization |
@@ -353,8 +385,10 @@ All paths stored in the database as relative to `LIBRARY_PATH.parent`, matching 
 | `frontend/src/components/AudiobookPipeline.jsx` | Pipeline tab container (progress + sub-tabs) |
 | `frontend/src/components/audiobook/CharacterRoster.jsx` | Character card grid with voice editing |
 | `frontend/src/components/audiobook/ScriptEditor.jsx` | Paginated sentence table with inline editing |
-| `frontend/src/components/audiobook/ChapterAssembly.jsx` | Chapter assembly status list |
-| `frontend/src/App.jsx` | +Audio Settings tab routing |
+| `frontend/src/components/audiobook/ChapterAssembly.jsx` | Chapter assembly status and manual preview controls |
+| `frontend/src/components/audiobook/AudiobookReader.jsx` | Playable preview chapters with read-along text |
+| `frontend/src/components/BookList.jsx` | Library audiobook filter and enabled counts |
+| `frontend/src/App.jsx` | +Audio Settings tab routing and audiobook-enabled sorting |
 | `frontend/src/components/BookSettings.jsx` | +Audiobook Pipeline tab |
 
 ---

--- a/docs/AUDIOBOOK_PIPELINE.md
+++ b/docs/AUDIOBOOK_PIPELINE.md
@@ -121,6 +121,7 @@ PUT /api/audiobook/sentences/{id}
 | id | Integer PK | |
 | book_id | FK → books CASCADE | |
 | chapter_number | Integer | Spine order |
+| content_file_name | String | Original EPUB spine document path used by SMIL text refs |
 | smil_file_path | String | Relative path to generated `.smil` |
 | audio_file_path | String | Relative path to concatenated chapter MP3 |
 | needs_reassembly | Boolean | Worker polls for `True` |
@@ -149,7 +150,9 @@ PUT /api/audiobook/sentences/{id}
 | audio_duration_ms | Integer | Used for SMIL timestamp calculation |
 | status | String | `pending_diarization` → `ready_for_audio` → `audio_generated` / `error` |
 
-**New column on `books`**: `audiobook_pipeline_status` (String, nullable)
+**New columns on `books`**:
+- `audiobook_enabled` (Boolean, default `false`) — per-book opt-in gate for this pipeline
+- `audiobook_pipeline_status` (String, nullable)
 Values: `None` (idle), `ingesting`, `roster_gen`, `diarizing`, `audio_gen`, `assembling`, `complete`, `error`, `paused`
 
 ---
@@ -271,6 +274,9 @@ All paths stored in the database as relative to `LIBRARY_PATH.parent`, matching 
 - `httpx>=0.27` — HTTP client for LLM and OmniVoice calls (moved from dev)
 - `pydub>=0.25` — MP3 concatenation
 - `mutagen>=1.47` — MP3 duration extraction
+
+**`Dockerfile.base`**:
+- `ffmpeg` — required by `pydub` for MP3 decode/export
 
 **`Dockerfile`** — after `uv pip install`:
 ```dockerfile

--- a/docs/AUDIOBOOK_PIPELINE.md
+++ b/docs/AUDIOBOOK_PIPELINE.md
@@ -199,6 +199,7 @@ Accept: audio/mpeg
 
 {
   "voice": "[gender-female][pitch-high][speed-normal]",
+  "voice_id": "series-character:42",
   "text": "She laughed. [laughter] \"I can't believe it,\" she said."
 }
 
@@ -229,7 +230,10 @@ Users can manually edit these values in the Character Roster UI.
 Story Manager includes a native adapter for the official
 [`k2-fsa/OmniVoice`](https://github.com/k2-fsa/OmniVoice) 0.2.0 release. It uses the upstream model directly, keeps it
 resident between requests, translates existing bracket-style voice profiles into official voice-design attributes,
-and converts the 24 kHz output to MP3.
+and converts the 24 kHz output to MP3. Story Manager sends a stable book- or series-character identity with every
+line. The adapter uses that identity to create one seeded calibration voice, caches the upstream reusable
+voice-clone prompt, and conditions every later line on that anchor. Actual sentence decoding disables stochastic
+position selection, improving line-to-line identity consistency while distinct characters retain distinct anchors.
 
 ```bash
 make run-omnivoice
@@ -275,7 +279,9 @@ curl http://127.0.0.1:11434/api/tags
 In **Audio Settings**, click **Use Recommended Local Ollama**, then **Save & Test LLM**. The preset uses provider
 `ollama`, base URL `http://127.0.0.1:11434`, and model `qwen3.5:9b`. Calls use Ollama's schema-constrained structured
 outputs, thinking disabled, temperature 0, and a 32K working context. This makes roster and speaker output directly
-machine-validated instead of relying on best-effort JSON prompting.
+machine-validated instead of relying on best-effort JSON prompting. Common trailing-comma errors are repaired
+locally. Malformed or incomplete assignment sets are retried against the same durable pending sentences with
+progressively smaller batches (40 → 20 → 10 → 5), so one oversized response does not fail an unattended book run.
 
 ## Review and Recovery Controls
 
@@ -286,16 +292,26 @@ has committed. **Pause Safely** is cooperative: diarization pauses between batch
 assembly between chapters. Roster LLM requests and individual external TTS calls finish before the pause is
 acknowledged. Starting or stepping again infers the next safe phase from durable chapter/sentence state, so an app
 restart does not require restarting the entire book.
+Application shutdown cancels the active worker immediately rather than waiting behind the rest of a multi-hour
+book job. Already committed sentence/chapter state remains durable, and startup recovery re-queues the same phase.
 
 Worker exceptions are stored in `audiobook_last_error` and returned by the status endpoint. Retrying clears the
 stale message; failed sentence audio is reset to `ready_for_audio` before TTS resumes.
 
 The Characters tab also offers **Regenerate Character Roster**. It preserves the parsed EPUB and sentence IDs while
 clearing roster, diarization, summaries, and derived audio state. Roster generation samples real story chapters
-across the book and sibling books in the same series. It supplements those excerpts with capitalized-name frequency
-hints and any existing series roster, reducing the chance that front matter or a one-scene cameo displaces a recurring
-speaker. **Sync Series Roster** can promote an already-generated standalone book roster after its series metadata is
-assigned.
+across the book and sibling books in the same series, stopping before acknowledgments, publisher ads, and next-book
+excerpts. It supplements those excerpts with whole-story name and dialogue-tag counts, canonicalizes first-name and
+surname references into grounded full identities, replaces speculative biographies with evidence counts, stores only
+source-grounded quotations, and can retain up to 20 useful voices. Canonical aliases are included in every
+diarization request. An explicit rebuild uses only profiles backed by sibling books, removes orphaned stale guesses,
+and refreshes linked series metadata; shared voice changes invalidate affected clips. **Sync Series Roster** can
+promote an already-generated standalone book roster after its series metadata is assigned.
+
+Speaker guardrails keep quote-free prose on the Narrator even in a first-person story, keep the protagonist's spoken
+dialogue as a separate voice, and route clearly gender-attributed unnamed dialogue to the matching minor voice. This
+prevents emotional first-person narration from drifting onto a character voice merely because a local model's
+rationale describes the protagonist.
 
 ## Manual Voice Evaluation
 

--- a/docs/AUDIOBOOK_PIPELINE.md
+++ b/docs/AUDIOBOOK_PIPELINE.md
@@ -1,0 +1,278 @@
+# EPUB-to-Audiobook Pipeline
+
+## Overview
+
+This pipeline converts any stored EPUB into an EPUB 3 Media Overlay audiobook. The system is a **sentence-level state machine**: each sentence in the book is independently tracked through diarization → TTS → assembly, enabling surgical regeneration of specific audio snippets without full rebuilds.
+
+The five pipeline phases are:
+1. **Ingestion** — parse EPUB, inject sentence `<span>` IDs, seed the database
+2. **Roster Generation** — LLM extracts named characters and assigns OmniVoice voice profiles
+3. **Diarization** — LLM assigns a speaker and non-verbal tags to every sentence
+4. **Audio Generation** — OmniVoice TTS produces an MP3 snippet per sentence
+5. **Assembly** — MP3 snippets are concatenated per chapter; SMIL timing files and the final EPUB 3 Media Overlay package are generated
+
+---
+
+## Architecture Flow
+
+```
+User: "Start Pipeline"
+        │
+        ▼
+POST /api/books/{id}/audiobook/start
+        │  sets books.audiobook_pipeline_status = "ingesting"
+        ▼
+AudiobookQueue.enqueue(book_id)
+        │
+        ▼
+┌──────────────────────────────────────────────────────────┐
+│  AudiobookQueue worker (_run loop)                        │
+│                                                          │
+│  Phase 1 – Ingestion (status="ingesting")                │
+│    audiobook_ingestion.ingest_epub(book_id)              │
+│    • parse EPUB via ebooklib                             │
+│    • tokenize with spaCy en_core_web_sm                  │
+│    • inject <span id="ch{N}_s{M}"> around each sentence  │
+│    • write modified EPUB to library/audiobooks/{id}/      │
+│    • INSERT audiobook_chapters + audiobook_sentences     │
+│    • set status = "roster_gen"                           │
+│                                                          │
+│  Phase 2 – Roster Gen (status="roster_gen")              │
+│    audiobook_llm.generate_character_roster(book_id)      │
+│    • chunk chapter text → LLM (provider from settings)   │
+│    • parse characters + voice params                     │
+│    • INSERT audiobook_characters (incl. Narrator)        │
+│    • set status = "diarizing"                            │
+│                                                          │
+│  Phase 3 – Diarization (status="diarizing")              │
+│    audiobook_llm.diarize_sentences(book_id)              │
+│    • batch 50 sentences + 5-sentence context window      │
+│    • LLM assigns character_id + tagged_text              │
+│    • UPDATE sentence status → "ready_for_audio"          │
+│    • set status = "audio_gen" when all done              │
+│                                                          │
+│  Phase 4 – TTS (status="audio_gen")                      │
+│    audiobook_tts.generate_audio_for_book(book_id)        │
+│    • for each "ready_for_audio" sentence:                │
+│      POST omnivoice_endpoint {voice_prompt, tagged_text} │
+│      save mp3 to library/audiobooks/{id}/snippets/       │
+│      UPDATE sentence: audio_file_path, duration_ms,     │
+│                        status="audio_generated"          │
+│    • when chapter complete → chapter.needs_reassembly=T  │
+│    • set status = "assembling" when all done             │
+│                                                          │
+│  Phase 5 – Assembly (status="assembling")                │
+│    audiobook_assembly.assemble_book(book_id)             │
+│    • for each chapter where needs_reassembly=True:       │
+│      concat snippets → ch{N}.mp3 (pydub)                │
+│      generate .smil from html_element_id + timestamps   │
+│      chapter.needs_reassembly = False                    │
+│    • patch content.opf media-overlay attributes          │
+│    • repackage modified EPUB                             │
+│    • set status = "complete"                             │
+└──────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Surgical Rebuild Logic
+
+Changes propagate via cascades without requiring full rebuilds.
+
+**Character voice profile updated:**
+```
+PUT /api/audiobook/characters/{id}
+  → UPDATE sentences SET status="ready_for_audio", audio_file_path=NULL
+      WHERE character_id = {id}
+  → UPDATE chapters SET needs_reassembly=TRUE
+      WHERE id IN (SELECT chapter_id FROM audiobook_sentences WHERE character_id = {id})
+  → Re-enqueue book starting at "audio_gen" phase
+```
+
+**Sentence speaker or tags changed:**
+```
+PUT /api/audiobook/sentences/{id}
+  → UPDATE sentence: character_id, tagged_text, status="ready_for_audio", audio_file_path=NULL
+  → UPDATE chapter SET needs_reassembly=TRUE WHERE id = sentence.chapter_id
+  → Re-enqueue book starting at "audio_gen" phase
+```
+
+---
+
+## Database Schema
+
+### New tables (migration 0018)
+
+**`audiobook_settings`** — global LLM and TTS configuration
+| Column | Type | Notes |
+|---|---|---|
+| id | Integer PK | |
+| llm_provider | String | `"openai"`, `"anthropic"`, `"custom"` |
+| llm_api_key | String | Stored plaintext; masked on GET |
+| llm_base_url | String | Override for custom/local LLMs |
+| llm_model | String | e.g. `"gpt-4o"`, `"claude-opus-4-7"` |
+| omnivoice_endpoint | String | Base URL of OmniVoice worker |
+| roster_prompt_template | Text | Override default roster extraction prompt |
+| diarization_prompt_template | Text | Override default diarization prompt |
+
+**`audiobook_chapters`**
+| Column | Type | Notes |
+|---|---|---|
+| id | Integer PK | |
+| book_id | FK → books CASCADE | |
+| chapter_number | Integer | Spine order |
+| smil_file_path | String | Relative path to generated `.smil` |
+| audio_file_path | String | Relative path to concatenated chapter MP3 |
+| needs_reassembly | Boolean | Worker polls for `True` |
+
+**`audiobook_characters`**
+| Column | Type | Notes |
+|---|---|---|
+| id | Integer PK | |
+| book_id | FK → books CASCADE | |
+| name | String | |
+| description | Text | LLM-generated summary |
+| voice_design_prompt | String | OmniVoice params e.g. `[gender-male][pitch-low]` |
+| is_narrator | Boolean | |
+
+**`audiobook_sentences`** — the state engine
+| Column | Type | Notes |
+|---|---|---|
+| id | Integer PK | |
+| chapter_id | FK → audiobook_chapters CASCADE | |
+| character_id | FK → audiobook_characters SET NULL | Nullable |
+| html_element_id | String | Matches injected span ID e.g. `ch1_s42` |
+| sequence_order | Integer | Absolute order within chapter |
+| original_text | Text | Pure extracted text |
+| tagged_text | Text | Text with non-verbal tags e.g. `[laughter]` |
+| audio_file_path | String | Path to snippet MP3 |
+| audio_duration_ms | Integer | Used for SMIL timestamp calculation |
+| status | String | `pending_diarization` → `ready_for_audio` → `audio_generated` / `error` |
+
+**New column on `books`**: `audiobook_pipeline_status` (String, nullable)
+Values: `None` (idle), `ingesting`, `roster_gen`, `diarizing`, `audio_gen`, `assembling`, `complete`, `error`, `paused`
+
+---
+
+## OmniVoice TTS Integration
+
+OmniVoice is a self-hosted TTS worker. The endpoint URL is configured in `audiobook_settings`.
+
+### HTTP Contract
+```
+POST {omnivoice_endpoint}/generate
+Content-Type: application/json
+Accept: audio/mpeg
+
+{
+  "voice": "[gender-female][pitch-high][speed-normal]",
+  "text": "She laughed. [laughter] \"I can't believe it,\" she said."
+}
+
+Response: 200 OK
+Content-Type: audio/mpeg
+Body: raw MP3 bytes
+```
+
+### Voice Design Prompt Schema
+The LLM roster prompt instructs the model to produce voice design strings using these parameters:
+
+```
+[gender-{male|female|neutral}]
+[pitch-{low|medium|high}]
+[speed-{slow|normal|fast}]
+[accent-{british|american|australian|...}]   # optional
+[age-{young|middle|old}]                     # optional
+```
+
+Examples:
+- Narrator: `[gender-male][pitch-low][speed-normal][age-middle]`
+- Child character: `[gender-female][pitch-high][speed-fast][age-young]`
+
+Users can manually edit these values in the Character Roster UI.
+
+---
+
+## File Storage Layout
+
+```
+library/
+└── audiobooks/
+    └── {book_id}/
+        ├── working.epub          # span-injected working copy of the EPUB
+        ├── snippets/
+        │   └── {sentence_id}.mp3 # per-sentence TTS output
+        ├── ch1.mp3               # assembled chapter audio
+        ├── ch1.smil              # EPUB 3 Media Overlay timing file
+        ├── ch2.mp3
+        ├── ch2.smil
+        └── audiobook.epub        # final repackaged EPUB 3 MO
+```
+
+All paths stored in the database as relative to `LIBRARY_PATH.parent`, matching the existing pattern for `immutable_path` and `current_path`.
+
+---
+
+## API Endpoints
+
+| Method | Path | Description |
+|---|---|---|
+| POST | `/api/books/{id}/audiobook/start` | Start or resume pipeline |
+| POST | `/api/books/{id}/audiobook/pause` | Pause workers (set status=paused) |
+| POST | `/api/books/{id}/audiobook/rebuild` | Force full rebuild |
+| GET | `/api/books/{id}/audiobook/status` | Pipeline status + sentence counts by status |
+| GET | `/api/books/{id}/audiobook/characters` | List characters |
+| PUT | `/api/audiobook/characters/{char_id}` | Update voice profile (triggers cascade) |
+| GET | `/api/books/{id}/audiobook/sentences` | Paginated sentence list (`?page=&limit=&chapter_id=`) |
+| PUT | `/api/audiobook/sentences/{id}` | Update speaker/tags (triggers cascade) |
+| GET | `/api/audiobook/sentences/{id}/audio` | Stream sentence snippet MP3 |
+| GET | `/api/books/{id}/audiobook/chapters` | Chapter list with assembly status |
+| GET | `/api/books/{id}/audiobook/chapters/{cid}/audio` | Stream chapter MP3 |
+| GET | `/api/audiobook/settings` | Get LLM/TTS config (API key masked) |
+| PUT | `/api/audiobook/settings` | Upsert LLM/TTS config |
+
+---
+
+## Backend File Map
+
+| File | Purpose |
+|---|---|
+| `backend/app/models.py` | +4 new models, +1 Book column |
+| `backend/alembic/versions/0018_audiobook_pipeline.py` | Schema migration |
+| `backend/app/crud/audiobook.py` | DB queries for all new tables |
+| `backend/app/services/audiobook_ingestion.py` | Phase 1: EPUB parse + span injection |
+| `backend/app/services/audiobook_llm.py` | Phases 2 & 3: character roster + diarization |
+| `backend/app/services/audiobook_tts.py` | Phase 4: OmniVoice TTS per sentence |
+| `backend/app/services/audiobook_assembly.py` | Phase 5: MP3 concat + SMIL + EPUB repackage |
+| `backend/app/services/audiobook_queue.py` | Async worker queue (mirrors `web_import_queue.py`) |
+| `backend/app/routers/audiobook.py` | All API endpoints |
+| `backend/app/main.py` | Wire queue lifecycle + router |
+
+## Frontend File Map
+
+| File | Purpose |
+|---|---|
+| `frontend/src/api/audiobook.js` | HTTP client helpers |
+| `frontend/src/lib/navigation.js` | +Audio Settings tab |
+| `frontend/src/components/AudiobookSettings.jsx` | Global LLM/TTS config page |
+| `frontend/src/components/AudiobookPipeline.jsx` | Pipeline tab container (progress + sub-tabs) |
+| `frontend/src/components/audiobook/CharacterRoster.jsx` | Character card grid with voice editing |
+| `frontend/src/components/audiobook/ScriptEditor.jsx` | Paginated sentence table with inline editing |
+| `frontend/src/components/audiobook/ChapterAssembly.jsx` | Chapter assembly status list |
+| `frontend/src/App.jsx` | +Audio Settings tab routing |
+| `frontend/src/components/BookSettings.jsx` | +Audiobook Pipeline tab |
+
+---
+
+## Dependencies Added
+
+**`pyproject.toml`** (core):
+- `spacy>=3.7,<4` — sentence tokenization
+- `httpx>=0.27` — HTTP client for LLM and OmniVoice calls (moved from dev)
+- `pydub>=0.25` — MP3 concatenation
+- `mutagen>=1.47` — MP3 duration extraction
+
+**`Dockerfile`** — after `uv pip install`:
+```dockerfile
+RUN python -m spacy download en_core_web_sm
+```

--- a/docs/AUDIOBOOK_PIPELINE.md
+++ b/docs/AUDIOBOOK_PIPELINE.md
@@ -281,12 +281,14 @@ In **Audio Settings**, click **Use Recommended Local Ollama**, then **Save & Tes
 outputs, thinking disabled, temperature 0, and a 32K working context. This makes roster and speaker output directly
 machine-validated instead of relying on best-effort JSON prompting. Common trailing-comma errors are repaired
 locally. Malformed or incomplete assignment sets are retried against the same durable pending sentences with
-progressively smaller batches (40 → 20 → 10 → 5), so one oversized response does not fail an unattended book run.
+progressively smaller batches (10 → 5), so one oversized response does not fail an unattended book run. The
+10-sentence default reflects full-book testing with the recommended 9B model: larger dialogue-heavy responses were
+more likely to omit trailing assignment IDs and cost more time in retries than they saved in request overhead.
 
 ## Review and Recovery Controls
 
 The book UI offers **Run Next Stage** for debugging or reviewing intermediate artifacts, **Run One Batch** for one
-40-sentence diarization batch, one TTS sentence, or one assembly chapter, and **Run to Completion**
+10-sentence diarization batch, one TTS sentence, or one assembly chapter, and **Run to Completion**
 for unattended processing. A single-stage run persists its target phase and moves to `paused` only after that phase
 has committed. **Pause Safely** is cooperative: diarization pauses between batches, TTS between sentences, and
 assembly between chapters. Roster LLM requests and individual external TTS calls finish before the pause is

--- a/docs/AUDIOBOOK_PIPELINE.md
+++ b/docs/AUDIOBOOK_PIPELINE.md
@@ -64,7 +64,7 @@ AudiobookQueue.enqueue(book_id)
 │  Phase 5 – Assembly (status="assembling")                │
 │    audiobook_assembly.assemble_book(book_id)             │
 │    • for each chapter where needs_reassembly=True:       │
-│      concat snippets → ch{N}.mp3 (pydub)                │
+│      concat snippets → ch{N}.mp3 (ffmpeg)               │
 │      generate .smil from html_element_id + timestamps   │
 │      chapter.needs_reassembly = False                    │
 │    • patch content.opf media-overlay attributes          │
@@ -107,7 +107,7 @@ PUT /api/audiobook/sentences/{id}
 | Column | Type | Notes |
 |---|---|---|
 | id | Integer PK | |
-| llm_provider | String | `"openai"`, `"anthropic"`, `"custom"` |
+| llm_provider | String | `"stub"`, `"openai"`, `"anthropic"`, `"custom"` |
 | llm_api_key | String | Stored plaintext; masked on GET |
 | llm_base_url | String | Override for custom/local LLMs |
 | llm_model | String | e.g. `"gpt-4o"`, `"claude-opus-4-7"` |
@@ -194,6 +194,17 @@ Examples:
 
 Users can manually edit these values in the Character Roster UI.
 
+## Deterministic Local Harness
+
+The pipeline works without API keys or network services. When no settings row exists—or when the LLM provider is
+`stub`—it creates a single Narrator, assigns every sentence to that narrator, and generates timed silent placeholder
+MP3s through the installed `ffmpeg` binary. This exercises ingestion, durable state transitions, surgical rebuilds,
+chapter assembly, SMIL generation, and final EPUB packaging end to end.
+
+Choose **Deterministic local harness** in Audio Settings to make this mode explicit. To switch to real generation,
+choose an LLM provider and configure an OmniVoice-compatible endpoint. The harness is intentionally deterministic;
+it is a validation and UI-development path, not synthetic speech.
+
 ---
 
 ## File Storage Layout
@@ -231,6 +242,7 @@ All paths stored in the database as relative to `LIBRARY_PATH.parent`, matching 
 | GET | `/api/audiobook/sentences/{id}/audio` | Stream sentence snippet MP3 |
 | GET | `/api/books/{id}/audiobook/chapters` | Chapter list with assembly status |
 | GET | `/api/books/{id}/audiobook/chapters/{cid}/audio` | Stream chapter MP3 |
+| GET | `/api/books/{id}/audiobook/download` | Download the completed EPUB 3 Media Overlay audiobook |
 | GET | `/api/audiobook/settings` | Get LLM/TTS config (API key masked) |
 | PUT | `/api/audiobook/settings` | Upsert LLM/TTS config |
 
@@ -271,14 +283,13 @@ All paths stored in the database as relative to `LIBRARY_PATH.parent`, matching 
 
 **`pyproject.toml`** (core):
 - `spacy>=3.7,<4` — sentence tokenization
-- `httpx>=0.27` — HTTP client for LLM and OmniVoice calls (moved from dev)
-- `pydub>=0.25` — MP3 concatenation
+- `httpx2==2.5.0` — HTTP client for LLM and OmniVoice calls (exports the `httpx` module)
 - `mutagen>=1.47` — MP3 duration extraction
 
-**`Dockerfile.base`**:
-- `ffmpeg` — required by `pydub` for MP3 decode/export
+**`Dockerfile`**:
+- `ffmpeg` — placeholder MP3 generation and chapter concatenation
 
-**`Dockerfile`** — after `uv pip install`:
+The application image also downloads the optional higher-quality spaCy English model after installing Python dependencies:
 ```dockerfile
 RUN python -m spacy download en_core_web_sm
 ```

--- a/docs/AUDIOBOOK_PIPELINE.md
+++ b/docs/AUDIOBOOK_PIPELINE.md
@@ -197,6 +197,28 @@ Examples:
 
 Users can manually edit these values in the Character Roster UI.
 
+### Official Local OmniVoice
+
+Story Manager includes a native adapter for the official
+[`k2-fsa/OmniVoice`](https://github.com/k2-fsa/OmniVoice) 0.2.0 release. It uses the upstream model directly, keeps it
+resident between requests, translates existing bracket-style voice profiles into official voice-design attributes,
+and converts the 24 kHz output to MP3.
+
+```bash
+make run-omnivoice
+curl http://127.0.0.1:8001/health
+```
+
+The isolated service environment lives under `services/omnivoice/.venv`. The first start downloads about 3.3 GB of
+public model weights. CUDA, Intel XPU, Apple MPS, and CPU are auto-detected; Apple Silicon uses native MPS with the
+upstream audio tokenizer on CPU. Configure `http://127.0.0.1:8001` as the OmniVoice endpoint in **Audio Settings**.
+The `stub` LLM provider may remain selected for deterministic local roster generation and diarization while the
+OmniVoice adapter produces real speech.
+
+The defaults use 16 diffusion steps for interactive local throughput. Set `OMNIVOICE_NUM_STEPS=32` before
+`make run-omnivoice` for the upstream quality default. Other adapter options are documented in
+`services/omnivoice/README.md`.
+
 ## Deterministic Local Harness
 
 The pipeline works without API keys or network services. When no settings row exists—or when the LLM provider is

--- a/docs/AUDIOBOOK_PIPELINE.md
+++ b/docs/AUDIOBOOK_PIPELINE.md
@@ -95,8 +95,13 @@ PUT /api/audiobook/characters/{id}
 PUT /api/audiobook/sentences/{id}
   → UPDATE sentence: character_id, tagged_text, status="ready_for_audio", audio_file_path=NULL
   → UPDATE chapter SET needs_reassembly=TRUE WHERE id = sentence.chapter_id
-  → wait for an explicit chapter preview or full pipeline run
+  → wait for an explicit sentence/chapter preview or full pipeline run
 ```
+
+In the Script Editor, **Generate audio** queues only that ready sentence. Its durable status moves through
+`audio_queued` → `audio_generating` → `audio_generated` (or `error`), and the row polls while work is active so the
+button is replaced with visible progress and then an audio player. Manual sentence jobs share the same serial worker
+as chapter previews and the full pipeline, and are recovered after an app restart.
 
 ---
 
@@ -342,6 +347,7 @@ All paths stored in the database as relative to `LIBRARY_PATH.parent`, matching 
 | POST | `/api/books/{id}/audiobook/roster/rebuild` | Preserve ingestion and regenerate roster/speaker analysis |
 | POST | `/api/books/{id}/audiobook/roster/share-series` | Link/promote the book roster into its series roster |
 | POST | `/api/books/{id}/audiobook/chapters/{cid}/preview-audio` | Queue an explicit single-chapter audio preview |
+| POST | `/api/books/{id}/audiobook/sentences/{sid}/generate-audio` | Queue speech generation for one ready sentence |
 | GET | `/api/books/{id}/audiobook/status` | Status, model, progress, summary, review flags, and sentence counts |
 | GET | `/api/books/{id}/audiobook/characters` | List characters |
 | PUT | `/api/audiobook/characters/{char_id}` | Update voice profile (triggers cascade) |

--- a/docs/AUDIOBOOK_PIPELINE.md
+++ b/docs/AUDIOBOOK_PIPELINE.md
@@ -39,15 +39,15 @@ AudiobookQueue.enqueue(book_id)
 │                                                          │
 │  Phase 2 – Roster Gen (status="roster_gen")              │
 │    audiobook_llm.generate_character_roster(book_id)      │
-│    • chunk chapter text → LLM (provider from settings)   │
+│    • sample story chapters across the book → LLM         │
 │    • parse characters + voice params                     │
 │    • INSERT audiobook_characters (incl. Narrator)        │
 │    • set status = "diarizing"                            │
 │                                                          │
 │  Phase 3 – Diarization (status="diarizing")              │
 │    audiobook_llm.diarize_sentences(book_id)              │
-│    • batch 50 sentences + 5-sentence context window      │
-│    • LLM assigns character_id + tagged_text              │
+│    • batch 40 sentences + 8-sentence context window      │
+│    • LLM assigns speaker, confidence, rationale + tags   │
 │    • UPDATE sentence status → "ready_for_audio"          │
 │    • set status = "audio_gen" when all done              │
 │                                                          │
@@ -107,7 +107,7 @@ PUT /api/audiobook/sentences/{id}
 | Column | Type | Notes |
 |---|---|---|
 | id | Integer PK | |
-| llm_provider | String | `"stub"`, `"openai"`, `"anthropic"`, `"custom"` |
+| llm_provider | String | `"stub"`, `"ollama"`, `"openai"`, `"anthropic"`, `"custom"` |
 | llm_api_key | String | Stored plaintext; masked on GET |
 | llm_base_url | String | Override for custom/local LLMs |
 | llm_model | String | e.g. `"gpt-4o"`, `"claude-opus-4-7"` |
@@ -149,6 +149,8 @@ PUT /api/audiobook/sentences/{id}
 | audio_file_path | String | Path to snippet MP3 |
 | audio_duration_ms | Integer | Used for SMIL timestamp calculation |
 | status | String | `pending_diarization` → `ready_for_audio` → `audio_generated` / `error` |
+| speaker_confidence | Float | Model confidence from `0` to `1`; manual assignments use `1` |
+| speaker_reason | Text | Short attribution rationale for review |
 
 **New columns on `books`**:
 - `audiobook_enabled` (Boolean, default `false`) — per-book opt-in gate for this pipeline
@@ -157,6 +159,15 @@ Values: `None` (idle), `ingesting`, `roster_gen`, `diarizing`, `audio_gen`, `ass
 - `audiobook_stop_after_phase` (String, nullable) — persisted checkpoint for a single-stage run
 - `audiobook_pause_requested` (Boolean, default `false`) — cooperative pause request acknowledged at a durable boundary
 - `audiobook_last_error` (Text, nullable) — actionable worker error shown in the book UI
+- `audiobook_summary` (Text, nullable) — roster-stage, spoiler-light story analysis
+- `audiobook_progress_current` / `audiobook_progress_total` — current phase work counters
+- `audiobook_progress_detail` — human-readable active operation
+- `audiobook_pipeline_started_at` / `audiobook_pipeline_updated_at` — run timing
+- `audiobook_batch_limit` — durable work-unit budget for **Run One Batch**
+- `audiobook_llm_requests` — model calls made during the current run
+
+Migration `0020_audiobook_observability.py` also adds chapter summaries, character aliases/evidence, and sentence
+confidence/rationales.
 
 ---
 
@@ -230,9 +241,30 @@ Choose **Deterministic local harness** in Audio Settings to make this mode expli
 choose an LLM provider and configure an OmniVoice-compatible endpoint. The harness is intentionally deterministic;
 it is a validation and UI-development path, not synthetic speech.
 
+## Recommended Local LLM (Ollama)
+
+The recommended local analysis model is `qwen3.5:9b`. The model is about 6.6 GB, has enough instruction-following
+capacity for schema-constrained roster and speaker assignment, and is substantially more practical for the many
+calls required by a full book than the 17 GB 27B quality tier. Install Ollama, start its service, and pull the model:
+
+```bash
+# macOS
+brew install ollama
+brew services start ollama
+make pull-ollama-model
+
+curl http://127.0.0.1:11434/api/tags
+```
+
+In **Audio Settings**, click **Use Recommended Local Ollama**, then **Save & Test LLM**. The preset uses provider
+`ollama`, base URL `http://127.0.0.1:11434`, and model `qwen3.5:9b`. Calls use Ollama's schema-constrained structured
+outputs, thinking disabled, temperature 0, and a 32K working context. This makes roster and speaker output directly
+machine-validated instead of relying on best-effort JSON prompting.
+
 ## Review and Recovery Controls
 
-The book UI offers **Run Next Stage** for debugging or reviewing intermediate artifacts and **Run to Completion**
+The book UI offers **Run Next Stage** for debugging or reviewing intermediate artifacts, **Run One Batch** for one
+40-sentence diarization batch, one TTS sentence, or one assembly chapter, and **Run to Completion**
 for unattended processing. A single-stage run persists its target phase and moves to `paused` only after that phase
 has committed. **Pause Safely** is cooperative: diarization pauses between batches, TTS between sentences, and
 assembly between chapters. Roster LLM requests and individual external TTS calls finish before the pause is
@@ -241,6 +273,11 @@ restart does not require restarting the entire book.
 
 Worker exceptions are stored in `audiobook_last_error` and returned by the status endpoint. Retrying clears the
 stale message; failed sentence audio is reset to `ready_for_audio` before TTS resumes.
+
+The Characters tab also offers **Regenerate Character Roster**. It preserves the parsed EPUB and sentence IDs while
+clearing roster, diarization, summaries, and derived audio state. Roster generation samples real story chapters
+across the book and supplements those excerpts with whole-book capitalized-name frequency hints, reducing the chance
+that front matter or a one-scene cameo displaces a recurring speaker.
 
 ---
 
@@ -270,12 +307,14 @@ All paths stored in the database as relative to `LIBRARY_PATH.parent`, matching 
 |---|---|---|
 | POST | `/api/books/{id}/audiobook/start` | Start or resume pipeline |
 | POST | `/api/books/{id}/audiobook/step` | Run only the next recoverable phase, then pause for review |
+| POST | `/api/books/{id}/audiobook/run-batch` | Run one diarization/TTS/assembly work unit, then pause |
 | POST | `/api/books/{id}/audiobook/pause` | Request a cooperative pause at the next durable boundary |
 | POST | `/api/books/{id}/audiobook/rebuild` | Force full rebuild |
-| GET | `/api/books/{id}/audiobook/status` | Status, next phase, controls, last error, and sentence counts |
+| POST | `/api/books/{id}/audiobook/roster/rebuild` | Preserve ingestion and regenerate roster/speaker analysis |
+| GET | `/api/books/{id}/audiobook/status` | Status, model, progress, summary, review flags, and sentence counts |
 | GET | `/api/books/{id}/audiobook/characters` | List characters |
 | PUT | `/api/audiobook/characters/{char_id}` | Update voice profile (triggers cascade) |
-| GET | `/api/books/{id}/audiobook/sentences` | Paginated sentence list (`?page=&limit=&chapter_id=`) |
+| GET | `/api/books/{id}/audiobook/sentences` | Paginated sentences (`?page=&limit=&chapter_id=&review_only=`) |
 | PUT | `/api/audiobook/sentences/{id}` | Update speaker/tags (triggers cascade) |
 | GET | `/api/audiobook/sentences/{id}/audio` | Stream sentence snippet MP3 |
 | GET | `/api/books/{id}/audiobook/chapters` | Chapter list with assembly status |
@@ -283,6 +322,7 @@ All paths stored in the database as relative to `LIBRARY_PATH.parent`, matching 
 | GET | `/api/books/{id}/audiobook/download` | Download the completed EPUB 3 Media Overlay audiobook |
 | GET | `/api/audiobook/settings` | Get LLM/TTS config (API key masked) |
 | PUT | `/api/audiobook/settings` | Upsert LLM/TTS config |
+| POST | `/api/audiobook/settings/test-llm` | Validate the saved model with a structured-output request |
 
 ---
 
@@ -293,6 +333,7 @@ All paths stored in the database as relative to `LIBRARY_PATH.parent`, matching 
 | `backend/app/models.py` | Audiobook models and per-book pipeline/control state |
 | `backend/alembic/versions/0018_audiobook_pipeline.py` | Core audiobook schema migration |
 | `backend/alembic/versions/0019_audiobook_pipeline_controls.py` | Review, pause, and error-state migration |
+| `backend/alembic/versions/0020_audiobook_observability.py` | Progress, summaries, evidence, confidence, and batch controls |
 | `backend/app/crud/audiobook.py` | DB queries for all new tables |
 | `backend/app/services/audiobook_ingestion.py` | Phase 1: EPUB parse + span injection |
 | `backend/app/services/audiobook_llm.py` | Phases 2 & 3: character roster + diarization |

--- a/docs/AUDIOBOOK_PIPELINE.md
+++ b/docs/AUDIOBOOK_PIPELINE.md
@@ -154,6 +154,9 @@ PUT /api/audiobook/sentences/{id}
 - `audiobook_enabled` (Boolean, default `false`) — per-book opt-in gate for this pipeline
 - `audiobook_pipeline_status` (String, nullable)
 Values: `None` (idle), `ingesting`, `roster_gen`, `diarizing`, `audio_gen`, `assembling`, `complete`, `error`, `paused`
+- `audiobook_stop_after_phase` (String, nullable) — persisted checkpoint for a single-stage run
+- `audiobook_pause_requested` (Boolean, default `false`) — cooperative pause request acknowledged at a durable boundary
+- `audiobook_last_error` (Text, nullable) — actionable worker error shown in the book UI
 
 ---
 
@@ -205,6 +208,18 @@ Choose **Deterministic local harness** in Audio Settings to make this mode expli
 choose an LLM provider and configure an OmniVoice-compatible endpoint. The harness is intentionally deterministic;
 it is a validation and UI-development path, not synthetic speech.
 
+## Review and Recovery Controls
+
+The book UI offers **Run Next Stage** for debugging or reviewing intermediate artifacts and **Run to Completion**
+for unattended processing. A single-stage run persists its target phase and moves to `paused` only after that phase
+has committed. **Pause Safely** is cooperative: diarization pauses between batches, TTS between sentences, and
+assembly between chapters. Roster LLM requests and individual external TTS calls finish before the pause is
+acknowledged. Starting or stepping again infers the next safe phase from durable chapter/sentence state, so an app
+restart does not require restarting the entire book.
+
+Worker exceptions are stored in `audiobook_last_error` and returned by the status endpoint. Retrying clears the
+stale message; failed sentence audio is reset to `ready_for_audio` before TTS resumes.
+
 ---
 
 ## File Storage Layout
@@ -232,9 +247,10 @@ All paths stored in the database as relative to `LIBRARY_PATH.parent`, matching 
 | Method | Path | Description |
 |---|---|---|
 | POST | `/api/books/{id}/audiobook/start` | Start or resume pipeline |
-| POST | `/api/books/{id}/audiobook/pause` | Pause workers (set status=paused) |
+| POST | `/api/books/{id}/audiobook/step` | Run only the next recoverable phase, then pause for review |
+| POST | `/api/books/{id}/audiobook/pause` | Request a cooperative pause at the next durable boundary |
 | POST | `/api/books/{id}/audiobook/rebuild` | Force full rebuild |
-| GET | `/api/books/{id}/audiobook/status` | Pipeline status + sentence counts by status |
+| GET | `/api/books/{id}/audiobook/status` | Status, next phase, controls, last error, and sentence counts |
 | GET | `/api/books/{id}/audiobook/characters` | List characters |
 | PUT | `/api/audiobook/characters/{char_id}` | Update voice profile (triggers cascade) |
 | GET | `/api/books/{id}/audiobook/sentences` | Paginated sentence list (`?page=&limit=&chapter_id=`) |
@@ -252,8 +268,9 @@ All paths stored in the database as relative to `LIBRARY_PATH.parent`, matching 
 
 | File | Purpose |
 |---|---|
-| `backend/app/models.py` | +4 new models, +1 Book column |
-| `backend/alembic/versions/0018_audiobook_pipeline.py` | Schema migration |
+| `backend/app/models.py` | Audiobook models and per-book pipeline/control state |
+| `backend/alembic/versions/0018_audiobook_pipeline.py` | Core audiobook schema migration |
+| `backend/alembic/versions/0019_audiobook_pipeline_controls.py` | Review, pause, and error-state migration |
 | `backend/app/crud/audiobook.py` | DB queries for all new tables |
 | `backend/app/services/audiobook_ingestion.py` | Phase 1: EPUB parse + span injection |
 | `backend/app/services/audiobook_llm.py` | Phases 2 & 3: character roster + diarization |

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1311,9 +1311,15 @@
 
 /* ─── Book Settings page ─────────────────────────────────── */
 .book-settings {
+  box-sizing: border-box;
+  width: 100%;
   max-width: 720px;
   margin: 0 auto;
   padding: 0 1.25rem 3rem;
+}
+
+.book-settings--wide {
+  max-width: 1440px;
 }
 
 .settings-header {
@@ -1394,6 +1400,11 @@
 .audiobook-pipeline {
   display: grid;
   gap: 1rem;
+  min-width: 0;
+}
+
+.sub-tab-content {
+  min-width: 0;
 }
 
 .pipeline-header,
@@ -1680,6 +1691,7 @@
 
 .script-table-wrap,
 .chapter-assembly {
+  max-width: 100%;
   overflow-x: auto;
 }
 
@@ -1688,6 +1700,11 @@
   width: 100%;
   border-collapse: collapse;
   font-size: 0.78rem;
+}
+
+.script-table {
+  min-width: 1050px;
+  table-layout: fixed;
 }
 
 .script-table th,
@@ -1814,13 +1831,12 @@
 }
 
 .sentence-text {
-  min-width: 16rem;
-  max-width: 24rem;
   line-height: 1.45;
+  overflow-wrap: anywhere;
 }
 
 .sentence-tags {
-  min-width: 12rem;
+  overflow-wrap: anywhere;
 }
 
 .sentence-tags-input,
@@ -1840,6 +1856,51 @@
 .confidence-badge--low {
   background: rgba(214, 143, 44, 0.15);
   color: var(--warning);
+}
+
+.sentence-seq {
+  width: 3rem;
+}
+
+.sentence-text,
+.sentence-tags {
+  width: 24%;
+}
+
+.sentence-speaker {
+  width: 11rem;
+}
+
+.sentence-confidence {
+  width: 6rem;
+}
+
+.sentence-status {
+  width: 8.5rem;
+  white-space: nowrap;
+}
+
+.sentence-status span + span {
+  margin-left: 0.35rem;
+}
+
+.sentence-audio {
+  width: 16rem;
+}
+
+.sentence-audio audio {
+  width: 100%;
+  min-width: 10rem;
+}
+
+.sentence-actions {
+  width: 7rem;
+}
+
+.sentence-audio-progress,
+.sentence-audio-error {
+  display: block;
+  font-size: 0.75rem;
 }
 
 @media (max-width: 720px) {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -6,7 +6,7 @@
 }
 
 .app-container.drag-over::after {
-  content: '';
+  content: "";
   position: fixed;
   inset: 0;
   border: 3px solid var(--accent);
@@ -92,7 +92,6 @@
     border-color: var(--accent);
     background: rgba(98, 114, 234, 0.1);
   }
-
 }
 
 /* ─── Collapsible Add Book ───────────────────────────────── */
@@ -1369,6 +1368,385 @@
 }
 .settings-actions h3 {
   display: none;
+}
+
+.settings-actions-inline {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+/* ─── Audiobook pipeline ────────────────────────────────── */
+.audiobook-pipeline {
+  display: grid;
+  gap: 1rem;
+}
+
+.pipeline-header,
+.pipeline-inspector,
+.analysis-book-summary,
+.chapter-analysis-card,
+.character-card,
+.script-editor,
+.chapter-assembly {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.pipeline-header {
+  display: grid;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.pipeline-progress {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 0.25rem;
+}
+
+.pipeline-step {
+  position: relative;
+  display: grid;
+  justify-items: center;
+  gap: 0.35rem;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  text-align: center;
+}
+
+.pipeline-step::before {
+  content: "";
+  position: absolute;
+  top: 0.38rem;
+  left: calc(-50% - 0.1rem);
+  width: 100%;
+  height: 2px;
+  background: var(--border);
+}
+
+.pipeline-step:first-child::before {
+  display: none;
+}
+
+.pipeline-step-dot {
+  z-index: 1;
+  width: 0.8rem;
+  height: 0.8rem;
+  border: 2px solid var(--border-strong);
+  border-radius: 999px;
+  background: var(--surface);
+}
+
+.pipeline-step--done,
+.pipeline-step--active {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.pipeline-step--done::before,
+.pipeline-step--active::before {
+  background: var(--accent);
+}
+
+.pipeline-step--done .pipeline-step-dot,
+.pipeline-step--active .pipeline-step-dot {
+  border-color: var(--accent);
+  background: var(--accent);
+}
+
+.pipeline-step--active .pipeline-step-dot {
+  box-shadow: 0 0 0 4px rgba(98, 114, 234, 0.16);
+}
+
+.pipeline-meta,
+.pipeline-controls,
+.script-editor-controls,
+.character-metrics,
+.chapter-analysis-counts {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.55rem;
+}
+
+.pipeline-controls {
+  padding-top: 0.25rem;
+}
+
+.pipeline-inspector {
+  display: grid;
+  gap: 0.9rem;
+  padding: 0.9rem;
+  background: var(--surface-2);
+}
+
+.pipeline-inspector-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.8rem;
+}
+
+.pipeline-inspector-grid > div {
+  display: grid;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.metric-label {
+  color: var(--text-muted);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.pipeline-work-progress,
+.chapter-analysis-card {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.pipeline-work-progress-label,
+.analysis-section-heading,
+.chapter-analysis-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.pipeline-work-progress-label {
+  font-size: 0.8rem;
+}
+
+.pipeline-work-progress progress,
+.chapter-analysis-card progress {
+  width: 100%;
+  accent-color: var(--accent);
+}
+
+.pipeline-summary summary,
+.character-evidence summary {
+  cursor: pointer;
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+.pipeline-summary p,
+.analysis-book-summary p,
+.chapter-analysis-card p {
+  margin: 0.55rem 0 0;
+  line-height: 1.55;
+}
+
+.sub-tabs {
+  display: flex;
+  gap: 0.25rem;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--border);
+}
+
+.sub-tab {
+  border: 0;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
+  background: none;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.sub-tab--active {
+  border-bottom-color: var(--accent);
+  color: var(--text);
+  font-weight: 600;
+}
+
+.analysis-overview,
+.character-roster {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.roster-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.7rem;
+  margin-bottom: 0.8rem;
+  padding: 0.75rem 0.9rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface-2);
+  color: var(--text-muted);
+  font-size: 0.8rem;
+}
+
+.analysis-book-summary,
+.chapter-analysis-card,
+.character-card {
+  padding: 1rem;
+}
+
+.analysis-section-heading h3 {
+  margin: 0.15rem 0 0;
+}
+
+.chapter-analysis-list,
+.character-roster {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.chapter-analysis-counts,
+.character-metrics,
+.character-aliases,
+.character-voice-hint {
+  color: var(--text-muted);
+  font-size: 0.78rem;
+}
+
+.character-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.character-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.character-description,
+.character-aliases,
+.character-voice-hint {
+  margin: 0;
+  line-height: 1.45;
+}
+
+.character-evidence ul {
+  margin-bottom: 0;
+  padding-left: 1.2rem;
+}
+
+.character-voice-label {
+  display: grid;
+  gap: 0.3rem;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+}
+
+.script-editor,
+.chapter-assembly {
+  overflow: hidden;
+}
+
+.script-editor-controls {
+  padding: 0.8rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.script-editor-controls label {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--text-muted);
+  font-size: 0.78rem;
+}
+
+.script-editor-controls .pagination {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-left: auto;
+}
+
+.script-table-wrap,
+.chapter-assembly {
+  overflow-x: auto;
+}
+
+.script-table,
+.chapter-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.78rem;
+}
+
+.script-table th,
+.script-table td,
+.chapter-table th,
+.chapter-table td {
+  padding: 0.55rem;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+  vertical-align: top;
+}
+
+.script-table th,
+.chapter-table th {
+  color: var(--text-muted);
+  font-size: 0.7rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.sentence-text {
+  min-width: 16rem;
+  max-width: 24rem;
+  line-height: 1.45;
+}
+
+.sentence-tags {
+  min-width: 12rem;
+}
+
+.sentence-tags-input,
+.sentence-speaker select {
+  width: 100%;
+}
+
+.confidence-badge {
+  display: inline-flex;
+  padding: 0.18rem 0.4rem;
+  border-radius: 999px;
+  background: rgba(48, 164, 108, 0.14);
+  color: var(--success);
+  font-weight: 700;
+}
+
+.confidence-badge--low {
+  background: rgba(214, 143, 44, 0.15);
+  color: var(--warning);
+}
+
+@media (max-width: 720px) {
+  .pipeline-inspector-grid,
+  .chapter-analysis-list,
+  .character-roster {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 480px) {
+  .pipeline-inspector-grid,
+  .chapter-analysis-list,
+  .character-roster {
+    grid-template-columns: 1fr;
+  }
+
+  .pipeline-step span {
+    font-size: 0.62rem;
+  }
+
+  .script-editor-controls .pagination {
+    width: 100%;
+    margin-left: 0;
+  }
 }
 
 /* ─── Actions bar ───────────────────────────────────────── */

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -737,6 +737,19 @@
   color: var(--accent);
   border-radius: 3px;
 }
+.badge-audiobook {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3em;
+  padding: 0.15em 0.55em;
+  font-size: 0.68rem;
+  font-weight: 650;
+  background: rgba(34, 197, 94, 0.14);
+  color: #79d99a;
+  border: 1px solid rgba(34, 197, 94, 0.22);
+  border-radius: 999px;
+  white-space: nowrap;
+}
 .badge-config {
   display: inline-block;
   padding: 0.15em 0.55em;
@@ -1693,6 +1706,111 @@
   font-size: 0.7rem;
   letter-spacing: 0.03em;
   text-transform: uppercase;
+}
+
+.chapter-preview-hint,
+.chapter-preview-error {
+  display: block;
+  margin-top: 0.35rem;
+  max-width: 18rem;
+}
+
+.chapter-preview-note {
+  color: var(--text-muted);
+  font-size: 0.82rem;
+  margin: 1rem;
+}
+
+.audiobook-reader {
+  display: grid;
+  grid-template-columns: minmax(150px, 220px) minmax(0, 1fr);
+  gap: 1rem;
+}
+
+.audiobook-reader-chapters {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  max-height: 70vh;
+  overflow-y: auto;
+}
+
+.audiobook-reader-chapters button {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.2rem;
+  text-align: left;
+  background: var(--surface);
+  border: 1px solid var(--border);
+}
+
+.audiobook-reader-chapters button.active {
+  border-color: var(--accent);
+  background: rgba(98, 114, 234, 0.12);
+}
+
+.audiobook-reader-chapters small {
+  color: var(--text-muted);
+}
+
+.audiobook-reader-content {
+  min-width: 0;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1rem;
+}
+
+.audiobook-reader-heading {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.audiobook-reader-heading h3 {
+  margin: 0.15rem 0 0;
+}
+
+.audiobook-reader-nav {
+  display: flex;
+  gap: 0.4rem;
+}
+
+.audiobook-reader-player {
+  width: 100%;
+  margin: 1rem 0;
+}
+
+.audiobook-reader-summary {
+  color: var(--text-muted);
+  border-left: 3px solid var(--accent);
+  padding-left: 0.8rem;
+}
+
+.audiobook-reader-text {
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 1.05rem;
+  line-height: 1.75;
+  max-height: 56vh;
+  overflow-y: auto;
+  padding-right: 0.75rem;
+}
+
+@media (max-width: 760px) {
+  .audiobook-reader {
+    grid-template-columns: 1fr;
+  }
+
+  .audiobook-reader-chapters {
+    flex-direction: row;
+    overflow-x: auto;
+  }
+
+  .audiobook-reader-chapters button {
+    min-width: 9rem;
+  }
 }
 
 .sentence-text {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import AdminLogin from "./components/AdminLogin.jsx";
 import BookList from "./components/BookList";
 import BookSettings from "./components/BookSettings";
 import AddBook from "./components/AddBook.jsx";
+import AudiobookSettings from "./components/AudiobookSettings.jsx";
 import CleaningConfigs from "./components/CleaningConfigs.jsx";
 import SchedulerStatus from "./components/SchedulerStatus.jsx";
 import Logs from "./components/Logs.jsx";
@@ -227,6 +228,8 @@ function App() {
         return <Logs />;
       case "utilities":
         return <Utilities />;
+      case "audio-settings":
+        return <AudiobookSettings />;
       default:
         return (
           <>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -139,7 +139,7 @@ function App() {
 
   const handleSortByChange = (newSortBy) => {
     setSortBy(newSortBy);
-    setSortOrder("asc");
+    setSortOrder(newSortBy === "audiobook_enabled" ? "desc" : "asc");
   };
 
   const handleToggleSortOrder = () => {
@@ -165,7 +165,10 @@ function App() {
     };
     const onDragLeave = (e) => {
       // Only clear when the drag exits the browser window entirely
-      if (e.relatedTarget === null || !document.documentElement.contains(e.relatedTarget)) {
+      if (
+        e.relatedTarget === null ||
+        !document.documentElement.contains(e.relatedTarget)
+      ) {
         setGlobalDragging(false);
       }
     };
@@ -179,7 +182,7 @@ function App() {
         (entry) =>
           entry.isDirectory ||
           entry.name.toLowerCase().endsWith(".epub") ||
-          entry.name.toLowerCase().endsWith(".zip")
+          entry.name.toLowerCase().endsWith(".zip"),
       );
       if (hasRelevant) {
         setActiveTab("library");
@@ -266,6 +269,7 @@ function App() {
               </div>
               <div className="sort-controls">
                 <select
+                  aria-label="Sort library by"
                   value={sortBy}
                   onChange={(e) => handleSortByChange(e.target.value)}
                 >
@@ -273,6 +277,7 @@ function App() {
                   <option value="author">Author</option>
                   <option value="word_count">Word Count</option>
                   <option value="updated_at">Last Updated</option>
+                  <option value="audiobook_enabled">Audiobook Enabled</option>
                 </select>
                 <button
                   className="sort-order-btn"

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -63,7 +63,13 @@ describe("App", () => {
 
   it("searches by unified query", async () => {
     const mockBooks = [
-      { id: 2, title: "Book B", author: "Author B", source_type: "epub", series: null },
+      {
+        id: 2,
+        title: "Book B",
+        author: "Author B",
+        source_type: "epub",
+        series: null,
+      },
     ];
 
     globalThis.fetch = vi.fn((url) => {
@@ -73,7 +79,9 @@ describe("App", () => {
           json: () => Promise.resolve([]),
         });
       }
-      if (url === "/api/books/catalog?q=Author%20B&sort_by=title&sort_order=asc") {
+      if (
+        url === "/api/books/catalog?q=Author%20B&sort_by=title&sort_order=asc"
+      ) {
         return Promise.resolve({
           ok: true,
           json: () => Promise.resolve(mockBooks),
@@ -171,8 +179,13 @@ describe("App", () => {
       expect(screen.getByText("Fantasy")).toBeInTheDocument();
     });
 
-    expect(globalThis.fetch).not.toHaveBeenCalledWith("/api/books/details?ids=1&ids=2");
-    expect(screen.getByAltText("Saga cover")).toHaveAttribute("src", "/api/covers/2");
+    expect(globalThis.fetch).not.toHaveBeenCalledWith(
+      "/api/books/details?ids=1&ids=2",
+    );
+    expect(screen.getByAltText("Saga cover")).toHaveAttribute(
+      "src",
+      "/api/covers/2",
+    );
 
     expect(screen.queryByText("Saga Book 1")).not.toBeInTheDocument();
 
@@ -239,12 +252,21 @@ describe("App", () => {
     fireEvent.click(screen.getByRole("button", { name: /genres/i }));
 
     await waitFor(() => {
-      expect(screen.getByPlaceholderText("Fantasy, Science Fiction, Progression Fantasy")).toBeInTheDocument();
+      expect(
+        screen.getByPlaceholderText(
+          "Fantasy, Science Fiction, Progression Fantasy",
+        ),
+      ).toBeInTheDocument();
     });
 
-    fireEvent.change(screen.getByPlaceholderText("Fantasy, Science Fiction, Progression Fantasy"), {
-      target: { value: "Fantasy, Epic Fantasy" },
-    });
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        "Fantasy, Science Fiction, Progression Fantasy",
+      ),
+      {
+        target: { value: "Fantasy, Epic Fantasy" },
+      },
+    );
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => {
@@ -264,7 +286,11 @@ describe("App", () => {
         author: "Author A",
         series: "Mixed Saga",
         effective_genre_tags: ["Fantasy"],
-        effective_series_genre_tags: ["Adventure", "Fantasy", "Progression Fantasy"],
+        effective_series_genre_tags: [
+          "Adventure",
+          "Fantasy",
+          "Progression Fantasy",
+        ],
         current_word_count: 1000,
         source_type: "epub",
       },
@@ -274,7 +300,11 @@ describe("App", () => {
         author: "Author A",
         series: "Mixed Saga",
         effective_genre_tags: ["Adventure"],
-        effective_series_genre_tags: ["Adventure", "Fantasy", "Progression Fantasy"],
+        effective_series_genre_tags: [
+          "Adventure",
+          "Fantasy",
+          "Progression Fantasy",
+        ],
         current_word_count: 1000,
         source_type: "epub",
       },
@@ -284,7 +314,11 @@ describe("App", () => {
         author: "Author A",
         series: "Mixed Saga",
         effective_genre_tags: ["Progression Fantasy"],
-        effective_series_genre_tags: ["Adventure", "Fantasy", "Progression Fantasy"],
+        effective_series_genre_tags: [
+          "Adventure",
+          "Fantasy",
+          "Progression Fantasy",
+        ],
         current_word_count: 1000,
         source_type: "epub",
       },
@@ -371,7 +405,9 @@ describe("App", () => {
     fireEvent.click(screen.getByRole("button", { name: /assign series/i }));
 
     await waitFor(() => {
-      expect(screen.getByPlaceholderText("Add to a series")).toBeInTheDocument();
+      expect(
+        screen.getByPlaceholderText("Add to a series"),
+      ).toBeInTheDocument();
     });
 
     fireEvent.change(screen.getByPlaceholderText("Add to a series"), {
@@ -385,6 +421,71 @@ describe("App", () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ series: "Saga" }),
       });
+    });
+  });
+
+  it("shows, filters, and sorts audiobook-enabled books", async () => {
+    const mockBooks = [
+      {
+        id: 31,
+        title: "Audio Ready",
+        author: "Narrator A",
+        current_word_count: 1200,
+        source_type: "epub",
+        series: null,
+        audiobook_enabled: true,
+        audiobook_pipeline_status: "paused",
+      },
+      {
+        id: 32,
+        title: "Text Only",
+        author: "Author B",
+        current_word_count: 900,
+        source_type: "epub",
+        series: null,
+        audiobook_enabled: false,
+      },
+    ];
+
+    globalThis.fetch = vi.fn((url) => {
+      if (
+        url === "/api/books/catalog?sort_by=title&sort_order=asc" ||
+        url === "/api/books/catalog?sort_by=audiobook_enabled&sort_order=desc"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockBooks),
+        });
+      }
+      if (url === "/api/series") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([]),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+    });
+
+    renderWithClient(<App />);
+    fireEvent.click(await screen.findByRole("tab", { name: /standalone/i }));
+
+    expect(await screen.findByTitle("Audiobook: paused")).toBeInTheDocument();
+    expect(screen.getByText("Showing 2 of 2 books")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Audiobook"), {
+      target: { value: "enabled" },
+    });
+    expect(screen.getByText("Showing 1 of 2 books")).toBeInTheDocument();
+    expect(screen.getByText("Audio Ready")).toBeInTheDocument();
+    expect(screen.queryByText("Text Only")).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Sort library by"), {
+      target: { value: "audiobook_enabled" },
+    });
+    await waitFor(() => {
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        "/api/books/catalog?sort_by=audiobook_enabled&sort_order=desc",
+      );
     });
   });
 });

--- a/frontend/src/api/audiobook.js
+++ b/frontend/src/api/audiobook.js
@@ -50,6 +50,23 @@ export function rebuildCharacterRoster(bookId) {
   });
 }
 
+export function shareCharacterRosterWithSeries(bookId) {
+  return sendWithoutBody(`/api/books/${bookId}/audiobook/roster/share-series`, {
+    method: "POST",
+    fallbackMessage: "Failed to sync the series character roster",
+  });
+}
+
+export function generateChapterPreview(bookId, chapterId) {
+  return sendWithoutBody(
+    `/api/books/${bookId}/audiobook/chapters/${chapterId}/preview-audio`,
+    {
+      method: "POST",
+      fallbackMessage: "Failed to queue the chapter preview",
+    },
+  );
+}
+
 // Characters
 export function getCharacters(bookId) {
   return getJson(

--- a/frontend/src/api/audiobook.js
+++ b/frontend/src/api/audiobook.js
@@ -67,6 +67,10 @@ export function getChapterAudioUrl(bookId, chapterId) {
   return `/api/books/${bookId}/audiobook/chapters/${chapterId}/audio`;
 }
 
+export function getAudiobookDownloadUrl(bookId) {
+  return `/api/books/${bookId}/audiobook/download`;
+}
+
 // Settings
 export function getAudiobookSettings() {
   return getJson("/api/audiobook/settings", "Failed to fetch audiobook settings");

--- a/frontend/src/api/audiobook.js
+++ b/frontend/src/api/audiobook.js
@@ -22,6 +22,13 @@ export function stepPipeline(bookId) {
   });
 }
 
+export function runPipelineBatch(bookId) {
+  return sendWithoutBody(`/api/books/${bookId}/audiobook/run-batch`, {
+    method: "POST",
+    fallbackMessage: "Failed to run one pipeline batch",
+  });
+}
+
 export function pausePipeline(bookId) {
   return sendWithoutBody(`/api/books/${bookId}/audiobook/pause`, {
     method: "POST",
@@ -33,6 +40,13 @@ export function rebuildPipeline(bookId) {
   return sendWithoutBody(`/api/books/${bookId}/audiobook/rebuild`, {
     method: "POST",
     fallbackMessage: "Failed to rebuild pipeline",
+  });
+}
+
+export function rebuildCharacterRoster(bookId) {
+  return sendWithoutBody(`/api/books/${bookId}/audiobook/roster/rebuild`, {
+    method: "POST",
+    fallbackMessage: "Failed to regenerate the character roster",
   });
 }
 
@@ -53,9 +67,13 @@ export function updateCharacter(charId, data) {
 }
 
 // Sentences
-export function getSentences(bookId, { page = 1, limit = 50, chapterId } = {}) {
+export function getSentences(
+  bookId,
+  { page = 1, limit = 50, chapterId, reviewOnly = false } = {},
+) {
   const params = new URLSearchParams({ page, limit });
   if (chapterId != null) params.set("chapter_id", chapterId);
+  if (reviewOnly) params.set("review_only", "true");
   return getJson(
     `/api/books/${bookId}/audiobook/sentences?${params}`,
     "Failed to fetch sentences",
@@ -103,5 +121,12 @@ export function updateAudiobookSettings(data) {
     method: "PUT",
     body: data,
     fallbackMessage: "Failed to save audiobook settings",
+  });
+}
+
+export function testAudiobookLlm() {
+  return sendWithoutBody("/api/audiobook/settings/test-llm", {
+    method: "POST",
+    fallbackMessage: "Failed to connect to the configured LLM",
   });
 }

--- a/frontend/src/api/audiobook.js
+++ b/frontend/src/api/audiobook.js
@@ -1,0 +1,81 @@
+import { getJson, sendJson, sendWithoutBody } from "./client";
+
+// Pipeline control
+export function getAudiobookStatus(bookId) {
+  return getJson(`/api/books/${bookId}/audiobook/status`, "Failed to fetch audiobook status");
+}
+
+export function startPipeline(bookId) {
+  return sendWithoutBody(`/api/books/${bookId}/audiobook/start`, {
+    method: "POST",
+    fallbackMessage: "Failed to start pipeline",
+  });
+}
+
+export function pausePipeline(bookId) {
+  return sendWithoutBody(`/api/books/${bookId}/audiobook/pause`, {
+    method: "POST",
+    fallbackMessage: "Failed to pause pipeline",
+  });
+}
+
+export function rebuildPipeline(bookId) {
+  return sendWithoutBody(`/api/books/${bookId}/audiobook/rebuild`, {
+    method: "POST",
+    fallbackMessage: "Failed to rebuild pipeline",
+  });
+}
+
+// Characters
+export function getCharacters(bookId) {
+  return getJson(`/api/books/${bookId}/audiobook/characters`, "Failed to fetch characters");
+}
+
+export function updateCharacter(charId, data) {
+  return sendJson(`/api/audiobook/characters/${charId}`, {
+    method: "PUT",
+    body: data,
+    fallbackMessage: "Failed to update character",
+  });
+}
+
+// Sentences
+export function getSentences(bookId, { page = 1, limit = 50, chapterId } = {}) {
+  const params = new URLSearchParams({ page, limit });
+  if (chapterId != null) params.set("chapter_id", chapterId);
+  return getJson(`/api/books/${bookId}/audiobook/sentences?${params}`, "Failed to fetch sentences");
+}
+
+export function updateSentence(sentenceId, data) {
+  return sendJson(`/api/audiobook/sentences/${sentenceId}`, {
+    method: "PUT",
+    body: data,
+    fallbackMessage: "Failed to update sentence",
+  });
+}
+
+export function getSentenceAudioUrl(sentenceId) {
+  return `/api/audiobook/sentences/${sentenceId}/audio`;
+}
+
+// Chapters
+export function getAudiobookChapters(bookId) {
+  return getJson(`/api/books/${bookId}/audiobook/chapters`, "Failed to fetch chapters");
+}
+
+export function getChapterAudioUrl(bookId, chapterId) {
+  return `/api/books/${bookId}/audiobook/chapters/${chapterId}/audio`;
+}
+
+// Settings
+export function getAudiobookSettings() {
+  return getJson("/api/audiobook/settings", "Failed to fetch audiobook settings");
+}
+
+export function updateAudiobookSettings(data) {
+  return sendJson("/api/audiobook/settings", {
+    method: "PUT",
+    body: data,
+    fallbackMessage: "Failed to save audiobook settings",
+  });
+}

--- a/frontend/src/api/audiobook.js
+++ b/frontend/src/api/audiobook.js
@@ -2,13 +2,23 @@ import { getJson, sendJson, sendWithoutBody } from "./client";
 
 // Pipeline control
 export function getAudiobookStatus(bookId) {
-  return getJson(`/api/books/${bookId}/audiobook/status`, "Failed to fetch audiobook status");
+  return getJson(
+    `/api/books/${bookId}/audiobook/status`,
+    "Failed to fetch audiobook status",
+  );
 }
 
 export function startPipeline(bookId) {
   return sendWithoutBody(`/api/books/${bookId}/audiobook/start`, {
     method: "POST",
     fallbackMessage: "Failed to start pipeline",
+  });
+}
+
+export function stepPipeline(bookId) {
+  return sendWithoutBody(`/api/books/${bookId}/audiobook/step`, {
+    method: "POST",
+    fallbackMessage: "Failed to run the next pipeline stage",
   });
 }
 
@@ -28,7 +38,10 @@ export function rebuildPipeline(bookId) {
 
 // Characters
 export function getCharacters(bookId) {
-  return getJson(`/api/books/${bookId}/audiobook/characters`, "Failed to fetch characters");
+  return getJson(
+    `/api/books/${bookId}/audiobook/characters`,
+    "Failed to fetch characters",
+  );
 }
 
 export function updateCharacter(charId, data) {
@@ -43,7 +56,10 @@ export function updateCharacter(charId, data) {
 export function getSentences(bookId, { page = 1, limit = 50, chapterId } = {}) {
   const params = new URLSearchParams({ page, limit });
   if (chapterId != null) params.set("chapter_id", chapterId);
-  return getJson(`/api/books/${bookId}/audiobook/sentences?${params}`, "Failed to fetch sentences");
+  return getJson(
+    `/api/books/${bookId}/audiobook/sentences?${params}`,
+    "Failed to fetch sentences",
+  );
 }
 
 export function updateSentence(sentenceId, data) {
@@ -60,7 +76,10 @@ export function getSentenceAudioUrl(sentenceId) {
 
 // Chapters
 export function getAudiobookChapters(bookId) {
-  return getJson(`/api/books/${bookId}/audiobook/chapters`, "Failed to fetch chapters");
+  return getJson(
+    `/api/books/${bookId}/audiobook/chapters`,
+    "Failed to fetch chapters",
+  );
 }
 
 export function getChapterAudioUrl(bookId, chapterId) {
@@ -73,7 +92,10 @@ export function getAudiobookDownloadUrl(bookId) {
 
 // Settings
 export function getAudiobookSettings() {
-  return getJson("/api/audiobook/settings", "Failed to fetch audiobook settings");
+  return getJson(
+    "/api/audiobook/settings",
+    "Failed to fetch audiobook settings",
+  );
 }
 
 export function updateAudiobookSettings(data) {

--- a/frontend/src/api/audiobook.js
+++ b/frontend/src/api/audiobook.js
@@ -105,6 +105,16 @@ export function updateSentence(sentenceId, data) {
   });
 }
 
+export function generateSentenceAudio(bookId, sentenceId) {
+  return sendWithoutBody(
+    `/api/books/${bookId}/audiobook/sentences/${sentenceId}/generate-audio`,
+    {
+      method: "POST",
+      fallbackMessage: "Failed to queue sentence audio",
+    },
+  );
+}
+
 export function getSentenceAudioUrl(sentenceId) {
   return `/api/audiobook/sentences/${sentenceId}/audio`;
 }

--- a/frontend/src/components/AudiobookPipeline.jsx
+++ b/frontend/src/components/AudiobookPipeline.jsx
@@ -1,0 +1,200 @@
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  getAudiobookStatus,
+  getCharacters,
+  getAudiobookChapters,
+  startPipeline,
+  pausePipeline,
+  rebuildPipeline,
+} from "../api/audiobook";
+import CharacterRoster from "./audiobook/CharacterRoster";
+import ScriptEditor from "./audiobook/ScriptEditor";
+import ChapterAssembly from "./audiobook/ChapterAssembly";
+
+const PIPELINE_STEPS = [
+  { status: "ingesting", label: "Ingesting" },
+  { status: "roster_gen", label: "Roster" },
+  { status: "diarizing", label: "Diarizing" },
+  { status: "audio_gen", label: "TTS" },
+  { status: "assembling", label: "Assembly" },
+  { status: "complete", label: "Complete" },
+];
+
+const ACTIVE_STATUSES = new Set(["ingesting", "roster_gen", "diarizing", "audio_gen", "assembling"]);
+
+function PipelineProgress({ status }) {
+  const currentIdx = PIPELINE_STEPS.findIndex((s) => s.status === status);
+  return (
+    <div className="pipeline-progress">
+      {PIPELINE_STEPS.map((step, idx) => {
+        let cls = "pipeline-step";
+        if (idx < currentIdx) cls += " pipeline-step--done";
+        else if (idx === currentIdx) cls += " pipeline-step--active";
+        return (
+          <div key={step.status} className={cls}>
+            <div className="pipeline-step-dot" />
+            <span>{step.label}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+const SUB_TABS = ["Characters", "Script Editor", "Chapter Assembly"];
+
+function AudiobookPipeline({ book }) {
+  const bookId = book.id;
+  const queryClient = useQueryClient();
+  const [subTab, setSubTab] = useState("Characters");
+  const [confirmRebuild, setConfirmRebuild] = useState(false);
+
+  const isActive = (status) => ACTIVE_STATUSES.has(status);
+
+  const { data: statusData } = useQuery({
+    queryKey: ["audiobook-status", bookId],
+    queryFn: () => getAudiobookStatus(bookId),
+    refetchInterval: ({ state }) => {
+      const s = state.data?.pipeline_status;
+      return s && isActive(s) ? 3000 : false;
+    },
+  });
+
+  const { data: characters = [] } = useQuery({
+    queryKey: ["audiobook-characters", bookId],
+    queryFn: () => getCharacters(bookId),
+  });
+
+  const { data: chapters = [] } = useQuery({
+    queryKey: ["audiobook-chapters", bookId],
+    queryFn: () => getAudiobookChapters(bookId),
+    refetchInterval: ({ state: queryState }) => {
+      const s = statusData?.pipeline_status;
+      return s && isActive(s) ? 5000 : false;
+    },
+  });
+
+  const invalidateAll = () => {
+    queryClient.invalidateQueries({ queryKey: ["audiobook-status", bookId] });
+    queryClient.invalidateQueries({ queryKey: ["audiobook-characters", bookId] });
+    queryClient.invalidateQueries({ queryKey: ["audiobook-chapters", bookId] });
+  };
+
+  const startMutation = useMutation({
+    mutationFn: () => startPipeline(bookId),
+    onSuccess: invalidateAll,
+  });
+
+  const pauseMutation = useMutation({
+    mutationFn: () => pausePipeline(bookId),
+    onSuccess: invalidateAll,
+  });
+
+  const rebuildMutation = useMutation({
+    mutationFn: () => rebuildPipeline(bookId),
+    onSuccess: () => {
+      setConfirmRebuild(false);
+      invalidateAll();
+    },
+  });
+
+  const pipelineStatus = statusData?.pipeline_status ?? null;
+  const sentenceCounts = statusData?.sentence_counts ?? {};
+  const totalSentences = Object.values(sentenceCounts).reduce((a, b) => a + b, 0);
+  const doneCount = sentenceCounts["audio_generated"] ?? 0;
+
+  return (
+    <div className="audiobook-pipeline">
+      <div className="pipeline-header">
+        <PipelineProgress status={pipelineStatus} />
+
+        <div className="pipeline-meta">
+          {totalSentences > 0 && (
+            <span className="pipeline-sentence-count">
+              {doneCount} / {totalSentences} sentences with audio
+            </span>
+          )}
+          {pipelineStatus === "error" && (
+            <span className="badge badge--error">Pipeline error — check logs</span>
+          )}
+          {pipelineStatus === "paused" && (
+            <span className="badge badge--warning">Paused</span>
+          )}
+        </div>
+
+        <div className="pipeline-controls">
+          {pipelineStatus !== "complete" && !isActive(pipelineStatus) && (
+            <button
+              onClick={() => startMutation.mutate()}
+              disabled={startMutation.isPending}
+              className="btn-primary"
+            >
+              {pipelineStatus ? "Resume Pipeline" : "Start Pipeline"}
+            </button>
+          )}
+          {isActive(pipelineStatus) && (
+            <button
+              onClick={() => pauseMutation.mutate()}
+              disabled={pauseMutation.isPending}
+            >
+              Pause Workers
+            </button>
+          )}
+          {!confirmRebuild ? (
+            <button className="btn-danger" onClick={() => setConfirmRebuild(true)}>
+              Force Full Rebuild
+            </button>
+          ) : (
+            <span className="confirm-inline">
+              Destroy all audio and re-run from scratch?{" "}
+              <button
+                className="btn-danger"
+                onClick={() => rebuildMutation.mutate()}
+                disabled={rebuildMutation.isPending}
+              >
+                {rebuildMutation.isPending ? "Rebuilding…" : "Yes, rebuild"}
+              </button>{" "}
+              <button className="btn-text" onClick={() => setConfirmRebuild(false)}>
+                Cancel
+              </button>
+            </span>
+          )}
+        </div>
+
+        {(startMutation.isError || pauseMutation.isError || rebuildMutation.isError) && (
+          <p className="error">
+            {(startMutation.error || pauseMutation.error || rebuildMutation.error)?.message ||
+              "Action failed"}
+          </p>
+        )}
+      </div>
+
+      <nav className="sub-tabs">
+        {SUB_TABS.map((t) => (
+          <button
+            key={t}
+            className={`sub-tab${subTab === t ? " sub-tab--active" : ""}`}
+            onClick={() => setSubTab(t)}
+          >
+            {t}
+          </button>
+        ))}
+      </nav>
+
+      <div className="sub-tab-content">
+        {subTab === "Characters" && (
+          <CharacterRoster characters={characters} bookId={bookId} />
+        )}
+        {subTab === "Script Editor" && (
+          <ScriptEditor bookId={bookId} characters={characters} />
+        )}
+        {subTab === "Chapter Assembly" && (
+          <ChapterAssembly chapters={chapters} bookId={bookId} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default AudiobookPipeline;

--- a/frontend/src/components/AudiobookPipeline.jsx
+++ b/frontend/src/components/AudiobookPipeline.jsx
@@ -69,7 +69,7 @@ function AudiobookPipeline({ book }) {
   const { data: chapters = [] } = useQuery({
     queryKey: ["audiobook-chapters", bookId],
     queryFn: () => getAudiobookChapters(bookId),
-    refetchInterval: ({ state: queryState }) => {
+    refetchInterval: () => {
       const s = statusData?.pipeline_status;
       return s && isActive(s) ? 5000 : false;
     },

--- a/frontend/src/components/AudiobookPipeline.jsx
+++ b/frontend/src/components/AudiobookPipeline.jsx
@@ -1,10 +1,11 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   getAudiobookStatus,
   getCharacters,
   getAudiobookChapters,
   startPipeline,
+  stepPipeline,
   pausePipeline,
   rebuildPipeline,
   getAudiobookDownloadUrl,
@@ -22,7 +23,13 @@ const PIPELINE_STEPS = [
   { status: "complete", label: "Complete" },
 ];
 
-const ACTIVE_STATUSES = new Set(["ingesting", "roster_gen", "diarizing", "audio_gen", "assembling"]);
+const ACTIVE_STATUSES = new Set([
+  "ingesting",
+  "roster_gen",
+  "diarizing",
+  "audio_gen",
+  "assembling",
+]);
 
 function PipelineProgress({ status }) {
   const currentIdx = PIPELINE_STEPS.findIndex((s) => s.status === status);
@@ -78,12 +85,19 @@ function AudiobookPipeline({ book }) {
 
   const invalidateAll = () => {
     queryClient.invalidateQueries({ queryKey: ["audiobook-status", bookId] });
-    queryClient.invalidateQueries({ queryKey: ["audiobook-characters", bookId] });
+    queryClient.invalidateQueries({
+      queryKey: ["audiobook-characters", bookId],
+    });
     queryClient.invalidateQueries({ queryKey: ["audiobook-chapters", bookId] });
   };
 
   const startMutation = useMutation({
     mutationFn: () => startPipeline(bookId),
+    onSuccess: invalidateAll,
+  });
+
+  const stepMutation = useMutation({
+    mutationFn: () => stepPipeline(bookId),
     onSuccess: invalidateAll,
   });
 
@@ -101,14 +115,40 @@ function AudiobookPipeline({ book }) {
   });
 
   const pipelineStatus = statusData?.pipeline_status ?? null;
+  const nextPhase = statusData?.next_phase ?? "ingesting";
+  const pauseRequested = statusData?.pause_requested ?? false;
+  const progressStatus =
+    isActive(pipelineStatus) || pipelineStatus === "complete"
+      ? pipelineStatus
+      : nextPhase;
+  const nextPhaseLabel =
+    PIPELINE_STEPS.find((step) => step.status === nextPhase)?.label ??
+    nextPhase;
   const sentenceCounts = statusData?.sentence_counts ?? {};
-  const totalSentences = Object.values(sentenceCounts).reduce((a, b) => a + b, 0);
+  const totalSentences = Object.values(sentenceCounts).reduce(
+    (a, b) => a + b,
+    0,
+  );
   const doneCount = sentenceCounts["audio_generated"] ?? 0;
+
+  // A fast local/stub phase can finish before the slower data queries poll.
+  // Refresh editor data whenever the durable pipeline state advances so the
+  // review screen always reflects the checkpoint that was just reached.
+  useEffect(() => {
+    if (pipelineStatus !== undefined) {
+      queryClient.invalidateQueries({
+        queryKey: ["audiobook-characters", bookId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["audiobook-chapters", bookId],
+      });
+    }
+  }, [bookId, pipelineStatus, queryClient]);
 
   return (
     <div className="audiobook-pipeline">
       <div className="pipeline-header">
-        <PipelineProgress status={pipelineStatus} />
+        <PipelineProgress status={progressStatus} />
 
         <div className="pipeline-meta">
           {totalSentences > 0 && (
@@ -117,38 +157,61 @@ function AudiobookPipeline({ book }) {
             </span>
           )}
           {pipelineStatus === "error" && (
-            <span className="badge badge--error">Pipeline error — check logs</span>
+            <span className="badge badge--error">Pipeline error</span>
           )}
           {pipelineStatus === "paused" && (
-            <span className="badge badge--warning">Paused</span>
+            <span className="badge badge--warning">
+              Paused — next: {nextPhaseLabel}
+            </span>
+          )}
+          {pauseRequested && (
+            <span className="badge badge--warning">Pause requested…</span>
+          )}
+          {statusData?.last_error && (
+            <p className="error">{statusData.last_error}</p>
           )}
         </div>
 
         <div className="pipeline-controls">
           {pipelineStatus === "complete" && (
-            <a className="btn btn-primary" href={getAudiobookDownloadUrl(bookId)} download>
+            <a
+              className="btn btn-primary"
+              href={getAudiobookDownloadUrl(bookId)}
+              download
+            >
               Download Audiobook EPUB
             </a>
           )}
           {pipelineStatus !== "complete" && !isActive(pipelineStatus) && (
-            <button
-              onClick={() => startMutation.mutate()}
-              disabled={startMutation.isPending}
-              className="btn-primary"
-            >
-              {pipelineStatus ? "Resume Pipeline" : "Start Pipeline"}
-            </button>
+            <>
+              <button
+                onClick={() => stepMutation.mutate()}
+                disabled={stepMutation.isPending || startMutation.isPending}
+              >
+                Run Next Stage: {nextPhaseLabel}
+              </button>
+              <button
+                onClick={() => startMutation.mutate()}
+                disabled={startMutation.isPending || stepMutation.isPending}
+                className="btn-primary"
+              >
+                Run to Completion
+              </button>
+            </>
           )}
           {isActive(pipelineStatus) && (
             <button
               onClick={() => pauseMutation.mutate()}
-              disabled={pauseMutation.isPending}
+              disabled={pauseMutation.isPending || pauseRequested}
             >
-              Pause Workers
+              {pauseRequested ? "Pause Requested…" : "Pause Safely"}
             </button>
           )}
           {!confirmRebuild ? (
-            <button className="btn-danger" onClick={() => setConfirmRebuild(true)}>
+            <button
+              className="btn-danger"
+              onClick={() => setConfirmRebuild(true)}
+            >
               Force Full Rebuild
             </button>
           ) : (
@@ -161,17 +224,27 @@ function AudiobookPipeline({ book }) {
               >
                 {rebuildMutation.isPending ? "Rebuilding…" : "Yes, rebuild"}
               </button>{" "}
-              <button className="btn-text" onClick={() => setConfirmRebuild(false)}>
+              <button
+                className="btn-text"
+                onClick={() => setConfirmRebuild(false)}
+              >
                 Cancel
               </button>
             </span>
           )}
         </div>
 
-        {(startMutation.isError || pauseMutation.isError || rebuildMutation.isError) && (
+        {(startMutation.isError ||
+          stepMutation.isError ||
+          pauseMutation.isError ||
+          rebuildMutation.isError) && (
           <p className="error">
-            {(startMutation.error || pauseMutation.error || rebuildMutation.error)?.message ||
-              "Action failed"}
+            {(
+              startMutation.error ||
+              stepMutation.error ||
+              pauseMutation.error ||
+              rebuildMutation.error
+            )?.message || "Action failed"}
           </p>
         )}
       </div>

--- a/frontend/src/components/AudiobookPipeline.jsx
+++ b/frontend/src/components/AudiobookPipeline.jsx
@@ -382,6 +382,7 @@ function AudiobookPipeline({ book }) {
             bookId={bookId}
             characters={characters}
             chapters={chapters}
+            pipelineActive={isActive(pipelineStatus)}
           />
         )}
         {subTab === "Chapter Assembly" && (

--- a/frontend/src/components/AudiobookPipeline.jsx
+++ b/frontend/src/components/AudiobookPipeline.jsx
@@ -15,6 +15,7 @@ import CharacterRoster from "./audiobook/CharacterRoster";
 import ScriptEditor from "./audiobook/ScriptEditor";
 import ChapterAssembly from "./audiobook/ChapterAssembly";
 import AnalysisOverview from "./audiobook/AnalysisOverview";
+import AudiobookReader from "./audiobook/AudiobookReader";
 
 const PIPELINE_STEPS = [
   { status: "ingesting", label: "Ingesting" },
@@ -113,6 +114,7 @@ const SUB_TABS = [
   "Analysis",
   "Characters",
   "Script Editor",
+  "Listen & Read",
   "Chapter Assembly",
 ];
 
@@ -141,9 +143,12 @@ function AudiobookPipeline({ book }) {
   const { data: chapters = [] } = useQuery({
     queryKey: ["audiobook-chapters", bookId],
     queryFn: () => getAudiobookChapters(bookId),
-    refetchInterval: () => {
+    refetchInterval: ({ state }) => {
       const s = statusData?.pipeline_status;
-      return s && isActive(s) ? 5000 : false;
+      const previewActive = state.data?.some((chapter) =>
+        ["queued", "generating"].includes(chapter.preview_status),
+      );
+      return (s && isActive(s)) || previewActive ? 3000 : false;
     },
   });
 
@@ -369,6 +374,7 @@ function AudiobookPipeline({ book }) {
             characters={characters}
             bookId={bookId}
             pipelineStatus={pipelineStatus}
+            series={book.series}
           />
         )}
         {subTab === "Script Editor" && (
@@ -379,7 +385,18 @@ function AudiobookPipeline({ book }) {
           />
         )}
         {subTab === "Chapter Assembly" && (
-          <ChapterAssembly chapters={chapters} bookId={bookId} />
+          <ChapterAssembly
+            chapters={chapters}
+            bookId={bookId}
+            pipelineActive={isActive(pipelineStatus)}
+          />
+        )}
+        {subTab === "Listen & Read" && (
+          <AudiobookReader
+            chapters={chapters}
+            characters={characters}
+            bookId={bookId}
+          />
         )}
       </div>
     </div>

--- a/frontend/src/components/AudiobookPipeline.jsx
+++ b/frontend/src/components/AudiobookPipeline.jsx
@@ -7,6 +7,7 @@ import {
   startPipeline,
   pausePipeline,
   rebuildPipeline,
+  getAudiobookDownloadUrl,
 } from "../api/audiobook";
 import CharacterRoster from "./audiobook/CharacterRoster";
 import ScriptEditor from "./audiobook/ScriptEditor";
@@ -124,6 +125,11 @@ function AudiobookPipeline({ book }) {
         </div>
 
         <div className="pipeline-controls">
+          {pipelineStatus === "complete" && (
+            <a className="btn btn-primary" href={getAudiobookDownloadUrl(bookId)} download>
+              Download Audiobook EPUB
+            </a>
+          )}
           {pipelineStatus !== "complete" && !isActive(pipelineStatus) && (
             <button
               onClick={() => startMutation.mutate()}

--- a/frontend/src/components/AudiobookPipeline.jsx
+++ b/frontend/src/components/AudiobookPipeline.jsx
@@ -6,6 +6,7 @@ import {
   getAudiobookChapters,
   startPipeline,
   stepPipeline,
+  runPipelineBatch,
   pausePipeline,
   rebuildPipeline,
   getAudiobookDownloadUrl,
@@ -13,6 +14,7 @@ import {
 import CharacterRoster from "./audiobook/CharacterRoster";
 import ScriptEditor from "./audiobook/ScriptEditor";
 import ChapterAssembly from "./audiobook/ChapterAssembly";
+import AnalysisOverview from "./audiobook/AnalysisOverview";
 
 const PIPELINE_STEPS = [
   { status: "ingesting", label: "Ingesting" },
@@ -30,6 +32,7 @@ const ACTIVE_STATUSES = new Set([
   "audio_gen",
   "assembling",
 ]);
+const BATCHABLE_STATUSES = new Set(["diarizing", "audio_gen", "assembling"]);
 
 function PipelineProgress({ status }) {
   const currentIdx = PIPELINE_STEPS.findIndex((s) => s.status === status);
@@ -50,12 +53,73 @@ function PipelineProgress({ status }) {
   );
 }
 
-const SUB_TABS = ["Characters", "Script Editor", "Chapter Assembly"];
+function JobInspector({ statusData, totalSentences, doneCount }) {
+  const progressTotal = statusData?.progress_total ?? 0;
+  const progressCurrent = statusData?.progress_current ?? 0;
+  const percent = statusData?.progress_percent ?? 0;
+  const review = statusData?.review_counts ?? {};
+
+  return (
+    <section className="pipeline-inspector" aria-label="Audiobook job details">
+      <div className="pipeline-inspector-grid">
+        <div>
+          <span className="metric-label">Active model</span>
+          <strong>
+            {statusData?.llm_provider || "stub"}
+            {statusData?.llm_model ? ` / ${statusData.llm_model}` : ""}
+          </strong>
+        </div>
+        <div>
+          <span className="metric-label">Model requests</span>
+          <strong>{statusData?.llm_requests ?? 0}</strong>
+        </div>
+        <div>
+          <span className="metric-label">Sentence state</span>
+          <strong>
+            {doneCount} audio / {totalSentences} total
+          </strong>
+        </div>
+        <div>
+          <span className="metric-label">Needs review</span>
+          <strong>
+            {review.low_confidence ?? 0} low confidence ·{" "}
+            {review.unassigned ?? 0} unassigned
+          </strong>
+        </div>
+      </div>
+      {progressTotal > 0 && (
+        <div className="pipeline-work-progress">
+          <div className="pipeline-work-progress-label">
+            <span>{statusData?.progress_detail || "Working…"}</span>
+            <strong>
+              {progressCurrent.toLocaleString()} /{" "}
+              {progressTotal.toLocaleString()} ({percent}%)
+            </strong>
+          </div>
+          <progress value={progressCurrent} max={progressTotal} />
+        </div>
+      )}
+      {statusData?.summary && (
+        <details className="pipeline-summary" open>
+          <summary>Model analysis summary · review required</summary>
+          <p>{statusData.summary}</p>
+        </details>
+      )}
+    </section>
+  );
+}
+
+const SUB_TABS = [
+  "Analysis",
+  "Characters",
+  "Script Editor",
+  "Chapter Assembly",
+];
 
 function AudiobookPipeline({ book }) {
   const bookId = book.id;
   const queryClient = useQueryClient();
-  const [subTab, setSubTab] = useState("Characters");
+  const [subTab, setSubTab] = useState("Analysis");
   const [confirmRebuild, setConfirmRebuild] = useState(false);
 
   const isActive = (status) => ACTIVE_STATUSES.has(status);
@@ -98,6 +162,11 @@ function AudiobookPipeline({ book }) {
 
   const stepMutation = useMutation({
     mutationFn: () => stepPipeline(bookId),
+    onSuccess: invalidateAll,
+  });
+
+  const batchMutation = useMutation({
+    mutationFn: () => runPipelineBatch(bookId),
     onSuccess: invalidateAll,
   });
 
@@ -172,6 +241,12 @@ function AudiobookPipeline({ book }) {
           )}
         </div>
 
+        <JobInspector
+          statusData={statusData}
+          totalSentences={totalSentences}
+          doneCount={doneCount}
+        />
+
         <div className="pipeline-controls">
           {pipelineStatus === "complete" && (
             <a
@@ -184,15 +259,37 @@ function AudiobookPipeline({ book }) {
           )}
           {pipelineStatus !== "complete" && !isActive(pipelineStatus) && (
             <>
+              {BATCHABLE_STATUSES.has(nextPhase) && (
+                <button
+                  onClick={() => batchMutation.mutate()}
+                  disabled={
+                    batchMutation.isPending ||
+                    stepMutation.isPending ||
+                    startMutation.isPending
+                  }
+                >
+                  {batchMutation.isPending
+                    ? "Starting Batch…"
+                    : "Run One Batch"}
+                </button>
+              )}
               <button
                 onClick={() => stepMutation.mutate()}
-                disabled={stepMutation.isPending || startMutation.isPending}
+                disabled={
+                  stepMutation.isPending ||
+                  startMutation.isPending ||
+                  batchMutation.isPending
+                }
               >
                 Run Next Stage: {nextPhaseLabel}
               </button>
               <button
                 onClick={() => startMutation.mutate()}
-                disabled={startMutation.isPending || stepMutation.isPending}
+                disabled={
+                  startMutation.isPending ||
+                  stepMutation.isPending ||
+                  batchMutation.isPending
+                }
                 className="btn-primary"
               >
                 Run to Completion
@@ -236,12 +333,14 @@ function AudiobookPipeline({ book }) {
 
         {(startMutation.isError ||
           stepMutation.isError ||
+          batchMutation.isError ||
           pauseMutation.isError ||
           rebuildMutation.isError) && (
           <p className="error">
             {(
               startMutation.error ||
               stepMutation.error ||
+              batchMutation.error ||
               pauseMutation.error ||
               rebuildMutation.error
             )?.message || "Action failed"}
@@ -262,11 +361,22 @@ function AudiobookPipeline({ book }) {
       </nav>
 
       <div className="sub-tab-content">
+        {subTab === "Analysis" && (
+          <AnalysisOverview status={statusData} chapters={chapters} />
+        )}
         {subTab === "Characters" && (
-          <CharacterRoster characters={characters} bookId={bookId} />
+          <CharacterRoster
+            characters={characters}
+            bookId={bookId}
+            pipelineStatus={pipelineStatus}
+          />
         )}
         {subTab === "Script Editor" && (
-          <ScriptEditor bookId={bookId} characters={characters} />
+          <ScriptEditor
+            bookId={bookId}
+            characters={characters}
+            chapters={chapters}
+          />
         )}
         {subTab === "Chapter Assembly" && (
           <ChapterAssembly chapters={chapters} bookId={bookId} />

--- a/frontend/src/components/AudiobookPipeline.test.jsx
+++ b/frontend/src/components/AudiobookPipeline.test.jsx
@@ -148,4 +148,106 @@ describe("AudiobookPipeline", () => {
       );
     });
   });
+
+  it("queues a manual chapter preview and exposes playable text and audio", async () => {
+    const chapter = {
+      id: 9,
+      chapter_number: 1,
+      sentence_count: 2,
+      processed_sentence_count: 2,
+      audio_generated_count: 0,
+      low_confidence_count: 0,
+      summary: "The opening scene.",
+      preview_status: null,
+      preview_error: null,
+      audio_file_path: "audiobooks/11/chapter_1.mp3",
+      smil_file_path: "audiobooks/11/chapter_1.smil",
+      needs_reassembly: false,
+    };
+    const fetchMock = vi.fn((url, options) => {
+      if (url === "/api/books/11/audiobook/status") {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              pipeline_status: "paused",
+              next_phase: "audio_gen",
+              pause_requested: false,
+              sentence_counts: { pending_audio: 2 },
+            }),
+        });
+      }
+      if (url === "/api/books/11/audiobook/characters") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([{ id: 4, name: "Avery" }]),
+        });
+      }
+      if (url === "/api/books/11/audiobook/chapters") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([chapter]),
+        });
+      }
+      if (
+        url === "/api/books/11/audiobook/chapters/9/preview-audio" &&
+        options?.method === "POST"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ queued: true }),
+        });
+      }
+      if (
+        url ===
+        "/api/books/11/audiobook/sentences?page=1&limit=1000&chapter_id=9"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              items: [
+                {
+                  id: 1,
+                  original_text: "Avery opened the door.",
+                  character_id: 4,
+                },
+                {
+                  id: 2,
+                  original_text: "The hall was quiet.",
+                  character_id: null,
+                },
+              ],
+            }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+    globalThis.fetch = fetchMock;
+
+    const { container } = renderWithClient(
+      <AudiobookPipeline book={{ id: 11, series: "The Saga" }} />,
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Chapter Assembly" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Rebuild Preview" }));
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/books/11/audiobook/chapters/9/preview-audio",
+        { method: "POST" },
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Listen & Read" }));
+    expect(
+      await screen.findByText("Avery opened the door."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("The hall was quiet.")).toBeInTheDocument();
+    expect(container.querySelector("audio")).toHaveAttribute(
+      "src",
+      "/api/books/11/audiobook/chapters/9/audio",
+    );
+  });
 });

--- a/frontend/src/components/AudiobookPipeline.test.jsx
+++ b/frontend/src/components/AudiobookPipeline.test.jsx
@@ -1,0 +1,67 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import AudiobookPipeline from "./AudiobookPipeline";
+import { renderWithClient } from "../test-utils";
+
+describe("AudiobookPipeline", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shows the actionable error and can run only the next stage", async () => {
+    const fetchMock = vi.fn((url, options) => {
+      if (url === "/api/books/11/audiobook/status") {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              pipeline_status: "error",
+              next_phase: "ingesting",
+              pause_requested: false,
+              stop_after_phase: null,
+              last_error: "EPUB contains no narratable text.",
+              sentence_counts: {},
+            }),
+        });
+      }
+      if (
+        url === "/api/books/11/audiobook/characters" ||
+        url === "/api/books/11/audiobook/chapters"
+      ) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+      }
+      if (
+        url === "/api/books/11/audiobook/step" &&
+        options?.method === "POST"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              status: "ingesting",
+              queued: true,
+              stop_after_phase: "ingesting",
+            }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+    globalThis.fetch = fetchMock;
+
+    renderWithClient(<AudiobookPipeline book={{ id: 11 }} />);
+
+    expect(
+      await screen.findByText("EPUB contains no narratable text."),
+    ).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Run Next Stage: Ingesting" }),
+    );
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/books/11/audiobook/step", {
+        method: "POST",
+      });
+    });
+  });
+});

--- a/frontend/src/components/AudiobookPipeline.test.jsx
+++ b/frontend/src/components/AudiobookPipeline.test.jsx
@@ -64,4 +64,88 @@ describe("AudiobookPipeline", () => {
       });
     });
   });
+
+  it("shows model progress and can run exactly one diarization batch", async () => {
+    const fetchMock = vi.fn((url, options) => {
+      if (url === "/api/books/11/audiobook/status") {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              pipeline_status: "paused",
+              next_phase: "diarizing",
+              pause_requested: false,
+              stop_after_phase: null,
+              last_error: null,
+              sentence_counts: { pending_diarization: 100 },
+              review_counts: {
+                low_confidence: 2,
+                unassigned: 100,
+              },
+              progress_current: 40,
+              progress_total: 100,
+              progress_percent: 40,
+              progress_detail: "Chapter 2: attributed 40 of 100 sentences",
+              llm_requests: 1,
+              llm_provider: "ollama",
+              llm_model: "qwen3.5:27b",
+              summary: "A test story summary.",
+            }),
+        });
+      }
+      if (url === "/api/books/11/audiobook/characters") {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+      }
+      if (url === "/api/books/11/audiobook/chapters") {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve([
+              {
+                id: 9,
+                chapter_number: 2,
+                sentence_count: 100,
+                processed_sentence_count: 40,
+                low_confidence_count: 2,
+                summary: "The story begins.",
+              },
+            ]),
+        });
+      }
+      if (
+        url === "/api/books/11/audiobook/run-batch" &&
+        options?.method === "POST"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              status: "diarizing",
+              queued: true,
+              batch_limit: 1,
+            }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+    globalThis.fetch = fetchMock;
+
+    renderWithClient(<AudiobookPipeline book={{ id: 11 }} />);
+
+    expect(await screen.findByText("ollama / qwen3.5:27b")).toBeInTheDocument();
+    expect(screen.getAllByText("A test story summary.")).toHaveLength(2);
+    expect(screen.getByText("The story begins.")).toBeInTheDocument();
+    expect(
+      screen.getByText("2 low confidence · 100 unassigned"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Run One Batch" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/books/11/audiobook/run-batch",
+        { method: "POST" },
+      );
+    });
+  });
 });

--- a/frontend/src/components/AudiobookPipeline.test.jsx
+++ b/frontend/src/components/AudiobookPipeline.test.jsx
@@ -250,4 +250,97 @@ describe("AudiobookPipeline", () => {
       "/api/books/11/audiobook/chapters/9/audio",
     );
   });
+
+  it("queues one ready sentence from the Script Editor and shows its state", async () => {
+    const fetchMock = vi.fn((url, options) => {
+      if (url === "/api/books/11/audiobook/status") {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              pipeline_status: "paused",
+              next_phase: "audio_gen",
+              pause_requested: false,
+              sentence_counts: { ready_for_audio: 1 },
+            }),
+        });
+      }
+      if (url === "/api/books/11/audiobook/characters") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([{ id: 4, name: "Avery" }]),
+        });
+      }
+      if (url === "/api/books/11/audiobook/chapters") {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve([
+              {
+                id: 9,
+                chapter_number: 1,
+                sentence_count: 1,
+                processed_sentence_count: 1,
+              },
+            ]),
+        });
+      }
+      if (
+        url === "/api/books/11/audiobook/sentences?page=1&limit=50" ||
+        url === "/api/books/11/audiobook/sentences?page=1&limit=50&chapter_id=9"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              items: [
+                {
+                  id: 31,
+                  chapter_id: 9,
+                  character_id: 4,
+                  sequence_order: 0,
+                  original_text: "Avery opened the door.",
+                  tagged_text: "Avery opened the door.",
+                  speaker_confidence: 0.96,
+                  speaker_reason: "Explicit attribution",
+                  status: "ready_for_audio",
+                },
+              ],
+              total: 1,
+            }),
+        });
+      }
+      if (
+        url === "/api/books/11/audiobook/sentences/31/generate-audio" &&
+        options?.method === "POST"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              status: "audio_queued",
+              queued: true,
+              sentence_id: 31,
+            }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+    globalThis.fetch = fetchMock;
+
+    renderWithClient(<AudiobookPipeline book={{ id: 11 }} />);
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Script Editor" }),
+    );
+    expect(await screen.findByText("Ready for audio")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Generate audio" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/books/11/audiobook/sentences/31/generate-audio",
+        { method: "POST" },
+      );
+    });
+  });
 });

--- a/frontend/src/components/AudiobookSettings.jsx
+++ b/frontend/src/components/AudiobookSettings.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   getAudiobookSettings,
+  testAudiobookLlm,
   updateAudiobookSettings,
 } from "../api/audiobook";
 
@@ -46,8 +47,7 @@ function AudiobookSettings() {
     },
   });
 
-  const handleSave = (e) => {
-    e.preventDefault();
+  const buildPayload = () => {
     const payload = {
       llm_provider: llmProvider || null,
       llm_base_url: llmBaseUrl || null,
@@ -59,7 +59,22 @@ function AudiobookSettings() {
     if (llmApiKey) {
       payload.llm_api_key = llmApiKey;
     }
-    saveMutation.mutate(payload);
+    return payload;
+  };
+
+  const testMutation = useMutation({
+    mutationFn: async () => {
+      await updateAudiobookSettings(buildPayload());
+      return testAudiobookLlm();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["audiobook-settings"] });
+    },
+  });
+
+  const handleSave = (e) => {
+    e.preventDefault();
+    saveMutation.mutate(buildPayload());
   };
 
   if (isLoading) return <p>Loading settings…</p>;
@@ -78,6 +93,7 @@ function AudiobookSettings() {
             >
               <option value="openai">OpenAI</option>
               <option value="anthropic">Anthropic</option>
+              <option value="ollama">Ollama (local)</option>
               <option value="custom">Custom / Local</option>
               <option value="stub">Deterministic local harness</option>
             </select>
@@ -113,6 +129,43 @@ function AudiobookSettings() {
               placeholder="e.g. gpt-4o or claude-opus-4-7"
             />
           </label>
+          <div className="settings-actions-inline">
+            <button
+              type="button"
+              className="btn-secondary"
+              onClick={() => {
+                setLlmProvider("ollama");
+                setLlmBaseUrl("http://127.0.0.1:11434");
+                setLlmModel("qwen3.5:9b");
+              }}
+            >
+              Use Recommended Local Ollama
+            </button>
+            <button
+              type="button"
+              onClick={() => testMutation.mutate()}
+              disabled={testMutation.isPending}
+            >
+              {testMutation.isPending ? "Testing…" : "Save & Test LLM"}
+            </button>
+          </div>
+          <p className="settings-hint">
+            Recommended local default: <code>qwen3.5:9b</code> (6.6 GB). Run{" "}
+            <code>ollama pull qwen3.5:9b</code> first. Story Manager uses
+            Ollama&apos;s schema-constrained JSON output and disables thinking
+            for predictable extraction latency.
+          </p>
+          {testMutation.isSuccess && (
+            <p className="success">
+              Connected to {testMutation.data.provider} /{" "}
+              {testMutation.data.model || "local harness"}.
+            </p>
+          )}
+          {testMutation.isError && (
+            <p className="error">
+              {testMutation.error?.message || "LLM test failed"}
+            </p>
+          )}
         </section>
 
         <section className="settings-section">

--- a/frontend/src/components/AudiobookSettings.jsx
+++ b/frontend/src/components/AudiobookSettings.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { getAudiobookSettings, updateAudiobookSettings } from "../api/audiobook";
 
@@ -22,15 +22,17 @@ function AudiobookSettings() {
   const [diarizationPrompt, setDiarizationPrompt] = useState("");
   const [initialised, setInitialised] = useState(false);
 
-  if (settings && !initialised) {
-    setLlmProvider(settings.llm_provider || "openai");
-    setLlmBaseUrl(settings.llm_base_url || "");
-    setLlmModel(settings.llm_model || "");
-    setOmnivoiceEndpoint(settings.omnivoice_endpoint || "");
-    setRosterPrompt(settings.roster_prompt_template || "");
-    setDiarizationPrompt(settings.diarization_prompt_template || "");
-    setInitialised(true);
-  }
+  useEffect(() => {
+    if (settings && !initialised) {
+      setLlmProvider(settings.llm_provider || "stub");
+      setLlmBaseUrl(settings.llm_base_url || "");
+      setLlmModel(settings.llm_model || "");
+      setOmnivoiceEndpoint(settings.omnivoice_endpoint || "");
+      setRosterPrompt(settings.roster_prompt_template || "");
+      setDiarizationPrompt(settings.diarization_prompt_template || "");
+      setInitialised(true);
+    }
+  }, [initialised, settings]);
 
   const saveMutation = useMutation({
     mutationFn: (data) => updateAudiobookSettings(data),
@@ -69,6 +71,7 @@ function AudiobookSettings() {
               <option value="openai">OpenAI</option>
               <option value="anthropic">Anthropic</option>
               <option value="custom">Custom / Local</option>
+              <option value="stub">Deterministic local harness</option>
             </select>
           </label>
           <label>
@@ -115,6 +118,10 @@ function AudiobookSettings() {
             OmniVoice receives <code>POST /generate</code> with{" "}
             <code>{"{ \"voice\": \"[gender-male][pitch-low]\", \"text\": \"...\" }"}</code> and
             returns raw MP3 bytes.
+          </p>
+          <p className="settings-hint">
+            For offline validation, choose the deterministic local harness and leave this blank.
+            It generates silent placeholder MP3s with realistic timing.
           </p>
         </section>
 

--- a/frontend/src/components/AudiobookSettings.jsx
+++ b/frontend/src/components/AudiobookSettings.jsx
@@ -1,9 +1,14 @@
 import { useEffect, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { getAudiobookSettings, updateAudiobookSettings } from "../api/audiobook";
+import {
+  getAudiobookSettings,
+  updateAudiobookSettings,
+} from "../api/audiobook";
 
-const DEFAULT_ROSTER_PROMPT_HINT = "Leave blank to use the built-in roster extraction prompt.";
-const DEFAULT_DIARIZATION_PROMPT_HINT = "Leave blank to use the built-in diarization prompt.";
+const DEFAULT_ROSTER_PROMPT_HINT =
+  "Leave blank to use the built-in roster extraction prompt.";
+const DEFAULT_DIARIZATION_PROMPT_HINT =
+  "Leave blank to use the built-in diarization prompt.";
 
 function AudiobookSettings() {
   const queryClient = useQueryClient();
@@ -67,7 +72,10 @@ function AudiobookSettings() {
           <h3>LLM Provider</h3>
           <label>
             Provider
-            <select value={llmProvider} onChange={(e) => setLlmProvider(e.target.value)}>
+            <select
+              value={llmProvider}
+              onChange={(e) => setLlmProvider(e.target.value)}
+            >
               <option value="openai">OpenAI</option>
               <option value="anthropic">Anthropic</option>
               <option value="custom">Custom / Local</option>
@@ -80,7 +88,11 @@ function AudiobookSettings() {
               type="password"
               value={llmApiKey}
               onChange={(e) => setLlmApiKey(e.target.value)}
-              placeholder={settings?.llm_api_key_set ? "••••••••  (set — enter new key to change)" : "Enter API key"}
+              placeholder={
+                settings?.llm_api_key_set
+                  ? "••••••••  (set — enter new key to change)"
+                  : "Enter API key"
+              }
             />
           </label>
           <label>
@@ -114,14 +126,29 @@ function AudiobookSettings() {
               placeholder="http://your-omnivoice-server:port"
             />
           </label>
+          <button
+            type="button"
+            className="btn-secondary"
+            onClick={() => setOmnivoiceEndpoint("http://127.0.0.1:8001")}
+          >
+            Use Local OmniVoice Adapter
+          </button>
           <p className="settings-hint">
             OmniVoice receives <code>POST /generate</code> with{" "}
-            <code>{"{ \"voice\": \"[gender-male][pitch-low]\", \"text\": \"...\" }"}</code> and
-            returns raw MP3 bytes.
+            <code>
+              {'{ "voice": "[gender-male][pitch-low]", "text": "..." }'}
+            </code>{" "}
+            and returns raw MP3 bytes.
           </p>
           <p className="settings-hint">
-            For offline validation, choose the deterministic local harness and leave this blank.
-            It generates silent placeholder MP3s with realistic timing.
+            For real local speech, run <code>make run-omnivoice</code>, choose
+            the local adapter above, and save settings. The first start
+            downloads the official model.
+          </p>
+          <p className="settings-hint">
+            For offline validation, choose the deterministic local harness and
+            leave this blank. It generates silent placeholder MP3s with
+            realistic timing.
           </p>
         </section>
 
@@ -148,7 +175,9 @@ function AudiobookSettings() {
         </section>
 
         {saveMutation.isError && (
-          <p className="error">{saveMutation.error?.message || "Save failed"}</p>
+          <p className="error">
+            {saveMutation.error?.message || "Save failed"}
+          </p>
         )}
         {saveMutation.isSuccess && <p className="success">Settings saved.</p>}
 

--- a/frontend/src/components/AudiobookSettings.jsx
+++ b/frontend/src/components/AudiobookSettings.jsx
@@ -1,0 +1,156 @@
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { getAudiobookSettings, updateAudiobookSettings } from "../api/audiobook";
+
+const DEFAULT_ROSTER_PROMPT_HINT = "Leave blank to use the built-in roster extraction prompt.";
+const DEFAULT_DIARIZATION_PROMPT_HINT = "Leave blank to use the built-in diarization prompt.";
+
+function AudiobookSettings() {
+  const queryClient = useQueryClient();
+
+  const { data: settings, isLoading } = useQuery({
+    queryKey: ["audiobook-settings"],
+    queryFn: getAudiobookSettings,
+  });
+
+  const [llmProvider, setLlmProvider] = useState("");
+  const [llmApiKey, setLlmApiKey] = useState("");
+  const [llmBaseUrl, setLlmBaseUrl] = useState("");
+  const [llmModel, setLlmModel] = useState("");
+  const [omnivoiceEndpoint, setOmnivoiceEndpoint] = useState("");
+  const [rosterPrompt, setRosterPrompt] = useState("");
+  const [diarizationPrompt, setDiarizationPrompt] = useState("");
+  const [initialised, setInitialised] = useState(false);
+
+  if (settings && !initialised) {
+    setLlmProvider(settings.llm_provider || "openai");
+    setLlmBaseUrl(settings.llm_base_url || "");
+    setLlmModel(settings.llm_model || "");
+    setOmnivoiceEndpoint(settings.omnivoice_endpoint || "");
+    setRosterPrompt(settings.roster_prompt_template || "");
+    setDiarizationPrompt(settings.diarization_prompt_template || "");
+    setInitialised(true);
+  }
+
+  const saveMutation = useMutation({
+    mutationFn: (data) => updateAudiobookSettings(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["audiobook-settings"] });
+    },
+  });
+
+  const handleSave = (e) => {
+    e.preventDefault();
+    const payload = {
+      llm_provider: llmProvider || null,
+      llm_base_url: llmBaseUrl || null,
+      llm_model: llmModel || null,
+      omnivoice_endpoint: omnivoiceEndpoint || null,
+      roster_prompt_template: rosterPrompt || null,
+      diarization_prompt_template: diarizationPrompt || null,
+    };
+    if (llmApiKey) {
+      payload.llm_api_key = llmApiKey;
+    }
+    saveMutation.mutate(payload);
+  };
+
+  if (isLoading) return <p>Loading settings…</p>;
+
+  return (
+    <div className="settings-page">
+      <h2>Audio &amp; AI Configuration</h2>
+      <form onSubmit={handleSave}>
+        <section className="settings-section">
+          <h3>LLM Provider</h3>
+          <label>
+            Provider
+            <select value={llmProvider} onChange={(e) => setLlmProvider(e.target.value)}>
+              <option value="openai">OpenAI</option>
+              <option value="anthropic">Anthropic</option>
+              <option value="custom">Custom / Local</option>
+            </select>
+          </label>
+          <label>
+            API Key
+            <input
+              type="password"
+              value={llmApiKey}
+              onChange={(e) => setLlmApiKey(e.target.value)}
+              placeholder={settings?.llm_api_key_set ? "••••••••  (set — enter new key to change)" : "Enter API key"}
+            />
+          </label>
+          <label>
+            Base URL
+            <input
+              type="url"
+              value={llmBaseUrl}
+              onChange={(e) => setLlmBaseUrl(e.target.value)}
+              placeholder="https://api.openai.com  (leave blank for provider default)"
+            />
+          </label>
+          <label>
+            Model
+            <input
+              type="text"
+              value={llmModel}
+              onChange={(e) => setLlmModel(e.target.value)}
+              placeholder="e.g. gpt-4o or claude-opus-4-7"
+            />
+          </label>
+        </section>
+
+        <section className="settings-section">
+          <h3>OmniVoice TTS</h3>
+          <label>
+            Endpoint URL
+            <input
+              type="url"
+              value={omnivoiceEndpoint}
+              onChange={(e) => setOmnivoiceEndpoint(e.target.value)}
+              placeholder="http://your-omnivoice-server:port"
+            />
+          </label>
+          <p className="settings-hint">
+            OmniVoice receives <code>POST /generate</code> with{" "}
+            <code>{"{ \"voice\": \"[gender-male][pitch-low]\", \"text\": \"...\" }"}</code> and
+            returns raw MP3 bytes.
+          </p>
+        </section>
+
+        <section className="settings-section">
+          <h3>Prompt Templates</h3>
+          <label>
+            Roster Extraction Prompt
+            <textarea
+              rows={6}
+              value={rosterPrompt}
+              onChange={(e) => setRosterPrompt(e.target.value)}
+              placeholder={DEFAULT_ROSTER_PROMPT_HINT}
+            />
+          </label>
+          <label>
+            Diarization Prompt
+            <textarea
+              rows={6}
+              value={diarizationPrompt}
+              onChange={(e) => setDiarizationPrompt(e.target.value)}
+              placeholder={DEFAULT_DIARIZATION_PROMPT_HINT}
+            />
+          </label>
+        </section>
+
+        {saveMutation.isError && (
+          <p className="error">{saveMutation.error?.message || "Save failed"}</p>
+        )}
+        {saveMutation.isSuccess && <p className="success">Settings saved.</p>}
+
+        <button type="submit" disabled={saveMutation.isPending}>
+          {saveMutation.isPending ? "Saving…" : "Save Settings"}
+        </button>
+      </form>
+    </div>
+  );
+}
+
+export default AudiobookSettings;

--- a/frontend/src/components/BookList.jsx
+++ b/frontend/src/components/BookList.jsx
@@ -56,7 +56,12 @@ function getWebNovelStatus(book) {
   };
 }
 
-function LibraryFilters({ reviewFilter, onReviewFilterChange }) {
+function LibraryFilters({
+  reviewFilter,
+  onReviewFilterChange,
+  audiobookFilter,
+  onAudiobookFilterChange,
+}) {
   return (
     <div className="library-filters" aria-label="Library filters">
       <label>
@@ -69,6 +74,17 @@ function LibraryFilters({ reviewFilter, onReviewFilterChange }) {
           <option value="missing-series">Missing series</option>
           <option value="refreshing">Refreshing or queued</option>
           <option value="refresh-error">Refresh needs attention</option>
+        </select>
+      </label>
+      <label>
+        Audiobook
+        <select
+          value={audiobookFilter}
+          onChange={(event) => onAudiobookFilterChange(event.target.value)}
+        >
+          <option value="">All books</option>
+          <option value="enabled">Enabled</option>
+          <option value="disabled">Not enabled</option>
         </select>
       </label>
     </div>
@@ -147,6 +163,7 @@ function BookList({
   const [showStandaloneSeriesEdit, setShowStandaloneSeriesEdit] =
     useState(false);
   const [reviewFilter, setReviewFilter] = useState("");
+  const [audiobookFilter, setAudiobookFilter] = useState("");
 
   const { data: allSeries = [] } = useQuery({
     queryKey: ["series"],
@@ -172,6 +189,12 @@ function BookList({
   const filteredBooks = useMemo(
     () =>
       books.filter((book) => {
+        if (audiobookFilter === "enabled" && !book.audiobook_enabled) {
+          return false;
+        }
+        if (audiobookFilter === "disabled" && book.audiobook_enabled) {
+          return false;
+        }
         if (reviewFilter === "missing-series") {
           return (
             !book.series && book.source_type !== "web" && !book.download_status
@@ -185,7 +208,7 @@ function BookList({
         }
         return true;
       }),
-    [books, reviewFilter],
+    [audiobookFilter, books, reviewFilter],
   );
 
   const { seriesMap, sortedSeries, standaloneBooks, webBooks, counts } =
@@ -225,6 +248,8 @@ function BookList({
       <LibraryFilters
         reviewFilter={reviewFilter}
         onReviewFilterChange={handleReviewFilterChange}
+        audiobookFilter={audiobookFilter}
+        onAudiobookFilterChange={setAudiobookFilter}
       />
       <div className="library-results-summary" role="status">
         Showing {filteredBooks.length} of {books.length} books

--- a/frontend/src/components/BookSettings.jsx
+++ b/frontend/src/components/BookSettings.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import AudiobookPipeline from "./AudiobookPipeline";
 

--- a/frontend/src/components/BookSettings.jsx
+++ b/frontend/src/components/BookSettings.jsx
@@ -1,5 +1,6 @@
 import { useState, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import AudiobookPipeline from "./AudiobookPipeline";
 
 import {
   deleteBook,
@@ -134,6 +135,7 @@ function BookSettings({ book: initialBook, onBack }) {
     getUpdatedFields,
   } = useBookSettingsForm(initialBook);
   const [previewedChapter, setPreviewedChapter] = useState(null);
+  const [bookTab, setBookTab] = useState("details");
 
   const { data: chapters = [], isLoading: chaptersLoading } = useQuery({
     queryKey: ["chapters", book.id],
@@ -344,6 +346,25 @@ function BookSettings({ book: initialBook, onBack }) {
         <h2>{book.title}</h2>
       </div>
 
+      <nav className="book-settings-tabs">
+        <button
+          className={`book-settings-tab${bookTab === "details" ? " book-settings-tab--active" : ""}`}
+          onClick={() => setBookTab("details")}
+        >
+          Details
+        </button>
+        <button
+          className={`book-settings-tab${bookTab === "audiobook" ? " book-settings-tab--active" : ""}`}
+          onClick={() => setBookTab("audiobook")}
+        >
+          Audiobook Pipeline
+        </button>
+      </nav>
+
+      {bookTab === "audiobook" && <AudiobookPipeline book={book} />}
+
+      {bookTab === "details" && (
+      <>
       {isRefreshing && (
         <div className="hint" role="status" style={{ marginBottom: "0.75rem" }}>
           {book.refresh_status === "queued"
@@ -837,6 +858,8 @@ function BookSettings({ book: initialBook, onBack }) {
       )}
       {deleteMutation.isError && (
         <p className="error">Delete failed: {deleteMutation.error.message}</p>
+      )}
+      </>
       )}
     </div>
   );

--- a/frontend/src/components/BookSettings.jsx
+++ b/frontend/src/components/BookSettings.jsx
@@ -1,5 +1,6 @@
 import { useState, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import AudiobookPipeline from "./AudiobookPipeline";
 
 import {
   deleteBook,
@@ -135,6 +136,7 @@ function BookSettings({ book: initialBook, onBack }) {
     getUpdatedFields,
   } = useBookSettingsForm(initialBook);
   const [previewedChapter, setPreviewedChapter] = useState(null);
+  const [bookTab, setBookTab] = useState("details");
 
   const { data: chapters = [], isLoading: chaptersLoading } = useQuery({
     queryKey: ["chapters", book.id],
@@ -345,6 +347,25 @@ function BookSettings({ book: initialBook, onBack }) {
         <h2>{book.title}</h2>
       </div>
 
+      <nav className="book-settings-tabs">
+        <button
+          className={`book-settings-tab${bookTab === "details" ? " book-settings-tab--active" : ""}`}
+          onClick={() => setBookTab("details")}
+        >
+          Details
+        </button>
+        <button
+          className={`book-settings-tab${bookTab === "audiobook" ? " book-settings-tab--active" : ""}`}
+          onClick={() => setBookTab("audiobook")}
+        >
+          Audiobook Pipeline
+        </button>
+      </nav>
+
+      {bookTab === "audiobook" && <AudiobookPipeline book={book} />}
+
+      {bookTab === "details" && (
+      <>
       {isRefreshing && (
         <div className="hint" role="status" style={{ marginBottom: "0.75rem" }}>
           {book.refresh_status === "queued"
@@ -770,6 +791,8 @@ function BookSettings({ book: initialBook, onBack }) {
       )}
       {deleteMutation.isError && (
         <p className="error">Delete failed: {deleteMutation.error.message}</p>
+      )}
+      </>
       )}
     </div>
   );

--- a/frontend/src/components/BookSettings.jsx
+++ b/frontend/src/components/BookSettings.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useEffect, useState, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import AudiobookPipeline from "./AudiobookPipeline";
 
@@ -175,9 +175,19 @@ function BookSettings({ book: initialBook, onBack }) {
 
   const saveMutation = useMutation({
     mutationFn: (data) => updateBook(book.id, data),
-    onSuccess: () => {
+    onSuccess: (updatedBook) => {
+      queryClient.setQueryData(["book", book.id], updatedBook);
       queryClient.invalidateQueries({ queryKey: ["book-catalog"] });
       queryClient.invalidateQueries({ queryKey: ["series"] });
+    },
+  });
+
+  const enableAudiobookMutation = useMutation({
+    mutationFn: () => updateBook(book.id, { audiobook_enabled: true }),
+    onSuccess: (updatedBook) => {
+      queryClient.setQueryData(["book", book.id], updatedBook);
+      queryClient.invalidateQueries({ queryKey: ["book-catalog"] });
+      setBookTab("audiobook");
     },
   });
 
@@ -232,6 +242,12 @@ function BookSettings({ book: initialBook, onBack }) {
   });
 
   const [coverUrl, setCoverUrl] = useState("");
+
+  useEffect(() => {
+    if (!book.audiobook_enabled && bookTab === "audiobook") {
+      setBookTab("details");
+    }
+  }, [book.audiobook_enabled, bookTab]);
 
   // Cover files live at a deterministic URL (/api/covers/{book_id}), so the
   // browser happily caches them. Whenever any cover mutation succeeds we bump
@@ -322,6 +338,7 @@ function BookSettings({ book: initialBook, onBack }) {
     refreshMutation.isPending ||
     detachSourceMutation.isPending ||
     deleteMutation.isPending ||
+    enableAudiobookMutation.isPending ||
     isRefreshing;
   const canDetachWebMarker =
     book.source_type === "web" && book.immutable_path && book.current_path;
@@ -337,7 +354,8 @@ function BookSettings({ book: initialBook, onBack }) {
             processMutation.isPending ||
             refreshMutation.isPending ||
             detachSourceMutation.isPending ||
-            deleteMutation.isPending
+            deleteMutation.isPending ||
+            enableAudiobookMutation.isPending
           }
           style={{ flexShrink: 0 }}
         >
@@ -353,513 +371,570 @@ function BookSettings({ book: initialBook, onBack }) {
         >
           Details
         </button>
-        <button
-          className={`book-settings-tab${bookTab === "audiobook" ? " book-settings-tab--active" : ""}`}
-          onClick={() => setBookTab("audiobook")}
-        >
-          Audiobook Pipeline
-        </button>
+        {book.audiobook_enabled && (
+          <button
+            className={`book-settings-tab${bookTab === "audiobook" ? " book-settings-tab--active" : ""}`}
+            onClick={() => setBookTab("audiobook")}
+          >
+            Audiobook Pipeline
+          </button>
+        )}
       </nav>
 
-      {bookTab === "audiobook" && <AudiobookPipeline book={book} />}
+      {book.audiobook_enabled && bookTab === "audiobook" && (
+        <AudiobookPipeline book={book} />
+      )}
 
       {bookTab === "details" && (
-      <>
-      {isRefreshing && (
-        <div className="hint" role="status" style={{ marginBottom: "0.75rem" }}>
-          {book.refresh_status === "queued"
-            ? "This book is queued for refresh. It will start once the previous job finishes."
-            : "Refreshing from source — pulling new chapters via FanFicFare. This can take a few minutes for long stories."}
-        </div>
-      )}
-      {refreshErrored && (
-        <p className="error" role="alert">
-          The last refresh attempt failed. Check the logs, then click “Refresh
-          from Source” to try again.
-        </p>
-      )}
+        <>
+          {isRefreshing && (
+            <div
+              className="hint"
+              role="status"
+              style={{ marginBottom: "0.75rem" }}
+            >
+              {book.refresh_status === "queued"
+                ? "This book is queued for refresh. It will start once the previous job finishes."
+                : "Refreshing from source — pulling new chapters via FanFicFare. This can take a few minutes for long stories."}
+            </div>
+          )}
+          {refreshErrored && (
+            <p className="error" role="alert">
+              The last refresh attempt failed. Check the logs, then click
+              “Refresh from Source” to try again.
+            </p>
+          )}
 
-      <section className="settings-section">
-        <h3>Metadata</h3>
-        <div className="settings-row-with-cover">
-          <div className="settings-fields">
-            <label>
-              Title
-              <input value={title} onChange={(e) => setTitle(e.target.value)} />
-            </label>
-            <label>
-              Author
-              <input
-                value={author}
-                onChange={(e) => setAuthor(e.target.value)}
-              />
-            </label>
-            <div className="field-row">
-              <label className="field-row-grow">
-                Series
+          <section className="settings-section">
+            <h3>Metadata</h3>
+            <div className="settings-row-with-cover">
+              <div className="settings-fields">
+                <label>
+                  Title
+                  <input
+                    value={title}
+                    onChange={(e) => setTitle(e.target.value)}
+                  />
+                </label>
+                <label>
+                  Author
+                  <input
+                    value={author}
+                    onChange={(e) => setAuthor(e.target.value)}
+                  />
+                </label>
+                <div className="field-row">
+                  <label className="field-row-grow">
+                    Series
+                    <input
+                      list="series-options"
+                      value={series}
+                      onChange={(e) => setSeries(e.target.value)}
+                      placeholder="Leave blank if none"
+                    />
+                    <datalist id="series-options">
+                      {allSeries.map((s) => (
+                        <option key={s} value={s} />
+                      ))}
+                    </datalist>
+                  </label>
+                  <label className="field-row-shrink">
+                    Order
+                    <input
+                      type="number"
+                      step="0.01"
+                      value={seriesIndex}
+                      onChange={(e) => setSeriesIndex(e.target.value)}
+                      placeholder="e.g. 2.5"
+                    />
+                  </label>
+                </div>
+                <div className="settings-tag-field">
+                  <span className="settings-field-label">
+                    Synced Genre Tags
+                  </span>
+                  <SyncedGenreTagList tags={book.genre_tags || []} />
+                </div>
+                {(book.source_tags || []).length > 0 && (
+                  <div className="settings-tag-field">
+                    <span className="settings-field-label">Source Tags</span>
+                    <SourceTagList tags={book.source_tags || []} />
+                  </div>
+                )}
+                <label>
+                  User Genre Tags
+                  <input
+                    value={userGenreTags}
+                    onChange={(e) => setUserGenreTags(e.target.value)}
+                    placeholder="Fantasy, Romance, LitRPG"
+                  />
+                </label>
+                {book.metadata_synced_at && (
+                  <p className="hint">
+                    Synced from {book.metadata_sync_source || "online metadata"}{" "}
+                    on {new Date(book.metadata_synced_at).toLocaleString()}.
+                  </p>
+                )}
+                <div className="settings-actions">
+                  <button
+                    type="button"
+                    onClick={() => metadataSyncMutation.mutate()}
+                    disabled={metadataSyncMutation.isPending}
+                  >
+                    {metadataSyncMutation.isPending
+                      ? "Queueing…"
+                      : "Recheck Online Metadata"}
+                  </button>
+                </div>
+                {metadataSyncMutation.isSuccess && (
+                  <p className="hint">Metadata recheck queued.</p>
+                )}
+              </div>
+              <div className="settings-cover-aside">
+                {book.cover_path ? (
+                  <img
+                    src={`${getApiCoverUrl(book.id)}?v=${coverVersion}`}
+                    alt="Cover"
+                    className="settings-cover-img"
+                  />
+                ) : (
+                  <div className="settings-cover-placeholder">No cover</div>
+                )}
                 <input
-                  list="series-options"
-                  value={series}
-                  onChange={(e) => setSeries(e.target.value)}
-                  placeholder="Leave blank if none"
+                  ref={coverInputRef}
+                  type="file"
+                  accept=".jpg,.jpeg,.png,.webp"
+                  style={{ display: "none" }}
+                  onChange={(e) =>
+                    e.target.files[0] && coverMutation.mutate(e.target.files[0])
+                  }
                 />
-                <datalist id="series-options">
-                  {allSeries.map((s) => (
-                    <option key={s} value={s} />
-                  ))}
-                </datalist>
-              </label>
-              <label className="field-row-shrink">
-                Order
-                <input
-                  type="number"
-                  step="0.01"
-                  value={seriesIndex}
-                  onChange={(e) => setSeriesIndex(e.target.value)}
-                  placeholder="e.g. 2.5"
-                />
-              </label>
+                <button
+                  className="btn-sm"
+                  onClick={() => coverInputRef.current.click()}
+                  disabled={
+                    coverMutation.isPending || coverUrlMutation.isPending
+                  }
+                >
+                  {coverMutation.isPending
+                    ? "Uploading…"
+                    : book.cover_path
+                      ? "Replace"
+                      : "Upload"}
+                </button>
+                {book.immutable_path && (
+                  <button
+                    className="btn-sm btn-secondary"
+                    onClick={() => retryCoverMutation.mutate()}
+                    disabled={
+                      retryCoverMutation.isPending ||
+                      coverMutation.isPending ||
+                      coverUrlMutation.isPending
+                    }
+                  >
+                    {retryCoverMutation.isPending ? "Retrying…" : "Re-extract"}
+                  </button>
+                )}
+                <div className="cover-url-row">
+                  <input
+                    type="text"
+                    placeholder="Image URL…"
+                    value={coverUrl}
+                    onChange={(e) => setCoverUrl(e.target.value)}
+                    onKeyDown={(e) =>
+                      e.key === "Enter" &&
+                      coverUrl.trim() &&
+                      coverUrlMutation.mutate(coverUrl.trim())
+                    }
+                  />
+                  <button
+                    className="btn-sm"
+                    onClick={() => coverUrlMutation.mutate(coverUrl.trim())}
+                    disabled={
+                      !coverUrl.trim() ||
+                      coverUrlMutation.isPending ||
+                      coverMutation.isPending
+                    }
+                  >
+                    {coverUrlMutation.isPending ? "…" : "Set"}
+                  </button>
+                </div>
+                {coverMutation.isError && (
+                  <p className="error">{coverMutation.error.message}</p>
+                )}
+                {coverUrlMutation.isError && (
+                  <p className="error">{coverUrlMutation.error.message}</p>
+                )}
+                {retryCoverMutation.isError && (
+                  <p className="error">{retryCoverMutation.error.message}</p>
+                )}
+              </div>
             </div>
-            <div className="settings-tag-field">
-              <span className="settings-field-label">Synced Genre Tags</span>
-              <SyncedGenreTagList tags={book.genre_tags || []} />
+          </section>
+
+          <section className="settings-section">
+            <h3>Notes</h3>
+            <textarea
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              placeholder="Personal notes about this book"
+              rows={3}
+            />
+          </section>
+
+          {!book.audiobook_enabled && (
+            <section className="settings-section">
+              <h3>Audiobook</h3>
+              <div className="settings-actions">
+                <span className="hint" style={{ margin: 0 }}>
+                  Disabled for this book.
+                </span>
+                <button
+                  type="button"
+                  onClick={() => enableAudiobookMutation.mutate()}
+                  disabled={isBusy || !book.current_path}
+                >
+                  {enableAudiobookMutation.isPending
+                    ? "Enabling…"
+                    : "Enable Audiobook Pipeline"}
+                </button>
+              </div>
+              {!book.current_path && (
+                <p className="hint">Requires an EPUB file first.</p>
+              )}
+              {enableAudiobookMutation.isError && (
+                <p className="error">
+                  {enableAudiobookMutation.error?.message ||
+                    "Failed to enable audiobook pipeline"}
+                </p>
+              )}
+            </section>
+          )}
+
+          {(book.source_url || book.source_type === "web") && (
+            <section className="settings-section">
+              <h3>Source</h3>
+              {book.source_url ? (
+                <div className="source-info">
+                  <span className="badge-web">{book.source_type}</span>
+                  <a
+                    href={book.source_url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="source-link"
+                  >
+                    {book.source_url}
+                  </a>
+                </div>
+              ) : (
+                <p className="hint">No source URL is currently attached.</p>
+              )}
+              {book.source_type === "web" && (
+                <div
+                  className="settings-actions"
+                  style={{ marginTop: "0.5rem" }}
+                >
+                  <button
+                    type="button"
+                    className="btn-danger btn-sm"
+                    onClick={handleDetachSource}
+                    disabled={isBusy || !canDetachWebMarker}
+                  >
+                    {detachSourceMutation.isPending
+                      ? "Removing…"
+                      : "Remove Web Marker"}
+                  </button>
+                  {!canDetachWebMarker && (
+                    <span
+                      className="hint"
+                      style={{ margin: 0, alignSelf: "center" }}
+                    >
+                      Requires EPUB files first
+                    </span>
+                  )}
+                </div>
+              )}
+            </section>
+          )}
+
+          {book.source_type === "web" && (
+            <ChapterUpdateHistory
+              updateHistory={updateHistory}
+              isLoading={updateHistoryLoading}
+              isError={updateHistoryIsError}
+              error={updateHistoryError}
+            />
+          )}
+
+          <section className="settings-section">
+            <div
+              className="collapsible-header"
+              onClick={() => setIdentifiersExpanded((e) => !e)}
+            >
+              <h3>
+                Identifiers
+                {(isbn10 ||
+                  isbn13 ||
+                  googleBooksVolumeId ||
+                  openLibraryWorkKey) && (
+                  <span className="field-count">
+                    {
+                      [
+                        isbn10,
+                        isbn13,
+                        googleBooksVolumeId,
+                        openLibraryWorkKey,
+                        openLibraryEditionKey,
+                        openLibraryAuthorKey,
+                      ].filter(Boolean).length
+                    }{" "}
+                    set
+                  </span>
+                )}
+              </h3>
+              <span className="collapse-toggle">
+                {identifiersExpanded ? "▲" : "▼"}
+              </span>
             </div>
-            {(book.source_tags || []).length > 0 && (
-              <div className="settings-tag-field">
-                <span className="settings-field-label">Source Tags</span>
-                <SourceTagList tags={book.source_tags || []} />
+            {identifiersExpanded && (
+              <div className="collapsible-body">
+                <div className="field-row">
+                  <label className="field-row-equal">
+                    ISBN-10
+                    <input
+                      value={isbn10}
+                      onChange={(e) => setIsbn10(e.target.value)}
+                      placeholder="Manual ISBN-10"
+                    />
+                  </label>
+                  <label className="field-row-equal">
+                    ISBN-13
+                    <input
+                      value={isbn13}
+                      onChange={(e) => setIsbn13(e.target.value)}
+                      placeholder="Manual ISBN-13"
+                    />
+                  </label>
+                </div>
+                <label>
+                  Google Books Volume ID
+                  <input
+                    value={googleBooksVolumeId}
+                    onChange={(e) => setGoogleBooksVolumeId(e.target.value)}
+                    placeholder="zyTCAlFPjgYC"
+                  />
+                </label>
+                <label>
+                  Open Library Work Key
+                  <input
+                    value={openLibraryWorkKey}
+                    onChange={(e) => setOpenLibraryWorkKey(e.target.value)}
+                    placeholder="/works/OL123W"
+                  />
+                </label>
+                <div className="field-row">
+                  <label className="field-row-equal">
+                    OL Edition Key
+                    <input
+                      value={openLibraryEditionKey}
+                      onChange={(e) => setOpenLibraryEditionKey(e.target.value)}
+                      placeholder="OL123M"
+                    />
+                  </label>
+                  <label className="field-row-equal">
+                    OL Author Key
+                    <input
+                      value={openLibraryAuthorKey}
+                      onChange={(e) => setOpenLibraryAuthorKey(e.target.value)}
+                      placeholder="OL123A"
+                    />
+                  </label>
+                </div>
+                <label>
+                  Other Identifiers (JSON)
+                  <textarea
+                    value={otherRemoteIdsJson}
+                    onChange={(e) => setOtherRemoteIdsJson(e.target.value)}
+                    placeholder={'{\n  "goodreads_id": "12345"\n}'}
+                    rows={3}
+                  />
+                </label>
+                {identifierError && <p className="error">{identifierError}</p>}
               </div>
             )}
-            <label>
-              User Genre Tags
-              <input
-                value={userGenreTags}
-                onChange={(e) => setUserGenreTags(e.target.value)}
-                placeholder="Fantasy, Romance, LitRPG"
-              />
-            </label>
-            {book.metadata_synced_at && (
+          </section>
+
+          {matchedConfigs.map((cfg) => (
+            <section key={cfg.id} className="settings-section">
+              <h3>
+                Inherited Cleaning Rules{" "}
+                <span className="badge-config">{cfg.name}</span>
+              </h3>
               <p className="hint">
-                Synced from {book.metadata_sync_source || "online metadata"} on{" "}
-                {new Date(book.metadata_synced_at).toLocaleString()}.
+                These site-wide rules apply automatically and cannot be edited
+                here.
               </p>
-            )}
-            <div className="settings-actions">
-              <button
-                type="button"
-                onClick={() => metadataSyncMutation.mutate()}
-                disabled={metadataSyncMutation.isPending}
-              >
-                {metadataSyncMutation.isPending
-                  ? "Queueing…"
-                  : "Recheck Online Metadata"}
-              </button>
-            </div>
-            {metadataSyncMutation.isSuccess && (
-              <p className="hint">Metadata recheck queued.</p>
-            )}
-          </div>
-          <div className="settings-cover-aside">
-            {book.cover_path ? (
-              <img
-                src={`${getApiCoverUrl(book.id)}?v=${coverVersion}`}
-                alt="Cover"
-                className="settings-cover-img"
-              />
-            ) : (
-              <div className="settings-cover-placeholder">No cover</div>
-            )}
-            <input
-              ref={coverInputRef}
-              type="file"
-              accept=".jpg,.jpeg,.png,.webp"
-              style={{ display: "none" }}
-              onChange={(e) =>
-                e.target.files[0] && coverMutation.mutate(e.target.files[0])
-              }
+              {cfg.chapter_selectors?.length > 0 && (
+                <div>
+                  <strong>Chapter selectors:</strong>
+                  <div className="pills readonly">
+                    {cfg.chapter_selectors.map((s) => (
+                      <span key={s} className="pill">
+                        {s}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
+              {cfg.content_selectors?.length > 0 && (
+                <div>
+                  <strong>Content selectors:</strong>
+                  <div className="pills readonly">
+                    {cfg.content_selectors.map((s) => (
+                      <span key={s} className="pill">
+                        {s}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </section>
+          ))}
+
+          <section className="settings-section">
+            <h3>Per-Book Content Selectors</h3>
+            <p className="hint">
+              CSS selectors for content to remove from this book only.
+            </p>
+            <SelectorPills
+              selectors={contentSelectors}
+              onChange={setContentSelectors}
             />
-            <button
-              className="btn-sm"
-              onClick={() => coverInputRef.current.click()}
-              disabled={coverMutation.isPending || coverUrlMutation.isPending}
+            <div
+              style={{
+                marginTop: "0.5rem",
+                display: "flex",
+                alignItems: "center",
+                gap: "1rem",
+              }}
             >
-              {coverMutation.isPending
-                ? "Uploading…"
-                : book.cover_path
-                  ? "Replace"
-                  : "Upload"}
-            </button>
-            {book.immutable_path && (
               <button
-                className="btn-sm btn-secondary"
-                onClick={() => retryCoverMutation.mutate()}
-                disabled={
-                  retryCoverMutation.isPending ||
-                  coverMutation.isPending ||
-                  coverUrlMutation.isPending
-                }
+                onClick={() => previewMutation.mutate()}
+                disabled={previewMutation.isPending}
               >
-                {retryCoverMutation.isPending ? "Retrying…" : "Re-extract"}
+                {previewMutation.isPending ? "Previewing..." : "Preview"}
               </button>
-            )}
-            <div className="cover-url-row">
-              <input
-                type="text"
-                placeholder="Image URL…"
-                value={coverUrl}
-                onChange={(e) => setCoverUrl(e.target.value)}
-                onKeyDown={(e) =>
-                  e.key === "Enter" &&
-                  coverUrl.trim() &&
-                  coverUrlMutation.mutate(coverUrl.trim())
-                }
-              />
-              <button
-                className="btn-sm"
-                onClick={() => coverUrlMutation.mutate(coverUrl.trim())}
-                disabled={
-                  !coverUrl.trim() ||
-                  coverUrlMutation.isPending ||
-                  coverMutation.isPending
-                }
-              >
-                {coverUrlMutation.isPending ? "…" : "Set"}
-              </button>
-            </div>
-            {coverMutation.isError && (
-              <p className="error">{coverMutation.error.message}</p>
-            )}
-            {coverUrlMutation.isError && (
-              <p className="error">{coverUrlMutation.error.message}</p>
-            )}
-            {retryCoverMutation.isError && (
-              <p className="error">{retryCoverMutation.error.message}</p>
-            )}
-          </div>
-        </div>
-      </section>
-
-      <section className="settings-section">
-        <h3>Notes</h3>
-        <textarea
-          value={notes}
-          onChange={(e) => setNotes(e.target.value)}
-          placeholder="Personal notes about this book"
-          rows={3}
-        />
-      </section>
-
-      {(book.source_url || book.source_type === "web") && (
-        <section className="settings-section">
-          <h3>Source</h3>
-          {book.source_url ? (
-            <div className="source-info">
-              <span className="badge-web">{book.source_type}</span>
-              <a
-                href={book.source_url}
-                target="_blank"
-                rel="noreferrer"
-                className="source-link"
-              >
-                {book.source_url}
-              </a>
-            </div>
-          ) : (
-            <p className="hint">No source URL is currently attached.</p>
-          )}
-          {book.source_type === "web" && (
-            <div className="settings-actions" style={{ marginTop: "0.5rem" }}>
-              <button
-                type="button"
-                className="btn-danger btn-sm"
-                onClick={handleDetachSource}
-                disabled={isBusy || !canDetachWebMarker}
-              >
-                {detachSourceMutation.isPending
-                  ? "Removing…"
-                  : "Remove Web Marker"}
-              </button>
-              {!canDetachWebMarker && (
-                <span
-                  className="hint"
-                  style={{ margin: 0, alignSelf: "center" }}
-                >
-                  Requires EPUB files first
+              {previewResult && (
+                <span className="hint">
+                  Would remove {previewResult.elements_removed} elements · ~
+                  {previewResult.estimated_word_count.toLocaleString()} words
+                  remaining
                 </span>
               )}
+              {previewMutation.isError && (
+                <span className="error">{previewMutation.error.message}</span>
+              )}
             </div>
-          )}
-        </section>
-      )}
+          </section>
 
-      {book.source_type === "web" && (
-        <ChapterUpdateHistory
-          updateHistory={updateHistory}
-          isLoading={updateHistoryLoading}
-          isError={updateHistoryIsError}
-          error={updateHistoryError}
-        />
-      )}
+          <BookSettingsChapters
+            book={book}
+            chapters={chapters}
+            cleanedChapters={cleanedChapters}
+            chaptersLoading={chaptersLoading}
+            cleanedChaptersLoading={cleanedChaptersLoading}
+            chaptersExpanded={chaptersExpanded}
+            setChaptersExpanded={setChaptersExpanded}
+            chapterPreviewMode={chapterPreviewMode}
+            setChapterPreviewMode={setChapterPreviewMode}
+            chapterSearch={chapterSearch}
+            setChapterSearch={setChapterSearch}
+            removedChapters={removedChapters}
+            toggleChapter={toggleChapter}
+            previewedChapter={previewedChapter}
+            toggleChapterPreview={toggleChapterPreview}
+          />
 
-      <section className="settings-section">
-        <div
-          className="collapsible-header"
-          onClick={() => setIdentifiersExpanded((e) => !e)}
-        >
-          <h3>
-            Identifiers
-            {(isbn10 ||
-              isbn13 ||
-              googleBooksVolumeId ||
-              openLibraryWorkKey) && (
-              <span className="field-count">
-                {
-                  [
-                    isbn10,
-                    isbn13,
-                    googleBooksVolumeId,
-                    openLibraryWorkKey,
-                    openLibraryEditionKey,
-                    openLibraryAuthorKey,
-                  ].filter(Boolean).length
-                }{" "}
-                set
-              </span>
-            )}
-          </h3>
-          <span className="collapse-toggle">
-            {identifiersExpanded ? "▲" : "▼"}
-          </span>
-        </div>
-        {identifiersExpanded && (
-          <div className="collapsible-body">
-            <div className="field-row">
-              <label className="field-row-equal">
-                ISBN-10
-                <input
-                  value={isbn10}
-                  onChange={(e) => setIsbn10(e.target.value)}
-                  placeholder="Manual ISBN-10"
-                />
-              </label>
-              <label className="field-row-equal">
-                ISBN-13
-                <input
-                  value={isbn13}
-                  onChange={(e) => setIsbn13(e.target.value)}
-                  placeholder="Manual ISBN-13"
-                />
-              </label>
+          <section className="settings-section actions-bar">
+            <div className="actions-primary">
+              <button
+                className="btn-primary"
+                onClick={handleSave}
+                disabled={isBusy}
+              >
+                {saveMutation.isPending ? "Saving..." : "Save Metadata"}
+              </button>
+              <button
+                onClick={handleProcess}
+                disabled={isBusy}
+                title="Save changes and rebuild the EPUB file with current cleaning rules"
+              >
+                {processMutation.isPending
+                  ? "Rebuilding..."
+                  : "Save & Rebuild EPUB"}
+              </button>
+              {book.source_type === "web" && (
+                <button
+                  onClick={() => refreshMutation.mutate()}
+                  disabled={isBusy}
+                >
+                  {refreshMutation.isPending
+                    ? "Queueing…"
+                    : book.refresh_status === "queued"
+                      ? "Queued for refresh…"
+                      : book.refresh_status === "processing"
+                        ? "Refreshing from source…"
+                        : "Refresh from Source"}
+                </button>
+              )}
             </div>
-            <label>
-              Google Books Volume ID
-              <input
-                value={googleBooksVolumeId}
-                onChange={(e) => setGoogleBooksVolumeId(e.target.value)}
-                placeholder="zyTCAlFPjgYC"
-              />
-            </label>
-            <label>
-              Open Library Work Key
-              <input
-                value={openLibraryWorkKey}
-                onChange={(e) => setOpenLibraryWorkKey(e.target.value)}
-                placeholder="/works/OL123W"
-              />
-            </label>
-            <div className="field-row">
-              <label className="field-row-equal">
-                OL Edition Key
-                <input
-                  value={openLibraryEditionKey}
-                  onChange={(e) => setOpenLibraryEditionKey(e.target.value)}
-                  placeholder="OL123M"
-                />
-              </label>
-              <label className="field-row-equal">
-                OL Author Key
-                <input
-                  value={openLibraryAuthorKey}
-                  onChange={(e) => setOpenLibraryAuthorKey(e.target.value)}
-                  placeholder="OL123A"
-                />
-              </label>
+            <p className="hint actions-hint">
+              <strong>Save Metadata</strong> updates the database only.{" "}
+              <strong>Save & Rebuild EPUB</strong> also regenerates the
+              downloadable file with your cleaning rules applied.
+            </p>
+            <div className="actions-secondary">
+              <a
+                href={`/api/books/${book.id}/download`}
+                download
+                className="btn btn-secondary btn-sm"
+              >
+                Download EPUB
+              </a>
+              <button
+                className="btn-danger btn-sm"
+                onClick={handleDelete}
+                disabled={isBusy}
+              >
+                Delete Book
+              </button>
             </div>
-            <label>
-              Other Identifiers (JSON)
-              <textarea
-                value={otherRemoteIdsJson}
-                onChange={(e) => setOtherRemoteIdsJson(e.target.value)}
-                placeholder={'{\n  "goodreads_id": "12345"\n}'}
-                rows={3}
-              />
-            </label>
-            {identifierError && <p className="error">{identifierError}</p>}
-          </div>
-        )}
-      </section>
+          </section>
 
-      {matchedConfigs.map((cfg) => (
-        <section key={cfg.id} className="settings-section">
-          <h3>
-            Inherited Cleaning Rules{" "}
-            <span className="badge-config">{cfg.name}</span>
-          </h3>
-          <p className="hint">
-            These site-wide rules apply automatically and cannot be edited here.
-          </p>
-          {cfg.chapter_selectors?.length > 0 && (
-            <div>
-              <strong>Chapter selectors:</strong>
-              <div className="pills readonly">
-                {cfg.chapter_selectors.map((s) => (
-                  <span key={s} className="pill">
-                    {s}
-                  </span>
-                ))}
-              </div>
-            </div>
+          {saveMutation.isError && (
+            <p className="error">Save failed: {saveMutation.error.message}</p>
           )}
-          {cfg.content_selectors?.length > 0 && (
-            <div>
-              <strong>Content selectors:</strong>
-              <div className="pills readonly">
-                {cfg.content_selectors.map((s) => (
-                  <span key={s} className="pill">
-                    {s}
-                  </span>
-                ))}
-              </div>
-            </div>
+          {processMutation.isError && (
+            <p className="error">
+              Process failed: {processMutation.error.message}
+            </p>
           )}
-        </section>
-      ))}
-
-      <section className="settings-section">
-        <h3>Per-Book Content Selectors</h3>
-        <p className="hint">
-          CSS selectors for content to remove from this book only.
-        </p>
-        <SelectorPills
-          selectors={contentSelectors}
-          onChange={setContentSelectors}
-        />
-        <div
-          style={{
-            marginTop: "0.5rem",
-            display: "flex",
-            alignItems: "center",
-            gap: "1rem",
-          }}
-        >
-          <button
-            onClick={() => previewMutation.mutate()}
-            disabled={previewMutation.isPending}
-          >
-            {previewMutation.isPending ? "Previewing..." : "Preview"}
-          </button>
-          {previewResult && (
-            <span className="hint">
-              Would remove {previewResult.elements_removed} elements · ~
-              {previewResult.estimated_word_count.toLocaleString()} words
-              remaining
-            </span>
+          {refreshMutation.isError && (
+            <p className="error">
+              Refresh failed: {refreshMutation.error.message}
+            </p>
           )}
-          {previewMutation.isError && (
-            <span className="error">{previewMutation.error.message}</span>
+          {detachSourceMutation.isError && (
+            <p className="error">
+              Remove web marker failed: {detachSourceMutation.error.message}
+            </p>
           )}
-        </div>
-      </section>
-
-      <BookSettingsChapters
-        book={book}
-        chapters={chapters}
-        cleanedChapters={cleanedChapters}
-        chaptersLoading={chaptersLoading}
-        cleanedChaptersLoading={cleanedChaptersLoading}
-        chaptersExpanded={chaptersExpanded}
-        setChaptersExpanded={setChaptersExpanded}
-        chapterPreviewMode={chapterPreviewMode}
-        setChapterPreviewMode={setChapterPreviewMode}
-        chapterSearch={chapterSearch}
-        setChapterSearch={setChapterSearch}
-        removedChapters={removedChapters}
-        toggleChapter={toggleChapter}
-        previewedChapter={previewedChapter}
-        toggleChapterPreview={toggleChapterPreview}
-      />
-
-      <section className="settings-section actions-bar">
-        <div className="actions-primary">
-          <button
-            className="btn-primary"
-            onClick={handleSave}
-            disabled={isBusy}
-          >
-            {saveMutation.isPending ? "Saving..." : "Save Metadata"}
-          </button>
-          <button
-            onClick={handleProcess}
-            disabled={isBusy}
-            title="Save changes and rebuild the EPUB file with current cleaning rules"
-          >
-            {processMutation.isPending
-              ? "Rebuilding..."
-              : "Save & Rebuild EPUB"}
-          </button>
-          {book.source_type === "web" && (
-            <button onClick={() => refreshMutation.mutate()} disabled={isBusy}>
-              {refreshMutation.isPending
-                ? "Queueing…"
-                : book.refresh_status === "queued"
-                  ? "Queued for refresh…"
-                  : book.refresh_status === "processing"
-                    ? "Refreshing from source…"
-                    : "Refresh from Source"}
-            </button>
+          {deleteMutation.isError && (
+            <p className="error">
+              Delete failed: {deleteMutation.error.message}
+            </p>
           )}
-        </div>
-        <p className="hint actions-hint">
-          <strong>Save Metadata</strong> updates the database only.{" "}
-          <strong>Save & Rebuild EPUB</strong> also regenerates the downloadable
-          file with your cleaning rules applied.
-        </p>
-        <div className="actions-secondary">
-          <a
-            href={`/api/books/${book.id}/download`}
-            download
-            className="btn btn-secondary btn-sm"
-          >
-            Download EPUB
-          </a>
-          <button
-            className="btn-danger btn-sm"
-            onClick={handleDelete}
-            disabled={isBusy}
-          >
-            Delete Book
-          </button>
-        </div>
-      </section>
-
-      {saveMutation.isError && (
-        <p className="error">Save failed: {saveMutation.error.message}</p>
-      )}
-      {processMutation.isError && (
-        <p className="error">Process failed: {processMutation.error.message}</p>
-      )}
-      {refreshMutation.isError && (
-        <p className="error">Refresh failed: {refreshMutation.error.message}</p>
-      )}
-      {detachSourceMutation.isError && (
-        <p className="error">
-          Remove web marker failed: {detachSourceMutation.error.message}
-        </p>
-      )}
-      {deleteMutation.isError && (
-        <p className="error">Delete failed: {deleteMutation.error.message}</p>
-      )}
-      </>
+        </>
       )}
     </div>
   );

--- a/frontend/src/components/BookSettings.jsx
+++ b/frontend/src/components/BookSettings.jsx
@@ -176,9 +176,19 @@ function BookSettings({ book: initialBook, onBack }) {
 
   const saveMutation = useMutation({
     mutationFn: (data) => updateBook(book.id, data),
-    onSuccess: () => {
+    onSuccess: (updatedBook) => {
+      queryClient.setQueryData(["book", book.id], updatedBook);
       queryClient.invalidateQueries({ queryKey: ["book-catalog"] });
       queryClient.invalidateQueries({ queryKey: ["series"] });
+    },
+  });
+
+  const enableAudiobookMutation = useMutation({
+    mutationFn: () => updateBook(book.id, { audiobook_enabled: true }),
+    onSuccess: (updatedBook) => {
+      queryClient.setQueryData(["book", book.id], updatedBook);
+      queryClient.invalidateQueries({ queryKey: ["book-catalog"] });
+      setBookTab("audiobook");
     },
   });
 
@@ -233,6 +243,12 @@ function BookSettings({ book: initialBook, onBack }) {
   });
 
   const [coverUrl, setCoverUrl] = useState("");
+
+  useEffect(() => {
+    if (!book.audiobook_enabled && bookTab === "audiobook") {
+      setBookTab("details");
+    }
+  }, [book.audiobook_enabled, bookTab]);
 
   // Cover files live at a deterministic URL (/api/covers/{book_id}), so the
   // browser happily caches them. Whenever any cover mutation succeeds we bump
@@ -323,6 +339,7 @@ function BookSettings({ book: initialBook, onBack }) {
     refreshMutation.isPending ||
     detachSourceMutation.isPending ||
     deleteMutation.isPending ||
+    enableAudiobookMutation.isPending ||
     isRefreshing;
   const canDetachWebMarker =
     book.source_type === "web" && book.immutable_path && book.current_path;
@@ -338,7 +355,8 @@ function BookSettings({ book: initialBook, onBack }) {
             processMutation.isPending ||
             refreshMutation.isPending ||
             detachSourceMutation.isPending ||
-            deleteMutation.isPending
+            deleteMutation.isPending ||
+            enableAudiobookMutation.isPending
           }
           style={{ flexShrink: 0 }}
         >
@@ -354,15 +372,19 @@ function BookSettings({ book: initialBook, onBack }) {
         >
           Details
         </button>
-        <button
-          className={`book-settings-tab${bookTab === "audiobook" ? " book-settings-tab--active" : ""}`}
-          onClick={() => setBookTab("audiobook")}
-        >
-          Audiobook Pipeline
-        </button>
+        {book.audiobook_enabled && (
+          <button
+            className={`book-settings-tab${bookTab === "audiobook" ? " book-settings-tab--active" : ""}`}
+            onClick={() => setBookTab("audiobook")}
+          >
+            Audiobook Pipeline
+          </button>
+        )}
       </nav>
 
-      {bookTab === "audiobook" && <AudiobookPipeline book={book} />}
+      {book.audiobook_enabled && bookTab === "audiobook" && (
+        <AudiobookPipeline book={book} />
+      )}
 
       {bookTab === "details" && (
       <>
@@ -539,6 +561,32 @@ function BookSettings({ book: initialBook, onBack }) {
           </div>
         </div>
       </section>
+
+      {!book.audiobook_enabled && (
+        <section className="settings-section">
+          <h3>Audiobook</h3>
+          <p className="hint">
+            Generate an EPUB 3 audiobook with synchronized sentence-level
+            narration. Enabling this creates processing records for this book;
+            it does not start generation until you ask it to.
+          </p>
+          <button
+            type="button"
+            onClick={() => enableAudiobookMutation.mutate()}
+            disabled={enableAudiobookMutation.isPending}
+          >
+            {enableAudiobookMutation.isPending
+              ? "Enabling…"
+              : "Enable Audiobook Pipeline"}
+          </button>
+          {enableAudiobookMutation.isError && (
+            <p className="error">
+              {enableAudiobookMutation.error?.message ||
+                "Failed to enable the audiobook pipeline"}
+            </p>
+          )}
+        </section>
+      )}
 
       <section className="settings-section">
         <h3>Notes</h3>

--- a/frontend/src/components/BookSettings.jsx
+++ b/frontend/src/components/BookSettings.jsx
@@ -345,7 +345,13 @@ function BookSettings({ book: initialBook, onBack }) {
     book.source_type === "web" && book.immutable_path && book.current_path;
 
   return (
-    <div className="book-settings">
+    <div
+      className={`book-settings${
+        book.audiobook_enabled && bookTab === "audiobook"
+          ? " book-settings--wide"
+          : ""
+      }`}
+    >
       <div className="settings-header">
         <button
           className="btn-text"

--- a/frontend/src/components/BookSettings.test.jsx
+++ b/frontend/src/components/BookSettings.test.jsx
@@ -513,4 +513,106 @@ describe("BookSettings", () => {
       });
     });
   });
+
+  it("keeps the audiobook pipeline hidden until the book is enabled", async () => {
+    const fetchMock = vi.fn((url, options) => {
+      if (
+        url === "/api/books/11/chapters" ||
+        url === "/api/books/11/matched-config" ||
+        url === "/api/series" ||
+        url === "/api/books/11/audiobook/characters" ||
+        url === "/api/books/11/audiobook/chapters"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([]),
+        });
+      }
+      if (url === "/api/books/11/audiobook/status") {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              pipeline_status: null,
+              sentence_counts: {},
+            }),
+        });
+      }
+      if (url === "/api/books/11" && options?.method === "PUT") {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              id: 11,
+              title: "Audio Candidate",
+              author: "Author",
+              series: null,
+              series_index: null,
+              source_type: "epub",
+              source_url: null,
+              immutable_path: "library/original.epub",
+              current_path: "library/current.epub",
+              removed_chapters: [],
+              content_selectors: [],
+              created_at: "2026-03-17T00:00:00Z",
+              content_updated_at: "2026-03-17T00:00:00Z",
+              content_version: 1,
+              audiobook_enabled: true,
+              audiobook_pipeline_status: null,
+            }),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([]),
+      });
+    });
+    globalThis.fetch = fetchMock;
+
+    renderWithClient(
+      <BookSettings
+        book={{
+          id: 11,
+          title: "Audio Candidate",
+          author: "Author",
+          series: null,
+          series_index: null,
+          source_type: "epub",
+          source_url: null,
+          immutable_path: "library/original.epub",
+          current_path: "library/current.epub",
+          removed_chapters: [],
+          content_selectors: [],
+          created_at: "2026-03-17T00:00:00Z",
+          content_updated_at: "2026-03-17T00:00:00Z",
+          content_version: 1,
+          audiobook_enabled: false,
+        }}
+        onBack={() => {}}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Audiobook Pipeline" }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Enable Audiobook Pipeline" }),
+    );
+
+    await waitFor(() => {
+      const enableCall = fetchMock.mock.calls.find(
+        ([url, options]) =>
+          url === "/api/books/11" && options?.method === "PUT",
+      );
+      expect(enableCall).toBeTruthy();
+      expect(JSON.parse(enableCall[1].body)).toEqual({
+        audiobook_enabled: true,
+      });
+    });
+
+    expect(
+      await screen.findByRole("button", { name: "Audiobook Pipeline" }),
+    ).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/audiobook/AnalysisOverview.jsx
+++ b/frontend/src/components/audiobook/AnalysisOverview.jsx
@@ -1,0 +1,67 @@
+function AnalysisOverview({ status, chapters = [] }) {
+  const analyzed = chapters.filter((chapter) => chapter.summary);
+
+  return (
+    <div className="analysis-overview">
+      <section className="analysis-book-summary">
+        <div className="analysis-section-heading">
+          <div>
+            <span className="metric-label">Book-level analysis</span>
+            <h3>Story summary</h3>
+          </div>
+          <span className="badge badge--neutral">
+            {analyzed.length} / {chapters.length} chapters analyzed
+          </span>
+        </div>
+        <p>
+          {status?.summary ||
+            "The roster stage will add a spoiler-light book summary here."}
+        </p>
+        {status?.summary && (
+          <small className="analysis-review-note">
+            Model-generated working analysis — verify names and plot details before production.
+          </small>
+        )}
+      </section>
+
+      <div className="chapter-analysis-list">
+        {chapters.map((chapter) => {
+          const percent = chapter.sentence_count
+            ? Math.round(
+                (chapter.processed_sentence_count * 100) /
+                  chapter.sentence_count,
+              )
+            : 0;
+          return (
+            <article className="chapter-analysis-card" key={chapter.id}>
+              <div className="chapter-analysis-header">
+                <strong>Chapter {chapter.chapter_number}</strong>
+                <span>{percent}% attributed</span>
+              </div>
+              <div className="chapter-analysis-counts">
+                <span>{chapter.sentence_count} sentences</span>
+                <span>{chapter.low_confidence_count} need review</span>
+              </div>
+              <progress
+                value={chapter.processed_sentence_count}
+                max={Math.max(1, chapter.sentence_count)}
+              />
+              <p>
+                {chapter.summary ||
+                  "No chapter summary yet. Run a diarization batch to analyze it."}
+              </p>
+            </article>
+          );
+        })}
+      </div>
+
+      {chapters.length === 0 && (
+        <p className="empty-state">
+          No chapters yet. Run the ingestion stage to inspect book structure.
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default AnalysisOverview;

--- a/frontend/src/components/audiobook/AudiobookReader.jsx
+++ b/frontend/src/components/audiobook/AudiobookReader.jsx
@@ -1,0 +1,118 @@
+import { useEffect, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { getChapterAudioUrl, getSentences } from "../../api/audiobook";
+
+function AudiobookReader({ chapters = [], characters = [], bookId }) {
+  const playable = useMemo(
+    () =>
+      chapters.filter(
+        (chapter) => chapter.audio_file_path && !chapter.needs_reassembly,
+      ),
+    [chapters],
+  );
+  const [chapterId, setChapterId] = useState(playable[0]?.id ?? null);
+
+  useEffect(() => {
+    if (!playable.some((chapter) => chapter.id === chapterId)) {
+      setChapterId(playable[0]?.id ?? null);
+    }
+  }, [chapterId, playable]);
+
+  const selectedIndex = playable.findIndex(
+    (chapter) => chapter.id === chapterId,
+  );
+  const selected = selectedIndex >= 0 ? playable[selectedIndex] : null;
+  const { data, isLoading } = useQuery({
+    queryKey: ["audiobook-reader-sentences", bookId, chapterId],
+    queryFn: () => getSentences(bookId, { chapterId, limit: 1000 }),
+    enabled: chapterId != null,
+  });
+  const characterNames = useMemo(
+    () =>
+      new Map(characters.map((character) => [character.id, character.name])),
+    [characters],
+  );
+
+  if (!playable.length) {
+    return (
+      <p className="empty-state">
+        No playable chapters yet. Fully analyze a chapter, then use Generate
+        Preview in Chapter Assembly.
+      </p>
+    );
+  }
+
+  return (
+    <div className="audiobook-reader">
+      <aside
+        className="audiobook-reader-chapters"
+        aria-label="Playable chapters"
+      >
+        {playable.map((chapter) => (
+          <button
+            type="button"
+            key={chapter.id}
+            className={chapter.id === chapterId ? "active" : ""}
+            onClick={() => setChapterId(chapter.id)}
+          >
+            Chapter {chapter.chapter_number}
+            <small>{chapter.sentence_count} sentences</small>
+          </button>
+        ))}
+      </aside>
+      <main className="audiobook-reader-content">
+        <div className="audiobook-reader-heading">
+          <div>
+            <span className="metric-label">Listen & read</span>
+            <h3>Chapter {selected?.chapter_number}</h3>
+          </div>
+          <div className="audiobook-reader-nav">
+            <button
+              type="button"
+              disabled={selectedIndex <= 0}
+              onClick={() => setChapterId(playable[selectedIndex - 1].id)}
+            >
+              Previous
+            </button>
+            <button
+              type="button"
+              disabled={selectedIndex >= playable.length - 1}
+              onClick={() => setChapterId(playable[selectedIndex + 1].id)}
+            >
+              Next
+            </button>
+          </div>
+        </div>
+        <audio
+          key={chapterId}
+          controls
+          src={getChapterAudioUrl(bookId, chapterId)}
+          preload="metadata"
+          className="audiobook-reader-player"
+        />
+        {selected?.summary && (
+          <p className="audiobook-reader-summary">{selected.summary}</p>
+        )}
+        {isLoading ? (
+          <p>Loading chapter text…</p>
+        ) : (
+          <div className="audiobook-reader-text">
+            {(data?.items || []).map((sentence) => (
+              <span
+                key={sentence.id}
+                title={
+                  characterNames.get(sentence.character_id) || "Unassigned"
+                }
+              >
+                {sentence.original_text}{" "}
+              </span>
+            ))}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}
+
+export default AudiobookReader;

--- a/frontend/src/components/audiobook/ChapterAssembly.jsx
+++ b/frontend/src/components/audiobook/ChapterAssembly.jsx
@@ -1,0 +1,65 @@
+import { getChapterAudioUrl } from "../../api/audiobook";
+
+function ChapterAssembly({ chapters, bookId }) {
+  if (!chapters || chapters.length === 0) {
+    return (
+      <p className="empty-state">
+        No chapters yet. Start the pipeline to begin processing.
+      </p>
+    );
+  }
+
+  return (
+    <div className="chapter-assembly">
+      <table className="chapter-table">
+        <thead>
+          <tr>
+            <th>Chapter</th>
+            <th>Assembly Status</th>
+            <th>Audio Preview</th>
+            <th>SMIL</th>
+          </tr>
+        </thead>
+        <tbody>
+          {chapters.map((chapter) => (
+            <tr key={chapter.id}>
+              <td>Chapter {chapter.chapter_number}</td>
+              <td>
+                {chapter.needs_reassembly ? (
+                  <span className="badge badge--warning">Rebuild Pending</span>
+                ) : chapter.audio_file_path ? (
+                  <span className="badge badge--success">Assembled</span>
+                ) : (
+                  <span className="badge badge--neutral">Not yet assembled</span>
+                )}
+              </td>
+              <td>
+                {chapter.audio_file_path && !chapter.needs_reassembly && (
+                  <audio
+                    controls
+                    src={getChapterAudioUrl(bookId, chapter.id)}
+                    preload="none"
+                    style={{ height: "28px" }}
+                  />
+                )}
+              </td>
+              <td>
+                {chapter.smil_file_path && !chapter.needs_reassembly && (
+                  <a
+                    href={`/library/audiobooks/${bookId}/${chapter.smil_file_path.split("/").pop()}`}
+                    download
+                    className="btn-text"
+                  >
+                    Download SMIL
+                  </a>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default ChapterAssembly;

--- a/frontend/src/components/audiobook/ChapterAssembly.jsx
+++ b/frontend/src/components/audiobook/ChapterAssembly.jsx
@@ -1,6 +1,20 @@
-import { getChapterAudioUrl } from "../../api/audiobook";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  generateChapterPreview,
+  getChapterAudioUrl,
+} from "../../api/audiobook";
 
-function ChapterAssembly({ chapters, bookId }) {
+function ChapterAssembly({ chapters, bookId, pipelineActive = false }) {
+  const queryClient = useQueryClient();
+  const previewMutation = useMutation({
+    mutationFn: (chapterId) => generateChapterPreview(bookId, chapterId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["audiobook-chapters", bookId],
+      });
+      queryClient.invalidateQueries({ queryKey: ["audiobook-status", bookId] });
+    },
+  });
   if (!chapters || chapters.length === 0) {
     return (
       <p className="empty-state">
@@ -17,47 +31,116 @@ function ChapterAssembly({ chapters, bookId }) {
             <th>Chapter</th>
             <th>Assembly Status</th>
             <th>Audio Preview</th>
+            <th>Manual Action</th>
             <th>SMIL</th>
           </tr>
         </thead>
         <tbody>
-          {chapters.map((chapter) => (
-            <tr key={chapter.id}>
-              <td>Chapter {chapter.chapter_number}</td>
-              <td>
-                {chapter.needs_reassembly ? (
-                  <span className="badge badge--warning">Rebuild Pending</span>
-                ) : chapter.audio_file_path ? (
-                  <span className="badge badge--success">Assembled</span>
-                ) : (
-                  <span className="badge badge--neutral">Not yet assembled</span>
-                )}
-              </td>
-              <td>
-                {chapter.audio_file_path && !chapter.needs_reassembly && (
-                  <audio
-                    controls
-                    src={getChapterAudioUrl(bookId, chapter.id)}
-                    preload="none"
-                    style={{ height: "28px" }}
-                  />
-                )}
-              </td>
-              <td>
-                {chapter.smil_file_path && !chapter.needs_reassembly && (
-                  <a
-                    href={`/library/audiobooks/${bookId}/${chapter.smil_file_path.split("/").pop()}`}
-                    download
-                    className="btn-text"
+          {chapters.map((chapter) => {
+            const analyzed =
+              chapter.sentence_count > 0 &&
+              chapter.processed_sentence_count === chapter.sentence_count;
+            const previewBusy = ["queued", "generating"].includes(
+              chapter.preview_status,
+            );
+            const previewReady =
+              chapter.audio_file_path && !chapter.needs_reassembly;
+            return (
+              <tr key={chapter.id}>
+                <td>Chapter {chapter.chapter_number}</td>
+                <td>
+                  {previewBusy ? (
+                    <span className="badge badge--warning">
+                      {chapter.preview_status === "queued"
+                        ? "Queued"
+                        : "Generating"}{" "}
+                      · {chapter.audio_generated_count}/{chapter.sentence_count}
+                    </span>
+                  ) : chapter.preview_status === "error" ? (
+                    <span className="badge badge--error">Preview failed</span>
+                  ) : chapter.needs_reassembly ? (
+                    <span className="badge badge--warning">
+                      Rebuild Pending
+                    </span>
+                  ) : chapter.audio_file_path ? (
+                    <span className="badge badge--success">Assembled</span>
+                  ) : (
+                    <span className="badge badge--neutral">
+                      Not yet assembled
+                    </span>
+                  )}
+                </td>
+                <td>
+                  {previewReady && (
+                    <audio
+                      controls
+                      src={getChapterAudioUrl(bookId, chapter.id)}
+                      preload="none"
+                      style={{ height: "28px" }}
+                    />
+                  )}
+                </td>
+                <td>
+                  <button
+                    type="button"
+                    className="btn btn-sm"
+                    onClick={() => previewMutation.mutate(chapter.id)}
+                    disabled={
+                      !analyzed ||
+                      pipelineActive ||
+                      previewBusy ||
+                      previewMutation.isPending
+                    }
+                    title={
+                      !analyzed
+                        ? `Analyze all ${chapter.sentence_count} sentences first`
+                        : pipelineActive
+                          ? "Pause the full-book pipeline first"
+                          : "Generate audio using the current voice profiles"
+                    }
                   >
-                    Download SMIL
-                  </a>
-                )}
-              </td>
-            </tr>
-          ))}
+                    {previewBusy
+                      ? "Working…"
+                      : previewReady
+                        ? "Rebuild Preview"
+                        : "Generate Preview"}
+                  </button>
+                  {!analyzed && (
+                    <small className="chapter-preview-hint">
+                      {chapter.processed_sentence_count}/
+                      {chapter.sentence_count} analyzed
+                    </small>
+                  )}
+                  {chapter.preview_error && (
+                    <small className="error chapter-preview-error">
+                      {chapter.preview_error}
+                    </small>
+                  )}
+                </td>
+                <td>
+                  {chapter.smil_file_path && !chapter.needs_reassembly && (
+                    <a
+                      href={`/library/audiobooks/${bookId}/${chapter.smil_file_path.split("/").pop()}`}
+                      download
+                      className="btn-text"
+                    >
+                      Download SMIL
+                    </a>
+                  )}
+                </td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
+      <p className="chapter-preview-note">
+        Chapter previews are manual and use the current shared voice profiles.
+        Rebuild a preview after tuning a voice; the full audiobook remains
+        paused.
+      </p>
+      {previewMutation.isError && (
+        <p className="error">{previewMutation.error?.message}</p>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/audiobook/CharacterRoster.jsx
+++ b/frontend/src/components/audiobook/CharacterRoster.jsx
@@ -1,6 +1,10 @@
 import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { rebuildCharacterRoster, updateCharacter } from "../../api/audiobook";
+import {
+  rebuildCharacterRoster,
+  shareCharacterRosterWithSeries,
+  updateCharacter,
+} from "../../api/audiobook";
 
 const ACTIVE_STATUSES = new Set([
   "ingesting",
@@ -38,6 +42,14 @@ function CharacterCard({ character, bookId }) {
       <div className="character-card-header">
         <strong>{character.name}</strong>
         {character.is_narrator && <span className="badge">Narrator</span>}
+        {character.shared_series_name && (
+          <span
+            className="badge badge--success"
+            title={`Shared across ${character.shared_series_name}`}
+          >
+            Series profile
+          </span>
+        )}
       </div>
       {character.description && (
         <p className="character-description">{character.description}</p>
@@ -88,7 +100,8 @@ function CharacterCard({ character, bookId }) {
       )}
       {saved && (
         <p className="success">
-          Saved — audio for this character will be regenerated.
+          Saved across the series. Existing clips were invalidated; use a
+          chapter preview when you are ready to compare the voice.
         </p>
       )}
       <button onClick={handleSave} disabled={mutation.isPending}>
@@ -98,7 +111,7 @@ function CharacterCard({ character, bookId }) {
   );
 }
 
-function CharacterRoster({ characters, bookId, pipelineStatus }) {
+function CharacterRoster({ characters, bookId, pipelineStatus, series }) {
   const queryClient = useQueryClient();
   const [confirmRegenerate, setConfirmRegenerate] = useState(false);
   const regenerateMutation = useMutation({
@@ -111,6 +124,14 @@ function CharacterRoster({ characters, bookId, pipelineStatus }) {
       });
       queryClient.invalidateQueries({
         queryKey: ["audiobook-chapters", bookId],
+      });
+    },
+  });
+  const shareMutation = useMutation({
+    mutationFn: () => shareCharacterRosterWithSeries(bookId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["audiobook-characters", bookId],
       });
     },
   });
@@ -129,8 +150,18 @@ function CharacterRoster({ characters, bookId, pipelineStatus }) {
         <span>
           {characters.length} voice profiles. Regenerating preserves EPUB
           ingestion but clears speaker assignments and invalidates generated
-          snippets.
+          snippets. {series ? `Profiles can be shared across ${series}.` : ""}
         </span>
+        {series && (
+          <button
+            onClick={() => shareMutation.mutate()}
+            disabled={
+              shareMutation.isPending || ACTIVE_STATUSES.has(pipelineStatus)
+            }
+          >
+            {shareMutation.isPending ? "Syncing series…" : "Sync Series Roster"}
+          </button>
+        )}
         {!confirmRegenerate ? (
           <button
             onClick={() => setConfirmRegenerate(true)}
@@ -160,6 +191,14 @@ function CharacterRoster({ characters, bookId, pipelineStatus }) {
         )}
         {regenerateMutation.isError && (
           <span className="error">{regenerateMutation.error?.message}</span>
+        )}
+        {shareMutation.isSuccess && (
+          <span className="success">
+            Shared profiles are now linked across {series}.
+          </span>
+        )}
+        {shareMutation.isError && (
+          <span className="error">{shareMutation.error?.message}</span>
         )}
       </div>
       <div className="character-roster">

--- a/frontend/src/components/audiobook/CharacterRoster.jsx
+++ b/frontend/src/components/audiobook/CharacterRoster.jsx
@@ -1,10 +1,20 @@
 import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { updateCharacter } from "../../api/audiobook";
+import { rebuildCharacterRoster, updateCharacter } from "../../api/audiobook";
+
+const ACTIVE_STATUSES = new Set([
+  "ingesting",
+  "roster_gen",
+  "diarizing",
+  "audio_gen",
+  "assembling",
+]);
 
 function CharacterCard({ character, bookId }) {
   const queryClient = useQueryClient();
-  const [voicePrompt, setVoicePrompt] = useState(character.voice_design_prompt || "");
+  const [voicePrompt, setVoicePrompt] = useState(
+    character.voice_design_prompt || "",
+  );
   const [saved, setSaved] = useState(false);
 
   const mutation = useMutation({
@@ -12,7 +22,9 @@ function CharacterCard({ character, bookId }) {
     onSuccess: () => {
       setSaved(true);
       setTimeout(() => setSaved(false), 3000);
-      queryClient.invalidateQueries({ queryKey: ["audiobook-characters", bookId] });
+      queryClient.invalidateQueries({
+        queryKey: ["audiobook-characters", bookId],
+      });
       queryClient.invalidateQueries({ queryKey: ["audiobook-status", bookId] });
     },
   });
@@ -29,6 +41,31 @@ function CharacterCard({ character, bookId }) {
       </div>
       {character.description && (
         <p className="character-description">{character.description}</p>
+      )}
+      <div className="character-metrics">
+        <span>{character.sentence_count ?? 0} assigned sentences</span>
+        {character.average_confidence != null && (
+          <span>
+            {Math.round(character.average_confidence * 100)}% average confidence
+          </span>
+        )}
+      </div>
+      {character.aliases?.length > 0 && (
+        <p className="character-aliases">
+          <strong>Also known as:</strong> {character.aliases.join(", ")}
+        </p>
+      )}
+      {character.evidence?.length > 0 && (
+        <details className="character-evidence">
+          <summary>
+            Identification evidence ({character.evidence.length})
+          </summary>
+          <ul>
+            {character.evidence.map((item, index) => (
+              <li key={`${character.id}-evidence-${index}`}>{item}</li>
+            ))}
+          </ul>
+        </details>
       )}
       <label className="character-voice-label">
         Voice Design Prompt
@@ -50,7 +87,9 @@ function CharacterCard({ character, bookId }) {
         <p className="error">{mutation.error?.message || "Save failed"}</p>
       )}
       {saved && (
-        <p className="success">Saved — audio for this character will be regenerated.</p>
+        <p className="success">
+          Saved — audio for this character will be regenerated.
+        </p>
       )}
       <button onClick={handleSave} disabled={mutation.isPending}>
         {mutation.isPending ? "Saving…" : "Save Profile"}
@@ -59,7 +98,23 @@ function CharacterCard({ character, bookId }) {
   );
 }
 
-function CharacterRoster({ characters, bookId }) {
+function CharacterRoster({ characters, bookId, pipelineStatus }) {
+  const queryClient = useQueryClient();
+  const [confirmRegenerate, setConfirmRegenerate] = useState(false);
+  const regenerateMutation = useMutation({
+    mutationFn: () => rebuildCharacterRoster(bookId),
+    onSuccess: () => {
+      setConfirmRegenerate(false);
+      queryClient.invalidateQueries({ queryKey: ["audiobook-status", bookId] });
+      queryClient.invalidateQueries({
+        queryKey: ["audiobook-characters", bookId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["audiobook-chapters", bookId],
+      });
+    },
+  });
+
   if (!characters || characters.length === 0) {
     return (
       <p className="empty-state">
@@ -69,11 +124,50 @@ function CharacterRoster({ characters, bookId }) {
   }
 
   return (
-    <div className="character-roster">
-      {characters.map((char) => (
-        <CharacterCard key={char.id} character={char} bookId={bookId} />
-      ))}
-    </div>
+    <>
+      <div className="roster-controls">
+        <span>
+          {characters.length} voice profiles. Regenerating preserves EPUB
+          ingestion but clears speaker assignments and invalidates generated
+          snippets.
+        </span>
+        {!confirmRegenerate ? (
+          <button
+            onClick={() => setConfirmRegenerate(true)}
+            disabled={ACTIVE_STATUSES.has(pipelineStatus)}
+          >
+            Regenerate Character Roster
+          </button>
+        ) : (
+          <span className="confirm-inline">
+            Clear existing speaker analysis?{" "}
+            <button
+              className="btn-danger"
+              onClick={() => regenerateMutation.mutate()}
+              disabled={regenerateMutation.isPending}
+            >
+              {regenerateMutation.isPending
+                ? "Regenerating…"
+                : "Yes, regenerate"}
+            </button>{" "}
+            <button
+              className="btn-text"
+              onClick={() => setConfirmRegenerate(false)}
+            >
+              Cancel
+            </button>
+          </span>
+        )}
+        {regenerateMutation.isError && (
+          <span className="error">{regenerateMutation.error?.message}</span>
+        )}
+      </div>
+      <div className="character-roster">
+        {characters.map((char) => (
+          <CharacterCard key={char.id} character={char} bookId={bookId} />
+        ))}
+      </div>
+    </>
   );
 }
 

--- a/frontend/src/components/audiobook/CharacterRoster.jsx
+++ b/frontend/src/components/audiobook/CharacterRoster.jsx
@@ -1,0 +1,80 @@
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { updateCharacter } from "../../api/audiobook";
+
+function CharacterCard({ character, bookId }) {
+  const queryClient = useQueryClient();
+  const [voicePrompt, setVoicePrompt] = useState(character.voice_design_prompt || "");
+  const [saved, setSaved] = useState(false);
+
+  const mutation = useMutation({
+    mutationFn: (data) => updateCharacter(character.id, data),
+    onSuccess: () => {
+      setSaved(true);
+      setTimeout(() => setSaved(false), 3000);
+      queryClient.invalidateQueries({ queryKey: ["audiobook-characters", bookId] });
+      queryClient.invalidateQueries({ queryKey: ["audiobook-status", bookId] });
+    },
+  });
+
+  const handleSave = () => {
+    mutation.mutate({ voice_design_prompt: voicePrompt });
+  };
+
+  return (
+    <div className="character-card">
+      <div className="character-card-header">
+        <strong>{character.name}</strong>
+        {character.is_narrator && <span className="badge">Narrator</span>}
+      </div>
+      {character.description && (
+        <p className="character-description">{character.description}</p>
+      )}
+      <label className="character-voice-label">
+        Voice Design Prompt
+        <input
+          type="text"
+          value={voicePrompt}
+          onChange={(e) => setVoicePrompt(e.target.value)}
+          placeholder="e.g. [gender-male][pitch-low][speed-normal]"
+        />
+      </label>
+      <p className="character-voice-hint">
+        Tokens: <code>[gender-male|female|neutral]</code>{" "}
+        <code>[pitch-low|medium|high]</code>{" "}
+        <code>[speed-slow|normal|fast]</code>{" "}
+        <code>[age-young|middle|old]</code>{" "}
+        <code>[accent-british|american|…]</code>
+      </p>
+      {mutation.isError && (
+        <p className="error">{mutation.error?.message || "Save failed"}</p>
+      )}
+      {saved && (
+        <p className="success">Saved — audio for this character will be regenerated.</p>
+      )}
+      <button onClick={handleSave} disabled={mutation.isPending}>
+        {mutation.isPending ? "Saving…" : "Save Profile"}
+      </button>
+    </div>
+  );
+}
+
+function CharacterRoster({ characters, bookId }) {
+  if (!characters || characters.length === 0) {
+    return (
+      <p className="empty-state">
+        No characters yet. Start the pipeline to generate the roster.
+      </p>
+    );
+  }
+
+  return (
+    <div className="character-roster">
+      {characters.map((char) => (
+        <CharacterCard key={char.id} character={char} bookId={bookId} />
+      ))}
+    </div>
+  );
+}
+
+export default CharacterRoster;

--- a/frontend/src/components/audiobook/ScriptEditor.jsx
+++ b/frontend/src/components/audiobook/ScriptEditor.jsx
@@ -1,0 +1,175 @@
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { getSentences, updateSentence, getSentenceAudioUrl } from "../../api/audiobook";
+
+const STATUS_ICONS = {
+  pending_diarization: { icon: "⏳", label: "Pending diarization" },
+  ready_for_audio: { icon: "🎙", label: "Ready for audio" },
+  audio_generated: { icon: "✅", label: "Audio generated" },
+  error: { icon: "❌", label: "Error" },
+};
+
+function SentenceRow({ sentence, characters, bookId }) {
+  const queryClient = useQueryClient();
+  const [tags, setTags] = useState(sentence.tagged_text || sentence.original_text);
+  const [characterId, setCharacterId] = useState(sentence.character_id ?? "");
+  const [editing, setEditing] = useState(false);
+
+  const mutation = useMutation({
+    mutationFn: (data) => updateSentence(sentence.id, data),
+    onSuccess: () => {
+      setEditing(false);
+      queryClient.invalidateQueries({ queryKey: ["audiobook-sentences", bookId] });
+      queryClient.invalidateQueries({ queryKey: ["audiobook-status", bookId] });
+    },
+  });
+
+  const handleSave = () => {
+    mutation.mutate({
+      character_id: characterId !== "" ? Number(characterId) : null,
+      tagged_text: tags,
+    });
+  };
+
+  const statusInfo = STATUS_ICONS[sentence.status] || { icon: "?", label: sentence.status };
+  const audioUrl = sentence.status === "audio_generated" ? getSentenceAudioUrl(sentence.id) : null;
+
+  return (
+    <tr className={`sentence-row sentence-row--${sentence.status}`}>
+      <td className="sentence-seq">{sentence.sequence_order}</td>
+      <td className="sentence-text">{sentence.original_text}</td>
+      <td className="sentence-tags">
+        {editing ? (
+          <input
+            type="text"
+            value={tags}
+            onChange={(e) => setTags(e.target.value)}
+            className="sentence-tags-input"
+          />
+        ) : (
+          <span onClick={() => setEditing(true)} title="Click to edit">
+            {tags}
+          </span>
+        )}
+      </td>
+      <td className="sentence-speaker">
+        <select
+          value={characterId}
+          onChange={(e) => {
+            setCharacterId(e.target.value);
+            setEditing(true);
+          }}
+        >
+          <option value="">— unassigned —</option>
+          {characters.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.name}
+            </option>
+          ))}
+        </select>
+      </td>
+      <td className="sentence-status" title={statusInfo.label}>
+        {statusInfo.icon}
+      </td>
+      <td className="sentence-audio">
+        {audioUrl && (
+          <audio controls src={audioUrl} preload="none" style={{ height: "24px" }} />
+        )}
+      </td>
+      <td className="sentence-actions">
+        {editing && (
+          <>
+            <button onClick={handleSave} disabled={mutation.isPending} className="btn-small">
+              {mutation.isPending ? "…" : "Save"}
+            </button>
+            <button
+              onClick={() => {
+                setTags(sentence.tagged_text || sentence.original_text);
+                setCharacterId(sentence.character_id ?? "");
+                setEditing(false);
+              }}
+              className="btn-small btn-text"
+            >
+              Cancel
+            </button>
+          </>
+        )}
+        {mutation.isError && <span className="error">{mutation.error?.message}</span>}
+      </td>
+    </tr>
+  );
+}
+
+function ScriptEditor({ bookId, characters }) {
+  const [page, setPage] = useState(1);
+  const [chapterFilter, setChapterFilter] = useState("");
+  const limit = 50;
+
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: ["audiobook-sentences", bookId, page, chapterFilter],
+    queryFn: () =>
+      getSentences(bookId, {
+        page,
+        limit,
+        chapterId: chapterFilter ? Number(chapterFilter) : undefined,
+      }),
+    keepPreviousData: true,
+  });
+
+  if (isLoading) return <p>Loading sentences…</p>;
+  if (isError) return <p className="error">{error?.message || "Failed to load sentences"}</p>;
+
+  const { items = [], total = 0 } = data || {};
+  const totalPages = Math.max(1, Math.ceil(total / limit));
+
+  return (
+    <div className="script-editor">
+      <div className="script-editor-controls">
+        <span>{total} sentences</span>
+        <div className="pagination">
+          <button onClick={() => setPage((p) => Math.max(1, p - 1))} disabled={page === 1}>
+            ‹ Prev
+          </button>
+          <span>
+            Page {page} / {totalPages}
+          </span>
+          <button onClick={() => setPage((p) => Math.min(totalPages, p + 1))} disabled={page === totalPages}>
+            Next ›
+          </button>
+        </div>
+      </div>
+
+      {items.length === 0 ? (
+        <p className="empty-state">No sentences found. Start the pipeline first.</p>
+      ) : (
+        <div className="script-table-wrap">
+          <table className="script-table">
+            <thead>
+              <tr>
+                <th>#</th>
+                <th>Original Text</th>
+                <th>Tags</th>
+                <th>Speaker</th>
+                <th>Status</th>
+                <th>Audio</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((sentence) => (
+                <SentenceRow
+                  key={sentence.id}
+                  sentence={sentence}
+                  characters={characters}
+                  bookId={bookId}
+                />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default ScriptEditor;

--- a/frontend/src/components/audiobook/ScriptEditor.jsx
+++ b/frontend/src/components/audiobook/ScriptEditor.jsx
@@ -102,7 +102,7 @@ function SentenceRow({ sentence, characters, bookId }) {
 
 function ScriptEditor({ bookId, characters }) {
   const [page, setPage] = useState(1);
-  const [chapterFilter, setChapterFilter] = useState("");
+  const [chapterFilter, _setChapterFilter] = useState("");
   const limit = 50;
 
   const { data, isLoading, isError, error } = useQuery({

--- a/frontend/src/components/audiobook/ScriptEditor.jsx
+++ b/frontend/src/components/audiobook/ScriptEditor.jsx
@@ -1,6 +1,10 @@
 import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { getSentences, updateSentence, getSentenceAudioUrl } from "../../api/audiobook";
+import {
+  getSentences,
+  updateSentence,
+  getSentenceAudioUrl,
+} from "../../api/audiobook";
 
 const STATUS_ICONS = {
   pending_diarization: { icon: "⏳", label: "Pending diarization" },
@@ -11,7 +15,9 @@ const STATUS_ICONS = {
 
 function SentenceRow({ sentence, characters, bookId }) {
   const queryClient = useQueryClient();
-  const [tags, setTags] = useState(sentence.tagged_text || sentence.original_text);
+  const [tags, setTags] = useState(
+    sentence.tagged_text || sentence.original_text,
+  );
   const [characterId, setCharacterId] = useState(sentence.character_id ?? "");
   const [editing, setEditing] = useState(false);
 
@@ -19,7 +25,9 @@ function SentenceRow({ sentence, characters, bookId }) {
     mutationFn: (data) => updateSentence(sentence.id, data),
     onSuccess: () => {
       setEditing(false);
-      queryClient.invalidateQueries({ queryKey: ["audiobook-sentences", bookId] });
+      queryClient.invalidateQueries({
+        queryKey: ["audiobook-sentences", bookId],
+      });
       queryClient.invalidateQueries({ queryKey: ["audiobook-status", bookId] });
     },
   });
@@ -31,8 +39,14 @@ function SentenceRow({ sentence, characters, bookId }) {
     });
   };
 
-  const statusInfo = STATUS_ICONS[sentence.status] || { icon: "?", label: sentence.status };
-  const audioUrl = sentence.status === "audio_generated" ? getSentenceAudioUrl(sentence.id) : null;
+  const statusInfo = STATUS_ICONS[sentence.status] || {
+    icon: "?",
+    label: sentence.status,
+  };
+  const audioUrl =
+    sentence.status === "audio_generated"
+      ? getSentenceAudioUrl(sentence.id)
+      : null;
 
   return (
     <tr className={`sentence-row sentence-row--${sentence.status}`}>
@@ -68,18 +82,43 @@ function SentenceRow({ sentence, characters, bookId }) {
           ))}
         </select>
       </td>
+      <td
+        className="sentence-confidence"
+        title={sentence.speaker_reason || "No model rationale"}
+      >
+        {sentence.speaker_confidence == null ? (
+          "—"
+        ) : (
+          <span
+            className={`confidence-badge${
+              sentence.speaker_confidence < 0.65 ? " confidence-badge--low" : ""
+            }`}
+          >
+            {Math.round(sentence.speaker_confidence * 100)}%
+          </span>
+        )}
+      </td>
       <td className="sentence-status" title={statusInfo.label}>
         {statusInfo.icon}
       </td>
       <td className="sentence-audio">
         {audioUrl && (
-          <audio controls src={audioUrl} preload="none" style={{ height: "24px" }} />
+          <audio
+            controls
+            src={audioUrl}
+            preload="none"
+            style={{ height: "24px" }}
+          />
         )}
       </td>
       <td className="sentence-actions">
         {editing && (
           <>
-            <button onClick={handleSave} disabled={mutation.isPending} className="btn-small">
+            <button
+              onClick={handleSave}
+              disabled={mutation.isPending}
+              className="btn-small"
+            >
               {mutation.isPending ? "…" : "Save"}
             </button>
             <button
@@ -94,30 +133,37 @@ function SentenceRow({ sentence, characters, bookId }) {
             </button>
           </>
         )}
-        {mutation.isError && <span className="error">{mutation.error?.message}</span>}
+        {mutation.isError && (
+          <span className="error">{mutation.error?.message}</span>
+        )}
       </td>
     </tr>
   );
 }
 
-function ScriptEditor({ bookId, characters }) {
+function ScriptEditor({ bookId, characters, chapters = [] }) {
   const [page, setPage] = useState(1);
-  const [chapterFilter, _setChapterFilter] = useState("");
+  const [chapterFilter, setChapterFilter] = useState("");
+  const [reviewOnly, setReviewOnly] = useState(false);
   const limit = 50;
 
   const { data, isLoading, isError, error } = useQuery({
-    queryKey: ["audiobook-sentences", bookId, page, chapterFilter],
+    queryKey: ["audiobook-sentences", bookId, page, chapterFilter, reviewOnly],
     queryFn: () =>
       getSentences(bookId, {
         page,
         limit,
         chapterId: chapterFilter ? Number(chapterFilter) : undefined,
+        reviewOnly,
       }),
     keepPreviousData: true,
   });
 
   if (isLoading) return <p>Loading sentences…</p>;
-  if (isError) return <p className="error">{error?.message || "Failed to load sentences"}</p>;
+  if (isError)
+    return (
+      <p className="error">{error?.message || "Failed to load sentences"}</p>
+    );
 
   const { items = [], total = 0 } = data || {};
   const totalPages = Math.max(1, Math.ceil(total / limit));
@@ -126,21 +172,58 @@ function ScriptEditor({ bookId, characters }) {
     <div className="script-editor">
       <div className="script-editor-controls">
         <span>{total} sentences</span>
+        <label>
+          Chapter
+          <select
+            value={chapterFilter}
+            onChange={(event) => {
+              setChapterFilter(event.target.value);
+              setPage(1);
+            }}
+          >
+            <option value="">All</option>
+            {chapters.map((chapter) => (
+              <option key={chapter.id} value={chapter.id}>
+                {chapter.chapter_number} · {chapter.processed_sentence_count}/
+                {chapter.sentence_count}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="review-filter">
+          <input
+            type="checkbox"
+            checked={reviewOnly}
+            onChange={(event) => {
+              setReviewOnly(event.target.checked);
+              setPage(1);
+            }}
+          />
+          Needs review only
+        </label>
         <div className="pagination">
-          <button onClick={() => setPage((p) => Math.max(1, p - 1))} disabled={page === 1}>
+          <button
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={page === 1}
+          >
             ‹ Prev
           </button>
           <span>
             Page {page} / {totalPages}
           </span>
-          <button onClick={() => setPage((p) => Math.min(totalPages, p + 1))} disabled={page === totalPages}>
+          <button
+            onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+            disabled={page === totalPages}
+          >
             Next ›
           </button>
         </div>
       </div>
 
       {items.length === 0 ? (
-        <p className="empty-state">No sentences found. Start the pipeline first.</p>
+        <p className="empty-state">
+          No sentences found. Start the pipeline first.
+        </p>
       ) : (
         <div className="script-table-wrap">
           <table className="script-table">
@@ -150,6 +233,7 @@ function ScriptEditor({ bookId, characters }) {
                 <th>Original Text</th>
                 <th>Tags</th>
                 <th>Speaker</th>
+                <th>Confidence</th>
                 <th>Status</th>
                 <th>Audio</th>
                 <th></th>

--- a/frontend/src/components/audiobook/ScriptEditor.jsx
+++ b/frontend/src/components/audiobook/ScriptEditor.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
+  generateSentenceAudio,
   getSentences,
   updateSentence,
   getSentenceAudioUrl,
@@ -9,11 +10,13 @@ import {
 const STATUS_ICONS = {
   pending_diarization: { icon: "⏳", label: "Pending diarization" },
   ready_for_audio: { icon: "🎙", label: "Ready for audio" },
+  audio_queued: { icon: "⏱", label: "Audio queued" },
+  audio_generating: { icon: "🔊", label: "Generating audio" },
   audio_generated: { icon: "✅", label: "Audio generated" },
   error: { icon: "❌", label: "Error" },
 };
 
-function SentenceRow({ sentence, characters, bookId }) {
+function SentenceRow({ sentence, characters, bookId, pipelineActive }) {
   const queryClient = useQueryClient();
   const [tags, setTags] = useState(
     sentence.tagged_text || sentence.original_text,
@@ -29,6 +32,19 @@ function SentenceRow({ sentence, characters, bookId }) {
         queryKey: ["audiobook-sentences", bookId],
       });
       queryClient.invalidateQueries({ queryKey: ["audiobook-status", bookId] });
+    },
+  });
+
+  const audioMutation = useMutation({
+    mutationFn: () => generateSentenceAudio(bookId, sentence.id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["audiobook-sentences", bookId],
+      });
+      queryClient.invalidateQueries({ queryKey: ["audiobook-status", bookId] });
+      queryClient.invalidateQueries({
+        queryKey: ["audiobook-chapters", bookId],
+      });
     },
   });
 
@@ -99,16 +115,54 @@ function SentenceRow({ sentence, characters, bookId }) {
         )}
       </td>
       <td className="sentence-status" title={statusInfo.label}>
-        {statusInfo.icon}
+        <span aria-hidden="true">{statusInfo.icon}</span>
+        <span>{statusInfo.label}</span>
       </td>
       <td className="sentence-audio">
-        {audioUrl && (
+        {audioUrl ? (
           <audio
             controls
             src={audioUrl}
             preload="none"
             style={{ height: "24px" }}
           />
+        ) : sentence.status === "ready_for_audio" ||
+          sentence.status === "error" ? (
+          <button
+            type="button"
+            className="btn-small"
+            onClick={() => audioMutation.mutate()}
+            disabled={
+              audioMutation.isPending ||
+              pipelineActive ||
+              editing ||
+              characterId === ""
+            }
+            title={
+              pipelineActive
+                ? "Pause the full-book pipeline first"
+                : editing
+                  ? "Save sentence edits before generating audio"
+                  : characterId === ""
+                    ? "Assign a speaker first"
+                    : "Generate only this sentence with its current voice profile"
+            }
+          >
+            {audioMutation.isPending
+              ? "Queueing…"
+              : sentence.status === "error"
+                ? "Retry audio"
+                : "Generate audio"}
+          </button>
+        ) : ["audio_queued", "audio_generating"].includes(sentence.status) ? (
+          <span className="sentence-audio-progress">
+            {sentence.status === "audio_queued" ? "Waiting…" : "Working…"}
+          </span>
+        ) : null}
+        {audioMutation.isError && (
+          <span className="error sentence-audio-error">
+            {audioMutation.error?.message}
+          </span>
         )}
       </td>
       <td className="sentence-actions">
@@ -141,7 +195,12 @@ function SentenceRow({ sentence, characters, bookId }) {
   );
 }
 
-function ScriptEditor({ bookId, characters, chapters = [] }) {
+function ScriptEditor({
+  bookId,
+  characters,
+  chapters = [],
+  pipelineActive = false,
+}) {
   const [page, setPage] = useState(1);
   const [chapterFilter, setChapterFilter] = useState("");
   const [reviewOnly, setReviewOnly] = useState(false);
@@ -157,6 +216,12 @@ function ScriptEditor({ bookId, characters, chapters = [] }) {
         reviewOnly,
       }),
     keepPreviousData: true,
+    refetchInterval: ({ state }) =>
+      state.data?.items?.some((sentence) =>
+        ["audio_queued", "audio_generating"].includes(sentence.status),
+      )
+        ? 1500
+        : false,
   });
 
   if (isLoading) return <p>Loading sentences…</p>;
@@ -246,6 +311,7 @@ function ScriptEditor({ bookId, characters, chapters = [] }) {
                   sentence={sentence}
                   characters={characters}
                   bookId={bookId}
+                  pipelineActive={pipelineActive}
                 />
               ))}
             </tbody>

--- a/frontend/src/components/book-list/BookCards.jsx
+++ b/frontend/src/components/book-list/BookCards.jsx
@@ -23,6 +23,20 @@ export function GenreTagList({ tags, className = "" }) {
   );
 }
 
+export function AudiobookBadge({ book }) {
+  if (!book.audiobook_enabled) return null;
+  const status = book.audiobook_pipeline_status;
+  return (
+    <span
+      className="badge-audiobook"
+      title={status ? `Audiobook: ${status}` : "Audiobook enabled"}
+    >
+      <span aria-hidden="true">🎧</span>{" "}
+      {status === "complete" ? "Audiobook ready" : "Audiobook"}
+    </span>
+  );
+}
+
 export function BookCard({ book, onEdit }) {
   const isPending = book.download_status === "pending";
   const isError = book.download_status === "error";
@@ -115,6 +129,7 @@ export function BookCard({ book, onEdit }) {
         {book.source_type === "web" && !isPending && (
           <span className="badge-web">Web</span>
         )}
+        {!isPending && <AudiobookBadge book={book} />}
         {isError && book.source_url && (
           <p className="book-error-url" title={book.source_url}>
             {book.source_url.length > 40
@@ -174,6 +189,7 @@ export function BookRow({
             {book.source_type === "web" && (
               <span className="badge-web">Web</span>
             )}
+            <AudiobookBadge book={book} />
           </div>
           {subtitle && <div className="book-row-subtitle">{subtitle}</div>}
           {status && (

--- a/frontend/src/components/book-list/SeriesSummaryRow.jsx
+++ b/frontend/src/components/book-list/SeriesSummaryRow.jsx
@@ -108,6 +108,8 @@ export default function SeriesSummaryRow({ series, books, onEdit, allSeries }) {
       authors,
       totalWords,
       hasWebNovel: orderedBooks.some((book) => book.source_type === "web"),
+      audiobookCount: orderedBooks.filter((book) => book.audiobook_enabled)
+        .length,
       coverBook,
       coverBooks,
       latestUpdate: latestUpdate.getTime() > 0 ? latestUpdate : null,
@@ -191,6 +193,12 @@ export default function SeriesSummaryRow({ series, books, onEdit, allSeries }) {
           <div className="series-summary-topline">
             <span className="series-name">{series}</span>
             {summary.hasWebNovel && <span className="badge-web">Web</span>}
+            {summary.audiobookCount > 0 && (
+              <span className="badge-audiobook">
+                <span aria-hidden="true">🎧</span> {summary.audiobookCount}/
+                {books.length}
+              </span>
+            )}
           </div>
           <div className="series-meta">
             <span className="series-meta-author">

--- a/frontend/src/lib/catalogGrouping.js
+++ b/frontend/src/lib/catalogGrouping.js
@@ -13,6 +13,32 @@ export function compareSeriesBooks(left, right) {
   return left.id - right.id;
 }
 
+function compareCatalogBooks(left, right, sortBy, sortOrder) {
+  const dir = sortOrder === "desc" ? -1 : 1;
+  let comparison;
+  if (sortBy === "author") {
+    comparison = (left.author || "").localeCompare(right.author || "");
+  } else if (sortBy === "word_count") {
+    comparison =
+      (left.current_word_count || 0) - (right.current_word_count || 0);
+  } else if (sortBy === "updated_at") {
+    comparison =
+      new Date(left.updated_at || 0).getTime() -
+      new Date(right.updated_at || 0).getTime();
+  } else if (sortBy === "audiobook_enabled") {
+    comparison =
+      Number(Boolean(left.audiobook_enabled)) -
+      Number(Boolean(right.audiobook_enabled));
+  } else {
+    comparison = (left.title || "").localeCompare(right.title || "");
+  }
+
+  if (comparison !== 0) return dir * comparison;
+  const byTitle = (left.title || "").localeCompare(right.title || "");
+  if (byTitle !== 0) return byTitle;
+  return left.id - right.id;
+}
+
 export function buildCatalogGroups(books, sortBy = "title", sortOrder = "asc") {
   const seriesMap = {};
   const standaloneBooks = [];
@@ -36,6 +62,13 @@ export function buildCatalogGroups(books, sortBy = "title", sortOrder = "asc") {
   for (const seriesBooks of Object.values(seriesMap)) {
     seriesBooks.sort(compareSeriesBooks);
   }
+
+  standaloneBooks.sort((left, right) =>
+    compareCatalogBooks(left, right, sortBy, sortOrder),
+  );
+  webBooks.sort((left, right) =>
+    compareCatalogBooks(left, right, sortBy, sortOrder),
+  );
 
   const dir = sortOrder === "desc" ? -1 : 1;
   const sortedSeries = Object.keys(seriesMap).sort((a, b) => {
@@ -65,6 +98,12 @@ export function buildCatalogGroups(books, sortBy = "title", sortOrder = "asc") {
         ...booksB.map((bk) => new Date(bk.updated_at || 0).getTime()),
       );
       return dir * (latestA - latestB);
+    }
+    if (sortBy === "audiobook_enabled") {
+      const enabledA = booksA.some((book) => book.audiobook_enabled);
+      const enabledB = booksB.some((book) => book.audiobook_enabled);
+      const byEnabled = Number(enabledA) - Number(enabledB);
+      return byEnabled !== 0 ? dir * byEnabled : a.localeCompare(b);
     }
     return dir * a.localeCompare(b);
   });

--- a/frontend/src/lib/catalogGrouping.test.js
+++ b/frontend/src/lib/catalogGrouping.test.js
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { buildCatalogGroups } from "./catalogGrouping";
+
+describe("buildCatalogGroups", () => {
+  it("keeps audiobook-enabled series and standalone books first", () => {
+    const books = [
+      {
+        id: 1,
+        title: "Alpha Text",
+        author: "Author",
+        series: "Alpha Series",
+        source_type: "epub",
+        audiobook_enabled: false,
+      },
+      {
+        id: 2,
+        title: "Zeta Audio",
+        author: "Author",
+        series: "Zeta Series",
+        source_type: "epub",
+        audiobook_enabled: true,
+      },
+      {
+        id: 3,
+        title: "Alpha Standalone",
+        author: "Author",
+        series: null,
+        source_type: "epub",
+        audiobook_enabled: false,
+      },
+      {
+        id: 4,
+        title: "Zeta Standalone",
+        author: "Author",
+        series: null,
+        source_type: "epub",
+        audiobook_enabled: true,
+      },
+    ];
+
+    const grouped = buildCatalogGroups(books, "audiobook_enabled", "desc");
+
+    expect(grouped.sortedSeries).toEqual(["Zeta Series", "Alpha Series"]);
+    expect(grouped.standaloneBooks.map((book) => book.id)).toEqual([4, 3]);
+  });
+});

--- a/frontend/src/lib/navigation.js
+++ b/frontend/src/lib/navigation.js
@@ -4,6 +4,7 @@ export const TABS = [
   { key: "scheduler", label: "Scheduler", path: "/scheduler" },
   { key: "logs", label: "Logs", path: "/logs" },
   { key: "utilities", label: "Utilities", path: "/utilities" },
+  { key: "audio-settings", label: "Audio Settings", path: "/audio-settings" },
 ];
 
 export const LIBRARY_VIEWS = ["series", "standalone", "web"];

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
     "mutagen>=1.47,<2",
     "idna==3.18",
     "lxml==6.1.1",
-    "pydub>=0.25,<1",
     "pydantic==2.13.2",
     "pydantic-core==2.46.2",
     "python-dotenv==1.2.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "certifi==2026.2.25",
     "chardet==7.4.3",
     "charset-normalizer==3.4.7",
-    "click==8.3.2",
+    "click==8.3.3",
     "cloudscraper==1.2.71",
     "ebooklib==0.20",
     "fanficfare==4.56.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,11 @@ dependencies = [
     "html5lib==1.1",
     "httpcore==1.0.9",
     "httptools==0.7.1",
+    "httpx>=0.27",
+    "mutagen>=1.47",
     "idna==3.11",
     "lxml==6.0.4",
+    "pydub>=0.25",
     "pydantic==2.13.2",
     "pydantic-core==2.46.2",
     "python-dotenv==1.2.2",
@@ -36,6 +39,7 @@ dependencies = [
     "requests-file==3.0.1",
     "requests-toolbelt==1.0.0",
     "six==1.17.0",
+    "spacy>=3.7,<4",
     "sniffio==1.3.1",
     "soupsieve==2.8.3",
     "sqlalchemy==2.0.49",
@@ -53,7 +57,6 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "aiosqlite==0.22.1",
-    "httpx==0.28.1",
     "iniconfig==2.3.0",
     "packaging==26.1",
     "pluggy==1.6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,11 @@ dependencies = [
     "html5lib==1.1",
     "httpcore==1.0.9",
     "httptools==0.7.1",
+    "httpx2==2.5.0",
+    "mutagen>=1.47,<2",
     "idna==3.18",
     "lxml==6.1.1",
+    "pydub>=0.25,<1",
     "pydantic==2.13.2",
     "pydantic-core==2.46.2",
     "python-dotenv==1.2.2",
@@ -36,6 +39,7 @@ dependencies = [
     "requests-file==3.0.1",
     "requests-toolbelt==1.0.0",
     "six==1.17.0",
+    "spacy>=3.7,<4",
     "sniffio==1.3.1",
     "soupsieve==2.8.4",
     "sqlalchemy==2.0.49",
@@ -53,7 +57,6 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "aiosqlite==0.22.1",
-    "httpx2==2.5.0",
     "iniconfig==2.3.0",
     "packaging==26.1",
     "pluggy==1.6.0",

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,1 @@
+"""Optional local services used by Story Manager."""

--- a/services/omnivoice/README.md
+++ b/services/omnivoice/README.md
@@ -35,8 +35,15 @@ LLM provider can remain selected; it will handle roster/diarization locally whil
 | `OMNIVOICE_NUM_STEPS` | `16` | Diffusion steps; use `32` for higher quality/slower output |
 | `OMNIVOICE_MP3_BITRATE` | `96k` | Returned MP3 bitrate |
 | `OMNIVOICE_PORT` | `8001` | Port used by the Make target |
+| `OMNIVOICE_VOICE_ANCHOR_TEXT` | Built-in neutral calibration sentence | Text used to create each stable character voice anchor |
 
 Legacy Story Manager profiles such as `[gender-female][pitch-low][speed-normal]` are translated into the official
 comma-separated voice-design attributes. Official instructions such as `female, middle-aged, low pitch` are also
 accepted directly. Supported OmniVoice non-verbal tags are preserved; unsupported historical tags are removed so
 one bad expression tag cannot fail a full audiobook run.
+
+When `voice_id` is included in a generation request, the adapter deterministically seeds a one-time voice-design
+sample for that identity, converts it into OmniVoice's reusable voice-clone prompt, and caches it in memory. All
+subsequent lines for that identity use the same anchor and deterministic position selection. Story Manager derives
+the identity from the shared series character when available, so a recurring character retains the same voice in
+sibling books. Restarting the adapter recreates the same seeded anchor on first use.

--- a/services/omnivoice/README.md
+++ b/services/omnivoice/README.md
@@ -1,0 +1,42 @@
+# Local OmniVoice Adapter
+
+This service wraps the official Apache-2.0
+[`k2-fsa/OmniVoice`](https://github.com/k2-fsa/OmniVoice) 0.2.0 model in Story Manager's
+`POST /generate` HTTP contract. It keeps the model loaded between sentence requests and returns MP3 bytes.
+
+## Run
+
+From the repository root:
+
+```bash
+make run-omnivoice
+```
+
+The service requires `ffmpeg` for MP3 encoding (`brew install ffmpeg` on macOS).
+The first run installs an isolated environment and downloads about 3.3 GB of public model weights to the standard
+Hugging Face cache. The adapter auto-selects CUDA, XPU, Apple MPS, or CPU in that order. On Apple Silicon it enables
+PyTorch's MPS fallback because the upstream audio tokenizer intentionally runs on CPU.
+
+Verify readiness:
+
+```bash
+curl http://127.0.0.1:8001/health
+```
+
+In Story Manager, open **Audio Settings**, click **Use Local OmniVoice Adapter**, and save. The deterministic `stub`
+LLM provider can remain selected; it will handle roster/diarization locally while this service produces real speech.
+
+## Configuration
+
+| Environment variable | Default | Purpose |
+|---|---|---|
+| `OMNIVOICE_MODEL` | `k2-fsa/OmniVoice` | Hugging Face model ID or local checkpoint |
+| `OMNIVOICE_DEVICE` | `auto` | Force `mps`, `cuda`, `xpu`, or `cpu` |
+| `OMNIVOICE_NUM_STEPS` | `16` | Diffusion steps; use `32` for higher quality/slower output |
+| `OMNIVOICE_MP3_BITRATE` | `96k` | Returned MP3 bitrate |
+| `OMNIVOICE_PORT` | `8001` | Port used by the Make target |
+
+Legacy Story Manager profiles such as `[gender-female][pitch-low][speed-normal]` are translated into the official
+comma-separated voice-design attributes. Official instructions such as `female, middle-aged, low pitch` are also
+accepted directly. Supported OmniVoice non-verbal tags are preserved; unsupported historical tags are removed so
+one bad expression tag cannot fail a full audiobook run.

--- a/services/omnivoice/__init__.py
+++ b/services/omnivoice/__init__.py
@@ -1,0 +1,1 @@
+"""Local OmniVoice HTTP adapter."""

--- a/services/omnivoice/prompt.py
+++ b/services/omnivoice/prompt.py
@@ -1,0 +1,101 @@
+"""Translate Story Manager voice tags into official OmniVoice arguments."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+_VOICE_TAG_RE = re.compile(r"\[([a-z]+)-([^\]]+)\]", re.IGNORECASE)
+_TEXT_TAG_RE = re.compile(r"\[([a-z][a-z-]*)\]", re.IGNORECASE)
+
+_SUPPORTED_NONVERBAL_TAGS = {
+    "confirmation-en",
+    "dissatisfaction-hnn",
+    "laughter",
+    "question-ah",
+    "question-ei",
+    "question-en",
+    "question-oh",
+    "question-yi",
+    "sigh",
+    "surprise-ah",
+    "surprise-oh",
+    "surprise-wa",
+    "surprise-yo",
+}
+
+_PITCH = {
+    "very-low": "very low pitch",
+    "low": "low pitch",
+    "medium": "moderate pitch",
+    "moderate": "moderate pitch",
+    "high": "high pitch",
+    "very-high": "very high pitch",
+}
+_AGE = {
+    "child": "child",
+    "teen": "teenager",
+    "teenager": "teenager",
+    "young": "young adult",
+    "young-adult": "young adult",
+    "middle": "middle-aged",
+    "middle-aged": "middle-aged",
+    "old": "elderly",
+    "elderly": "elderly",
+}
+_SPEED = {"slow": 0.85, "normal": 1.0, "fast": 1.15}
+
+
+@dataclass(frozen=True)
+class GenerationPrompt:
+    text: str
+    instruct: str | None
+    speed: float
+
+
+def translate_generation_prompt(voice: str | None, text: str) -> GenerationPrompt:
+    """Return official ``instruct``/``speed`` values and supported inline tags.
+
+    Story Manager originally stored compact tags such as ``[pitch-low]``.
+    OmniVoice 0.2 expects comma-separated attributes such as ``low pitch``.
+    Existing profiles remain valid through this translation layer.
+    """
+
+    attributes: dict[str, str] = {}
+    speed = 1.0
+    raw_voice = (voice or "").strip()
+
+    matches = list(_VOICE_TAG_RE.finditer(raw_voice))
+    if matches:
+        for match in matches:
+            category = match.group(1).lower()
+            value = match.group(2).lower().strip()
+            if category == "gender" and value in {"male", "female"}:
+                attributes["gender"] = value
+            elif category == "pitch" and value in _PITCH:
+                attributes["pitch"] = _PITCH[value]
+            elif category == "age" and value in _AGE:
+                attributes["age"] = _AGE[value]
+            elif category == "accent" and value:
+                attributes["accent"] = f"{value} accent"
+            elif category == "style" and value == "whisper":
+                attributes["style"] = "whisper"
+            elif category == "speed" and value in _SPEED:
+                speed = _SPEED[value]
+    elif raw_voice:
+        # Also accept native OmniVoice instructions for new/manual profiles.
+        attributes["native"] = raw_voice
+
+    def replace_text_tag(match: re.Match[str]) -> str:
+        tag = match.group(1).lower()
+        if tag in _SUPPORTED_NONVERBAL_TAGS:
+            return f"[{tag}]"
+        if tag == "whisper":
+            attributes["style"] = "whisper"
+        # Story Manager historically offered tags such as [shout] that are not
+        # accepted by OmniVoice. Remove them instead of failing the whole book.
+        return ""
+
+    normalized_text = re.sub(r"\s+", " ", _TEXT_TAG_RE.sub(replace_text_tag, text)).strip()
+    instruct = ", ".join(attributes.values()) or None
+    return GenerationPrompt(text=normalized_text, instruct=instruct, speed=speed)

--- a/services/omnivoice/pyproject.toml
+++ b/services/omnivoice/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "story-manager-omnivoice-adapter"
+version = "0.1.0"
+description = "Local official OmniVoice adapter for Story Manager"
+requires-python = ">=3.13,<3.14"
+dependencies = [
+    "fastapi==0.139.0",
+    "numpy==2.4.6",
+    "omnivoice==0.2.0",
+    "pydub==0.25.1",
+    "torch==2.8.0",
+    "torchaudio==2.8.0",
+    "uvicorn[standard]==0.51.0",
+]
+
+[tool.uv]
+package = false
+constraint-dependencies = [
+    "torch==2.8.0",
+    "torchaudio==2.8.0",
+]

--- a/services/omnivoice/server.py
+++ b/services/omnivoice/server.py
@@ -1,0 +1,122 @@
+"""FastAPI adapter exposing official OmniVoice through Story Manager's API."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from io import BytesIO
+import logging
+import os
+import threading
+
+# Let unsupported MPS operations fall back to CPU rather than terminating a
+# long audiobook run. This must be set before importing torch.
+os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+
+import numpy as np
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import Response
+from omnivoice import OmniVoice
+from omnivoice.utils.common import get_best_device
+from pydantic import BaseModel, Field
+from pydub import AudioSegment
+import torch
+
+from .prompt import translate_generation_prompt
+
+logger = logging.getLogger(__name__)
+
+MODEL_ID = os.getenv("OMNIVOICE_MODEL", "k2-fsa/OmniVoice")
+DEVICE = os.getenv("OMNIVOICE_DEVICE", "auto")
+NUM_STEPS = int(os.getenv("OMNIVOICE_NUM_STEPS", "16"))
+MP3_BITRATE = os.getenv("OMNIVOICE_MP3_BITRATE", "96k")
+
+
+class GenerateRequest(BaseModel):
+    text: str = Field(min_length=1, max_length=4000)
+    voice: str | None = None
+    language: str | None = None
+
+
+class OmniVoiceRuntime:
+    def __init__(self) -> None:
+        self.model: OmniVoice | None = None
+        self.device = "unloaded"
+        self._generate_lock = threading.Lock()
+
+    def load(self) -> None:
+        self.device = get_best_device() if DEVICE == "auto" else DEVICE
+        dtype = torch.float32 if self.device == "cpu" else torch.float16
+        logger.info("Loading %s on %s (%s).", MODEL_ID, self.device, dtype)
+        self.model = OmniVoice.from_pretrained(
+            MODEL_ID,
+            device_map=self.device,
+            dtype=dtype,
+        )
+        logger.info("OmniVoice ready at %s Hz.", self.model.sampling_rate)
+
+    def generate(self, request: GenerateRequest) -> tuple[bytes, int]:
+        if self.model is None:
+            raise RuntimeError("OmniVoice model is not loaded")
+
+        prompt = translate_generation_prompt(request.voice, request.text)
+        with self._generate_lock:
+            audio = self.model.generate(
+                text=prompt.text,
+                language=request.language,
+                instruct=prompt.instruct,
+                speed=prompt.speed,
+                num_step=NUM_STEPS,
+                class_temperature=0.0,
+                postprocess_output=True,
+            )[0]
+
+        pcm = np.clip(audio * 32767, -32768, 32767).astype(np.int16)
+        segment = AudioSegment(
+            pcm.tobytes(),
+            frame_rate=self.model.sampling_rate,
+            sample_width=2,
+            channels=1,
+        )
+        output = BytesIO()
+        segment.export(output, format="mp3", bitrate=MP3_BITRATE)
+        return output.getvalue(), len(segment)
+
+
+runtime = OmniVoiceRuntime()
+
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI):
+    await asyncio.to_thread(runtime.load)
+    yield
+
+
+app = FastAPI(title="Story Manager OmniVoice Adapter", lifespan=lifespan)
+
+
+@app.get("/health")
+async def health() -> dict[str, object]:
+    return {
+        "status": "ready" if runtime.model is not None else "loading",
+        "model": MODEL_ID,
+        "device": runtime.device,
+        "num_steps": NUM_STEPS,
+    }
+
+
+@app.post("/generate")
+async def generate(request: GenerateRequest) -> Response:
+    try:
+        audio, duration_ms = await asyncio.to_thread(runtime.generate, request)
+    except Exception as exc:
+        logger.exception("OmniVoice generation failed.")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    return Response(
+        audio,
+        media_type="audio/mpeg",
+        headers={
+            "X-Audio-Duration-Ms": str(duration_ms),
+            "X-OmniVoice-Device": runtime.device,
+        },
+    )

--- a/services/omnivoice/server.py
+++ b/services/omnivoice/server.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from contextlib import asynccontextmanager
 from io import BytesIO
+import hashlib
 import logging
 import os
 import threading
@@ -30,11 +31,17 @@ MODEL_ID = os.getenv("OMNIVOICE_MODEL", "k2-fsa/OmniVoice")
 DEVICE = os.getenv("OMNIVOICE_DEVICE", "auto")
 NUM_STEPS = int(os.getenv("OMNIVOICE_NUM_STEPS", "16"))
 MP3_BITRATE = os.getenv("OMNIVOICE_MP3_BITRATE", "96k")
+VOICE_ANCHOR_VERSION = "v1"
+VOICE_ANCHOR_TEXT = os.getenv(
+    "OMNIVOICE_VOICE_ANCHOR_TEXT",
+    "I speak with a steady, natural voice, clearly carrying each thought from beginning to end.",
+)
 
 
 class GenerateRequest(BaseModel):
     text: str = Field(min_length=1, max_length=4000)
     voice: str | None = None
+    voice_id: str | None = Field(default=None, max_length=200)
     language: str | None = None
 
 
@@ -43,6 +50,7 @@ class OmniVoiceRuntime:
         self.model: OmniVoice | None = None
         self.device = "unloaded"
         self._generate_lock = threading.Lock()
+        self._voice_clone_prompts: dict[str, object] = {}
 
     def load(self) -> None:
         self.device = get_best_device() if DEVICE == "auto" else DEVICE
@@ -55,18 +63,72 @@ class OmniVoiceRuntime:
         )
         logger.info("OmniVoice ready at %s Hz.", self.model.sampling_rate)
 
-    def generate(self, request: GenerateRequest) -> tuple[bytes, int]:
+    @staticmethod
+    def _voice_cache_key(request: GenerateRequest, instruct: str | None, speed: float) -> str:
+        identity = request.voice_id or ""
+        material = "|".join([VOICE_ANCHOR_VERSION, identity, instruct or "", str(speed), request.language or ""])
+        return hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+    def _get_voice_clone_prompt(
+        self,
+        request: GenerateRequest,
+        *,
+        instruct: str | None,
+        speed: float,
+    ) -> object:
+        if self.model is None:
+            raise RuntimeError("OmniVoice model is not loaded")
+        cache_key = self._voice_cache_key(request, instruct, speed)
+        cached = self._voice_clone_prompts.get(cache_key)
+        if cached is not None:
+            return cached
+
+        # The voice-design mode has stochastic position selection. Seed that
+        # one-time choice from the durable character identity, then clone the
+        # resulting calibration voice for every real line.
+        seed = int(cache_key[:16], 16) % (2**31)
+        torch.manual_seed(seed)
+        anchor = self.model.generate(
+            text=VOICE_ANCHOR_TEXT,
+            language=request.language,
+            instruct=instruct,
+            speed=speed,
+            num_step=NUM_STEPS,
+            position_temperature=5.0,
+            class_temperature=0.0,
+            postprocess_output=True,
+        )[0]
+        clone_prompt = self.model.create_voice_clone_prompt(
+            (torch.from_numpy(anchor), self.model.sampling_rate),
+            ref_text=VOICE_ANCHOR_TEXT,
+        )
+        self._voice_clone_prompts[cache_key] = clone_prompt
+        logger.info("Created stable voice anchor for %s.", request.voice_id)
+        return clone_prompt
+
+    def generate(self, request: GenerateRequest) -> tuple[bytes, int, str]:
         if self.model is None:
             raise RuntimeError("OmniVoice model is not loaded")
 
         prompt = translate_generation_prompt(request.voice, request.text)
         with self._generate_lock:
+            clone_prompt = None
+            voice_mode = "deterministic-design"
+            if request.voice_id:
+                clone_prompt = self._get_voice_clone_prompt(
+                    request,
+                    instruct=prompt.instruct,
+                    speed=prompt.speed,
+                )
+                voice_mode = "anchored-clone"
             audio = self.model.generate(
                 text=prompt.text,
                 language=request.language,
+                voice_clone_prompt=clone_prompt,
                 instruct=prompt.instruct,
                 speed=prompt.speed,
                 num_step=NUM_STEPS,
+                position_temperature=0.0,
                 class_temperature=0.0,
                 postprocess_output=True,
             )[0]
@@ -80,7 +142,7 @@ class OmniVoiceRuntime:
         )
         output = BytesIO()
         segment.export(output, format="mp3", bitrate=MP3_BITRATE)
-        return output.getvalue(), len(segment)
+        return output.getvalue(), len(segment), voice_mode
 
 
 runtime = OmniVoiceRuntime()
@@ -102,13 +164,15 @@ async def health() -> dict[str, object]:
         "model": MODEL_ID,
         "device": runtime.device,
         "num_steps": NUM_STEPS,
+        "voice_consistency": "anchored-clone-v1",
+        "cached_voice_anchors": len(runtime._voice_clone_prompts),
     }
 
 
 @app.post("/generate")
 async def generate(request: GenerateRequest) -> Response:
     try:
-        audio, duration_ms = await asyncio.to_thread(runtime.generate, request)
+        audio, duration_ms, voice_mode = await asyncio.to_thread(runtime.generate, request)
     except Exception as exc:
         logger.exception("OmniVoice generation failed.")
         raise HTTPException(status_code=500, detail=str(exc)) from exc
@@ -118,5 +182,6 @@ async def generate(request: GenerateRequest) -> Response:
         headers={
             "X-Audio-Duration-Ms": str(duration_ms),
             "X-OmniVoice-Device": runtime.device,
+            "X-OmniVoice-Voice-Mode": voice_mode,
         },
     )

--- a/services/omnivoice/uv.lock
+++ b/services/omnivoice/uv.lock
@@ -1,0 +1,1698 @@
+version = 1
+revision = 3
+requires-python = "==3.13.*"
+resolution-markers = [
+    "sys_platform == 'win32'",
+    "sys_platform == 'emscripten'",
+    "sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+
+[manifest]
+constraints = [
+    { name = "torch", specifier = "==2.8.0" },
+    { name = "torchaudio", specifier = "==2.8.0" },
+]
+
+[[package]]
+name = "accelerate"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "pyyaml" },
+    { name = "safetensors" },
+    { name = "torch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8d/75/94cd5d389649578aca399e5aa822637eec18319a1dadc400ffe2f9a7493f/accelerate-1.14.0.tar.gz", hash = "sha256:41b9c4377a54e0b460a959b0defa1b736e4ca0a2373252d9a539964c2afe3c8d", size = 412167, upload-time = "2026-06-11T13:45:52.326Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/db/253133d7e7cb40d3af384bb2f5c0b4a2b7fdcffbc95c688cc67a20a3c103/accelerate-1.14.0-py3-none-any.whl", hash = "sha256:e94390c2863b873be18f623f9df48a0d8fe5eff13ea7f1a00092b0a7904888c6", size = 389246, upload-time = "2026-06-11T13:45:50.477Z" },
+]
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
+name = "audioop-lts"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/53/946db57842a50b2da2e0c1e34bd37f36f5aadba1a929a3971c5d7841dbca/audioop_lts-0.2.2.tar.gz", hash = "sha256:64d0c62d88e67b98a1a5e71987b7aa7b5bcffc7dcee65b635823dbdd0a8dbbd0", size = 30686, upload-time = "2025-08-05T16:43:17.409Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/d4/94d277ca941de5a507b07f0b592f199c22454eeaec8f008a286b3fbbacd6/audioop_lts-0.2.2-cp313-abi3-macosx_10_13_universal2.whl", hash = "sha256:fd3d4602dc64914d462924a08c1a9816435a2155d74f325853c1f1ac3b2d9800", size = 46523, upload-time = "2025-08-05T16:42:20.836Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/5a/656d1c2da4b555920ce4177167bfeb8623d98765594af59702c8873f60ec/audioop_lts-0.2.2-cp313-abi3-macosx_10_13_x86_64.whl", hash = "sha256:550c114a8df0aafe9a05442a1162dfc8fec37e9af1d625ae6060fed6e756f303", size = 27455, upload-time = "2025-08-05T16:42:22.283Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/83/ea581e364ce7b0d41456fb79d6ee0ad482beda61faf0cab20cbd4c63a541/audioop_lts-0.2.2-cp313-abi3-macosx_11_0_arm64.whl", hash = "sha256:9a13dc409f2564de15dd68be65b462ba0dde01b19663720c68c1140c782d1d75", size = 26997, upload-time = "2025-08-05T16:42:23.849Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/3b/e8964210b5e216e5041593b7d33e97ee65967f17c282e8510d19c666dab4/audioop_lts-0.2.2-cp313-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:51c916108c56aa6e426ce611946f901badac950ee2ddaf302b7ed35d9958970d", size = 85844, upload-time = "2025-08-05T16:42:25.208Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/2e/0a1c52faf10d51def20531a59ce4c706cb7952323b11709e10de324d6493/audioop_lts-0.2.2-cp313-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:47eba38322370347b1c47024defbd36374a211e8dd5b0dcbce7b34fdb6f8847b", size = 85056, upload-time = "2025-08-05T16:42:26.559Z" },
+    { url = "https://files.pythonhosted.org/packages/75/e8/cd95eef479656cb75ab05dfece8c1f8c395d17a7c651d88f8e6e291a63ab/audioop_lts-0.2.2-cp313-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ba7c3a7e5f23e215cb271516197030c32aef2e754252c4c70a50aaff7031a2c8", size = 93892, upload-time = "2025-08-05T16:42:27.902Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/1e/a0c42570b74f83efa5cca34905b3eef03f7ab09fe5637015df538a7f3345/audioop_lts-0.2.2-cp313-abi3-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:def246fe9e180626731b26e89816e79aae2276f825420a07b4a647abaa84becc", size = 96660, upload-time = "2025-08-05T16:42:28.9Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d5/8a0ae607ca07dbb34027bac8db805498ee7bfecc05fd2c148cc1ed7646e7/audioop_lts-0.2.2-cp313-abi3-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e160bf9df356d841bb6c180eeeea1834085464626dc1b68fa4e1d59070affdc3", size = 79143, upload-time = "2025-08-05T16:42:29.929Z" },
+    { url = "https://files.pythonhosted.org/packages/12/17/0d28c46179e7910bfb0bb62760ccb33edb5de973052cb2230b662c14ca2e/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4b4cd51a57b698b2d06cb9993b7ac8dfe89a3b2878e96bc7948e9f19ff51dba6", size = 84313, upload-time = "2025-08-05T16:42:30.949Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ba/bd5d3806641564f2024e97ca98ea8f8811d4e01d9b9f9831474bc9e14f9e/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:4a53aa7c16a60a6857e6b0b165261436396ef7293f8b5c9c828a3a203147ed4a", size = 93044, upload-time = "2025-08-05T16:42:31.959Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/5e/435ce8d5642f1f7679540d1e73c1c42d933331c0976eb397d1717d7f01a3/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:3fc38008969796f0f689f1453722a0f463da1b8a6fbee11987830bfbb664f623", size = 78766, upload-time = "2025-08-05T16:42:33.302Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3b/b909e76b606cbfd53875693ec8c156e93e15a1366a012f0b7e4fb52d3c34/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_s390x.whl", hash = "sha256:15ab25dd3e620790f40e9ead897f91e79c0d3ce65fe193c8ed6c26cffdd24be7", size = 87640, upload-time = "2025-08-05T16:42:34.854Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e7/8f1603b4572d79b775f2140d7952f200f5e6c62904585d08a01f0a70393a/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:03f061a1915538fd96272bac9551841859dbb2e3bf73ebe4a23ef043766f5449", size = 86052, upload-time = "2025-08-05T16:42:35.839Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/96/c37846df657ccdda62ba1ae2b6534fa90e2e1b1742ca8dcf8ebd38c53801/audioop_lts-0.2.2-cp313-abi3-win32.whl", hash = "sha256:3bcddaaf6cc5935a300a8387c99f7a7fbbe212a11568ec6cf6e4bc458c048636", size = 26185, upload-time = "2025-08-05T16:42:37.04Z" },
+    { url = "https://files.pythonhosted.org/packages/34/a5/9d78fdb5b844a83da8a71226c7bdae7cc638861085fff7a1d707cb4823fa/audioop_lts-0.2.2-cp313-abi3-win_amd64.whl", hash = "sha256:a2c2a947fae7d1062ef08c4e369e0ba2086049a5e598fda41122535557012e9e", size = 30503, upload-time = "2025-08-05T16:42:38.427Z" },
+    { url = "https://files.pythonhosted.org/packages/34/25/20d8fde083123e90c61b51afb547bb0ea7e77bab50d98c0ab243d02a0e43/audioop_lts-0.2.2-cp313-abi3-win_arm64.whl", hash = "sha256:5f93a5db13927a37d2d09637ccca4b2b6b48c19cd9eda7b17a2e9f77edee6a6f", size = 24173, upload-time = "2025-08-05T16:42:39.704Z" },
+    { url = "https://files.pythonhosted.org/packages/58/a7/0a764f77b5c4ac58dc13c01a580f5d32ae8c74c92020b961556a43e26d02/audioop_lts-0.2.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:73f80bf4cd5d2ca7814da30a120de1f9408ee0619cc75da87d0641273d202a09", size = 47096, upload-time = "2025-08-05T16:42:40.684Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ed/ebebedde1a18848b085ad0fa54b66ceb95f1f94a3fc04f1cd1b5ccb0ed42/audioop_lts-0.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:106753a83a25ee4d6f473f2be6b0966fc1c9af7e0017192f5531a3e7463dce58", size = 27748, upload-time = "2025-08-05T16:42:41.992Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/6e/11ca8c21af79f15dbb1c7f8017952ee8c810c438ce4e2b25638dfef2b02c/audioop_lts-0.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fbdd522624141e40948ab3e8cdae6e04c748d78710e9f0f8d4dae2750831de19", size = 27329, upload-time = "2025-08-05T16:42:42.987Z" },
+    { url = "https://files.pythonhosted.org/packages/84/52/0022f93d56d85eec5da6b9da6a958a1ef09e80c39f2cc0a590c6af81dcbb/audioop_lts-0.2.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:143fad0311e8209ece30a8dbddab3b65ab419cbe8c0dde6e8828da25999be911", size = 92407, upload-time = "2025-08-05T16:42:44.336Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1d/48a889855e67be8718adbc7a01f3c01d5743c325453a5e81cf3717664aad/audioop_lts-0.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dfbbc74ec68a0fd08cfec1f4b5e8cca3d3cd7de5501b01c4b5d209995033cde9", size = 91811, upload-time = "2025-08-05T16:42:45.325Z" },
+    { url = "https://files.pythonhosted.org/packages/98/a6/94b7213190e8077547ffae75e13ed05edc488653c85aa5c41472c297d295/audioop_lts-0.2.2-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cfcac6aa6f42397471e4943e0feb2244549db5c5d01efcd02725b96af417f3fe", size = 100470, upload-time = "2025-08-05T16:42:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/e9/78450d7cb921ede0cfc33426d3a8023a3bda755883c95c868ee36db8d48d/audioop_lts-0.2.2-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:752d76472d9804ac60f0078c79cdae8b956f293177acd2316cd1e15149aee132", size = 103878, upload-time = "2025-08-05T16:42:47.576Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/e2/cd5439aad4f3e34ae1ee852025dc6aa8f67a82b97641e390bf7bd9891d3e/audioop_lts-0.2.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:83c381767e2cc10e93e40281a04852facc4cd9334550e0f392f72d1c0a9c5753", size = 84867, upload-time = "2025-08-05T16:42:49.003Z" },
+    { url = "https://files.pythonhosted.org/packages/68/4b/9d853e9076c43ebba0d411e8d2aa19061083349ac695a7d082540bad64d0/audioop_lts-0.2.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c0022283e9556e0f3643b7c3c03f05063ca72b3063291834cca43234f20c60bb", size = 90001, upload-time = "2025-08-05T16:42:50.038Z" },
+    { url = "https://files.pythonhosted.org/packages/58/26/4bae7f9d2f116ed5593989d0e521d679b0d583973d203384679323d8fa85/audioop_lts-0.2.2-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:a2d4f1513d63c795e82948e1305f31a6d530626e5f9f2605408b300ae6095093", size = 99046, upload-time = "2025-08-05T16:42:51.111Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/67/a9f4fb3e250dda9e9046f8866e9fa7d52664f8985e445c6b4ad6dfb55641/audioop_lts-0.2.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:c9c8e68d8b4a56fda8c025e538e639f8c5953f5073886b596c93ec9b620055e7", size = 84788, upload-time = "2025-08-05T16:42:52.198Z" },
+    { url = "https://files.pythonhosted.org/packages/70/f7/3de86562db0121956148bcb0fe5b506615e3bcf6e63c4357a612b910765a/audioop_lts-0.2.2-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:96f19de485a2925314f5020e85911fb447ff5fbef56e8c7c6927851b95533a1c", size = 94472, upload-time = "2025-08-05T16:42:53.59Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/32/fd772bf9078ae1001207d2df1eef3da05bea611a87dd0e8217989b2848fa/audioop_lts-0.2.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e541c3ef484852ef36545f66209444c48b28661e864ccadb29daddb6a4b8e5f5", size = 92279, upload-time = "2025-08-05T16:42:54.632Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/41/affea7181592ab0ab560044632571a38edaf9130b84928177823fbf3176a/audioop_lts-0.2.2-cp313-cp313t-win32.whl", hash = "sha256:d5e73fa573e273e4f2e5ff96f9043858a5e9311e94ffefd88a3186a910c70917", size = 26568, upload-time = "2025-08-05T16:42:55.627Z" },
+    { url = "https://files.pythonhosted.org/packages/28/2b/0372842877016641db8fc54d5c88596b542eec2f8f6c20a36fb6612bf9ee/audioop_lts-0.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:9191d68659eda01e448188f60364c7763a7ca6653ed3f87ebb165822153a8547", size = 30942, upload-time = "2025-08-05T16:42:56.674Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/baf2b9cc7e96c179bb4a54f30fcd83e6ecb340031bde68f486403f943768/audioop_lts-0.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c174e322bb5783c099aaf87faeb240c8d210686b04bd61dfd05a8e5a83d88969", size = 24603, upload-time = "2025-08-05T16:42:57.571Z" },
+]
+
+[[package]]
+name = "audioread"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "standard-aifc" },
+    { name = "standard-sunau" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/4a/874ecf9b472f998130c2b5e145dcdb9f6131e84786111489103b66772143/audioread-3.1.0.tar.gz", hash = "sha256:1c4ab2f2972764c896a8ac61ac53e261c8d29f0c6ccd652f84e18f08a4cab190", size = 20082, upload-time = "2025-10-26T19:44:13.484Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/16/fbe8e1e185a45042f7cd3a282def5bb8d95bb69ab9e9ef6a5368aa17e426/audioread-3.1.0-py3-none-any.whl", hash = "sha256:b30d1df6c5d3de5dcef0fb0e256f6ea17bdcf5f979408df0297d8a408e2971b4", size = 23143, upload-time = "2025-10-26T19:44:12.016Z" },
+]
+
+[[package]]
+name = "braceexpand"
+version = "0.1.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/93/badd4f5ccf25209f3fef2573073da9fe4a45a3da99fca2f800f942130c0f/braceexpand-0.1.7.tar.gz", hash = "sha256:e6e539bd20eaea53547472ff94f4fb5c3d3bf9d0a89388c4b56663aba765f705", size = 7777, upload-time = "2021-05-07T13:49:07.323Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/93/e8c04e80e82391a6e51f218ca49720f64236bc824e92152a2633b74cf7ab/braceexpand-0.1.7-py2.py3-none-any.whl", hash = "sha256:91332d53de7828103dcae5773fb43bc34950b0c8160e35e0f44c4427a3b85014", size = 5923, upload-time = "2021-05-07T13:49:05.146Z" },
+]
+
+[[package]]
+name = "brotli"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/16/c92ca344d646e71a43b8bb353f0a6490d7f6e06210f8554c8f874e454285/brotli-1.2.0.tar.gz", hash = "sha256:e310f77e41941c13340a95976fe66a8a95b01e783d430eeaf7a2f87e0a57dd0a", size = 7388632, upload-time = "2025-11-05T18:39:42.86Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/d4/4ad5432ac98c73096159d9ce7ffeb82d151c2ac84adcc6168e476bb54674/brotli-1.2.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9e5825ba2c9998375530504578fd4d5d1059d09621a02065d1b6bfc41a8e05ab", size = 861523, upload-time = "2025-11-05T18:38:34.67Z" },
+    { url = "https://files.pythonhosted.org/packages/91/9f/9cc5bd03ee68a85dc4bc89114f7067c056a3c14b3d95f171918c088bf88d/brotli-1.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0cf8c3b8ba93d496b2fae778039e2f5ecc7cff99df84df337ca31d8f2252896c", size = 444289, upload-time = "2025-11-05T18:38:35.6Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b6/fe84227c56a865d16a6614e2c4722864b380cb14b13f3e6bef441e73a85a/brotli-1.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c8565e3cdc1808b1a34714b553b262c5de5fbda202285782173ec137fd13709f", size = 1528076, upload-time = "2025-11-05T18:38:36.639Z" },
+    { url = "https://files.pythonhosted.org/packages/55/de/de4ae0aaca06c790371cf6e7ee93a024f6b4bb0568727da8c3de112e726c/brotli-1.2.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:26e8d3ecb0ee458a9804f47f21b74845cc823fd1bb19f02272be70774f56e2a6", size = 1626880, upload-time = "2025-11-05T18:38:37.623Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/16/a1b22cbea436642e071adcaf8d4b350a2ad02f5e0ad0da879a1be16188a0/brotli-1.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:67a91c5187e1eec76a61625c77a6c8c785650f5b576ca732bd33ef58b0dff49c", size = 1419737, upload-time = "2025-11-05T18:38:38.729Z" },
+    { url = "https://files.pythonhosted.org/packages/46/63/c968a97cbb3bdbf7f974ef5a6ab467a2879b82afbc5ffb65b8acbb744f95/brotli-1.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4ecdb3b6dc36e6d6e14d3a1bdc6c1057c8cbf80db04031d566eb6080ce283a48", size = 1484440, upload-time = "2025-11-05T18:38:39.916Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9d/102c67ea5c9fc171f423e8399e585dabea29b5bc79b05572891e70013cdd/brotli-1.2.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3e1b35d56856f3ed326b140d3c6d9db91740f22e14b06e840fe4bb1923439a18", size = 1593313, upload-time = "2025-11-05T18:38:41.24Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/4a/9526d14fa6b87bc827ba1755a8440e214ff90de03095cacd78a64abe2b7d/brotli-1.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:54a50a9dad16b32136b2241ddea9e4df159b41247b2ce6aac0b3276a66a8f1e5", size = 1487945, upload-time = "2025-11-05T18:38:42.277Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e8/3fe1ffed70cbef83c5236166acaed7bb9c766509b157854c80e2f766b38c/brotli-1.2.0-cp313-cp313-win32.whl", hash = "sha256:1b1d6a4efedd53671c793be6dd760fcf2107da3a52331ad9ea429edf0902f27a", size = 334368, upload-time = "2025-11-05T18:38:43.345Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/91/e739587be970a113b37b821eae8097aac5a48e5f0eca438c22e4c7dd8648/brotli-1.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:b63daa43d82f0cdabf98dee215b375b4058cce72871fd07934f179885aad16e8", size = 369116, upload-time = "2025-11-05T18:38:44.609Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.6.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/5f/ff100cae70ebe9d8df1c01a00e510e45d9adb5c1fdda84791b199141de97/cffi-2.1.0.tar.gz", hash = "sha256:efc1cdd798b1aaf39b4610bba7aad28c9bea9b910f25c784ccf9ec1fa719d1f9", size = 531036, upload-time = "2026-07-06T21:34:30.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/88/a996879e2eeccb815f6e3a5967b12a308257412acec882039d386bd2aa7b/cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:10537b1df4967ca26d21e5072d7d54188354483b91dc75058968d3f0cf13fbda", size = 194331, upload-time = "2026-07-06T21:33:03.697Z" },
+    { url = "https://files.pythonhosted.org/packages/58/85/7ae00d5c8dd6266f4e944c3db630f3c5c9a98b61d469c714d848b1d8138a/cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:a95b05f9baf29b91171b3a8bd2020b028835243e7b0ff6bb23e2a3c228518b1b", size = 196966, upload-time = "2026-07-06T21:33:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e9/45c3a76ad8d43ad9261f4c95436da61128d3ca545d72b9612c0ab5be0b1c/cffi-2.1.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:15faec4adfff450819f3aee0e2e02c812de6edb88203aa58807955db2003472a", size = 184795, upload-time = "2026-07-06T21:33:06.699Z" },
+    { url = "https://files.pythonhosted.org/packages/84/4c/82f132cb4418ee6d953d982b19191e87e2a6372c8a4ce36e50b69d6ade4a/cffi-2.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:716ff8ec22f20b4d988b12884086bcef0fc99737043e503f7a3935a6be99b1ea", size = 184746, upload-time = "2026-07-06T21:33:08.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1c/4ed5a0e5bdca6cbc275556de3328dd1b76fd0c11cc13c88fe66d1d8715f2/cffi-2.1.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:63960549e4f8dc41e31accb97b975abaecfc44c03e396c093a6436763c2ea7db", size = 214747, upload-time = "2026-07-06T21:33:09.671Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/a6/e879bb68cc23a2bc9ba8f4b7d8019f0c2694bad2ab6c4a3701d429439f58/cffi-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ff067a8d8d880e7809e4ac88eb009bb848870115317b306666502ccad30b147f", size = 222392, upload-time = "2026-07-06T21:33:10.896Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f6/01890cfd63c08f8eb96a8319b0443690197d240a8bd6346048cf7bde9190/cffi-2.1.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3b926723c13eba9f81d2ef3820d63aeceec3b2d4639906047bf675cb8a7a500d", size = 210285, upload-time = "2026-07-06T21:33:12.251Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/cf/2b684132056f438567b61e19d690dd31cd0921ace051e0a458be6074369e/cffi-2.1.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:47ff3a8bfd8cb9da1af7524b965127095055654c177fcfc7578debcb015eecd0", size = 208801, upload-time = "2026-07-06T21:33:13.617Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/08/f2e7d62c460faae0926f2d6e423694aa409ced3bc1fe2927a0a6e5f05416/cffi-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:799416bae98336e400981ff6e532d67d5c709cfb30afb79865a1315f94b0e224", size = 221808, upload-time = "2026-07-06T21:33:15.466Z" },
+    { url = "https://files.pythonhosted.org/packages/38/37/04f54b8e63a02f3d908332c9effbf8c366167c6f733ed8a3d4f79b7e2a1e/cffi-2.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:961be50688f7fba2fa65f63712d3b9b341a22311f5253460ce933f52f0de1c8c", size = 225241, upload-time = "2026-07-06T21:33:16.869Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/d6/c72eecca433cd3e681c65ed313ab4835d9d4a379704d0f628a6a05f51c2e/cffi-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bf5c6cf48238b0eb4c086978c492ad1cbc22373fc5b2d7353b3a598ce6db887a", size = 223588, upload-time = "2026-07-06T21:33:18.239Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/4b/e706f67279140f92939da3475ad610df18bfd52d50f14953a8e5fede71d5/cffi-2.1.0-cp313-cp313-win32.whl", hash = "sha256:db3eb7d46527159a878ec3460e9d40615bc25ba337d477db681aea6e4f05c5d2", size = 175248, upload-time = "2026-07-06T21:33:19.799Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/47/59eb7975cb0e4ef0afa764ea945b29a5bb4537a9f771cb7d6c8a5dd74c95/cffi-2.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:8e74a6135550c4748af665b1b1118b6aab33b1fc6a16f9aff630af107c3b4512", size = 185717, upload-time = "2026-07-06T21:33:21.47Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/af/34fee85c48f8d94efc8597bc09470c9dd274c145f1c12e0fbc6ab6d38d74/cffi-2.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:2282cd5e38aa8accd03e99d1256af8411c84cdbee6a89d841b563fdbd1f3e50f", size = 180114, upload-time = "2026-07-06T21:33:22.515Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/2a/23f34ec9d04624958e137efdc394888716353190e75f25dd22c7a2c7a8aa/charset_normalizer-3.4.9.tar.gz", hash = "sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b", size = 152439, upload-time = "2026-07-07T14:34:58.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/06/97ec2aeae780b31d742b6352218b43841a6871e2564578ca522dce4a45c3/charset_normalizer-3.4.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:440eede837960000d74978f0eba527be106b5b9aee0daf779d395276ed0b0614", size = 317688, upload-time = "2026-07-07T14:33:35.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/39/8ff066c672434225f8d25f8b739f992af250944392173dcc88362681c9bf/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21e764fd1e70b6a3e205a0e46f3051701f98a8cb3fad66eeb80e48bb502f8698", size = 214982, upload-time = "2026-07-07T14:33:36.996Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8f/3a47a3667c83c2df9483d91644c6c107de3bf8874aa1793da9d3012eb986/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e4fd89cc178bced6ad29cb3e6dd4aa63fa5017c3524dbd0b25998fb64a87cc8b", size = 236460, upload-time = "2026-07-07T14:33:38.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/60/b22cdbee7e4013dab8b0d7647fc6181120fbbbc8f7025c226d15bd5a47fc/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bd47ba7fc3ca94896759ea0109775132d3e7ab921fbf54038e1bab2e46c313c9", size = 232003, upload-time = "2026-07-07T14:33:40.059Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f8/72eb13dcabe7257035cea8aefd922caad2f110d252bf9f67c4c2ca763aee/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:84fd18bcc17526fc2b3c1af7d2b9217d32c9c04448c16ec693b9b4f1985c3d33", size = 223149, upload-time = "2026-07-07T14:33:41.631Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3e/faee8f9de92b14ee1198e9163252bb15efee7301b31256a3b6d9ebfdd0dd/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:5b10cd92fc5c498b35a8635df6d5a100207f88b63a4dc1de7ef9a548e1e2cd63", size = 207901, upload-time = "2026-07-07T14:33:43.209Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/25/45f30093ae27dd7b92a793b61882a38685f993700113ca36e0c9c14965e1/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a4fbdde9dd4a9ce5fd52c2b3a347bb50cc89483ef783f1cb00d408c13f7a96c0", size = 219176, upload-time = "2026-07-07T14:33:44.725Z" },
+    { url = "https://files.pythonhosted.org/packages/48/18/c8f397329c35e32f6a837e488986f4ae03bd2abebc453b48714991630c2f/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:416c229f77e5ea25b3dfd4b582f8d73d7e43c22320302b9ab128a2d3a0b38efe", size = 217356, upload-time = "2026-07-07T14:33:46.192Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7e/5ce0bba863470fd1902d5e5843968951bddf38abe4742fc97116ef4598b3/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:75286256590a6320cf106a0d28970d3560aad9ee09aa7b34fb40524792436d35", size = 209614, upload-time = "2026-07-07T14:33:47.705Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ef/2473d3c4d869155be4af1191111d59c4d5c4e0173026f7e85b176e23bf65/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:69b157c5d3292bcd443faca052f3096f637f1e074b98212a933c074ae23dc3b8", size = 224991, upload-time = "2026-07-07T14:33:49.238Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/a3/53ddae3db108a088156aa8ddfafd411ebbc1340f48c5573f697b27f69a39/charset_normalizer-3.4.9-cp313-cp313-win32.whl", hash = "sha256:51307f5c71007673a2bf8232ad973483d281e74cb99c8c5a990af1eefa6277d9", size = 150622, upload-time = "2026-07-07T14:33:50.711Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ef/6953a77c7cf2c2ff9998e6f575ab3e380119f100223381565a4f94c1f836/charset_normalizer-3.4.9-cp313-cp313-win_amd64.whl", hash = "sha256:fe2c7201c642b7c308f1675355ad7ff7b66acfe3541625efe5a3ad38f29d6115", size = 161947, upload-time = "2026-07-07T14:33:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/fb/d560d1d1555debbfe7849d9cac6145c1b537709d79576bf22557ed803b82/charset_normalizer-3.4.9-cp313-cp313-win_arm64.whl", hash = "sha256:611057cc5d5c0afc743ba8be6bd828c17e0aaa8643f9d0a9b9bb7dea80eb8012", size = 152594, upload-time = "2026-07-07T14:33:53.486Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl", hash = "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5", size = 64538, upload-time = "2026-07-07T14:34:56.993Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "decorator"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/8b/32f9823da46cde7df2087faa08cd98d01b908f8dcab982cdba9c84e85355/decorator-5.3.1.tar.gz", hash = "sha256:4cbcdd55a6efadb9dbea26b858f4fb3264567b52d69ca0d25b721b553f60ea82", size = 58084, upload-time = "2026-05-18T06:03:28.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/7f/798705f5296a58ca505d600456748d1be48078eac8a7050d8a98bc9edb89/decorator-5.3.1-py3-none-any.whl", hash = "sha256:f47fe6fdbd2edd623ecfe36875d37aba411624e2670dd395dddae1358689bb3c", size = 10365, upload-time = "2026-05-18T06:03:26.517Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.139.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/af/a5f50ccfa659ec1802cb4ca842c23f06d906a8cc9aef6016a2caeea3d4ed/fastapi-0.139.0.tar.gz", hash = "sha256:99ab7b2d92223c76d6cf10757ab3f89d45b38267fc20b2a136cf02f6beac3145", size = 423016, upload-time = "2026-07-01T16:35:33.436Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/7c/8e3c6ad324ea5cb36604fc3f968554887891c316d9dfde57761611d907ad/fastapi-0.139.0-py3-none-any.whl", hash = "sha256:cf15e1e9e667ddb0ad63811e60bd11390d1aac838ca4a7a23f421807b2308189", size = 130339, upload-time = "2026-07-01T16:35:32.19Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.29.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/94/00f2059e4835eace3ae8fde680b932c496f8ec7bdc99168dfa53fb2e6b79/filelock-3.29.7.tar.gz", hash = "sha256:5b481979797ae69e72f0b389d89a80bdd585c260c5b3f1fb9c0a5ba9bb3f195d", size = 71521, upload-time = "2026-07-08T05:46:58.716Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/02/be4a57b60c7149b55b9e3b3c13f609cd8eb5307c751f22bd8fb8d262e75b/filelock-3.29.7-py3-none-any.whl", hash = "sha256:987db6f789a3a2a59f55081801b2b3697cb97e2a736b5f1a9e99b559285fbc51", size = 46036, upload-time = "2026-07-08T05:46:57.53Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/a1/ae4e3e5003468d6391d2c77b6fa1cd73bd5d13511d81c642d7b28ac90ed4/fsspec-2026.6.0.tar.gz", hash = "sha256:f5bac145310fe30e16e1471bd6840b2d990d609e872251d7e674241822abf01a", size = 313646, upload-time = "2026-06-16T01:57:28.105Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/22/4222d7ddf3da30f363edaa98e329c2bce6c65497c9cb2810931c8b2c0fbc/fsspec-2026.6.0-py3-none-any.whl", hash = "sha256:02e0b71817df9b2169dc30a16832045764def1191b43dcff5bb85bdee212d2a1", size = 203949, upload-time = "2026-06-16T01:57:26.358Z" },
+]
+
+[[package]]
+name = "gradio"
+version = "6.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "audioop-lts" },
+    { name = "brotli" },
+    { name = "fastapi" },
+    { name = "gradio-client" },
+    { name = "groovy" },
+    { name = "hf-gradio" },
+    { name = "httpx" },
+    { name = "huggingface-hub" },
+    { name = "jinja2" },
+    { name = "markupsafe" },
+    { name = "numpy" },
+    { name = "orjson" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "pillow" },
+    { name = "pydantic" },
+    { name = "pydub" },
+    { name = "python-multipart" },
+    { name = "pytz" },
+    { name = "pyyaml" },
+    { name = "safehttpx" },
+    { name = "semantic-version" },
+    { name = "starlette" },
+    { name = "tomlkit" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+    { name = "uvicorn" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/96/3618f8a189180ab3d4e5f8b258fd92e419eda9f49b6ab4dd50c6782cda33/gradio-6.20.0.tar.gz", hash = "sha256:8672866e9225a1f8297325a6742bb525a3a0ddc8aa4d75d99beb10a27ea2915f", size = 44844340, upload-time = "2026-07-07T18:53:57.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/f4/7dc4540836e326391a9d1ba20193d795d5a4582839b60f5c10397f5120bb/gradio-6.20.0-py3-none-any.whl", hash = "sha256:91d2ec29c37917d55b18dba87aa15bb15c4796d84dce9a9ef4ec7d87453a7fee", size = 30964820, upload-time = "2026-07-07T18:53:52.403Z" },
+]
+
+[[package]]
+name = "gradio-client"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fsspec" },
+    { name = "httpx" },
+    { name = "huggingface-hub" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/e6/6b6029f5fe2ad7f1211105d530e34d991014c2cae463f9223033031cfc4f/gradio_client-2.5.0.tar.gz", hash = "sha256:4cde99bad62149595c30c90876ca2e405e3a13687ecf895474f3412cb476673d", size = 59013, upload-time = "2026-04-20T23:16:21.518Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/81/0a861b8e1ff42960139c6cd4c7dd591292fa09ea1ae2d87677441cba4c00/gradio_client-2.5.0-py3-none-any.whl", hash = "sha256:d43e2179c29076292a76485ad7ed2e6eaa19d14ac58283bd7f5beabfe4ca958c", size = 59952, upload-time = "2026-04-20T23:16:20.186Z" },
+]
+
+[[package]]
+name = "groovy"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/36/bbdede67400277bef33d3ec0e6a31750da972c469f75966b4930c753218f/groovy-0.1.2.tar.gz", hash = "sha256:25c1dc09b3f9d7e292458aa762c6beb96ea037071bf5e917fc81fb78d2231083", size = 17325, upload-time = "2025-02-28T20:24:56.068Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/27/3d6dcadc8a3214d8522c1e7f6a19554e33659be44546d44a2f7572ac7d2a/groovy-0.1.2-py3-none-any.whl", hash = "sha256:7f7975bab18c729a257a8b1ae9dcd70b7cafb1720481beae47719af57c35fa64", size = 14090, upload-time = "2025-02-28T20:24:55.152Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "hf-gradio"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gradio-client" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/86/c9694b7cfada5780e75769e60dc161a161f4dd7fc91b61db5e3a3338bef9/hf_gradio-0.4.1.tar.gz", hash = "sha256:a017d942618f0d495a58ee4563047fa04bef614c00e0cb789a9a6d0633cffa7b", size = 6560, upload-time = "2026-04-22T14:01:32.334Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/2d/afff2ee87e75d8eb85c92bb8cf0e15b05c23c2ebd8fd8dec781d8601ed7f/hf_gradio-0.4.1-py3-none-any.whl", hash = "sha256:76b8cb8be6abe62d74c1ad2d35b42f0629db89aa9e1a8d033cecfe7c856eeab3", size = 4482, upload-time = "2026-04-17T19:53:31.827Z" },
+]
+
+[[package]]
+name = "hf-xet"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/2d/57fd21d84d93efb4bd0b962383790e19dd1bc053501b4264c97903b4e83e/hf_xet-1.5.1.tar.gz", hash = "sha256:51ef4500dab3764b41135ee1381a4b62ce56fc54d4c92b719b59e597d6df5bf6", size = 876636, upload-time = "2026-06-08T23:02:53.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/ee/dd9ba7beae1005e54131b7d45263cc74c8a066d47d354e6d58ae9445a388/hf_xet-1.5.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:dbf48c0d02cf0b2e568944330c60d9120c272dabe013bd892d48e25bc6797577", size = 4069485, upload-time = "2026-06-08T23:02:13.193Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/bc/9cae6cfeb4e03070874e73e5c97c66eb90369d3206b6a2b1ef5f96520888/hf_xet-1.5.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78e4e5192ad2b674c2e1160b651cb9134db974f8ae1835bdfbfb0166b894a43", size = 3838493, upload-time = "2026-06-08T23:02:15.282Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/b4/d5c01e0eb6d9f2ca2dacd84d0d1b71e6cfbb2ef3208c968528e010e9b3d7/hf_xet-1.5.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6f7a04a8ad962422e225bc49fbbac99dc1806764b1f3e54dbd154bffa7593947", size = 4505658, upload-time = "2026-06-08T23:02:17.196Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c5/29a7598c0c6383c523dc22186d577f4e04267a626cd95ae60f67c00bfe66/hf_xet-1.5.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d48199c2bf4f8df0adc55d31d1368b6ec0e4d4f45bc86b08038089c23db0bed8", size = 4292822, upload-time = "2026-06-08T23:02:18.608Z" },
+    { url = "https://files.pythonhosted.org/packages/04/9a/dceaf6ca69390126b86ea825fb354b93d01163199070b7bd849225de9468/hf_xet-1.5.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:97f212a88d14bbf573619a74b7fecb238de77d08fc702e54dec6f78276ca3283", size = 4491255, upload-time = "2026-06-08T23:02:20.124Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/e5a7afaacf6c1791fdbeeac42951fb81c3d2bc482992b115dedcc86d963e/hf_xet-1.5.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f61e3665892a6c8c5e765395838b8ddf36185da835253d4bc4509a81e49fb342", size = 4711062, upload-time = "2026-06-08T23:02:21.863Z" },
+    { url = "https://files.pythonhosted.org/packages/53/49/2802f8433c9742ce281bddc1e65c02c32268ca3098d66828b05e12e45ee2/hf_xet-1.5.1-cp313-cp313t-win_amd64.whl", hash = "sha256:f4ad3ebd4c32dd2b27099d69dc7b2df821e30767e46fb6ee6a0713778243b8ff", size = 4017205, upload-time = "2026-06-08T23:02:23.495Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5a/50c71195b9fb883659f596e7252faf4c18c58e753a9013bdbf9bac5d2250/hf_xet-1.5.1-cp313-cp313t-win_arm64.whl", hash = "sha256:8298485c1e36e7e67cbd01eeb1376619b7af43d4f1ec245caae306f890a8a32d", size = 3845426, upload-time = "2026-06-08T23:02:25.124Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/d8/5e54cf37434759d1f4f2ba9b66077ff9d4c4e1f37b6bd7975da5c40d94ab/hf_xet-1.5.1-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6abd35c3221eff63836618ddfb954dcf84798603f71d8e33e3ed7b04acfdbe6e", size = 4077794, upload-time = "2026-06-08T23:02:40.656Z" },
+    { url = "https://files.pythonhosted.org/packages/35/94/4b2ecfbad8f8b04701a23aefb62f540b9137d058b7e1dbef16a32676f0e9/hf_xet-1.5.1-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:94e761bbd266bf4c03cee73753916062665ce8365aa40ed321f45afcb934b41e", size = 3845354, upload-time = "2026-06-08T23:02:42.702Z" },
+    { url = "https://files.pythonhosted.org/packages/de/cc/f99f4bc7295023d7bd9ebbfd51f75cc530ca262c1227666268b8208f4b77/hf_xet-1.5.1-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:892e3a3a3aecc12aded8b93cf4f9cd059282c7de0732f7d55026f3abdf474350", size = 4514864, upload-time = "2026-06-08T23:02:44.497Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/6e/21f7e5a2381278bd3b7b7a5a4d90038518bb6308a0c1daf5d9f8268bb178/hf_xet-1.5.1-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a93df2039190502835b1db8cd7e178b0b7b889fe9ab51299d5ced26e0dd879a4", size = 4303784, upload-time = "2026-06-08T23:02:46.203Z" },
+    { url = "https://files.pythonhosted.org/packages/35/0e/f992bb6927ac1cb30ef74e62268f551f338bc32b2191f7c96a44c6f7283e/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0c97106032ef70467b4f6bc2d0ccc266d7613ee076afc56516c502f87ce1c4a6", size = 4500703, upload-time = "2026-06-08T23:02:47.628Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d1/90a498d05447980b977b1669246eeeeae4cfb0ea3e7a286eaba627f91bf9/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6208adb15d192b90e4c2ad2a27ed864359b2cb0f2494eb6d7c7f3699ac02e2bf", size = 4719498, upload-time = "2026-06-08T23:02:49.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b6/20f99cfe97cc663a711f7b33cc21d4793e51968e9a26125b4afcd77315ba/hf_xet-1.5.1-cp37-abi3-win_amd64.whl", hash = "sha256:f7b3002f95d1c13e24bcb4537baa8f0eb3838957067c91bb4959bc004a6435f5", size = 4026419, upload-time = "2026-06-08T23:02:50.829Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/fa/77453694888f03e5a8c8852d1514a0894d8e81c622d39edbaf308ea0dcf4/hf_xet-1.5.1-cp37-abi3-win_arm64.whl", hash = "sha256:93d090b57b211133f6c0dab0205ef5cb6d89162979ba75a74845045cc3063b8e", size = 3855178, upload-time = "2026-06-08T23:02:52.452Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httptools"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/e5/d471fcb0e14523fe1c3f4ba58ca52480e7bd70ad7109a3846bc75892f7fb/httptools-0.8.0.tar.gz", hash = "sha256:6b2a32f18d97e16e90827d7a819ffa8dbd8cc245fc4e1fa9d1095b54ef4bd999", size = 271342, upload-time = "2026-05-25T22:17:48.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/e5/8cfcabc5546e8022f168be28bcdaa128a240a0befdd03b59d558b4f18bd6/httptools-0.8.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:614ceea8ea606848bece2338ac03b3ce5324bcb4be8dc7d377ed708012fa4db8", size = 205148, upload-time = "2026-05-25T22:17:16.333Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/0e/0fb14848c19a686c8062ff9067c1a48793e3224b47bc5b201535b6036fce/httptools-0.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2d689918c15a013c65ef52d9fd495d766893ab831a2c8d89f2ac5940a5df847c", size = 111368, upload-time = "2026-05-25T22:17:17.586Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1b/46f1cecf06b9bbde8e4b8c88034ac7908989e5ff7a3a388ef38392949c1f/httptools-0.8.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:eb3028cca2fc0a6d720e52ef61d8ebb62fcbfeb1de56874546d858d3f25a26b7", size = 486447, upload-time = "2026-05-25T22:17:18.564Z" },
+    { url = "https://files.pythonhosted.org/packages/77/00/258bfc0837221f81d9725c45f9b948a6a6b2994a147a4fb66e85100c668f/httptools-0.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:88bdd940f2b5d487b4d032c6afa5489a7dc4694410d43de3c38c4fb3af0dc45d", size = 482448, upload-time = "2026-05-25T22:17:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/04/ab/d1cef3b5523f4d272a70f42a776c3169a2dddfe3a54de4b2ce4a36341528/httptools-0.8.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6a43c9dd399758ccc0531acb0a3c4a6c299ee893ee9400e9c893b7bdcfae0681", size = 464460, upload-time = "2026-05-25T22:17:20.882Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/5d1d072442277bb2b3434e0e60690b8e8c23840ef7de8b6ea54040a536d3/httptools-0.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0770728beb05094c809b98e814edff5fef69d26ad7d21185f2f6d5884a0ba683", size = 471312, upload-time = "2026-05-25T22:17:22.085Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/66/b96623b27e51a68199ef4efdda0613cced9233fe3062ac74e50749c5ad37/httptools-0.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:7685df791fad561384bfb139e77fde27a1ffd93134e016f95a0db424ffbf77b1", size = 90117, upload-time = "2026-05-25T22:17:23.074Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.23.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/8f/999e4dda11c6187c78f090eac00895a47e11a0049308f07579bcb7aa3aa2/huggingface_hub-1.23.0.tar.gz", hash = "sha256:c04997fb8bbdace1e57b7703d30ed7678af51f70d00d241819ff411b92ae9a88", size = 919163, upload-time = "2026-07-09T14:49:32.315Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/ce/13b2ba57838b8db1e6bd033c1b21ce0b9f6153b87d4e4939f77074e41eb0/huggingface_hub-1.23.0-py3-none-any.whl", hash = "sha256:b1d604788f5adc7f0eb246e03e0ec19011ca06e38400218c347dccc3dffa64a2", size = 770336, upload-time = "2026-07-09T14:49:30.597Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
+name = "lazy-loader"
+version = "0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/ac/21a1f8aa3777f5658576777ea76bfb124b702c520bbe90edf4ae9915eafa/lazy_loader-0.5.tar.gz", hash = "sha256:717f9179a0dbed357012ddad50a5ad3d5e4d9a0b8712680d4e687f5e6e6ed9b3", size = 15294, upload-time = "2026-03-06T15:45:09.054Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/a1/8d812e53a5da1687abb10445275d41a8b13adb781bbf7196ddbcf8d88505/lazy_loader-0.5-py3-none-any.whl", hash = "sha256:ab0ea149e9c554d4ffeeb21105ac60bed7f3b4fd69b1d2360a4add51b170b005", size = 8044, upload-time = "2026-03-06T15:45:07.668Z" },
+]
+
+[[package]]
+name = "librosa"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "audioread" },
+    { name = "decorator" },
+    { name = "joblib" },
+    { name = "lazy-loader" },
+    { name = "msgpack" },
+    { name = "numba" },
+    { name = "numpy" },
+    { name = "pooch" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+    { name = "soundfile" },
+    { name = "soxr" },
+    { name = "standard-aifc" },
+    { name = "standard-sunau" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/36/360b5aafa0238e29758729e9486c6ed92a6f37fa403b7875e06c115cdf4a/librosa-0.11.0.tar.gz", hash = "sha256:f5ed951ca189b375bbe2e33b2abd7e040ceeee302b9bbaeeffdfddb8d0ace908", size = 327001, upload-time = "2025-03-11T15:09:54.884Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/ba/c63c5786dfee4c3417094c4b00966e61e4a63efecee22cb7b4c0387dda83/librosa-0.11.0-py3-none-any.whl", hash = "sha256:0b6415c4fd68bff4c29288abe67c6d80b587e0e1e2cfb0aad23e4559504a7fa1", size = 260749, upload-time = "2025-03-11T15:09:52.982Z" },
+]
+
+[[package]]
+name = "llvmlite"
+version = "0.48.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/a0/acc8ffcd5bdc63df0097e22c719bfcd61b604358343089313a8aebbb24ab/llvmlite-0.48.0.tar.gz", hash = "sha256:543b19f9ef8f3c7c60d1468191e4ee1b1537bf9f8a3d56f64c0ddd98de92edd2", size = 184016, upload-time = "2026-07-02T20:20:05.308Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/23/fe9316d14626b42c73ef0b502e724705a6ee9450afe53759c0a99c37c2d7/llvmlite-0.48.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:a83a99ef0c05b4ccddf9b6218ed9fe84b653a0caf7c1d9dbe148d6d16c67f518", size = 40480652, upload-time = "2026-07-01T18:41:52.216Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/4a/90715fa12006d681270b08d881195b6fab3ec39572e048764a1f7f59fed7/llvmlite-0.48.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8761b9e522f55207e24424fcd98370289eec2710bf8e915c82d1053f642450dc", size = 59890120, upload-time = "2026-07-01T18:42:00.748Z" },
+    { url = "https://files.pythonhosted.org/packages/70/5e/7b3e20d64650ca3c80af0cdb664ec4b575ec83d9d4dd05bea8bd31f9bbb6/llvmlite-0.48.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2fe5cb59b2063bfa039dcb8ca6481c0181bf552f340d10dcf61d7996a665556e", size = 58343457, upload-time = "2026-07-01T18:41:56.41Z" },
+    { url = "https://files.pythonhosted.org/packages/17/97/5a430055d1838cf1fb7a01cfa943300f5e4c026fc6333a522c5e4a03b0c1/llvmlite-0.48.0-cp313-cp313-win_amd64.whl", hash = "sha256:91c7e24e74cde3f02b88aa5acca678373f9e069f3b98531b3dbb3a142d9d10bb", size = 41865022, upload-time = "2026-07-01T18:42:04.57Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
+name = "msgpack"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/f9/c0a1c127f9049db9155afc316952ea571720dd01833ff5e4d7e8e6352dbb/msgpack-1.2.1.tar.gz", hash = "sha256:04c721c2c7448767e9e3f2520a475663d8ee0f09c31890f6d2bd70fd636a9647", size = 183960, upload-time = "2026-06-18T16:13:52.594Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/ac/dcddcab6f6c20ecb387ca5e980371cdb3f87ff69aeca388be97eebc4c074/msgpack-1.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0a70e3cf2804a300d921bb0940426e35f4e489a23adfb77a808892241db0a064", size = 83151, upload-time = "2026-06-18T16:13:12.173Z" },
+    { url = "https://files.pythonhosted.org/packages/64/71/fbcfa83a1d6a9c6091942d1cfd070962244664b87427a9a49a6897b1b219/msgpack-1.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:491cc39455ca765fad51fb451bf2915eb2cf41192ab5801ce8d67c1d614fe056", size = 82351, upload-time = "2026-06-18T16:13:13.194Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/10/ddf7b06db879e8792d13934ddda09ff20bd2a583fd84c9b59aae9b0e650b/msgpack-1.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f310233ef7fb9c14e201c93639fe5f5260b005f56f0b29048e999c30935596cc", size = 407518, upload-time = "2026-06-18T16:13:14.233Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d3/36a46a8ed992b781acbc05928bd5bee3c810cb0c3563bf81a7b0c04a1a76/msgpack-1.2.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:787c9bebb5833e8f6fc8abca3c0597683d8d87f56a8842b6b89c75a5f3176e2d", size = 416405, upload-time = "2026-06-18T16:13:15.435Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/84/e8e9598b557c0ba6ddae901a73780a4c75ac667dddf59414b1e56a42fb34/msgpack-1.2.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dc871b997a9370d855b7394465f2f350e847a5b806dd38dcc9c989e7d87da155", size = 376257, upload-time = "2026-06-18T16:13:17.022Z" },
+    { url = "https://files.pythonhosted.org/packages/40/16/738fe6d875ad7e2a9429c165322a4ec088f4f273cdfae63d96a89c467961/msgpack-1.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:85f57e960d877f2977f6430896191b04a21f8901b3b4baf2e4604329f4db5402", size = 397469, upload-time = "2026-06-18T16:13:18.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/be/6d5952df75a7f24f35833af764c3a6860780364cb3a0030beb8099e1b2b4/msgpack-1.2.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:1233ee2dd0cefba127583de50ea654677277047d238303521db35def3d7b2e7c", size = 372802, upload-time = "2026-06-18T16:13:19.685Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/39/e2ef7dbf0473bcb8dc7c50bf782a892d67414877b63e47fc88eb189ef5e6/msgpack-1.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e3dc2feb0876209d9c38aa56cb1de169bd6c4348f1aa48271f241226590993e6", size = 411273, upload-time = "2026-06-18T16:13:21.028Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/c5/133f4512a56e983a93445c836c9d94d88f3bc2e0980ff4b9e577bd8416ce/msgpack-1.2.1-cp313-cp313-win32.whl", hash = "sha256:6d09badf350af2be9d189184e04e64cf54ad93569ab3d96fca58bd3e84aad707", size = 64471, upload-time = "2026-06-18T16:13:22.293Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/98/577e10b055096a7dd40732358cabaf7180a20c79ed1dcdbb618e4b9deac7/msgpack-1.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:33f14fba63278b714efe6ad07e50ea5f03d91537aa6a1c5f1ceca4cf44013ca9", size = 71274, upload-time = "2026-06-18T16:13:23.455Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/ee/0c0048e7cfbef23c6a94791b8959ab28155232e7956de8a305b5ff588f05/msgpack-1.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:afc5febcd4c99effbc02b528e49d6fd0760b2b7d48c05239e345a5fa6e743d9a", size = 64795, upload-time = "2026-06-18T16:13:24.687Z" },
+]
+
+[[package]]
+name = "narwhals"
+version = "2.24.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/1d/58946e5aab18393e793bd4add6985b95d0e01c3a2d832f38f54468b10dcd/narwhals-2.24.0.tar.gz", hash = "sha256:b5c0f684ccd9d7475b564111e319a4964abcf2baf79d3cf6b1003d06ac9b828d", size = 661143, upload-time = "2026-07-13T10:49:19.086Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/85/a5bfaebfd305ac18b57b0854d74e37e586809061a91fda62f0bd50c8518e/narwhals-2.24.0-py3-none-any.whl", hash = "sha256:42fdedf44e5b2ca7505630d45b4ac3058f38d8485cba9fe1652ca23152df7489", size = 461030, upload-time = "2026-07-13T10:49:17.571Z" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
+]
+
+[[package]]
+name = "numba"
+version = "0.66.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "llvmlite" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/a0/570e3dc53e5602b49108f62a13e529f1eec8bfc7ef37d49c825924dcf546/numba-0.66.0.tar.gz", hash = "sha256:b900e63a0e26c05ea9a6d5a3a5a0a177cb64c5011887bf43edb8c3ed2c38d363", size = 2806181, upload-time = "2026-07-01T23:12:46.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/52/176c02d005c5c5143cde10a85bbcdcb6236d9e34c3aac089380e0506cd1d/numba-0.66.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:380b2556a2019ccd1e956ae77dd257eaa39403f7520768b626d44b755112785e", size = 2727084, upload-time = "2026-07-01T23:12:25.434Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b5/e930010965568fe7f2c6c962fd2849d458cb9f62c3ab7584af8a19a2b40a/numba-0.66.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:939316d5d8619751207b8972a67852b5a7646665298cb4de693cd6bf135152f4", size = 3873663, upload-time = "2026-07-01T23:12:27.308Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ec/5b51457cbe96e4831141d83e892e65191b23a1b78728456c62909d231ace/numba-0.66.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cdf506775d9f02eb92a87bf5c5b1e0d25506fd18cafd769f4ed914a8feac73e7", size = 3573529, upload-time = "2026-07-01T23:12:28.944Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7e/cea7710e96913d3c7f2999f16db1b28e6c5be5171cbf40f77f98333a7243/numba-0.66.0-cp313-cp313-win_amd64.whl", hash = "sha256:c5bfe5350284509ab0474390321454c3a8627a188af5b68c910e83df3e2db4a7", size = 2797247, upload-time = "2026-07-01T23:12:30.774Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/82/bdab26d7438c6791ca31b7c024ca37c1eab8b726ba236129005cd4a06e45/numpy-2.4.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:511dbaf848decaaaf4b4ca48032619fb3138710c4bf7da7617765edad1ef96b0", size = 16684648, upload-time = "2026-05-18T23:34:29.41Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/30/a80189bcc7f5e4258b3fbc3968d909d1756f54d023299ecc39ad6fdb9ef8/numpy-2.4.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bf162abab1c1a736333192707cef898e735a5ca00f38f27eeedf44b39d9e85eb", size = 14693902, upload-time = "2026-05-18T23:34:33.013Z" },
+    { url = "https://files.pythonhosted.org/packages/97/12/70b5d0d7c15e1ebb8a6a84a8caa1d19e181d84fb58bb6d70aca29099dec1/numpy-2.4.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:043191bfa8eab18c776647b62723ac9dddece59743b13f49b2016094129c2b3f", size = 5198992, upload-time = "2026-05-18T23:34:36.132Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/ebd2a8f8a83541f8d38cc5667e8c2b69cecfd30da6e45693e8158857d44b/numpy-2.4.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:6180d8b35af935aed8ece3a85e0a43f87393ae0ac87c8d2c8bd2c993f7270ef3", size = 6546944, upload-time = "2026-05-18T23:34:38.484Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/c5/7b863a97a91671a0338f4253bd3b5a3d3852f0692dae91711c9f4a10e787/numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b", size = 15669392, upload-time = "2026-05-18T23:34:41.257Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9d/3584b9984ca4c047aea75214ce1a4c4c73d849bd71b604264b7f5653f8a8/numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089", size = 16633220, upload-time = "2026-05-18T23:34:45.075Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ae/7c67fba23bd98caec7c99261f3a16072ade14813486b0282cb29846de832/numpy-2.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ef4aea96ce4d3b074422cb4f2f64e216bf9e213004bb58ecfdf50ea02ea8eb9a", size = 17020800, upload-time = "2026-05-18T23:34:49.065Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/5d/3b6725cb31d983c5e66916f5d36f6d7e5521129e4c4404d64f918292a5b6/numpy-2.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfa20cc6ca228e6b155b11da03825975ce66aea520985dbbddf0f2a5a495c605", size = 18357600, upload-time = "2026-05-18T23:34:52.709Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/da/2ccc6c2fe8898dee01d90c75c5f5f914a23daf99e3e0f59516a08760c8b5/numpy-2.4.6-cp313-cp313-win32.whl", hash = "sha256:56b39e5e0622a09a25bf5baf62f4bcf0cb8a41ae6e2819cf49bbc5a74c083f91", size = 5961134, upload-time = "2026-05-18T23:34:55.618Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/cd/9cc4dc876fb065d5c220aae4d5e14826b2715331bb7618ce1fb07a679d99/numpy-2.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:c4fc99836233ea196540b17ab0983aff60ed07941751930f5f4d05bc3b3b7359", size = 12318598, upload-time = "2026-05-18T23:34:58.928Z" },
+    { url = "https://files.pythonhosted.org/packages/39/1e/c0bcba1f8694116485fe28fd1be698c278fcda4141c5b0e53a2aed8b12a8/numpy-2.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a7c711e21628b52034bb5ab8d1bce291f752fcc5e92accc615778acee1ff4778", size = 10222272, upload-time = "2026-05-18T23:35:02.167Z" },
+    { url = "https://files.pythonhosted.org/packages/63/6d/cc5619247c8f4204e507f5883528372e4ac4bb189e579fb859a12e480b1f/numpy-2.4.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:112b06a867b235ef466ed3508ddf0238050df9c727cafb5301ac385b899189a1", size = 14821197, upload-time = "2026-05-18T23:35:05.468Z" },
+    { url = "https://files.pythonhosted.org/packages/00/58/f1c39161c87d9e9bed660f1ed4bafc0e403d5ec9650b6dd77aead07d489b/numpy-2.4.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:eaf7fa2de5c0be8ae6ff8e9bea2ccd725e980541244521d8d4b5f3354a27babe", size = 5326287, upload-time = "2026-05-18T23:35:08.693Z" },
+    { url = "https://files.pythonhosted.org/packages/af/57/3917ab0fd97f271a8694513581b8a36c655f111c446852c302f04ccdb6fc/numpy-2.4.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:7265a2f3d436e54ef9f2b52b5c937e6be778781bd97a590319d7348f1c1ca997", size = 6646763, upload-time = "2026-05-18T23:35:11.459Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0f/037e64c494b67581ae18193d770adef354c41f3f2c8ebf865602d949bf8f/numpy-2.4.6-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f74a575920ab21fe304421a3fc28793d82e299cae9eccb37084e9fc7f3617c20", size = 15728070, upload-time = "2026-05-18T23:35:14.79Z" },
+    { url = "https://files.pythonhosted.org/packages/21/a6/5d2bae9c9542eb4df16dc9c46dc79c186e9bad53805dfa5399a6023c6db0/numpy-2.4.6-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ede83e07a75dd06bc501566c1eca2afc0d61677c1472ac9ad93fdee6e638a48d", size = 16681752, upload-time = "2026-05-18T23:35:18.836Z" },
+    { url = "https://files.pythonhosted.org/packages/92/14/23d1dfb410ae362cd59ce53e936b1513d545eb40db3949ced632e19a459e/numpy-2.4.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:68bb27509ac1b9a3443094260f6326150663b06abe40b73a2f81160623da5b67", size = 17086024, upload-time = "2026-05-18T23:35:22.52Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/23595a2c642cdf3bc567877064bdd7f91c8b0038a4453cf2daf7248eafe9/numpy-2.4.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a0df0043bdb289bde1f62da130d20df23d58b45429f752bc7a8fc5325a225ecd", size = 18403398, upload-time = "2026-05-18T23:35:26.398Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/90/0ac3bc947217e66dec77e7cbc6a1979d1af70b6461b82f620d3bccd5e4c8/numpy-2.4.6-cp313-cp313t-win32.whl", hash = "sha256:29a287e0cf63ff528da061de6b9f64a4618da591ca1046aafc54062e40ca7eab", size = 6084971, upload-time = "2026-05-18T23:35:29.387Z" },
+    { url = "https://files.pythonhosted.org/packages/77/71/5673e351671a1d2bd6063b91b44f70c0affea7d1516fa7a6572941ba4aa1/numpy-2.4.6-cp313-cp313t-win_amd64.whl", hash = "sha256:25c692919ac5a01f170a3bfcd62d745b24fd095c353d50812637d6fcab442e75", size = 12458532, upload-time = "2026-05-18T23:35:32.175Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/88/19d3503c5046e688f049274b27a3ef3d771152fa80d3ba3d01a3dff61abe/numpy-2.4.6-cp313-cp313t-win_arm64.whl", hash = "sha256:1e978ec1e8bd0e0e4de6bb75de9d30cbb74db6b6a2bb727618613703ca0167dd", size = 10291881, upload-time = "2026-05-18T23:35:35.465Z" },
+]
+
+[[package]]
+name = "nvidia-cublas-cu12"
+version = "12.8.4.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/61/e24b560ab2e2eaeb3c839129175fb330dfcfc29e5203196e5541a4c44682/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:8ac4e771d5a348c551b2a426eda6193c19aa630236b418086020df5ba9667142", size = 594346921, upload-time = "2025-03-07T01:44:31.254Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-cupti-cu12"
+version = "12.8.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/02/2adcaa145158bf1a8295d83591d22e4103dbfd821bcaf6f3f53151ca4ffa/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ea0cb07ebda26bb9b29ba82cda34849e73c166c18162d3913575b0c9db9a6182", size = 10248621, upload-time = "2025-03-07T01:40:21.213Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc-cu12"
+version = "12.8.93"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/6b/32f747947df2da6994e999492ab306a903659555dddc0fbdeb9d71f75e52/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:a7756528852ef889772a84c6cd89d41dfa74667e24cca16bb31f8f061e3e9994", size = 88040029, upload-time = "2025-03-07T01:42:13.562Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime-cu12"
+version = "12.8.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/9b/a997b638fcd068ad6e4d53b8551a7d30fe8b404d6f1804abf1df69838932/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adade8dcbd0edf427b7204d480d6066d33902cab2a4707dcfc48a2d0fd44ab90", size = 954765, upload-time = "2025-03-07T01:40:01.615Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu12"
+version = "9.10.2.21"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
+]
+
+[[package]]
+name = "nvidia-cufft-cu12"
+version = "11.3.3.83"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
+]
+
+[[package]]
+name = "nvidia-cufile-cu12"
+version = "1.13.1.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/fe/1bcba1dfbfb8d01be8d93f07bfc502c93fa23afa6fd5ab3fc7c1df71038a/nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1d069003be650e131b21c932ec3d8969c1715379251f8d23a1860554b1cb24fc", size = 1197834, upload-time = "2025-03-07T01:45:50.723Z" },
+]
+
+[[package]]
+name = "nvidia-curand-cu12"
+version = "10.3.9.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/aa/6584b56dc84ebe9cf93226a5cde4d99080c8e90ab40f0c27bda7a0f29aa1/nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:b32331d4f4df5d6eefa0554c565b626c7216f87a06a4f56fab27c3b68a830ec9", size = 63619976, upload-time = "2025-03-07T01:46:23.323Z" },
+]
+
+[[package]]
+name = "nvidia-cusolver-cu12"
+version = "11.7.3.90"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
+]
+
+[[package]]
+name = "nvidia-cusparse-cu12"
+version = "12.5.8.93"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
+]
+
+[[package]]
+name = "nvidia-cusparselt-cu12"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/79/12978b96bd44274fe38b5dde5cfb660b1d114f70a65ef962bcbbed99b549/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f1bb701d6b930d5a7cea44c19ceb973311500847f81b634d802b7b539dc55623", size = 287193691, upload-time = "2025-02-26T00:15:44.104Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu12"
+version = "2.27.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/5b/4e4fff7bad39adf89f735f2bc87248c81db71205b62bcc0d5ca5b606b3c3/nvidia_nccl_cu12-2.27.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adf27ccf4238253e0b826bce3ff5fa532d65fc42322c8bfdfaf28024c0fbe039", size = 322364134, upload-time = "2025-06-03T21:58:04.013Z" },
+]
+
+[[package]]
+name = "nvidia-nvjitlink-cu12"
+version = "12.8.93"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/74/86a07f1d0f42998ca31312f998bd3b9a7eff7f52378f4f270c8679c77fb9/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:81ff63371a7ebd6e6451970684f916be2eab07321b73c9d244dc2b4da7f73b88", size = 39254836, upload-time = "2025-03-07T01:49:55.661Z" },
+]
+
+[[package]]
+name = "nvidia-nvtx-cu12"
+version = "12.8.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f", size = 89954, upload-time = "2025-03-07T01:42:44.131Z" },
+]
+
+[[package]]
+name = "omnivoice"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "accelerate" },
+    { name = "gradio" },
+    { name = "librosa" },
+    { name = "numpy" },
+    { name = "pydub" },
+    { name = "soundfile" },
+    { name = "tensorboardx" },
+    { name = "torch" },
+    { name = "torchaudio" },
+    { name = "transformers" },
+    { name = "webdataset" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/39/fda2cb716b877bff9896f59b4dc31575091c09e9138b0917b35ab8ceb476/omnivoice-0.2.0.tar.gz", hash = "sha256:227db01ad828eb2ba1cabd259f29d0e42158b80af60af672da2b823324a83721", size = 114332, upload-time = "2026-07-06T09:42:19.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/07/27e19dba17035ddb21e957c59b8eb2fbfae65d2fb004e0ba66ea93e3ed9c/omnivoice-0.2.0-py3-none-any.whl", hash = "sha256:d3f027df94888702dc2adae3045c9ad58cb659582f5f9797daf1af92e352c9c0", size = 163047, upload-time = "2026-07-06T09:42:18.399Z" },
+]
+
+[[package]]
+name = "orjson"
+version = "3.11.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/0c/964746fcafbd16f8ff53219ad9f6b412b34f345c75f384ad434ceaadb538/orjson-3.11.9.tar.gz", hash = "sha256:4fef17e1f8722c11587a6ef18e35902450221da0028e65dbaaa543619e68e48f", size = 5599163, upload-time = "2026-05-06T15:11:08.309Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/33/93fcc25907235c344ae73122f8a4e01d2d393ef062b4af7d2e2487a32c37/orjson-3.11.9-cp313-cp313-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:4bab1b2d6141fe7b32ae71dac905666ece4f94936efbfb13d55bb7739a3a6021", size = 228458, upload-time = "2026-05-06T15:10:20.079Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/27/b1e6dadb3c080313c03fdd8067b85e6a0460c7d8d6a1c3984ef77b904e4d/orjson-3.11.9-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:844417969855fc7a41be124aafe83dc424592a7f77cd4501900c67307122b92c", size = 128368, upload-time = "2026-05-06T15:10:21.549Z" },
+    { url = "https://files.pythonhosted.org/packages/21/0f/c9ede0bf052f6b4051e64a7d4fa91b725cccf8321a6a786e86eb03519f00/orjson-3.11.9-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffe02797b5e9f3a9d8292ddcd289b474ad13e81ad83cd1891a240811f1d2cb81", size = 132070, upload-time = "2026-05-06T15:10:23.371Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/26/d398e28048dc18205bbe812f2c88cb9b40313db2470778e25964796458fe/orjson-3.11.9-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e4eed3b200023042814d2fc8a5d2e880f13b52e1ed2485e83da4f3962f7dc1a", size = 127892, upload-time = "2026-05-06T15:10:24.714Z" },
+    { url = "https://files.pythonhosted.org/packages/66/60/52b0054c4c700d5aa7fc5b7ca96917400d8f061307778578e67a10e25852/orjson-3.11.9-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8aff7da9952a5ad1cef8e68017724d96c7b9a66e99e91d6252e1b133d67a7b10", size = 135217, upload-time = "2026-05-06T15:10:26.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/97/1e3dc2b2a28b7b2528f403d2fc1d79ec5f39af3bc143ab65d3ec26426385/orjson-3.11.9-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4d4e98d6f3b8afed8bc8cd9718ec0cdf46661826beefb53fe8eafb37f2bf0362", size = 145980, upload-time = "2026-05-06T15:10:28.062Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/39/31fbfe7850f2de32dee7e7e5c09f26d403ab01e440ac96001c6b01ad3c99/orjson-3.11.9-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3a81d52442a7c99b3662333235b3adf96a1715864658b35bb797212be7bddb97", size = 132738, upload-time = "2026-05-06T15:10:29.727Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/08/dca0082dd2a194acb93e5457e73455388e2e2ca464a2672449a9ddbb679d/orjson-3.11.9-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e39364e726a8fff737309aff059ff67d8a8c8d5b677be7bb49a8b3e84b7e218", size = 134033, upload-time = "2026-05-06T15:10:31.152Z" },
+    { url = "https://files.pythonhosted.org/packages/11/d4/5bdb0626801230139987385554c5d4c42255218ac906525bf4347f22cd95/orjson-3.11.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4fd66214623f1b17501df9f0543bef0b833979ab5b6ded1e1d123222866aa8c9", size = 141492, upload-time = "2026-05-06T15:10:32.641Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/88/a21fb53b3ede6703aede6dce4710ed4111e5b201cfa6bbff5e544f9d47d7/orjson-3.11.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:8ecc30f10465fa1e0ce13fd01d9e22c316e5053a719a8d915d4545a09a5ff677", size = 415087, upload-time = "2026-05-06T15:10:34.438Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/57/1b30daf70f0d8180e9a73cefbfbdd99e4bf19eb020466502b01fba7e0e50/orjson-3.11.9-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:97db4c94a7db398a5bd636273324f0b3fd58b350bbbac8bb380ceb825a9b40f4", size = 148031, upload-time = "2026-05-06T15:10:36.358Z" },
+    { url = "https://files.pythonhosted.org/packages/04/83/45fbb6d962e260807f99441db9613cee868ceda4baceda59b3720a563f97/orjson-3.11.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9f78cf8fec5bd627f4082b8dfeac7871b43d7f3274904492a43dab39f18a19a0", size = 136915, upload-time = "2026-05-06T15:10:38.013Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/cc/2d10025f9056d376e4127ec05a5808b218d46f035fdc08178a5411b34250/orjson-3.11.9-cp313-cp313-win32.whl", hash = "sha256:d4087e5c0209a0a8efe4de3303c234b9c44d1174161dcd851e8eea07c7560b32", size = 131613, upload-time = "2026-05-06T15:10:39.569Z" },
+    { url = "https://files.pythonhosted.org/packages/67/bd/2775ff28bfe883b9aa1ff348300542eb2ef1ee18d8ae0e3a49846817a865/orjson-3.11.9-cp313-cp313-win_amd64.whl", hash = "sha256:051b102c93b4f634e89f3866b07b9a9a98915ada541f4ec30f177067b2694979", size = 127086, upload-time = "2026-05-06T15:10:41.262Z" },
+    { url = "https://files.pythonhosted.org/packages/91/2b/d26799e580939e32a7da9a39531bc9e58e15ca32ffaa6a8cb3e9bb0d22cd/orjson-3.11.9-cp313-cp313-win_arm64.whl", hash = "sha256:cce9127885941bd28f080cecf1f1d288336b7e0d812c345b08be88b572796254", size = 126696, upload-time = "2026-05-06T15:10:42.651Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/90/62d8302883c44308c477e222c3daf7c813a34c8e96985882fbd53d964352/pandas-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:67b3b64c11910cfa29f4e94a14d3bff9ee693b6fc76055e7cad549cee0aec5fa", size = 10331071, upload-time = "2026-05-11T18:52:58.838Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ae/6a6493c783a101f165e4356953ba3c74d6f77f0042fa7d753da9dfbb640c/pandas-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:39436b377d56d2a2e52d0395bdbee171f01068e99af5250509aceeb929f765c7", size = 9875690, upload-time = "2026-05-11T18:53:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7c/5df8e9f56c69a2769fbe9382a5ef8f2658c007e376434e1e2cbb57ad895f/pandas-3.0.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4be06d68f9ddcfc645b87534911da79a8fbffc7573c80e0edcf42a5020624d8", size = 10381634, upload-time = "2026-05-11T18:53:04.393Z" },
+    { url = "https://files.pythonhosted.org/packages/99/68/1237369725aa617bb358263d535803e3053fdbc593513ec5ed9c9896b5b6/pandas-3.0.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a4eeb6830daf35a71cc09649bd823e2b542dac246cdee9614c6e4bd65028cd6a", size = 10891243, upload-time = "2026-05-11T18:53:07.643Z" },
+    { url = "https://files.pythonhosted.org/packages/25/93/77d108e8af7222b4a503ebde0e30215b1c2e4f8e53a526431890f22d5586/pandas-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1928e07221f82db493cd4af1e23c1bfca524a19a4699887975bff68f49a72bfb", size = 11388659, upload-time = "2026-05-11T18:53:10.634Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/bd/eff5b4399f332ac386c853f6cd2bd3fa2ca0061b9f36ecd9c4d7c4265649/pandas-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51b1fe551acb77dac643c6fda86084d8d446c10fe64b06a9cc29c4cc8540e7f2", size = 11942880, upload-time = "2026-05-11T18:53:13.536Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/20/559ace4200982c3887d0b86bfd0d856a2143ef8ddab63cc07934951a964c/pandas-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:a82d532a3351d435432cd913edbccaf8b8e01d4dd0e5ced5a8d2e8ecd94c7e44", size = 9757091, upload-time = "2026-05-11T18:53:16.306Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/66/69055a09fe200f29f922a3eeec4804611900b95f52d932ece3393c3c0c19/pandas-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:275c14e0fce14a2ec20eee474aecd305478ea3c1e6f6a9d8fe219a165542717e", size = 9057282, upload-time = "2026-05-11T18:53:18.768Z" },
+    { url = "https://files.pythonhosted.org/packages/57/0e/efe801b0e6811e8e650cd21b7f2608e30f08a7067e2bf6e8752b0d56ee3c/pandas-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:46997386d528eb40376ecd6b033cf4a8a1e5282580f68f43de875b78cba2199d", size = 10767016, upload-time = "2026-05-11T18:53:21.227Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/dc/eb55135a1d5f0f0519f28da1f609a206d2cad1f9c35c32d51e38dd7261ae/pandas-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:261e308dfb22448384b7580cf719d2f998fe2966c92893c3e77d14008af1f066", size = 10420210, upload-time = "2026-05-11T18:53:23.982Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/3e/b1d5d955ce33ffecb407465a60bc32769d74fcf68224b7ae67ae11d4dea4/pandas-3.0.3-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dd1a5d1def6a46002e964510bdc67c368aa0951df5d1d9f8365336f5a1f490cd", size = 10336126, upload-time = "2026-05-11T18:53:26.731Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/76/a01261711ab60a22d71b862f0de20e4c504bf80457270ad8cb42110f6abc/pandas-3.0.3-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d72828c20c6d6e83e1e22a6a3b47b326b71664112fa9705dcbccfd7a39b62085", size = 10728051, upload-time = "2026-05-11T18:53:29.125Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/21/ea191195e587b18cf682e97f433f81b2d0fbe341380e80a3e0d6e4403c8e/pandas-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d26cbe1fcfc12e8fd900e2454163e466b2d3af84f7c75481df7683ffc073d870", size = 11350796, upload-time = "2026-05-11T18:53:32.056Z" },
+    { url = "https://files.pythonhosted.org/packages/64/69/f0eaaf54939f0e8c6768fd06be9af2cef9b36048b96dfb9e1b2c685a807e/pandas-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3e91cec1879ada0624fc3dc9953c5cbd60208e59c0db28f540c5d6d47502422f", size = 11799741, upload-time = "2026-05-11T18:53:34.985Z" },
+    { url = "https://files.pythonhosted.org/packages/45/a4/865e0e510cae5fc2194de4db28be638952de942571ba9125934fd9c01d47/pandas-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:08d789b41f87e0905880e293cedf6197ce71fe67cc081358b1e148a491b9bd13", size = 10499958, upload-time = "2026-05-11T18:53:37.857Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "12.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/3d/bb7fca845737cf9d7dbde16ed1843984665ff2e0a518f5db43e77ec540b9/pillow-12.3.0.tar.gz", hash = "sha256:3b8182a766685eaa002637e28b4ec8d6b18819a0c71f579bf0dbaa5830297cce", size = 47025035, upload-time = "2026-07-01T11:56:38.965Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/ac/31fb64e1e7efb5a4b50cd3d92049ba89ac6e4d8d3bb6a74e15048ca3353e/pillow-12.3.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:21900ce7ba264168cd50defae43cd75d25c833ad4ad6e73ffc5596d12e25ac89", size = 4161684, upload-time = "2026-07-01T11:54:25.934Z" },
+    { url = "https://files.pythonhosted.org/packages/87/b4/9805e23d2b4d77842b468513841fda254ee42f0289d25088340e4ff46e2d/pillow-12.3.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:4e8c2a84d977f50b9daed6eeaf3baef67d00d5d74d932288f02cb94518ee3ace", size = 4255487, upload-time = "2026-07-01T11:54:27.935Z" },
+    { url = "https://files.pythonhosted.org/packages/df/39/ecf519435a200c693fe053a6ee4d835b41cf963a4dfc2551c4e637cb2a71/pillow-12.3.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:ae26d61dfa7a47befdc7572b521024e8745f3d809bd95ca9505a7bba9ef849ec", size = 3696433, upload-time = "2026-07-01T11:54:29.813Z" },
+    { url = "https://files.pythonhosted.org/packages/42/92/2fc3ffad878ae8dd5469ec1bc8eb83b71f48e13efdf68f02709003982a32/pillow-12.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7a743ff716f746fc19a9557f60dab1600d4613255f8a7aeb3cdde4db7eb15a66", size = 5345889, upload-time = "2026-07-01T11:54:31.97Z" },
+    { url = "https://files.pythonhosted.org/packages/10/76/8803c13605b763d33d156c4678fc77f8443389c0c51c8aef707bb02015f4/pillow-12.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d69141514cc30b774ceea5e3ed3a6635c8d8a96edf664689b890f4089111fb35", size = 4780109, upload-time = "2026-07-01T11:54:34.026Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/01/e18aff37cb0b4aac47ac90f016d347a49aca667ef97f190b06ac2aabc928/pillow-12.3.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f7401aebd7f581d7f83a439d87d474999317ee099218e5ad25d125290990ba65", size = 6263736, upload-time = "2026-07-01T11:54:36.131Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/62/de5bdd77d935331f4f802edc11e4d82950f642caad6cb2f949837b8560e2/pillow-12.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0847a763afefb695bc912d7c131e7e0632d4edc1d8698f58ddabec8e46b8b6d3", size = 6937129, upload-time = "2026-07-01T11:54:38.216Z" },
+    { url = "https://files.pythonhosted.org/packages/70/4d/105627a13300c5e0df1d174230b32fd1273062c96f7745fd552b945d1e1d/pillow-12.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:571b9fcb07b97ef3a492028fb3d2dc0993ca23a06138b0315286566d29ef718a", size = 6339562, upload-time = "2026-07-01T11:54:40.354Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/1d/f13de01a553988ab895ba1c722e06cf3144d4f57656fd5b81b6d881f1179/pillow-12.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:756c768d0c9c2955feb7a56c37ea24aea2e369f8d36a88da270b6a9f19e62b5e", size = 7049439, upload-time = "2026-07-01T11:54:42.489Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/f9/066794cca041b969964f779ee5fa66a9498bbf34248ac39c5d7954e4198f/pillow-12.3.0-cp313-cp313-win32.whl", hash = "sha256:a876864214e136f0eb367788dbd7df045f4806801518e2cfe9e13229cfe06d8f", size = 6473287, upload-time = "2026-07-01T11:54:44.9Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/9b/7a58e61d62be561da3a356fe2384d4059a6345fc130e23ef1c36a5b81d24/pillow-12.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:1cca606cd25738df4ed873d5ad46bbdb3d83b5cbca291f6b4ff13a4df6b0bbe8", size = 7239691, upload-time = "2026-07-01T11:54:47.141Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b0/c4ed4f0ef8f8fa5ee8351537db6650bb8189f7e118842978dd6589065692/pillow-12.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:b629de27fda84b42cde7edef0d85f13b958b47f6e9bbcbba9b673c562a89bd8b", size = 2568185, upload-time = "2026-07-01T11:54:49.137Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
+]
+
+[[package]]
+name = "pooch"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/43/85ef45e8b36c6a48546af7b266592dc32d7f67837a6514d111bced6d7d75/pooch-1.9.0.tar.gz", hash = "sha256:de46729579b9857ffd3e741987a2f6d5e0e03219892c167c6578c0091fb511ed", size = 61788, upload-time = "2026-01-30T19:15:09.649Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/2d/d4bf65e47cea8ff2c794a600c4fd1273a7902f268757c531e0ee9f18aa58/pooch-1.9.0-py3-none-any.whl", hash = "sha256:f265597baa9f760d25ceb29d0beb8186c243d6607b0f60b83ecf14078dbc703b", size = 67175, upload-time = "2026-01-30T19:15:08.36Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.35.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/01/9ef0afd7999eb9badb3a768b4aedd78c86d4c65cfaf1958ab276199e76b4/protobuf-7.35.1.tar.gz", hash = "sha256:ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a", size = 458717, upload-time = "2026-06-11T21:55:40.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/03/8aeeb7458d22546bf64b5250ca1daeb5ff757d900e8e4a7476c6f0db843e/protobuf-7.35.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:24f857477359a85c0c235261b8ba905fd51b2562f4a64ca1df5473f29850cbf6", size = 433226, upload-time = "2026-06-11T21:55:31.719Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4b/dfb89eb0e652a1ff073c39a59fb5e3a83cfe9b57a2c83fa6d78270101767/protobuf-7.35.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:11d6b0ec246892d85215b0a13ca6e0233cf5284b68f0ac02646427f4ff88a799", size = 328847, upload-time = "2026-06-11T21:55:34.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/58/dc12f2cd484951524af6e3382c785869b9b3fb5e52ee95ae23add53ee8f9/protobuf-7.35.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:b73f9489a4b8b1c9cb1f8ed951c736392592edb24b9d6819f36d2e10b171d5b4", size = 344030, upload-time = "2026-06-11T21:55:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:74758715c53d7158fb76caf4f0cfdacc5329a4b1bb994f865d6cf302d413a1c4", size = 327130, upload-time = "2026-06-11T21:55:35.921Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/bc/6d6c7ba8709c85f8f2c390b2b118d6fb08a783676a572271851bf45a7d22/protobuf-7.35.1-cp310-abi3-win32.whl", hash = "sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30", size = 428945, upload-time = "2026-06-11T21:55:37.034Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/19/8d0cb6f20a1ef7b18f1c8986ad5783f22f84cce39c6ce9a6e645ea55192e/protobuf-7.35.1-cp310-abi3-win_amd64.whl", hash = "sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87", size = 439996, upload-time = "2026-06-11T21:55:38.123Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659, upload-time = "2026-06-11T21:55:39.155Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+]
+
+[[package]]
+name = "pydub"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/9a/e6bca0eed82db26562c73b5076539a4a08d3cffd19c3cc5913a3e61145fd/pydub-0.25.1.tar.gz", hash = "sha256:980a33ce9949cab2a569606b65674d748ecbca4f0796887fd6f46173a7b0d30f", size = 38326, upload-time = "2021-03-10T02:09:54.659Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/53/d78dc063216e62fc55f6b2eebb447f6a4b0a59f55c8406376f76bf959b08/pydub-0.25.1-py2.py3-none-any.whl", hash = "sha256:65617e33033874b59d87db603aa1ed450633288aefead953b30bded59cb599a6", size = 32327, upload-time = "2021-03-10T02:09:53.503Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
+name = "pytz"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/46/dd499ec9038423421951e4fad73051febaa13d2df82b4064f87af8b8c0c3/pytz-2026.2.tar.gz", hash = "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a", size = 320861, upload-time = "2026-05-04T01:35:29.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/dd/96da98f892250475bdf2328112d7468abdd4acc7b902b6af23f4ed958ea0/pytz-2026.2-py2.py3-none-any.whl", hash = "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126", size = 510141, upload-time = "2026-05-04T01:35:27.408Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+]
+
+[[package]]
+name = "regex"
+version = "2026.7.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/37/451aaddbf50922f34d744ad5ca919ae1fcfac112123885d9728f52a484b3/regex-2026.7.10.tar.gz", hash = "sha256:1050fedf0a8a92e843971120c2f57c3a99bea86c0dfa1d63a9fac053fe54b135", size = 416282, upload-time = "2026-07-10T19:49:46.267Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/88/0c977b9f3ba9b08645516eca236388c340f56f7a87054d41a187a04e134c/regex-2026.7.10-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:4db009b4fc533d79af3e841d6c8538730423f82ea8508e353a3713725de7901c", size = 496868, upload-time = "2026-07-10T19:47:41.675Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/51/600882cd5d9a3cf083fd66a4064f5b7f243ba2a7de2437d42823e286edaf/regex-2026.7.10-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b96341cb29a3faa5db05aff29c77d141d827414f145330e5d8846892119351c1", size = 297306, upload-time = "2026-07-10T19:47:43.521Z" },
+    { url = "https://files.pythonhosted.org/packages/52/6f/48a912054ffcb756e374207bb8f4430c5c3e0ffa9627b3c7b6661844b30a/regex-2026.7.10-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:14d27f6bd04beb01f6a25a1153d73e58c290fd45d92ba56af1bb44199fd1010d", size = 291950, upload-time = "2026-07-10T19:47:45.267Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c8/8e1c3c86ebcee7effccbd1f7fc54fe3af22aa0e9204503e2baea4a6ff001/regex-2026.7.10-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e6b6a11bf898cca3ce7bfaa17b646901107f3975677fbd5097f36e5eb5641983", size = 796817, upload-time = "2026-07-10T19:47:48.054Z" },
+    { url = "https://files.pythonhosted.org/packages/65/39/3e49d9ff0e0737eb8180a00569b47aabb59b84611f48392eba4d998d91a0/regex-2026.7.10-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:234f8e0d65cf1df9becadae98648f74030ee85a8f12edcb5eb0f60a22a602197", size = 865513, upload-time = "2026-07-10T19:47:49.855Z" },
+    { url = "https://files.pythonhosted.org/packages/70/57/6511ad809bb3122c65bbeeffa5b750652bb03d273d29f3acb0754109b183/regex-2026.7.10-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:91b916d495db3e1b473c7c8e68733beec4dce8e487442db61764fff94f59740e", size = 912391, upload-time = "2026-07-10T19:47:51.776Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/29/a1b0c109c9e878cb04b931bfe4c54332d692b93c322e127b5ae9f25b0d9e/regex-2026.7.10-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1f0d4ccf70b1d13711242de0ba78967db5c35d12ac408378c70e06295c3f6644", size = 801338, upload-time = "2026-07-10T19:47:53.38Z" },
+    { url = "https://files.pythonhosted.org/packages/33/be/171c3dad4d77000e1befeff2883ca88734696dfd97b2951e5e074f32e4dd/regex-2026.7.10-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c622f4c638a725c39abcb2e680b1bd592663c83b672a4ed350a17f806d75618e", size = 777149, upload-time = "2026-07-10T19:47:54.944Z" },
+    { url = "https://files.pythonhosted.org/packages/33/61/41ab0de0e4574da1071c151f67d1eb9db3d92c43e31d64d2e6863c3d89bf/regex-2026.7.10-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:41a47c2b28d9421e2509a4583a22510dc31d83212fcf38e1508a7013140f71a8", size = 785216, upload-time = "2026-07-10T19:47:56.56Z" },
+    { url = "https://files.pythonhosted.org/packages/66/28/372859ea693736f07cf7023247c7eca8f221d9c6df8697ff9f93371cca08/regex-2026.7.10-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:13fba679fe035037e9d5286620f88bbfd105df4d5fcd975942edd282ab986775", size = 860229, upload-time = "2026-07-10T19:47:58.278Z" },
+    { url = "https://files.pythonhosted.org/packages/50/b1/e1d32cd944b599534ae655d35e8640d0ec790c0fa12e1fb29bf434d50f55/regex-2026.7.10-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:8e26a075fa9945b9e44a3d02cc83d776c3b76bb1ff4b133bbfa620d5650131da", size = 765797, upload-time = "2026-07-10T19:48:00.291Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/79a2cd9556a3329351e370929743ef4f0ccc0aaff6b3dc414ae5fa4a1302/regex-2026.7.10-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:d0834c84ae8750ae1c4cede59b0afd4d2f775be958e11b18a3eea24ed9d0d9f1", size = 852130, upload-time = "2026-07-10T19:48:01.972Z" },
+    { url = "https://files.pythonhosted.org/packages/66/58/76fec29898cf5d359ab63face50f9d4f7135cc2eca3477139227b1d09952/regex-2026.7.10-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64722a5031aeace7f6c8d5ea9a9b22d9368af0d6e8fa532585da8158549ea963", size = 789644, upload-time = "2026-07-10T19:48:03.748Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/06/3c7cec7817bda293e13c8f88aed227bbcf8b37e5990936ff6442a8fdf11a/regex-2026.7.10-cp313-cp313-win32.whl", hash = "sha256:74ae61d8573ecd51b5eeee7be2218e4c56e99c14fa8fcf97cf7519611d4be92e", size = 267130, upload-time = "2026-07-10T19:48:05.677Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6c/e2a6f9a6a905f923cfc912298a5949737e9504b1ca24f29eda8d04d05ece/regex-2026.7.10-cp313-cp313-win_amd64.whl", hash = "sha256:5e792367e5f9b4ffb8cad93f1beaa91837056b94da98aa5c65a0db0c1b474927", size = 277722, upload-time = "2026-07-10T19:48:07.318Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a6/9d8935aaa940c388496aa1a0c82669cc4b5d06291c2712d595e3f0cf16d3/regex-2026.7.10-cp313-cp313-win_arm64.whl", hash = "sha256:82ab8330e7e2e416c2d42fcec67f02c242393b8681014750d4b70b3f158e1f08", size = 277059, upload-time = "2026-07-10T19:48:08.977Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/e9/26decfd3e85c09e42ff7b0d23a6f51085ca4c268db15f084928ca33459c6/regex-2026.7.10-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:2b93eafd92c4128bab2f93500e8912cc9ecb3d3765f6685b902c6820d0909b6b", size = 501508, upload-time = "2026-07-10T19:48:10.668Z" },
+    { url = "https://files.pythonhosted.org/packages/38/a5/5b167cebde101945690219bf34361481c9f07e858a4f46d9996b80ec1490/regex-2026.7.10-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:3f03b92fb6ec739df042e45b06423fc717ecf0063e07ffe2897f7b2d5735e1e8", size = 299705, upload-time = "2026-07-10T19:48:12.544Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/20/7909be4b9f449f8c282c14b6762d59aa722aeaeebe7ee4f9bb623eeaa5e0/regex-2026.7.10-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:bb5aab464a0c5e03a97abad5bdf54517061ebbf72340d576e99ff661a42575cc", size = 294605, upload-time = "2026-07-10T19:48:14.495Z" },
+    { url = "https://files.pythonhosted.org/packages/82/88/e52550185d6fda68f549b01239698697de47320fd599f5e880b1986b7673/regex-2026.7.10-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fadb07dbe36a541283ff454b1a268afd54b077d917043f2e1e5615372cb5f200", size = 811747, upload-time = "2026-07-10T19:48:16.197Z" },
+    { url = "https://files.pythonhosted.org/packages/06/98/16c255c909714de1ee04da6ae30f3ee04170f300cdc0dcf57a314ee4816a/regex-2026.7.10-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:21150500b970b12202879dfd82e7fd809d8e853140fff84d08e57a90cf1e154e", size = 871203, upload-time = "2026-07-10T19:48:18.12Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/32/423ed27c9bae2092a453e853da2b6628a658d08bb5a6117db8d591183d85/regex-2026.7.10-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a68b637451d64ba30ed8ae125c973fa834cc2d37dfa7f154c2b479015d477ba8", size = 917334, upload-time = "2026-07-10T19:48:19.952Z" },
+    { url = "https://files.pythonhosted.org/packages/73/87/74dac8efb500db31cb000fda6bae2be45fc2fbf1fa9412f445fbb8acbe37/regex-2026.7.10-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3e23458d8903e33e7d27196d7a311523dc4e2f4137a5f34e4dbd30c8d37ff33e", size = 816379, upload-time = "2026-07-10T19:48:21.616Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/9f/1859403654e3e030b288f06d49233c6a4f889d62b84c4ef3f3a28653173d/regex-2026.7.10-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cae27622c094558e519abf3242cf4272db961d12c5c9a9ffb7a1b44b2627d5c6", size = 785563, upload-time = "2026-07-10T19:48:23.643Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d8/35d30d6bdf1ef6a5430e8982607b3a6db4df1ddedbe001e43435585d88ba/regex-2026.7.10-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ee877b6d78f9dff1da94fef51ae8cf9cce0967e043fdcc864c40b85cf293c192", size = 801415, upload-time = "2026-07-10T19:48:25.499Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/22/630f31f5ea4826167b2b064d9cac2093a5b3222af380aa432cfe1a5dabcd/regex-2026.7.10-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:2c66a8a1969cfd506d1e203c0005fd0fc3fe6efc83c945606566b6f9611d4851", size = 866560, upload-time = "2026-07-10T19:48:27.789Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/14/f5914a6d9c5bc63b9bed8c9a1169fb0be35dbe05cdc460e17d953031a366/regex-2026.7.10-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:2bc350e1c5fa250f30ab0c3e38e5cfdffcd82cb8af224df69955cab4e3003812", size = 772877, upload-time = "2026-07-10T19:48:29.563Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/0f/7c13999eef3e4186f7c79d4950fa56f041bf4de107682fb82c80db605ff9/regex-2026.7.10-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:53f54993b462f3f91fea0f2076b46deb6619a5f45d70dbd1f543f789d8b900ef", size = 856648, upload-time = "2026-07-10T19:48:31.282Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/71/a48e43909b6450fb48fa94e783bef2d9a37179258bc32ef2283955df7be7/regex-2026.7.10-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:cfcec18f7da682c4e2d82112829ce906569cb8d69fa6c26f3a50dfbed5ceb682", size = 803520, upload-time = "2026-07-10T19:48:33.275Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/b8/f037d1bf2c133cb24ceb6e7d81d08417080390eddab6ddfd701aa7091874/regex-2026.7.10-cp313-cp313t-win32.whl", hash = "sha256:a2d6d30be35ddd70ce0f8ee259a4c25f24d6d689a45a5ac440f03e6bcc5a21d1", size = 269168, upload-time = "2026-07-10T19:48:35.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/9c/eaac34f8452a838956e7e89852ad049678cdc1af5d14f72d3b3b658b1ea5/regex-2026.7.10-cp313-cp313t-win_amd64.whl", hash = "sha256:c57b6ad3f7a1bdd101b2966f29dc161adf49727b1e8d3e1e89db2eda8a75c344", size = 280004, upload-time = "2026-07-10T19:48:37.106Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/a9/e22e997587bc1d588b0b2cd0572027d39dd3a006216e40bbf0361688c51c/regex-2026.7.10-cp313-cp313t-win_arm64.whl", hash = "sha256:3d8ef9df02c8083c7b4b855e3cb87c8e0ebbcfea088d98c7a886aaefdf88d837", size = 279308, upload-time = "2026-07-10T19:48:38.907Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "safehttpx"
+version = "0.1.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/d1/4282284d9cf1ee873607a46442da977fc3c985059315ab23610be31d5885/safehttpx-0.1.7.tar.gz", hash = "sha256:db201c0978c41eddb8bb480f3eee59dd67304fdd91646035e9d9a720049a9d23", size = 10385, upload-time = "2025-10-24T18:30:09.783Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/a3/0f0b7d78e2f1eb9e8e1afbff1d2bff8d60144aee17aca51c065b516743dd/safehttpx-0.1.7-py3-none-any.whl", hash = "sha256:c4f4a162db6993464d7ca3d7cc4af0ffc6515a606dfd220b9f82c6945d869cde", size = 8959, upload-time = "2025-10-24T18:30:08.733Z" },
+]
+
+[[package]]
+name = "safetensors"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/06/f955dbbb1859e3bd23c8ac6141af5106e7ad5fedec4a3a6e3d60f94b7001/safetensors-0.8.0.tar.gz", hash = "sha256:fabaf3e0f18a6618d9b36560682562157f77c2b71fcffc7b432be2baed9d753d", size = 325846, upload-time = "2026-06-09T07:52:25.563Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/a0/f718cda65b05407d228f97602cf60dca269c979867aa5beb25410de26cd3/safetensors-0.8.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c554f85858e05226d3c2828e32395e677434685d6d94594a41643361c5e837f0", size = 473568, upload-time = "2026-06-09T07:52:18.829Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/b1/fa7c600e7dceae12e9606c7578cbc9ff1e1ed55844883ee5c92205e86226/safetensors-0.8.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:c80201d22cbf405b80647a60ada77bba06c8fba2da2743ba1e89cdcc39a81f25", size = 484562, upload-time = "2026-06-09T07:52:17.518Z" },
+    { url = "https://files.pythonhosted.org/packages/09/7d/65a7de0af421317bb36a067241e4235fff194eed60b961ed6d3f59a3fc60/safetensors-0.8.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a46e5ff292c356d6991e60942ba7f79817682d3a2cef0702136448cb9c4d235", size = 502844, upload-time = "2026-06-09T07:52:07.624Z" },
+    { url = "https://files.pythonhosted.org/packages/91/4f/3175c9d75634e0e0dda0082794193521035edd7c70a6f212bf33ca06ddf4/safetensors-0.8.0-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4124502b78f03534117c848f87a39b8f31e577b15eff423bf8bfb95f2a8c30d0", size = 511823, upload-time = "2026-06-09T07:52:09.565Z" },
+    { url = "https://files.pythonhosted.org/packages/20/87/846c289e7aa2299eff406335717cf43ce8777194ece8aad75772e0411615/safetensors-0.8.0-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7bc0a787ba8a35be368ee3574edfa2b1ad389eebd0a72e482ae275490e3f6c98", size = 633461, upload-time = "2026-06-09T07:52:11.128Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/8d64d9df2c45d5ded401df889d0ad90882804ca172d79ec4f0df8f727fe0/safetensors-0.8.0-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:040070828e36dc8e122178bbbd5830ff9e97920affb84cbe0f46442497bed358", size = 545148, upload-time = "2026-06-09T07:52:13.603Z" },
+    { url = "https://files.pythonhosted.org/packages/28/50/f203ff3a3ddfe19308efc83c5a3a29ed02bf786732ec35e68bf9162f3365/safetensors-0.8.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd6f3f93c9a0a7cc2788ee63fb763353d4bd2e89b0751bc78fcf7dda00bea774", size = 516040, upload-time = "2026-06-09T07:52:16.29Z" },
+    { url = "https://files.pythonhosted.org/packages/46/fb/cdaed17ceb2948784fd9c36b6fd3e951b608547cea81a48e8ee6f8cfdfcb/safetensors-0.8.0-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:fcdd41ec4628fee5799f807c73c353629130fbd942aa23d83c623dd6c9d52d78", size = 513832, upload-time = "2026-06-09T07:52:12.37Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/49/1e15de264dcc3b77943d2d0c56a95809956883b1c2d6d585c792523f180b/safetensors-0.8.0-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8e9f537aa183a38ace122d27303dcd986b26bd2a7591f9181d7f0c396f4677ca", size = 559930, upload-time = "2026-06-09T07:52:14.743Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/43/bf38443278eab4b1be1fce2931e2b012ad9cb7df52ada751d0aab8f7659a/safetensors-0.8.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:87eec7ffed2b809f05a398a8becb7d013f19f7837cd15d9748580d6cf30dbaf4", size = 678670, upload-time = "2026-06-09T07:52:20.032Z" },
+    { url = "https://files.pythonhosted.org/packages/72/e3/68cd3fa5b48488e84add63e04cb12f3bc28ae4638c06d4508c6e88823d0e/safetensors-0.8.0-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:4a95ae2b05d7726d751da4ebf626a2ca782b706e101bd894c95bc2450b1cffcc", size = 786679, upload-time = "2026-06-09T07:52:21.322Z" },
+    { url = "https://files.pythonhosted.org/packages/29/4b/1c19c509d56e01f4fbb3d0a2e597450f6cc04d1d56cf52defb0a62dfd715/safetensors-0.8.0-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae091f16662658bdc019a4ff6cb4c085bb7d725eb5978b183ffd265863b6d2d", size = 765683, upload-time = "2026-06-09T07:52:22.594Z" },
+    { url = "https://files.pythonhosted.org/packages/27/43/41c1621732edd934d868a00d1b891584c892a7b62a9aab82ea5a0a5623ee/safetensors-0.8.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8e080062fcde23be189565e1c3305d16751a218ecf9412c8601e64204eb6f846", size = 722361, upload-time = "2026-06-09T07:52:23.924Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3f/73ccf82579412b4a71c4ca673f10b5f1f888d7cf5af7fe24f27d30307be4/safetensors-0.8.0-cp310-abi3-win32.whl", hash = "sha256:2ddf52eac562eda224f99acfa7889d02968c1fd59a5b011ae7d8137c37e9c02d", size = 342401, upload-time = "2026-06-09T07:52:28.895Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/6d/3fba214c1e5e0f69991677ec3bc17023f0421776975e1de0c682dca475e2/safetensors-0.8.0-cp310-abi3-win_amd64.whl", hash = "sha256:096ec1a98435df7beb08853bb5aa9081a84f23d0adc67ed1a0a10550f608373f", size = 355540, upload-time = "2026-06-09T07:52:27.832Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/fc/7eedc3510d97878876e32774eebbeb61c43f148a96e915c84229a3e967aa/safetensors-0.8.0-cp310-abi3-win_arm64.whl", hash = "sha256:f7838e5135a406ad3e02efdcb8cf2e5397d368b0154537c4fec682dbc544d452", size = 340500, upload-time = "2026-06-09T07:52:26.745Z" },
+]
+
+[[package]]
+name = "scikit-learn"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "narwhals" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/6f/37092bdb25f712817231799fc5674d8e704066a8a70c1d2d40517e18b4ab/scikit_learn-1.9.0.tar.gz", hash = "sha256:8833266989d3a5110178a9fae30783675460724d0e1efb13b14901d2c660c557", size = 7750767, upload-time = "2026-06-02T11:54:32.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/01/cf3310626b6d48d3e9be69a1223f9180360b5e6edb045f50fade723ce494/scikit_learn-1.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:80746d63bd4b6eaca54d36fe5feaf4d28bb38dc6f9470f81c7cad7c40155f119", size = 8705188, upload-time = "2026-06-02T11:53:41.964Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/04/5acd7ae280c5f93b6ac5ef6cdec14eef4c8d1cd91d85b3292989c94d96b1/scikit_learn-1.9.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5b934c45c252844a91d69fda3a34cff5e7307e1db10d77cb10a3980312c74713", size = 8228299, upload-time = "2026-06-02T11:53:44.817Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/39/ffe829a5b8ecb40a518724a997794657fdc354ada5e8fe8e64d998c0bac9/scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:38c3dcb9a1ffb85505ec53d54c7b4aea0cff70050425a7760c2af661ac85df05", size = 8789690, upload-time = "2026-06-02T11:53:47.461Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/88/8dab5de10c638c083772a6be83a3d8106ced492f74a928c8693638e5bb50/scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:da76d09304a4706db7cc1e3ebaa3b6b98a67365cc11d2996c4f1e58ba47df714", size = 9087723, upload-time = "2026-06-02T11:53:50.702Z" },
+    { url = "https://files.pythonhosted.org/packages/20/3f/7917ca72464038f6240ec70c29f94862d08a34a74291ae4d4ec5eb8186a0/scikit_learn-1.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:5808d98f15c6bf6d9d96d2348c1997392a5888ce7097e664105f930c4bca1277", size = 8184330, upload-time = "2026-06-02T11:53:53.396Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c7/15739eb2f61fda3c54639e9942414e5a19ad8a8d1f5a3266afad7cb7df80/scikit_learn-1.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:d77f54c017633791bc0225a43e2f8d03745fdcfe4880268fcc4df15f505dec2e", size = 7840653, upload-time = "2026-06-02T11:53:56.035Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/52/9c0136c2de7ae0779b7b366447766cec6d9f0702c56bb8ffeb04c8fd3af4/scipy-1.18.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:09143f676d157d9f546d663504ef9c1becb819824f1afc018814176411942446", size = 31036107, upload-time = "2026-06-19T15:00:14.03Z" },
+    { url = "https://files.pythonhosted.org/packages/02/73/0291a64843270f4efb86cdcf2ee0f2048631b65ec6b405398b2b4dbf11bf/scipy-1.18.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5efe260f69417b97ddae455bfb5a95e8359f7f66ad7fa9522a60feb66f169520", size = 28663303, upload-time = "2026-06-19T15:00:16.819Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/0f/10ffa0b697a572f4e0d48b92a88895d366422f019f723e7e14a84c050dac/scipy-1.18.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:68363b7eaacd8b5dd426df56d782cc156468ac79a127a1b87ca597d6e2e82197", size = 20404960, upload-time = "2026-06-19T15:00:19.635Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/d2/e896cea21ba8edd6c81d4c55b1ffcc717e79698dcbebf9641b4cfb4c6622/scipy-1.18.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:c5557d8be5da8e41353fcd4d21491fdbab83b062fc579e94dc09a7c8ab4f669b", size = 23034074, upload-time = "2026-06-19T15:00:22.107Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/b2/e83ea34279a52c03374477c74006256ec78df65fc877baa4617d6de1d202/scipy-1.18.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0d13bca67c096d89fb95ced0d8921807300fce0275643aef9533cc63a0773468", size = 33942038, upload-time = "2026-06-19T15:00:24.964Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/af/e8fe5fb136f51e2b01678b92cb4106d10d8cd68ec147ead2e7cb0ac75398/scipy-1.18.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a46f9273dbd0eb1cefba61c9b8648b4dfe3cbc14a080176f9a73e44b8336dc7f", size = 35266390, upload-time = "2026-06-19T15:00:28.059Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/49/2c5cbb907b56695fc67517811d1db234dfd83381a84814ec220aded2794d/scipy-1.18.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5aba46108853ddfc77906b6557aac839d2b52e900c1d72a1180adaaab58d265f", size = 35551324, upload-time = "2026-06-19T15:00:31.014Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/73/eda39f7a2d306ff0ffc574afd13c0bbb6d10a603d9a413998ee269487a80/scipy-1.18.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b6f758e35f12757b5d95c00bc6de2438e229c2664b7a92e96f205959d9f2dfa4", size = 37404785, upload-time = "2026-06-19T15:00:34.072Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/d2/ae881ee28d014f38e0ccbfd974a06a919ba9af34f1f74bf42b5301891d63/scipy-1.18.0-cp313-cp313-win_amd64.whl", hash = "sha256:1afac4a847207c7ff8efd321734a50b06d0280b3b2a2c0fc2f413101747ad7c7", size = 36554943, upload-time = "2026-06-19T15:00:36.903Z" },
+    { url = "https://files.pythonhosted.org/packages/70/3a/21154e2d54eb3639c6bf4dbae2e531c68356bfe95990daa30df33b30d556/scipy-1.18.0-cp313-cp313-win_arm64.whl", hash = "sha256:c5dbddf60e58c2312316d097271a8e73d40eaf2eabfa4d95ed7d3695bbf2ce7b", size = 24350911, upload-time = "2026-06-19T15:00:40.062Z" },
+]
+
+[[package]]
+name = "semantic-version"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/31/f2289ce78b9b473d582568c234e104d2a342fd658cc288a7553d83bb8595/semantic_version-2.10.0.tar.gz", hash = "sha256:bdabb6d336998cbb378d4b9db3a4b56a1e3235701dc05ea2690d9a997ed5041c", size = 52289, upload-time = "2022-05-26T13:35:23.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/23/8146aad7d88f4fcb3a6218f41a60f6c2d4e3a72de72da1825dc7c8f7877c/semantic_version-2.10.0-py2.py3-none-any.whl", hash = "sha256:de78a3b8e0feda74cabc54aab2da702113e33ac9d9eb9d2389bcf1f58b7d9177", size = 15552, upload-time = "2022-05-26T13:35:21.206Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "83.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "soundfile"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/db/949331952a6fb1c5b12e9de80fd08747966c2039d1a61db4764fbd3981c2/soundfile-0.14.0.tar.gz", hash = "sha256:ba1c1a2d618bca5c406647c83b89f07cc8810fa506a50622a6993ba130c1de11", size = 47842, upload-time = "2026-06-06T08:58:47.869Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/d1/5e338af9ca6ed0786cd5bb03f6d60de1c325728c1189014f3b59aae7403c/soundfile-0.14.0-py2.py3-none-any.whl", hash = "sha256:8ba81ae3a89fd5ab3bef8a8eb481fbbe794e806309675a89b4df48b8d31908a8", size = 26799, upload-time = "2026-06-06T08:58:33.269Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/72/c6b21e58d3113596e7e8de0a08d6f1d95173492cfbca0a4db14148cbba2a/soundfile-0.14.0-py2.py3-none-macosx_10_9_x86_64.whl", hash = "sha256:19be05428da76ed61a4cad29b8e4bcf43a3e5c100089d2ec81dc961eed1b0dd4", size = 1144568, upload-time = "2026-06-06T08:58:35.231Z" },
+    { url = "https://files.pythonhosted.org/packages/63/7a/dfdd6f8c748988427119f75eb860a3cedd858d1aea1fe28f39ad8559ef22/soundfile-0.14.0-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:d828d35a059626da52f1415b5faee610aeab393319cb3fc4a9aef47b619fc14c", size = 1103726, upload-time = "2026-06-06T08:58:37.948Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/f8/fc39fad6f879633461d27394cd1ddaf1f769ffa0597dca35872f51b16461/soundfile-0.14.0-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:e85724a90bc99a6e8062c0b4ddf725f53b2a3b70afd4da875e9d2cfc4e92f377", size = 1238050, upload-time = "2026-06-06T08:58:39.932Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/a2/70fd4432b924684c372df8b0a45708c36c057ef3596c9eb53e0a806b980b/soundfile-0.14.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:1e38bac1853412871318e82a1ba69a8be677619b56025bbfcccdb41b6cafe82d", size = 1315963, upload-time = "2026-06-06T08:58:41.716Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/34/c9e80783d83eab739a9531fdee03675d53e0bf1b2ccb4bb3af5844675046/soundfile-0.14.0-py2.py3-none-win32.whl", hash = "sha256:0a6ae43c50c71b4e020cc55382925cb89451c1ed1a0c3d0f5d802da269226849", size = 902199, upload-time = "2026-06-06T08:58:43.289Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/97/b39c18ac1df45e755ca22b8b00e872929da5d107998a207a5e4ac831bfda/soundfile-0.14.0-py2.py3-none-win_amd64.whl", hash = "sha256:299491d3499460fb1b74bb4bd78b57ffc2d243a5fafa7b6ec1b264875c78453e", size = 1021480, upload-time = "2026-06-06T08:58:45.016Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/83/55c65e61cf457805ce2ec157c1c6ae17715d0851aa2374422de0538838ca/soundfile-0.14.0-py2.py3-none-win_arm64.whl", hash = "sha256:e090704718e124e7c844695236f1fce8d18a5e761eaf7c82dfcd124620805f98", size = 888858, upload-time = "2026-06-06T08:58:46.593Z" },
+]
+
+[[package]]
+name = "soxr"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/11/27cebce4a108f77afea7c80545115536b45e3f11ebfb914f638fdd9ba847/soxr-1.1.0.tar.gz", hash = "sha256:9f228ae21c78fa9359ca98d8a5e8e91f30639e438e574133dace62c5b5309e44", size = 173067, upload-time = "2026-05-03T00:15:18.214Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/8a/f3da7973b5f1b05d2d7e94d5376b881dcbc05297900cae6c3d33d95b209b/soxr-1.1.0-cp312-abi3-macosx_10_14_x86_64.whl", hash = "sha256:e0e09fa633ce2e67df08b298afced4d184f6e753fc330f241022250f1d0d61da", size = 204124, upload-time = "2026-05-03T00:14:54.505Z" },
+    { url = "https://files.pythonhosted.org/packages/03/dc/200013a74641f8774664bbcd2346c695c05c2e300ea792adcb40a293eed0/soxr-1.1.0-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:d6a7ad82b8d5f3fcc04b1d2ca055562b96af571e1d4fa7c6c61d0fb509ac43b4", size = 165457, upload-time = "2026-05-03T00:14:56.007Z" },
+    { url = "https://files.pythonhosted.org/packages/88/2b/2e5eba817a762a2ec589ff165b8bc5955b25a0ad140045f7cd8e45410543/soxr-1.1.0-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bf98c0d7b7d5ef5bf072fee8d3020e8b664f2d195933ea7bc5089267c2e22a06", size = 206529, upload-time = "2026-05-03T00:14:57.646Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/f1/0e55195893228609c9a08c3b13b7a83a46c3a992cd00d3304f0f320cfb07/soxr-1.1.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b033078e86f3c4a658e5697fac8995764fad9e799563616b630136b613167f1", size = 240413, upload-time = "2026-05-03T00:14:59.363Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/4d/621e4150e4815246ad552d215a8a294a90143fedd19ee442cf82d3b3abc8/soxr-1.1.0-cp312-abi3-win_amd64.whl", hash = "sha256:6ae2a174bffea94e8ead857dad85999d3f49f091774dbad5b046c0417d7092f4", size = 174357, upload-time = "2026-05-03T00:15:00.724Z" },
+]
+
+[[package]]
+name = "standard-aifc"
+version = "3.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "audioop-lts" },
+    { name = "standard-chunk" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/53/6050dc3dde1671eb3db592c13b55a8005e5040131f7509cef0215212cb84/standard_aifc-3.13.0.tar.gz", hash = "sha256:64e249c7cb4b3daf2fdba4e95721f811bde8bdfc43ad9f936589b7bb2fae2e43", size = 15240, upload-time = "2024-10-30T16:01:31.772Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/52/5fbb203394cc852334d1575cc020f6bcec768d2265355984dfd361968f36/standard_aifc-3.13.0-py3-none-any.whl", hash = "sha256:f7ae09cc57de1224a0dd8e3eb8f73830be7c3d0bc485de4c1f82b4a7f645ac66", size = 10492, upload-time = "2024-10-30T16:01:07.071Z" },
+]
+
+[[package]]
+name = "standard-chunk"
+version = "3.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/06/ce1bb165c1f111c7d23a1ad17204d67224baa69725bb6857a264db61beaf/standard_chunk-3.13.0.tar.gz", hash = "sha256:4ac345d37d7e686d2755e01836b8d98eda0d1a3ee90375e597ae43aaf064d654", size = 4672, upload-time = "2024-10-30T16:18:28.326Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/90/a5c1084d87767d787a6caba615aa50dc587229646308d9420c960cb5e4c0/standard_chunk-3.13.0-py3-none-any.whl", hash = "sha256:17880a26c285189c644bd5bd8f8ed2bdb795d216e3293e6dbe55bbd848e2982c", size = 4944, upload-time = "2024-10-30T16:18:26.694Z" },
+]
+
+[[package]]
+name = "standard-sunau"
+version = "3.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "audioop-lts" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/e3/ce8d38cb2d70e05ffeddc28bb09bad77cfef979eb0a299c9117f7ed4e6a9/standard_sunau-3.13.0.tar.gz", hash = "sha256:b319a1ac95a09a2378a8442f403c66f4fd4b36616d6df6ae82b8e536ee790908", size = 9368, upload-time = "2024-10-30T16:01:41.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/ae/e3707f6c1bc6f7aa0df600ba8075bfb8a19252140cd595335be60e25f9ee/standard_sunau-3.13.0-py3-none-any.whl", hash = "sha256:53af624a9529c41062f4c2fd33837f297f3baa196b0cfceffea6555654602622", size = 7364, upload-time = "2024-10-30T16:01:28.003Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
+name = "story-manager-omnivoice-adapter"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "fastapi" },
+    { name = "numpy" },
+    { name = "omnivoice" },
+    { name = "pydub" },
+    { name = "torch" },
+    { name = "torchaudio" },
+    { name = "uvicorn", extra = ["standard"] },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastapi", specifier = "==0.139.0" },
+    { name = "numpy", specifier = "==2.4.6" },
+    { name = "omnivoice", specifier = "==0.2.0" },
+    { name = "pydub", specifier = "==0.25.1" },
+    { name = "torch", specifier = "==2.8.0" },
+    { name = "torchaudio", specifier = "==2.8.0" },
+    { name = "uvicorn", extras = ["standard"], specifier = "==0.51.0" },
+]
+
+[[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
+name = "tensorboardx"
+version = "2.6.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/a9/fc520ea91ab1f3ba51cbf3fe24f2b6364ed3b49046969e0868d46d6da372/tensorboardx-2.6.5.tar.gz", hash = "sha256:ca176db3997ee8c07d2eb77381225956a3fd1c10c91beafab1f17069adc47017", size = 4770195, upload-time = "2026-04-03T15:40:23.803Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/0f/69fbab4c30b2f3a76e6de67585ea72a8eccf381751f5c0046b966fde9658/tensorboardx-2.6.5-py3-none-any.whl", hash = "sha256:c10b891d00af306537cb8b58a039b2ba41571f0da06f433a41c4ca8d6abe1373", size = 87510, upload-time = "2026-04-03T15:40:22.111Z" },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", size = 372115, upload-time = "2026-01-05T10:45:15.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/97/5dbfabf04c7e348e655e907ed27913e03db0923abb5dfdd120d7b25630e1/tokenizers-0.22.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:544dd704ae7238755d790de45ba8da072e9af3eea688f698b137915ae959281c", size = 3100275, upload-time = "2026-01-05T10:41:02.158Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/47/174dca0502ef88b28f1c9e06b73ce33500eedfac7a7692108aec220464e7/tokenizers-0.22.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1e418a55456beedca4621dbab65a318981467a2b188e982a23e117f115ce5001", size = 2981472, upload-time = "2026-01-05T10:41:00.276Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/84/7990e799f1309a8b87af6b948f31edaa12a3ed22d11b352eaf4f4b2e5753/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2249487018adec45d6e3554c71d46eb39fa8ea67156c640f7513eb26f318cec7", size = 3290736, upload-time = "2026-01-05T10:40:32.165Z" },
+    { url = "https://files.pythonhosted.org/packages/78/59/09d0d9ba94dcd5f4f1368d4858d24546b4bdc0231c2354aa31d6199f0399/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25b85325d0815e86e0bac263506dd114578953b7b53d7de09a6485e4a160a7dd", size = 3168835, upload-time = "2026-01-05T10:40:38.847Z" },
+    { url = "https://files.pythonhosted.org/packages/47/50/b3ebb4243e7160bda8d34b731e54dd8ab8b133e50775872e7a434e524c28/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bfb88f22a209ff7b40a576d5324bf8286b519d7358663db21d6246fb17eea2d5", size = 3521673, upload-time = "2026-01-05T10:40:56.614Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/fa/89f4cb9e08df770b57adb96f8cbb7e22695a4cb6c2bd5f0c4f0ebcf33b66/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1c774b1276f71e1ef716e5486f21e76333464f47bece56bbd554485982a9e03e", size = 3724818, upload-time = "2026-01-05T10:40:44.507Z" },
+    { url = "https://files.pythonhosted.org/packages/64/04/ca2363f0bfbe3b3d36e95bf67e56a4c88c8e3362b658e616d1ac185d47f2/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:df6c4265b289083bf710dff49bc51ef252f9d5be33a45ee2bed151114a56207b", size = 3379195, upload-time = "2026-01-05T10:40:51.139Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/76/932be4b50ef6ccedf9d3c6639b056a967a86258c6d9200643f01269211ca/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:369cc9fc8cc10cb24143873a0d95438bb8ee257bb80c71989e3ee290e8d72c67", size = 3274982, upload-time = "2026-01-05T10:40:58.331Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/28/5f9f5a4cc211b69e89420980e483831bcc29dade307955cc9dc858a40f01/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:29c30b83d8dcd061078b05ae0cb94d3c710555fbb44861139f9f83dcca3dc3e4", size = 9478245, upload-time = "2026-01-05T10:41:04.053Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fb/66e2da4704d6aadebf8cb39f1d6d1957df667ab24cff2326b77cda0dcb85/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:37ae80a28c1d3265bb1f22464c856bd23c02a05bb211e56d0c5301a435be6c1a", size = 9560069, upload-time = "2026-01-05T10:45:10.673Z" },
+    { url = "https://files.pythonhosted.org/packages/16/04/fed398b05caa87ce9b1a1bb5166645e38196081b225059a6edaff6440fac/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:791135ee325f2336f498590eb2f11dc5c295232f288e75c99a36c5dbce63088a", size = 9899263, upload-time = "2026-01-05T10:45:12.559Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a1/d62dfe7376beaaf1394917e0f8e93ee5f67fea8fcf4107501db35996586b/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:38337540fbbddff8e999d59970f3c6f35a82de10053206a7562f1ea02d046fa5", size = 10033429, upload-time = "2026-01-05T10:45:14.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
+    { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/af/14b24e41977adb296d6bd1fb59402cf7d60ce364f90c890bd2ec65c43b5a/tomlkit-0.14.0.tar.gz", hash = "sha256:cf00efca415dbd57575befb1f6634c4f42d2d87dbba376128adb42c121b87064", size = 187167, upload-time = "2026-01-13T01:14:53.304Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl", hash = "sha256:592064ed85b40fa213469f81ac584f67a4f2992509a7c3ea2d632208623a3680", size = 39310, upload-time = "2026-01-13T01:14:51.965Z" },
+]
+
+[[package]]
+name = "torch"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/4e/469ced5a0603245d6a19a556e9053300033f9c5baccf43a3d25ba73e189e/torch-2.8.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:2b2f96814e0345f5a5aed9bf9734efa913678ed19caf6dc2cddb7930672d6128", size = 101936856, upload-time = "2025-08-06T14:54:01.526Z" },
+    { url = "https://files.pythonhosted.org/packages/16/82/3948e54c01b2109238357c6f86242e6ecbf0c63a1af46906772902f82057/torch-2.8.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:65616ca8ec6f43245e1f5f296603e33923f4c30f93d65e103d9e50c25b35150b", size = 887922844, upload-time = "2025-08-06T14:55:50.78Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/54/941ea0a860f2717d86a811adf0c2cd01b3983bdd460d0803053c4e0b8649/torch-2.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:659df54119ae03e83a800addc125856effda88b016dfc54d9f65215c3975be16", size = 241330968, upload-time = "2025-08-06T14:54:45.293Z" },
+    { url = "https://files.pythonhosted.org/packages/de/69/8b7b13bba430f5e21d77708b616f767683629fc4f8037564a177d20f90ed/torch-2.8.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:1a62a1ec4b0498930e2543535cf70b1bef8c777713de7ceb84cd79115f553767", size = 73915128, upload-time = "2025-08-06T14:54:34.769Z" },
+    { url = "https://files.pythonhosted.org/packages/15/0e/8a800e093b7f7430dbaefa80075aee9158ec22e4c4fc3c1a66e4fb96cb4f/torch-2.8.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:83c13411a26fac3d101fe8035a6b0476ae606deb8688e904e796a3534c197def", size = 102020139, upload-time = "2025-08-06T14:54:39.047Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/15/5e488ca0bc6162c86a33b58642bc577c84ded17c7b72d97e49b5833e2d73/torch-2.8.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:8f0a9d617a66509ded240add3754e462430a6c1fc5589f86c17b433dd808f97a", size = 887990692, upload-time = "2025-08-06T14:56:18.286Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/a8/6a04e4b54472fc5dba7ca2341ab219e529f3c07b6941059fbf18dccac31f/torch-2.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:a7242b86f42be98ac674b88a4988643b9bc6145437ec8f048fea23f72feb5eca", size = 241603453, upload-time = "2025-08-06T14:55:22.945Z" },
+    { url = "https://files.pythonhosted.org/packages/04/6e/650bb7f28f771af0cb791b02348db8b7f5f64f40f6829ee82aa6ce99aabe/torch-2.8.0-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:7b677e17f5a3e69fdef7eb3b9da72622f8d322692930297e4ccb52fefc6c8211", size = 73632395, upload-time = "2025-08-06T14:55:28.645Z" },
+]
+
+[[package]]
+name = "torchaudio"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "torch" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ea/2a68259c4dbb5fe44ebfdcfa40b115010d8c677221a7ef0f5577f3c4f5f1/torchaudio-2.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f851d32e94ca05e470f0c60e25726ec1e0eb71cb2ca5a0206b7fd03272ccc3c8", size = 1857045, upload-time = "2025-08-06T14:58:51.984Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/a3/1c79a8ef29fe403b83bdfc033db852bc2a888b80c406325e5c6fb37a7f2d/torchaudio-2.8.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:09535a9b727c0793cd07c1ace99f3f353626281bcc3e30c2f2314e3ebc9d3f96", size = 1692755, upload-time = "2025-08-06T14:58:50.868Z" },
+    { url = "https://files.pythonhosted.org/packages/49/df/61941198e9ac6bcebfdd57e1836e4f3c23409308e3d8d7458f0198a6a366/torchaudio-2.8.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:d2a85b124494736241884372fe1c6dd8c15e9bc1931bd325838c5c00238c7378", size = 4013897, upload-time = "2025-08-06T14:59:01.66Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/ab/7175d35a4bbc4a465a9f1388571842f16eb6dec5069d7ea9c8c2d7b5b401/torchaudio-2.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:c1b5139c840367a7855a062a06688a416619f6fd2ca46d9b9299b49a7d133dfd", size = 2500085, upload-time = "2025-08-06T14:58:44.95Z" },
+    { url = "https://files.pythonhosted.org/packages/34/1a/69b9f8349d9d57953d5e7e445075cbf74000173fb5f5d5d9e9d59415fc63/torchaudio-2.8.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:68df9c9068984edff8065c2b6656725e6114fe89281b0cf122c7505305fc98a4", size = 1935600, upload-time = "2025-08-06T14:58:46.051Z" },
+    { url = "https://files.pythonhosted.org/packages/71/76/40fec21b65bccfdc5c8cdb9d511033ab07a7ad4b05f0a5b07f85c68279fc/torchaudio-2.8.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:1951f10ed092f2dda57634f6a3950ef21c9d9352551aa84a9fccd51bbda18095", size = 1704199, upload-time = "2025-08-06T14:58:43.594Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/53/95c3363413c2f2009f805144160b093a385f641224465fbcd717449c71fb/torchaudio-2.8.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:4f7d97494698d98854129349b12061e8c3398d33bd84c929fa9aed5fd1389f73", size = 4020596, upload-time = "2025-08-06T14:59:03.031Z" },
+    { url = "https://files.pythonhosted.org/packages/52/27/7fc2d7435af044ffbe0b9b8e98d99eac096d43f128a5cde23c04825d5dcf/torchaudio-2.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:d4a715d09ac28c920d031ee1e60ecbc91e8a5079ad8c61c0277e658436c821a6", size = 2549553, upload-time = "2025-08-06T14:59:00.019Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.68.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/5f/57ff8b434839e70dab45601284ea413e947a63799891b7553e5960a793a8/tqdm-4.68.4.tar.gz", hash = "sha256:19829c9673638f2a0b8617da4cdcb927e831cd88bcfcb6e78d42a4d1af131520", size = 792418, upload-time = "2026-07-07T09:58:18.369Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/2a/5e5e750890ada51017d18d0d4c30da696e5b5bd3180947729927628fc3cb/tqdm-4.68.4-py3-none-any.whl", hash = "sha256:5168118b2368f48c561afda8020fd79195b1bdb0bdf8086b88442c267a315dc2", size = 676612, upload-time = "2026-07-07T09:58:16.256Z" },
+]
+
+[[package]]
+name = "transformers"
+version = "5.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "safetensors" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/f7/418169401560cec2b61512e6bf37b0cfb4c8e27700cfa868a1de073cb65d/transformers-5.13.1.tar.gz", hash = "sha256:1e2452d6778a7482158df5d5dacf6bf775d5b2fdcfce33caaf7f6b0e5f3e3397", size = 9196891, upload-time = "2026-07-11T09:15:50.845Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/47/54eacf96b5c835bbd6ca631aa2740e7705ed63d9e3a8afd2d2cc6d09cae5/transformers-5.13.1-py3-none-any.whl", hash = "sha256:53f0ea8aa397e29244c2377ba981bcaf0c87adcf44fbdd447ef6306522afcacd", size = 11503977, upload-time = "2026-07-11T09:15:46.801Z" },
+]
+
+[[package]]
+name = "triton"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "setuptools", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/7b/0a685684ed5322d2af0bddefed7906674f67974aa88b0fae6e82e3b766f6/triton-3.4.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00be2964616f4c619193cb0d1b29a99bd4b001d7dc333816073f92cf2a8ccdeb", size = 155569223, upload-time = "2025-07-30T19:58:44.017Z" },
+    { url = "https://files.pythonhosted.org/packages/20/63/8cb444ad5cdb25d999b7d647abac25af0ee37d292afc009940c05b82dda0/triton-3.4.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7936b18a3499ed62059414d7df563e6c163c5e16c3773678a3ee3d417865035d", size = 155659780, upload-time = "2025-07-30T19:58:51.171Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.26.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/f7/68adc395201b20b872d68e975386832e8005ffeacedd43a1d837a32815be/typer-0.26.8.tar.gz", hash = "sha256:c244a6bd558886fe3f8780efb6bdd28bb9aff005a94eedebaa5cb32926fe2f7e", size = 202097, upload-time = "2026-06-26T09:22:45.705Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/87/b9fd69c92c6102a066e1b86a35243f53e70bd4c709f2a26d9f4fee4f4dc0/typer-0.26.8-py3-none-any.whl", hash = "sha256:3512ca79ac5c11113414b36e80281b872884477722440691c89d1112e321a49c", size = 122564, upload-time = "2026-06-26T09:22:44.72Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.51.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/65/b7c6c443ccc58678c91e1e973bbe2a878591538655d6e1d47f24ba1c51f3/uvicorn-0.51.0.tar.gz", hash = "sha256:f6f4b69b657c312f516dd2d268ab9ae6f254b11e4bac504f37b2ab58b24dd0b0", size = 94412, upload-time = "2026-07-08T10:59:05.962Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/ec/dbb7e5a6b91f86bfb9eb7d2988a2730907b6a729875b949c7f022e8b88fa/uvicorn-0.51.0-py3-none-any.whl", hash = "sha256:5d38af6cd620f2ae3849fb44fd4879e0890aa1febe8d47eb355fb45d93fe6a5b", size = 73219, upload-time = "2026-07-08T10:59:04.44Z" },
+]
+
+[package.optional-dependencies]
+standard = [
+    { name = "httptools" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+
+[[package]]
+name = "uvloop"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250, upload-time = "2025-10-16T22:17:19.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/8c/182a2a593195bfd39842ea68ebc084e20c850806117213f5a299dfc513d9/uvloop-0.22.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:561577354eb94200d75aca23fbde86ee11be36b00e52a4eaf8f50fb0c86b7705", size = 1358611, upload-time = "2025-10-16T22:16:36.833Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/e301ee96a6dc95224b6f1162cd3312f6d1217be3907b79173b06785f2fe7/uvloop-0.22.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cdf5192ab3e674ca26da2eada35b288d2fa49fdd0f357a19f0e7c4e7d5077c8", size = 751811, upload-time = "2025-10-16T22:16:38.275Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/02/654426ce265ac19e2980bfd9ea6590ca96a56f10c76e63801a2df01c0486/uvloop-0.22.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e2ea3d6190a2968f4a14a23019d3b16870dd2190cd69c8180f7c632d21de68d", size = 4288562, upload-time = "2025-10-16T22:16:39.375Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c0/0be24758891ef825f2065cd5db8741aaddabe3e248ee6acc5e8a80f04005/uvloop-0.22.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0530a5fbad9c9e4ee3f2b33b148c6a64d47bbad8000ea63704fa8260f4cf728e", size = 4366890, upload-time = "2025-10-16T22:16:40.547Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/53/8369e5219a5855869bcee5f4d317f6da0e2c669aecf0ef7d371e3d084449/uvloop-0.22.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bc5ef13bbc10b5335792360623cc378d52d7e62c2de64660616478c32cd0598e", size = 4119472, upload-time = "2025-10-16T22:16:41.694Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ba/d69adbe699b768f6b29a5eec7b47dd610bd17a69de51b251126a801369ea/uvloop-0.22.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1f38ec5e3f18c8a10ded09742f7fb8de0108796eb673f30ce7762ce1b8550cad", size = 4239051, upload-time = "2025-10-16T22:16:43.224Z" },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/41/5e1a4bb12aac5f1493fa1bdc11154eca3b258ca4eba65d39c473fe19d8e9/watchfiles-1.2.0.tar.gz", hash = "sha256:c995fba777f1ea992f090f9236e9284cf7a5d1a0130dd5a3d82c598cacd76838", size = 108252, upload-time = "2026-05-18T04:32:04.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/4d/70a7feced9f87e2ff26dba42667290f41694fc64646c67261fbb8cab5d5c/watchfiles-1.2.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:01ea8d66f0693b9b60a6541c8d10263091ca9a9060d242f3c1f3143f9aad2c98", size = 399730, upload-time = "2026-05-18T04:31:38.162Z" },
+    { url = "https://files.pythonhosted.org/packages/31/3a/0da302f2307aee316922806ebd5726c542cbd787c938271cf14a074c7daf/watchfiles-1.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7ba0480b9a74af058f43b337e937a451e109295c420916d68ad24e3dc02f5e44", size = 392842, upload-time = "2026-05-18T04:30:27.051Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ef/d5bdb705c224dbc256aa0c1ec47bf4e61ec52558f2afb44a71a1fe4d7015/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f34e26a19f91f710c08e0183429f0d1d15df734e6bc78c31e77b9ea9c433658", size = 452989, upload-time = "2026-05-18T04:31:11.945Z" },
+    { url = "https://files.pythonhosted.org/packages/71/29/5495f2c1661949ef7a35e4d71111d129cfe7606414a26887a919d0a55406/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b4e77f6a55f858504069abd35d336a637555c09bca453dde1ee1e5ada8a6a1fb", size = 458978, upload-time = "2026-05-18T04:30:52.606Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/8c/7f9c07c433811c2fffd93e13fdfb7135de9aab5f2ae41be08960fa0047dc/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0cb4d80e212f116474a545c21c912b445f16bb0cef9e6a73a498164223e14e2f", size = 490248, upload-time = "2026-05-18T04:31:36.003Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/11/d93632febc52fbc21be90231bb7c17fd5387f46c9076fd40a5f9c2ae6910/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b974946a10af379d425e2eef5b62f5c6ebeaccf91d45eaad6f5b27ecd4f91aa0", size = 571847, upload-time = "2026-05-18T04:31:10.862Z" },
+    { url = "https://files.pythonhosted.org/packages/55/b4/383173e73aabb07ad1d9c7aa859d95437ac46a6d6a1e11005facda0c9d19/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:86bc13c25a8d1fcd70b51d0ce7c9b65e90de5666fcbfd3e34957cc73ee19aeb5", size = 465974, upload-time = "2026-05-18T04:30:17.006Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6c/89b1a230a78f57c52dd8893adb1f92f94411721b6ec12596c56d98c74356/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca148d73dea36c9763aaa351e4d7a51780ec1584217c45276f4fe8239c768b71", size = 454782, upload-time = "2026-05-18T04:30:35.656Z" },
+    { url = "https://files.pythonhosted.org/packages/24/62/1732118367cfff0a9fce3bf62ff4bfded09ef5df21d9d446b858b3f70a96/watchfiles-1.2.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:c525543d91961c6955b2636b308569e84a1d1c5f5f2932041ab9ef46422f43e3", size = 465182, upload-time = "2026-05-18T04:30:20.846Z" },
+    { url = "https://files.pythonhosted.org/packages/28/96/716f7e5f51339bf22963f3345f9f27d7f3b30e2eadc597e257c881dd3c53/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:a204794696ffb8f9b10fba6f7cb5216d42f3b2b71860ccac6b6e42f5f10973b0", size = 629841, upload-time = "2026-05-18T04:31:05.397Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/c40783950fd771ccf66ab3ec2722d188a9af1c7f96c6e811f36e40c6e03f/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:10d86db20695afe7997ac9e1717637d6714a8d0220458c33f3d2061f54cec427", size = 658028, upload-time = "2026-05-18T04:31:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/71/72/4508db1856d1d87fcbb3b63f4839bab1b5682cb0e8d224d122263c09654a/watchfiles-1.2.0-cp313-cp313-win32.whl", hash = "sha256:eb283ee99e21ad6443c8cdb06ac5b34b1308c329cbdf03fa02b445363714c799", size = 275183, upload-time = "2026-05-18T04:30:59.57Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/36/14b76ca57652e5cc5fd1c11f32a261292c08a0d19a00351013c2549cbfb2/watchfiles-1.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:a0f27f01bee51861392bb6b7c4fdb290b27d1eb194e9e28788d68102a0e898d9", size = 288059, upload-time = "2026-05-18T04:32:07.937Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/8d/0a85e395398d8d20fadfe5c5d32c726eee17a519e78fb356f2cf7531bffe/watchfiles-1.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:3651aa7058595e9cfb75d35dd5ada2bf9f48a5b8a0f3562821d3e210c507e077", size = 280186, upload-time = "2026-05-18T04:31:54.484Z" },
+    { url = "https://files.pythonhosted.org/packages/37/68/36db056f1fdcc5f07302f56e631774d6835bcd6fa3ace402304621d5f9e5/watchfiles-1.2.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:faea288b6f0ab1902ef08f4ca6de005dccf856c4e0c4f21b8c5fce02d90a1b08", size = 399031, upload-time = "2026-05-18T04:30:44.576Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/64/01a9d6f66a82a5c101ce939274106cc72759d62427e153f01edd2b9f87c2/watchfiles-1.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:01859b11fd9fbca670f4d5da00fbac282cfea9bd67a2125d8b2833a3b5617ea9", size = 391205, upload-time = "2026-05-18T04:30:25.413Z" },
+    { url = "https://files.pythonhosted.org/packages/84/2c/0a44fe058cb4bb7b8ede6b6670698bbb7c0400740e378d00022189b7b31d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fff610d7bb2256a317bb1e96f0d7862c7aa8076733ee5df0fd41bbe76a24a4f4", size = 451892, upload-time = "2026-05-18T04:32:14.005Z" },
+    { url = "https://files.pythonhosted.org/packages/67/a1/351e0d56cd35e6488b5c8b4fb11a809a5bc923e8fe8fed9faf8920be0c89/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b141a4891c995a039cd89e9a49e62df1dc8a559a5d1a6e4c7106d16c12777a55", size = 458867, upload-time = "2026-05-18T04:31:22.279Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/7d/9d09605187f1b838998624049fcf8bf47b73c1a3b76901fcac1782f62277/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f22943b7770483f6ea0721c6b11d022947a98eb0acae14694de034f4d0d38925", size = 490217, upload-time = "2026-05-18T04:31:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5d/a17a16eccb182f04188cd308ec24b1a71a9b5c4e7098269cf35d9fa56d02/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1bc6195825b7dcd217968bb1f801a60fd4c16e8eeab5bedc7fe917d7d5995ab4", size = 571458, upload-time = "2026-05-18T04:32:11.875Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/3d/4dd457062083ab1938e5dfd45032eb425cee2ac817287ca8ff4356183e5d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4a4b147f5dca2a5d325a06a832fb43f345751adfbc63204aec30e0d9ca965a2", size = 464707, upload-time = "2026-05-18T04:30:43.492Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/71/ea8c57b128f5383de74d0c7d2d9c57ad7c9a65a930c451bd25d524b295b7/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4543579a9bdb0c9560039b4ffddbdb39545707659fbc430ce4c10f3f68d557f9", size = 454663, upload-time = "2026-05-18T04:30:16.061Z" },
+    { url = "https://files.pythonhosted.org/packages/53/fd/2e812bf938406d7db351f0703ddd3fc6c061cf30d96153a77bc79a943a44/watchfiles-1.2.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:20aa0e708b920bde876a4aa82dc7dd6ebea228a63a67cda6632c2fc87b787efa", size = 463537, upload-time = "2026-05-18T04:31:44.9Z" },
+    { url = "https://files.pythonhosted.org/packages/86/56/d17a7f1dd1bc3035f1072694a551301272f1739c2d8e319c927cb9e29b38/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:d413349d565dab74297f2a63e84a097936be69bf8f3b3801f27f380e32040f44", size = 629194, upload-time = "2026-05-18T04:31:14.141Z" },
+    { url = "https://files.pythonhosted.org/packages/be/06/f1ff66bf5cae50aa4062779a0ecd0bbaf15e466195719074078947d9a17d/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f28b2725eb8cce327b9b3ab02415c853011dc55c95832fe90de6bc56f5315f72", size = 656194, upload-time = "2026-05-18T04:31:47.14Z" },
+]
+
+[[package]]
+name = "webdataset"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "braceexpand" },
+    { name = "numpy" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/3a/68800d92e065cf4750ebecf973b13979c0c929b439e1293012938862038d/webdataset-1.0.2.tar.gz", hash = "sha256:7f0498be827cfa46cc5430a58768a24e2c6a410676a61be1838f53d61afdaab4", size = 80090, upload-time = "2025-06-19T23:26:21.945Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/00/aca6beb3658dab4ed3dbb41a78e6e7f31342e0b41d28088f205525751601/webdataset-1.0.2-py3-none-any.whl", hash = "sha256:3dbfced32b25c0d199c6b9787937b6f85742bc3c84f652c846893075c1c082d9", size = 74956, upload-time = "2025-06-19T23:26:20.354Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/02/b9a097e1e16fee4e2fd1ec8c39f6a9c5d6257bae8fa12640caf869f54436/websockets-16.1.tar.gz", hash = "sha256:299468cbe42e2b9981134c7c51d99387d8a7bf562b00183b3eec53f882846dad", size = 182530, upload-time = "2026-07-10T06:32:57.734Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/63/df158b155420b566f025e75613424ad9649a24bcb0e9f259321ab3d58bea/websockets-16.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:b0232ed141cec3df2af5a3959a071c51f40036336b0d37e17faf9ef52fc73e47", size = 179791, upload-time = "2026-07-10T06:31:33.108Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cf/00fe9414dfeafa6fe54eae9f5716c8c8e9ac59d192be3b893c096d395846/websockets-16.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a71b73d143991714144e159f767b698f03c4a70b8a65ae1733b650cff488045b", size = 177472, upload-time = "2026-07-10T06:31:34.522Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/76/b10633424d40681b4e892ffd08ca5226322b2426e62d4ab71eae484c3a32/websockets-16.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:187323204c3b2fc465e8fc2609e60437c521790cb9c1acb49c4c452a33e57f37", size = 177737, upload-time = "2026-07-10T06:31:35.964Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/61/d3bb03b2229bb1afd72008742d586cf1ea240dce64dd48c71c8c7fd3294c/websockets-16.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9dba74233c8c3ce368850818c98354dad2570f57231b3fd3bd00d7aa57628881", size = 187403, upload-time = "2026-07-10T06:31:37.496Z" },
+    { url = "https://files.pythonhosted.org/packages/26/16/cc2e80478f688fc3c39c67dc1fac6a0783858058914ebc2489917462cb42/websockets-16.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:63339bc8c63c86a463177775cb7c677691f5bcfac7b3b2f01b286d42acd41600", size = 188639, upload-time = "2026-07-10T06:31:38.86Z" },
+    { url = "https://files.pythonhosted.org/packages/15/d6/ad87b2507e57de1cbf897a56c963f2925962ed5e85fbe06aaa83ced27acd/websockets-16.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:23e545ea8ae4263e37cdfd4e22a217f519e48e432728bc461185bbf585f38a83", size = 190078, upload-time = "2026-07-10T06:31:40.218Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/1a/5b37b3fd335d5811f29fc829f2646a3e6d1463a4bf09c3100708684c766e/websockets-16.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2237081454846fb40403a80ba86d82e2038b9c45865ab96af0abe7d002a91045", size = 189267, upload-time = "2026-07-10T06:31:41.523Z" },
+    { url = "https://files.pythonhosted.org/packages/42/98/06afc33e9450d4230f94c664db78875d90f5f6a5fb77f0bc6ec15ae74e1c/websockets-16.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5f5218de1ed047385ca53744caba9435d65f75d008364970a3fae95a05812cf9", size = 188022, upload-time = "2026-07-10T06:31:42.838Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/42fef5d5887c18cf2d148b02debf56cecb9cfbffc68027cde9b12c8f432c/websockets-16.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:75c98e3920039d0edff03b74478ada504b7ce3a1bc406db2cabfca84320f7baf", size = 185435, upload-time = "2026-07-10T06:31:44.219Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/9b/8021c133add5fe40ed40312553a6cd1408c069d7efe3444ad483d4973ed3/websockets-16.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1facd189d8190af30487a55b4c3688484dd50801628a3b5b2ccd26db08e67057", size = 188080, upload-time = "2026-07-10T06:31:45.986Z" },
+    { url = "https://files.pythonhosted.org/packages/69/54/1e37384f395eaa127383aab15c1c45e200890a7d7b99db5c312233d193e0/websockets-16.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:cc0c6a6eef613c7da32d4fb068f82ef834b58134f6a16b54e6c1e5bf9529ab3d", size = 186678, upload-time = "2026-07-10T06:31:47.449Z" },
+    { url = "https://files.pythonhosted.org/packages/68/79/1caeacab5bc2081e4519288d248bc8bd2de30652e6eaa94be6be09a1fe5b/websockets-16.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:ad9411eded8988b879be6038206698bf7106c85a78f642c004485bcb95be17eb", size = 188554, upload-time = "2026-07-10T06:31:48.886Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/83/b3dca5fad71487b726e31cb0acf56f226792c1cc34e6ab18cbf146bd2d74/websockets-16.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:cd68f0914f3b64694895bc5e9b14e8b447e41d7bf5ffaf989bb8dcb5e2dfdce7", size = 186109, upload-time = "2026-07-10T06:31:50.508Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/0b/8f246c3712f07f207b52ea5fb47f3b2b66fafec7303162644c74aed51c6a/websockets-16.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:fef2debfe7f7ebdda12176f26166f95b7af17af05ba06150fcf889032e0213e9", size = 187061, upload-time = "2026-07-10T06:31:51.861Z" },
+    { url = "https://files.pythonhosted.org/packages/47/eb/27d6c92a01696b6495386af4fc941d7d0a13f2eab2bf9c336111d7321491/websockets-16.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a3cd6c9b798218798f4bb7b2e71c38f0e744bb94ca537b13376f88019d46384d", size = 187347, upload-time = "2026-07-10T06:31:53.246Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/d5/eeee439921f55d5eaeabcea18d0f7ce32cdc39cb8fc1e185431a094c5c7b/websockets-16.1-cp313-cp313-win32.whl", hash = "sha256:84c170c6869633536921e4474b1cce7254c0c9b0053ef5725f966cee47e718e4", size = 180149, upload-time = "2026-07-10T06:31:55.058Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/03/971e98d4a4864cf263f9e94c5b2b7c9a9b7682d77bfbba4e732c55ee85a9/websockets-16.1-cp313-cp313-win_amd64.whl", hash = "sha256:bef52d327d70fa75dad93ee61ea2cb1d1489aca9f35c188833563f5a3b4df0a5", size = 180458, upload-time = "2026-07-10T06:31:56.767Z" },
+    { url = "https://files.pythonhosted.org/packages/66/58/bd83247f39ddc26ffc2c24eb05087a3b749e00cb4509fc6d19daa23c8495/websockets-16.1-py3-none-any.whl", hash = "sha256:c5149dfe490ec7e5ee5dbf624c642fb725f93a5575c7f00ab594ca9eddb8dd81", size = 174031, upload-time = "2026-07-10T06:32:56.079Z" },
+]

--- a/uv.lock
+++ b/uv.lock
@@ -368,14 +368,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.2"
+version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d", size = 108379, upload-time = "2026-04-03T19:14:43.505Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
 ]
 
 [[package]]
@@ -2035,7 +2035,7 @@ requires-dist = [
     { name = "certifi", specifier = "==2026.2.25" },
     { name = "chardet", specifier = "==7.4.3" },
     { name = "charset-normalizer", specifier = "==3.4.7" },
-    { name = "click", specifier = "==8.3.2" },
+    { name = "click", specifier = "==8.3.3" },
     { name = "cloudscraper", specifier = "==1.2.71" },
     { name = "ebooklib", specifier = "==0.20" },
     { name = "fanficfare", specifier = "==4.56.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version < '3.12'",
+]
 
 [[package]]
 name = "aiosqlite"
@@ -131,6 +135,46 @@ wheels = [
 ]
 
 [[package]]
+name = "blis"
+version = "1.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/d0/d8cc8c9a4488a787e7fa430f6055e5bd1ddb22c340a751d9e901b82e2efe/blis-1.3.3.tar.gz", hash = "sha256:034d4560ff3cc43e8aa37e188451b0440e3261d989bb8a42ceee865607715ecd", size = 2644873, upload-time = "2025-11-17T12:28:30.511Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/0a/a4c8736bc497d386b0ffc76d321f478c03f1a4725e52092f93b38beb3786/blis-1.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e10c8d3e892b1dbdff365b9d00e08291876fc336915bf1a5e9f188ed087e1a91", size = 6925522, upload-time = "2025-11-17T12:27:29.199Z" },
+    { url = "https://files.pythonhosted.org/packages/83/5a/3437009282f23684ecd3963a8b034f9307cdd2bf4484972e5a6b096bf9ac/blis-1.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:66e6249564f1db22e8af1e0513ff64134041fa7e03c8dd73df74db3f4d8415a7", size = 1232787, upload-time = "2025-11-17T12:27:30.996Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/0e/82221910d16259ce3017c1442c468a3f206a4143a96fbba9f5b5b81d62e8/blis-1.3.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7260da065958b4e5475f62f44895ef9d673b0f47dcf61b672b22b7dae1a18505", size = 2844596, upload-time = "2025-11-17T12:27:32.601Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/93/ab547f1a5c23e20bca16fbcf04021c32aac3f969be737ea4980509a7ca90/blis-1.3.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e9327a6ca67de8ae76fe071e8584cc7f3b2e8bfadece4961d40f2826e1cda2df", size = 11377746, upload-time = "2025-11-17T12:27:35.342Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/a6/7733820aa62da32526287a63cd85c103b2b323b186c8ee43b7772ff7017c/blis-1.3.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c4ae70629cf302035d268858a10ca4eb6242a01b2dc8d64422f8e6dcb8a8ee74", size = 3041954, upload-time = "2025-11-17T12:27:37.479Z" },
+    { url = "https://files.pythonhosted.org/packages/87/53/e39d67fd3296b649772780ca6aab081412838ecb54e0b0c6432d01626a50/blis-1.3.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:45866a9027d43b93e8b59980a23c5d7358b6536fc04606286e39fdcfce1101c2", size = 14251222, upload-time = "2025-11-17T12:27:39.705Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/44/b749f8777b020b420bceaaf60f66432fc30cc904ca5b69640ec9cbef11ed/blis-1.3.3-cp311-cp311-win_amd64.whl", hash = "sha256:27f82b8633030f8d095d2b412dffa7eb6dbc8ee43813139909a20012e54422ea", size = 6171233, upload-time = "2025-11-17T12:27:41.921Z" },
+    { url = "https://files.pythonhosted.org/packages/16/d1/429cf0cf693d4c7dc2efed969bd474e315aab636e4a95f66c4ed7264912d/blis-1.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2a1c74e100665f8e918ebdbae2794576adf1f691680b5cdb8b29578432f623ef", size = 6929663, upload-time = "2025-11-17T12:27:44.482Z" },
+    { url = "https://files.pythonhosted.org/packages/11/69/363c8df8d98b3cc97be19aad6aabb2c9c53f372490d79316bdee92d476e7/blis-1.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3f6c595185176ce021316263e1a1d636a3425b6c48366c1fd712d08d0b71849a", size = 1230939, upload-time = "2025-11-17T12:27:46.19Z" },
+    { url = "https://files.pythonhosted.org/packages/96/2a/fbf65d906d823d839076c5150a6f8eb5ecbc5f9135e0b6510609bda1e6b7/blis-1.3.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d734b19fba0be7944f272dfa7b443b37c61f9476d9ab054a9ac53555ceadd2e0", size = 2818835, upload-time = "2025-11-17T12:27:48.167Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ad/58deaa3ad856dd3cc96493e40ffd2ed043d18d4d304f85a65cde1ccbf644/blis-1.3.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ef6d6e2b599a3a2788eb6d9b443533961265aa4ec49d574ed4bb846e548dcdb", size = 11366550, upload-time = "2025-11-17T12:27:49.958Z" },
+    { url = "https://files.pythonhosted.org/packages/78/82/816a7adfe1f7acc8151f01ec86ef64467a3c833932d8f19f8e06613b8a4e/blis-1.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8c888438ae99c500422d50698e3028b65caa8ebb44e24204d87fda2df64058f7", size = 3023686, upload-time = "2025-11-17T12:27:52.062Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/e2/0e93b865f648b5519360846669a35f28ee8f4e1d93d054f6850d8afbabde/blis-1.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8177879fd3590b5eecdd377f9deafb5dc8af6d684f065bd01553302fb3fcf9a7", size = 14250939, upload-time = "2025-11-17T12:27:53.847Z" },
+    { url = "https://files.pythonhosted.org/packages/20/07/fb43edc2ff0a6a367e4a94fc39eb3b85aa1e55e24cc857af2db145ce9f0d/blis-1.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:f20f7ad69aaffd1ce14fe77de557b6df9b61e0c9e582f75a843715d836b5c8af", size = 6192759, upload-time = "2025-11-17T12:27:56.176Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/f7/d26e62d9be3d70473a63e0a5d30bae49c2fe138bebac224adddcdef8a7ce/blis-1.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1e647341f958421a86b028a2efe16ce19c67dba2a05f79e8f7e80b1ff45328aa", size = 6928322, upload-time = "2025-11-17T12:27:57.965Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/78/750d12da388f714958eb2f2fd177652323bbe7ec528365c37129edd6eb84/blis-1.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d563160f874abb78a57e346f07312c5323f7ad67b6370052b6b17087ef234a8e", size = 1229635, upload-time = "2025-11-17T12:28:00.118Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/36/eac4199c5b200a5f3e93cad197da8d26d909f218eb444c4f552647c95240/blis-1.3.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:30b8a5b90cb6cb81d1ada9ae05aa55fb8e70d9a0ae9db40d2401bb9c1c8f14c4", size = 2815650, upload-time = "2025-11-17T12:28:02.544Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/51/472e7b36a6bedb5242a9757e7486f702c3619eff76e256735d0c8b1679c6/blis-1.3.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e9f5c53b277f6ac5b3ca30bc12ebab7ea16c8f8c36b14428abb56924213dc127", size = 11359008, upload-time = "2025-11-17T12:28:04.589Z" },
+    { url = "https://files.pythonhosted.org/packages/84/da/d0dfb6d6e6321ae44df0321384c32c322bd07b15740d7422727a1a49fc5d/blis-1.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6297e7616c158b305c9a8a4e47ca5fc9b0785194dd96c903b1a1591a7ca21ddf", size = 3011959, upload-time = "2025-11-17T12:28:06.862Z" },
+    { url = "https://files.pythonhosted.org/packages/20/c5/2b0b5e556fa0364ed671051ea078a6d6d7b979b1cfef78d64ad3ca5f0c7f/blis-1.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:3f966ca74f89f8a33e568b9a1d71992fc9a0d29a423e047f0a212643e21b5458", size = 14232456, upload-time = "2025-11-17T12:28:08.779Z" },
+    { url = "https://files.pythonhosted.org/packages/31/07/4cdc81a47bf862c0b06d91f1bc6782064e8b69ac9b5d4ff51d97e4ff03da/blis-1.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:7a0fc4b237a3a453bdc3c7ab48d91439fcd2d013b665c46948d9eaf9c3e45a97", size = 6192624, upload-time = "2025-11-17T12:28:14.197Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/8a/80f7c68fbc24a76fc9c18522c46d6d69329c320abb18e26a707a5d874083/blis-1.3.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c3e33cfbf22a418373766816343fcfcd0556012aa3ffdf562c29cddec448a415", size = 6934081, upload-time = "2025-11-17T12:28:16.436Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/52/d1aa3a51a7fc299b0c89dcaa971922714f50b1202769eebbdaadd1b5cff7/blis-1.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6f165930e8d3a85c606d2003211497e28d528c7416fbfeafb6b15600963f7c9b", size = 1231486, upload-time = "2025-11-17T12:28:18.008Z" },
+    { url = "https://files.pythonhosted.org/packages/99/4f/badc7bd7f74861b26c10123bba7b9d16f99cd9535ad0128780360713820f/blis-1.3.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:878d4d96d8f2c7a2459024f013f2e4e5f46d708b23437dae970d998e7bff14a0", size = 2814944, upload-time = "2025-11-17T12:28:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/72/a6/f62a3bd814ca19ec7e29ac889fd354adea1217df3183e10217de51e2eb8b/blis-1.3.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f36c0ca84a05ee5d3dbaa38056c4423c1fc29948b17a7923dd2fed8967375d74", size = 11345825, upload-time = "2025-11-17T12:28:21.354Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/6c/671af79ee42bc4c968cae35c091ac89e8721c795bfa4639100670dc59139/blis-1.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e5a662c48cd4aad5dae1a950345df23957524f071315837a4c6feb7d3b288990", size = 3008771, upload-time = "2025-11-17T12:28:23.637Z" },
+    { url = "https://files.pythonhosted.org/packages/be/92/7cd7f8490da7c98ee01557f2105885cc597217b0e7fd2eeb9e22cdd4ef23/blis-1.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9de26fbd72bac900c273b76d46f0b45b77a28eace2e01f6ac6c2239531a413bb", size = 14219213, upload-time = "2025-11-17T12:28:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/de/acae8e9f9a1f4bb393d41c8265898b0f29772e38eac14e9f69d191e2c006/blis-1.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:9e5fdf4211b1972400f8ff6dafe87cb689c5d84f046b4a76b207c0bd2270faaf", size = 6324695, upload-time = "2025-11-17T12:28:28.401Z" },
+]
+
+[[package]]
 name = "brotli"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -176,6 +220,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/73/3183c9e41ca755713bdf2cc1d0810df742c09484e2e1ddd693bee53877c1/brotli-1.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d2d085ded05278d1c7f65560aae97b3160aeb2ea2c0b3e26204856beccb60888", size = 1488164, upload-time = "2025-11-05T18:38:53.079Z" },
     { url = "https://files.pythonhosted.org/packages/64/6a/0c78d8f3a582859236482fd9fa86a65a60328a00983006bcf6d83b7b2253/brotli-1.2.0-cp314-cp314-win32.whl", hash = "sha256:832c115a020e463c2f67664560449a7bea26b0c1fdd690352addad6d0a08714d", size = 339280, upload-time = "2025-11-05T18:38:54.02Z" },
     { url = "https://files.pythonhosted.org/packages/f5/10/56978295c14794b2c12007b07f3e41ba26acda9257457d7085b0bb3bb90c/brotli-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:e7c0af964e0b4e3412a0ebf341ea26ec767fa0b4cf81abb5e897c9338b5ad6a3", size = 375639, upload-time = "2025-11-05T18:38:55.67Z" },
+]
+
+[[package]]
+name = "catalogue"
+version = "2.0.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/b4/244d58127e1cdf04cf2dc7d9566f0d24ef01d5ce21811bab088ecc62b5ea/catalogue-2.0.10.tar.gz", hash = "sha256:4f56daa940913d3f09d589c191c74e5a6d51762b3a9e37dd53b7437afd6cda15", size = 19561, upload-time = "2023-09-25T06:29:24.962Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/96/d32b941a501ab566a16358d68b6eb4e4acc373fab3c3c4d7d9e649f7b4bb/catalogue-2.0.10-py3-none-any.whl", hash = "sha256:58c2de0020aa90f4a2da7dfad161bf7b3b054c86a5f09fcedc0b2b740c109a9f", size = 17325, upload-time = "2023-09-25T06:29:23.337Z" },
 ]
 
 [[package]]
@@ -326,6 +379,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cloudpathlib"
+version = "0.24.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/19/58bc6b5d7d0f81c7209b05445af477e147c486552f96665a5912211839b9/cloudpathlib-0.24.0.tar.gz", hash = "sha256:c521a984e77b47e656fe78e20a7e3e260e0ab45fc69e33ac01094227c979e34a", size = 53600, upload-time = "2026-04-30T00:54:43.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/5b/ba933f896d9b0b07608d575a8501e2b4e32166b60d84c430a4a7285ebe64/cloudpathlib-0.24.0-py3-none-any.whl", hash = "sha256:b1c51e2d2ec7dc4fed6538991f4aea849d6cf11a7e6b9069f86e461aa1f9b5b4", size = 63214, upload-time = "2026-04-30T00:54:42.06Z" },
+]
+
+[[package]]
 name = "cloudscraper"
 version = "1.2.71"
 source = { registry = "https://pypi.org/simple" }
@@ -346,6 +408,71 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "confection"
+version = "1.3.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/65/efd0fe8a936fc8ca2978cb7b82581fb20d901c6039e746a808f746b7647b/confection-1.3.3.tar.gz", hash = "sha256:f0f6810d567ff73993fe74d218ca5e1ffb6a44fb03f391257fc5d033546cbfaa", size = 54895, upload-time = "2026-03-24T18:45:24.331Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/e4/d66708bdf0d92fb4d49b22cdff4b10cec38aca5dcd7e81d909bb55c65cd7/confection-1.3.3-py3-none-any.whl", hash = "sha256:b9fef9ee84b237ef4611ec3eb5797b70e13063e6310ad9f15536373f5e313c82", size = 35902, upload-time = "2026-03-24T18:45:22.664Z" },
+]
+
+[[package]]
+name = "cymem"
+version = "2.0.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/2f0fbb32535c3731b7c2974c569fb9325e0a38ed5565a08e1139a3b71e82/cymem-2.0.13.tar.gz", hash = "sha256:1c91a92ae8c7104275ac26bd4d29b08ccd3e7faff5893d3858cb6fadf1bc1588", size = 12320, upload-time = "2025-11-14T14:58:36.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/64/1db41f7576a6b69f70367e3c15e968fd775ba7419e12059c9966ceb826f8/cymem-2.0.13-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:673183466b0ff2e060d97ec5116711d44200b8f7be524323e080d215ee2d44a5", size = 43587, upload-time = "2025-11-14T14:57:22.39Z" },
+    { url = "https://files.pythonhosted.org/packages/81/13/57f936fc08551323aab3f92ff6b7f4d4b89d5b4e495c870a67cb8d279757/cymem-2.0.13-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bee2791b3f6fc034ce41268851462bf662ff87e8947e35fb6dd0115b4644a61f", size = 43139, upload-time = "2025-11-14T14:57:23.363Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a6/9345754be51e0479aa387b7b6cffc289d0fd3201aaeb8dade4623abd1e02/cymem-2.0.13-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f3aee3adf16272bca81c5826eed55ba3c938add6d8c9e273f01c6b829ecfde22", size = 245063, upload-time = "2025-11-14T14:57:24.839Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/01/6bc654101526fa86e82bf6b05d99b2cd47c30a333cfe8622c26c0592beb2/cymem-2.0.13-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:30c4e75a3a1d809e89106b0b21803eb78e839881aa1f5b9bd27b454bc73afde3", size = 244496, upload-time = "2025-11-14T14:57:26.42Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/fb/853b7b021e701a1f41687f3704d5f469aeb2a4f898c3fbb8076806885955/cymem-2.0.13-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ec99efa03cf8ec11c8906aa4d4cc0c47df393bc9095c9dd64b89b9b43e220b04", size = 243287, upload-time = "2025-11-14T14:57:27.542Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/2b/0e4664cafc581de2896d75000651fd2ce7094d33263f466185c28ffc96e4/cymem-2.0.13-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c90a6ecba994a15b17a3f45d7ec74d34081df2f73bd1b090e2adc0317e4e01b6", size = 248287, upload-time = "2025-11-14T14:57:29.055Z" },
+    { url = "https://files.pythonhosted.org/packages/21/0f/f94c6950edbfc2aafb81194fc40b6cacc8e994e9359d3cb4328c5705b9b5/cymem-2.0.13-cp311-cp311-win_amd64.whl", hash = "sha256:ce821e6ba59148ed17c4567113b8683a6a0be9c9ac86f14e969919121efb61a5", size = 40116, upload-time = "2025-11-14T14:57:30.592Z" },
+    { url = "https://files.pythonhosted.org/packages/00/df/2455eff6ac0381ff165db6883b311f7016e222e3dd62185517f8e8187ed0/cymem-2.0.13-cp311-cp311-win_arm64.whl", hash = "sha256:0dca715e708e545fd1d97693542378a00394b20a37779c1ae2c8bdbb43acef79", size = 36349, upload-time = "2025-11-14T14:57:31.573Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/52/478a2911ab5028cb710b4900d64aceba6f4f882fcb13fd8d40a456a1b6dc/cymem-2.0.13-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e8afbc5162a0fe14b6463e1c4e45248a1b2fe2cbcecc8a5b9e511117080da0eb", size = 43745, upload-time = "2025-11-14T14:57:32.52Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/71/f0f8adee945524774b16af326bd314a14a478ed369a728a22834e6785a18/cymem-2.0.13-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c9251d889348fe79a75e9b3e4d1b5fa651fca8a64500820685d73a3acc21b6a8", size = 42927, upload-time = "2025-11-14T14:57:33.827Z" },
+    { url = "https://files.pythonhosted.org/packages/62/6d/159780fe162ff715d62b809246e5fc20901cef87ca28b67d255a8d741861/cymem-2.0.13-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:742fc19764467a49ed22e56a4d2134c262d73a6c635409584ae3bf9afa092c33", size = 258346, upload-time = "2025-11-14T14:57:34.917Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/12/678d16f7aa1996f947bf17b8cfb917ea9c9674ef5e2bd3690c04123d5680/cymem-2.0.13-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f190a92fe46197ee64d32560eb121c2809bb843341733227f51538ce77b3410d", size = 260843, upload-time = "2025-11-14T14:57:36.503Z" },
+    { url = "https://files.pythonhosted.org/packages/31/5d/0dd8c167c08cd85e70d274b7235cfe1e31b3cebc99221178eaf4bbb95c6f/cymem-2.0.13-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d670329ee8dbbbf241b7c08069fe3f1d3a1a3e2d69c7d05ea008a7010d826298", size = 254607, upload-time = "2025-11-14T14:57:38.036Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/c9/d6514a412a1160aa65db539836b3d47f9b59f6675f294ec34ae32f867c82/cymem-2.0.13-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a84ba3178d9128b9ffb52ce81ebab456e9fe959125b51109f5b73ebdfc6b60d6", size = 262421, upload-time = "2025-11-14T14:57:39.265Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/fe/3ee37d02ca4040f2fb22d34eb415198f955862b5dd47eee01df4c8f5454c/cymem-2.0.13-cp312-cp312-win_amd64.whl", hash = "sha256:2ff1c41fd59b789579fdace78aa587c5fc091991fa59458c382b116fc36e30dc", size = 40176, upload-time = "2025-11-14T14:57:40.706Z" },
+    { url = "https://files.pythonhosted.org/packages/94/fb/1b681635bfd5f2274d0caa8f934b58435db6c091b97f5593738065ddb786/cymem-2.0.13-cp312-cp312-win_arm64.whl", hash = "sha256:6bbd701338df7bf408648191dff52472a9b334f71bcd31a21a41d83821050f67", size = 35959, upload-time = "2025-11-14T14:57:41.682Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/0f/95a4d1e3bebfdfa7829252369357cf9a764f67569328cd9221f21e2c952e/cymem-2.0.13-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:891fd9030293a8b652dc7fb9fdc79a910a6c76fc679cd775e6741b819ffea476", size = 43478, upload-time = "2025-11-14T14:57:42.682Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/a0/8fc929cc29ae466b7b4efc23ece99cbd3ea34992ccff319089c624d667fd/cymem-2.0.13-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:89c4889bd16513ce1644ccfe1e7c473ba7ca150f0621e66feac3a571bde09e7e", size = 42695, upload-time = "2025-11-14T14:57:43.741Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/b3/deeb01354ebaf384438083ffe0310209ef903db3e7ba5a8f584b06d28387/cymem-2.0.13-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:45dcaba0f48bef9cc3d8b0b92058640244a95a9f12542210b51318da97c2cf28", size = 250573, upload-time = "2025-11-14T14:57:44.81Z" },
+    { url = "https://files.pythonhosted.org/packages/36/36/bc980b9a14409f3356309c45a8d88d58797d02002a9d794dd6c84e809d3a/cymem-2.0.13-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e96848faaafccc0abd631f1c5fb194eac0caee4f5a8777fdbb3e349d3a21741c", size = 254572, upload-time = "2025-11-14T14:57:46.023Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/dd/a12522952624685bd0f8968e26d2ed6d059c967413ce6eb52292f538f1b0/cymem-2.0.13-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e02d3e2c3bfeb21185d5a4a70790d9df40629a87d8d7617dc22b4e864f665fa3", size = 248060, upload-time = "2025-11-14T14:57:47.605Z" },
+    { url = "https://files.pythonhosted.org/packages/08/11/5dc933ddfeb2dfea747a0b935cb965b9a7580b324d96fc5f5a1b5ff8df29/cymem-2.0.13-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fece5229fd5ecdcd7a0738affb8c59890e13073ae5626544e13825f26c019d3c", size = 254601, upload-time = "2025-11-14T14:57:48.861Z" },
+    { url = "https://files.pythonhosted.org/packages/70/66/d23b06166864fa94e13a98e5922986ce774832936473578febce64448d75/cymem-2.0.13-cp313-cp313-win_amd64.whl", hash = "sha256:38aefeb269597c1a0c2ddf1567dd8605489b661fa0369c6406c1acd433b4c7ba", size = 40103, upload-time = "2025-11-14T14:57:50.396Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/9e/c7b21271ab88a21760f3afdec84d2bc09ffa9e6c8d774ad9d4f1afab0416/cymem-2.0.13-cp313-cp313-win_arm64.whl", hash = "sha256:717270dcfd8c8096b479c42708b151002ff98e434a7b6f1f916387a6c791e2ad", size = 36016, upload-time = "2025-11-14T14:57:51.611Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/28/d3b03427edc04ae04910edf1c24b993881c3ba93a9729a42bcbb816a1808/cymem-2.0.13-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:7e1a863a7f144ffb345397813701509cfc74fc9ed360a4d92799805b4b865dd1", size = 46429, upload-time = "2025-11-14T14:57:52.582Z" },
+    { url = "https://files.pythonhosted.org/packages/35/a9/7ed53e481f47ebfb922b0b42e980cec83e98ccb2137dc597ea156642440c/cymem-2.0.13-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:c16cb80efc017b054f78998c6b4b013cef509c7b3d802707ce1f85a1d68361bf", size = 46205, upload-time = "2025-11-14T14:57:53.64Z" },
+    { url = "https://files.pythonhosted.org/packages/61/39/a3d6ad073cf7f0fbbb8bbf09698c3c8fac11be3f791d710239a4e8dd3438/cymem-2.0.13-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0d78a27c88b26c89bd1ece247d1d5939dba05a1dae6305aad8fd8056b17ddb51", size = 296083, upload-time = "2025-11-14T14:57:55.922Z" },
+    { url = "https://files.pythonhosted.org/packages/36/0c/20697c8bc19f624a595833e566f37d7bcb9167b0ce69de896eba7cfc9c2d/cymem-2.0.13-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6d36710760f817194dacb09d9fc45cb6a5062ed75e85f0ef7ad7aeeb13d80cc3", size = 286159, upload-time = "2025-11-14T14:57:57.106Z" },
+    { url = "https://files.pythonhosted.org/packages/82/d4/9326e3422d1c2d2b4a8fb859bdcce80138f6ab721ddafa4cba328a505c71/cymem-2.0.13-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c8f30971cadd5dcf73bcfbbc5849b1f1e1f40db8cd846c4aa7d3b5e035c7b583", size = 288186, upload-time = "2025-11-14T14:57:58.334Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/bc/68da7dd749b72884dc22e898562f335002d70306069d496376e5ff3b6153/cymem-2.0.13-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:9d441d0e45798ec1fd330373bf7ffa6b795f229275f64016b6a193e6e2a51522", size = 290353, upload-time = "2025-11-14T14:58:00.562Z" },
+    { url = "https://files.pythonhosted.org/packages/50/23/dbf2ad6ecd19b99b3aab6203b1a06608bbd04a09c522d836b854f2f30f73/cymem-2.0.13-cp313-cp313t-win_amd64.whl", hash = "sha256:d1c950eebb9f0f15e3ef3591313482a5a611d16fc12d545e2018cd607f40f472", size = 44764, upload-time = "2025-11-14T14:58:01.793Z" },
+    { url = "https://files.pythonhosted.org/packages/54/3f/35701c13e1fc7b0895198c8b20068c569a841e0daf8e0b14d1dc0816b28f/cymem-2.0.13-cp313-cp313t-win_arm64.whl", hash = "sha256:042e8611ef862c34a97b13241f5d0da86d58aca3cecc45c533496678e75c5a1f", size = 38964, upload-time = "2025-11-14T14:58:02.87Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/2e/f0e1596010a9a57fa9ebd124a678c07c5b2092283781ae51e79edcf5cb98/cymem-2.0.13-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d2a4bf67db76c7b6afc33de44fb1c318207c3224a30da02c70901936b5aafdf1", size = 43812, upload-time = "2025-11-14T14:58:04.227Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/45/8ccc21df08fcbfa6aa3efeb7efc11a1c81c90e7476e255768bb9c29ba02a/cymem-2.0.13-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:92a2ce50afa5625fb5ce7c9302cee61e23a57ccac52cd0410b4858e572f8614b", size = 42951, upload-time = "2025-11-14T14:58:05.424Z" },
+    { url = "https://files.pythonhosted.org/packages/01/8c/fe16531631f051d3d1226fa42e2d76fd2c8d5cfa893ec93baee90c7a9d90/cymem-2.0.13-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bc116a70cc3a5dc3d1684db5268eff9399a0be8603980005e5b889564f1ea42f", size = 249878, upload-time = "2025-11-14T14:58:06.95Z" },
+    { url = "https://files.pythonhosted.org/packages/47/4b/39d67b80ffb260457c05fcc545de37d82e9e2dbafc93dd6b64f17e09b933/cymem-2.0.13-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:68489bf0035c4c280614067ab6a82815b01dc9fcd486742a5306fe9f68deb7ef", size = 252571, upload-time = "2025-11-14T14:58:08.232Z" },
+    { url = "https://files.pythonhosted.org/packages/53/0e/76f6531f74dfdfe7107899cce93ab063bb7ee086ccd3910522b31f623c08/cymem-2.0.13-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:03cb7bdb55718d5eb6ef0340b1d2430ba1386db30d33e9134d01ba9d6d34d705", size = 248555, upload-time = "2025-11-14T14:58:09.429Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7c/eee56757db81f0aefc2615267677ae145aff74228f529838425057003c0d/cymem-2.0.13-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1710390e7fb2510a8091a1991024d8ae838fd06b02cdfdcd35f006192e3c6b0e", size = 254177, upload-time = "2025-11-14T14:58:10.594Z" },
+    { url = "https://files.pythonhosted.org/packages/77/e0/a4b58ec9e53c836dce07ef39837a64a599f4a21a134fc7ca57a3a8f9a4b5/cymem-2.0.13-cp314-cp314-win_amd64.whl", hash = "sha256:ac699c8ec72a3a9de8109bd78821ab22f60b14cf2abccd970b5ff310e14158ed", size = 40853, upload-time = "2025-11-14T14:58:12.116Z" },
+    { url = "https://files.pythonhosted.org/packages/61/81/9931d1f83e5aeba175440af0b28f0c2e6f71274a5a7b688bc3e907669388/cymem-2.0.13-cp314-cp314-win_arm64.whl", hash = "sha256:90c2d0c04bcda12cd5cebe9be93ce3af6742ad8da96e1b1907e3f8e00291def1", size = 36970, upload-time = "2025-11-14T14:58:13.114Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/ef/af447c2184dec6dec973be14614df8ccb4d16d1c74e0784ab4f02538433c/cymem-2.0.13-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:ff036bbc1464993552fd1251b0a83fe102af334b301e3896d7aa05a4999ad042", size = 46804, upload-time = "2025-11-14T14:58:14.113Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/95/e10f33a8d4fc17f9b933d451038218437f9326c2abb15a3e7f58ce2a06ec/cymem-2.0.13-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:fb8291691ba7ff4e6e000224cc97a744a8d9588418535c9454fd8436911df612", size = 46254, upload-time = "2025-11-14T14:58:15.156Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/7a/5efeb2d2ea6ebad2745301ad33a4fa9a8f9a33b66623ee4d9185683007a6/cymem-2.0.13-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d8d06ea59006b1251ad5794bcc00121e148434826090ead0073c7b7fedebe431", size = 296061, upload-time = "2025-11-14T14:58:16.254Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/28/2a3f65842cc8443c2c0650cf23d525be06c8761ab212e0a095a88627be1b/cymem-2.0.13-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c0046a619ecc845ccb4528b37b63426a0cbcb4f14d7940add3391f59f13701e6", size = 285784, upload-time = "2025-11-14T14:58:17.412Z" },
+    { url = "https://files.pythonhosted.org/packages/98/73/dd5f9729398f0108c2e71d942253d0d484d299d08b02e474d7cfc43ed0b0/cymem-2.0.13-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:18ad5b116a82fa3674bc8838bd3792891b428971e2123ae8c0fd3ca472157c5e", size = 288062, upload-time = "2025-11-14T14:58:20.225Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/01/ffe51729a8f961a437920560659073e47f575d4627445216c1177ecd4a41/cymem-2.0.13-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:666ce6146bc61b9318aa70d91ce33f126b6344a25cf0b925621baed0c161e9cc", size = 290465, upload-time = "2025-11-14T14:58:21.815Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/ac/c9e7d68607f71ef978c81e334ab2898b426944c71950212b1467186f69f9/cymem-2.0.13-cp314-cp314t-win_amd64.whl", hash = "sha256:84c1168c563d9d1e04546cb65e3e54fde2bf814f7c7faf11fc06436598e386d1", size = 46665, upload-time = "2025-11-14T14:58:23.512Z" },
+    { url = "https://files.pythonhosted.org/packages/66/66/150e406a2db5535533aa3c946de58f0371f2e412e23f050c704588023e6e/cymem-2.0.13-cp314-cp314t-win_arm64.whl", hash = "sha256:e9027764dc5f1999fb4b4cabee1d0322c59e330c0a6485b436a68275f614277f", size = 39715, upload-time = "2025-11-14T14:58:24.773Z" },
 ]
 
 [[package]]
@@ -563,6 +690,21 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
 name = "httpx2"
 version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -594,6 +736,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
 ]
 
 [[package]]
@@ -711,6 +865,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -794,12 +960,222 @@ wheels = [
 ]
 
 [[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "murmurhash"
+version = "1.0.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/2e/88c147931ea9725d634840d538622e94122bceaf346233349b7b5c62964b/murmurhash-1.0.15.tar.gz", hash = "sha256:58e2b27b7847f9e2a6edf10b47a8c8dd70a4705f45dccb7bf76aeadacf56ba01", size = 13291, upload-time = "2025-11-14T09:51:15.272Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/ca/77d3e69924a8eb4508bb4f0ad34e46adbeedeb93616a71080e61e53dad71/murmurhash-1.0.15-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f32307fb9347680bb4fe1cbef6362fb39bd994f1b59abd8c09ca174e44199081", size = 27397, upload-time = "2025-11-14T09:50:03.077Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/53/a936f577d35b245d47b310f29e5e9f09fcac776c8c992f1ab51a9fb0cee2/murmurhash-1.0.15-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:539d8405885d1d19c005f3a2313b47e8e54b0ee89915eb8dfbb430b194328e6c", size = 27692, upload-time = "2025-11-14T09:50:04.144Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/64/5f8cfd1fd9cbeb43fcff96672f5bd9e7e1598d1c970f808ecd915490dc20/murmurhash-1.0.15-cp311-cp311-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c4cd739a00f5a4602201b74568ddabae46ec304719d9be752fd8f534a9464b5e", size = 128396, upload-time = "2025-11-14T09:50:05.268Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/10/d9ce29d559a75db0d8a3f13ea12c7f541ec9de2afca38dc70418b890eedb/murmurhash-1.0.15-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:44d211bcc3ec203c47dac06f48ee871093fcbdffa6652a6cc5ea7180306680a8", size = 128687, upload-time = "2025-11-14T09:50:06.527Z" },
+    { url = "https://files.pythonhosted.org/packages/48/cd/dc97ab7e68cdfa1537a56e36dbc846c5a66701cc39ecee2d4399fe61996c/murmurhash-1.0.15-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:f9bf47101354fb1dc4b2e313192566f04ba295c28a37e2f71c692759acc1ba3c", size = 128198, upload-time = "2025-11-14T09:50:08.062Z" },
+    { url = "https://files.pythonhosted.org/packages/53/73/32f2aaa22c1e4afae337106baf0c938abf36a6cc879cfee83a00461bbbf7/murmurhash-1.0.15-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3c69b4d3bcd6233782a78907fe10b9b7a796bdc5d28060cf097d067bec280a5d", size = 127214, upload-time = "2025-11-14T09:50:09.265Z" },
+    { url = "https://files.pythonhosted.org/packages/82/ed/812103a7f353eba2d83655b08205e13a38c93b4db0692f94756e1eb44516/murmurhash-1.0.15-cp311-cp311-win_amd64.whl", hash = "sha256:e43a69496342ce530bdd670264cb7c8f45490b296e4764c837ce577e3c7ebd53", size = 25241, upload-time = "2025-11-14T09:50:10.373Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/5f/2c511bdd28f7c24da37a00116ffd0432b65669d098f0d0260c66ac0ffdc2/murmurhash-1.0.15-cp311-cp311-win_arm64.whl", hash = "sha256:f3e99a6ee36ef5372df5f138e3d9c801420776d3641a34a49e5c2555f44edba7", size = 23216, upload-time = "2025-11-14T09:50:11.651Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/46/be8522d3456fdccf1b8b049c6d82e7a3c1114c4fc2cfe14b04cba4b3e701/murmurhash-1.0.15-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d37e3ae44746bca80b1a917c2ea625cf216913564ed43f69d2888e5df97db0cb", size = 27884, upload-time = "2025-11-14T09:50:13.133Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/cc/630449bf4f6178d7daf948ce46ad00b25d279065fc30abd8d706be3d87e0/murmurhash-1.0.15-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0861cb11039409eaf46878456b7d985ef17b6b484103a6fc367b2ecec846891d", size = 27855, upload-time = "2025-11-14T09:50:14.859Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/30/ea8f601a9bf44db99468696efd59eb9cff1157cd55cb586d67116697583f/murmurhash-1.0.15-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5a301decfaccfec70fe55cb01dde2a012c3014a874542eaa7cc73477bb749616", size = 134088, upload-time = "2025-11-14T09:50:15.958Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/de/c40ce8c0877d406691e735b8d6e9c815f36a82b499d358313db5dbe219d7/murmurhash-1.0.15-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:32c6fde7bd7e9407003370a07b5f4addacabe1556ad3dc2cac246b7a2bba3400", size = 133978, upload-time = "2025-11-14T09:50:17.572Z" },
+    { url = "https://files.pythonhosted.org/packages/47/84/bd49963ecd84ebab2fe66595e2d1ed41d5e8b5153af5dc930f0bd827007c/murmurhash-1.0.15-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5d8b43a7011540dc3c7ce66f2134df9732e2bc3bbb4a35f6458bc755e48bde26", size = 132956, upload-time = "2025-11-14T09:50:18.742Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/7c/2530769c545074417c862583f05f4245644599f1e9ff619b3dfe2969aafc/murmurhash-1.0.15-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:43bf4541892ecd95963fcd307bf1c575fc0fee1682f41c93007adee71ca2bb40", size = 134184, upload-time = "2025-11-14T09:50:19.941Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a4/b249b042f5afe34d14ada2dc4afc777e883c15863296756179652e081c44/murmurhash-1.0.15-cp312-cp312-win_amd64.whl", hash = "sha256:f4ac15a2089dc42e6eb0966622d42d2521590a12c92480aafecf34c085302cca", size = 25647, upload-time = "2025-11-14T09:50:21.049Z" },
+    { url = "https://files.pythonhosted.org/packages/13/bf/028179259aebc18fd4ba5cae2601d1d47517427a537ab44336446431a215/murmurhash-1.0.15-cp312-cp312-win_arm64.whl", hash = "sha256:4a70ca4ae19e600d9be3da64d00710e79dde388a4d162f22078d64844d0ebdda", size = 23338, upload-time = "2025-11-14T09:50:22.359Z" },
+    { url = "https://files.pythonhosted.org/packages/29/2f/ba300b5f04dae0409202d6285668b8a9d3ade43a846abee3ef611cb388d5/murmurhash-1.0.15-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fe50dc70e52786759358fd1471e309b94dddfffb9320d9dfea233c7684c894ba", size = 27861, upload-time = "2025-11-14T09:50:23.804Z" },
+    { url = "https://files.pythonhosted.org/packages/34/02/29c19d268e6f4ea1ed2a462c901eed1ed35b454e2cbc57da592fad663ac6/murmurhash-1.0.15-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1349a7c23f6092e7998ddc5bd28546cc31a595afc61e9fdb3afc423feec3d7ad", size = 27840, upload-time = "2025-11-14T09:50:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/63/58e2de2b5232cd294c64092688c422196e74f9fa8b3958bdf02d33df24b9/murmurhash-1.0.15-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b3ba6d05de2613535b5a9227d4ad8ef40a540465f64660d4a8800634ae10e04f", size = 133080, upload-time = "2025-11-14T09:50:26.566Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/9a/d13e2e9f8ba1ced06840921a50f7cece0a475453284158a3018b72679761/murmurhash-1.0.15-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fa1b70b3cc2801ab44179c65827bbd12009c68b34e9d9ce7125b6a0bd35af63c", size = 132648, upload-time = "2025-11-14T09:50:27.788Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e1/47994f1813fa205c84977b0ff51ae6709f8539af052c7491a5f863d82bdc/murmurhash-1.0.15-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:213d710fb6f4ef3bc11abbfad0fa94a75ffb675b7dc158c123471e5de869f9af", size = 131502, upload-time = "2025-11-14T09:50:29.339Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ea/90c1fd00b4aeb704fb5e84cd666b33ffd7f245155048071ffbb51d2bb57d/murmurhash-1.0.15-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b65a5c4e7f5d71f7ccac2d2b60bdf7092d7976270878cfec59d5a66a533db823", size = 132736, upload-time = "2025-11-14T09:50:30.545Z" },
+    { url = "https://files.pythonhosted.org/packages/00/db/da73462dbfa77f6433b128d2120ba7ba300f8c06dc4f4e022c38d240a5f5/murmurhash-1.0.15-cp313-cp313-win_amd64.whl", hash = "sha256:9aba94c5d841e1904cd110e94ceb7f49cfb60a874bbfb27e0373622998fb7c7c", size = 25682, upload-time = "2025-11-14T09:50:31.624Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/83/032729ef14971b938fbef41ee125fc8800020ee229bd35178b6ede8ee934/murmurhash-1.0.15-cp313-cp313-win_arm64.whl", hash = "sha256:263807eca40d08c7b702413e45cca75ecb5883aa337237dc5addb660f1483378", size = 23370, upload-time = "2025-11-14T09:50:33.264Z" },
+    { url = "https://files.pythonhosted.org/packages/10/83/7547d9205e9bd2f8e5dfd0b682cc9277594f98909f228eb359489baec1df/murmurhash-1.0.15-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:694fd42a74b7ce257169d14c24aa616aa6cd4ccf8abe50eca0557e08da99d055", size = 29955, upload-time = "2025-11-14T09:50:34.488Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/c7/3afd5de7a5b3ae07fe2d3a3271b327ee1489c58ba2b2f2159bd31a25edb9/murmurhash-1.0.15-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a2ea4546ba426390beff3cd10db8f0152fdc9072c4f2583ec7d8aa9f3e4ac070", size = 30108, upload-time = "2025-11-14T09:50:35.53Z" },
+    { url = "https://files.pythonhosted.org/packages/02/69/d6637ee67d78ebb2538c00411f28ea5c154886bbe1db16c49435a8a4ab16/murmurhash-1.0.15-cp313-cp313t-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:34e5a91139c40b10f98d0b297907f5d5267b4b1b2e5dd2eb74a021824f751b98", size = 164054, upload-time = "2025-11-14T09:50:36.591Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/4c/89e590165b4c7da6bf941441212a721a270195332d3aacfdfdf527d466ca/murmurhash-1.0.15-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:dc35606868a5961cf42e79314ca0bddf5a400ce377b14d83192057928d6252ec", size = 168153, upload-time = "2025-11-14T09:50:37.856Z" },
+    { url = "https://files.pythonhosted.org/packages/07/7a/95c42df0c21d2e413b9fcd17317a7587351daeb264dc29c6aec1fdbd26f8/murmurhash-1.0.15-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:43cc6ac3b91ca0f7a5ae9c063ba4d6c26972c97fd7c25280ecc666413e4c5535", size = 164345, upload-time = "2025-11-14T09:50:39.346Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/22/9d02c880a88b83bb3ce7d6a38fb727373ab78d82e5f3d8d9fc5612219f90/murmurhash-1.0.15-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:847d712136cb462f0e4bd6229ee2d9eb996d8854eb8312dff3d20c8f5181fda5", size = 161990, upload-time = "2025-11-14T09:50:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e3/750232524e0dc262e8dcede6536dafc766faadd9a52f1d23746b02948ad8/murmurhash-1.0.15-cp313-cp313t-win_amd64.whl", hash = "sha256:2680851af6901dbe66cc4aa7ef8e263de47e6e1b425ae324caa571bdf18f8d58", size = 28812, upload-time = "2025-11-14T09:50:41.971Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/89/4ad9d215ef6ade89f27a72dc4e86b98ef1a43534cc3e6a6900a362a0bf0a/murmurhash-1.0.15-cp313-cp313t-win_arm64.whl", hash = "sha256:189a8de4d657b5da9efd66601b0636330b08262b3a55431f2379097c986995d0", size = 25398, upload-time = "2025-11-14T09:50:43.023Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/69/726df275edf07688146966e15eaaa23168100b933a2e1a29b37eb56c6db8/murmurhash-1.0.15-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:7c4280136b738e85ff76b4bdc4341d0b867ee753e73fd8b6994288080c040d0b", size = 28029, upload-time = "2025-11-14T09:50:44.124Z" },
+    { url = "https://files.pythonhosted.org/packages/59/8f/24ecf9061bc2b20933df8aba47c73e904274ea8811c8300cab92f6f82372/murmurhash-1.0.15-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d4d681f474830489e2ec1d912095cfff027fbaf2baa5414c7e9d25b89f0fab68", size = 27912, upload-time = "2025-11-14T09:50:45.266Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/26/fff3caba25aa3c0622114e03c69fb66c839b22335b04d7cce91a3a126d44/murmurhash-1.0.15-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d7e47c5746785db6a43b65fac47b9e63dd71dfbd89a8c92693425b9715e68c6e", size = 131847, upload-time = "2025-11-14T09:50:46.819Z" },
+    { url = "https://files.pythonhosted.org/packages/df/e4/0f2b9fc533467a27afb4e906c33f32d5f637477de87dd94690e0c44335a6/murmurhash-1.0.15-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e8e674f02a99828c8a671ba99cd03299381b2f0744e6f25c29cadfc6151dc724", size = 132267, upload-time = "2025-11-14T09:50:48.298Z" },
+    { url = "https://files.pythonhosted.org/packages/da/bf/9d1c107989728ec46e25773d503aa54070b32822a18cfa7f9d5f41bc17a5/murmurhash-1.0.15-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:26fd7c7855ac4850ad8737991d7b0e3e501df93ebaf0cf45aa5954303085fdba", size = 131894, upload-time = "2025-11-14T09:50:49.485Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/81/dcf27c71445c0e993b10e33169a098ca60ee702c5c58fcbde205fa6332a6/murmurhash-1.0.15-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cb8ebafae60d5f892acff533cc599a359954d8c016a829514cb3f6e9ee10f322", size = 132054, upload-time = "2025-11-14T09:50:50.747Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/32/e874a14b2d2246bd2d16f80f49fad393a3865d4ee7d66d2cae939a67a29a/murmurhash-1.0.15-cp314-cp314-win_amd64.whl", hash = "sha256:898a629bf111f1aeba4437e533b5b836c0a9d2dd12d6880a9c75f6ca13e30e22", size = 26579, upload-time = "2025-11-14T09:50:52.278Z" },
+    { url = "https://files.pythonhosted.org/packages/af/8e/4fca051ed8ae4d23a15aaf0a82b18cb368e8cf84f1e3b474d5749ec46069/murmurhash-1.0.15-cp314-cp314-win_arm64.whl", hash = "sha256:88dc1dd53b7b37c0df1b8b6bce190c12763014492f0269ff7620dc6027f470f4", size = 24341, upload-time = "2025-11-14T09:50:53.295Z" },
+    { url = "https://files.pythonhosted.org/packages/38/9c/c72c2a4edd86aac829337ab9f83cf04cdb15e5d503e4c9a3a243f30a261c/murmurhash-1.0.15-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:6cb4e962ec4f928b30c271b2d84e6707eff6d942552765b663743cfa618b294b", size = 30146, upload-time = "2025-11-14T09:50:54.705Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d7/72b47ebc86436cd0aa1fd4c6e8779521ec389397ac11389990278d0f7a47/murmurhash-1.0.15-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5678a3ea4fbf0cbaaca2bed9b445f556f294d5f799c67185d05ffcb221a77faf", size = 30141, upload-time = "2025-11-14T09:50:55.829Z" },
+    { url = "https://files.pythonhosted.org/packages/64/bb/6d2f09135079c34dc2d26e961c52742d558b320c61503f273eab6ba743d9/murmurhash-1.0.15-cp314-cp314t-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ef19f38c6b858eef83caf710773db98c8f7eb2193b4c324650c74f3d8ba299e0", size = 163898, upload-time = "2025-11-14T09:50:56.946Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/e2/9c1b462e33f9cb2d632056f07c90b502fc20bd7da50a15d0557343bd2fed/murmurhash-1.0.15-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22aa3ceaedd2e57078b491ed08852d512b84ff4ff9bb2ff3f9bf0eec7f214c9e", size = 168040, upload-time = "2025-11-14T09:50:58.234Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/73/8694db1408fcdfa73589f7df6c445437ea146986fa1e393ec60d26d6e30c/murmurhash-1.0.15-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bba0e0262c0d08682b028cb963ac477bd9839029486fa1333fc5c01fb6072749", size = 164239, upload-time = "2025-11-14T09:50:59.95Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/f9/8e360bdfc3c44e267e7e046f0e0b9922766da92da26959a6963f597e6bb5/murmurhash-1.0.15-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4fd8189ee293a09f30f4931408f40c28ccd42d9de4f66595f8814879339378bc", size = 161811, upload-time = "2025-11-14T09:51:01.289Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/31/97649680595b1096803d877ababb9a67c07f4378f177ec885eea28b9db6d/murmurhash-1.0.15-cp314-cp314t-win_amd64.whl", hash = "sha256:66395b1388f7daa5103db92debe06842ae3be4c0749ef6db68b444518666cdcc", size = 29817, upload-time = "2025-11-14T09:51:02.493Z" },
+    { url = "https://files.pythonhosted.org/packages/76/66/4fce8755f25d77324401886c00017c556be7ca3039575b94037aff905385/murmurhash-1.0.15-cp314-cp314t-win_arm64.whl", hash = "sha256:c22e56c6a0b70598a66e456de5272f76088bc623688da84ef403148a6d41851d", size = 26219, upload-time = "2025-11-14T09:51:03.563Z" },
+]
+
+[[package]]
+name = "mutagen"
+version = "1.48.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/70/1675da133ea92227da41bf5b24e1c66be597ff736a1533ade41da986852f/mutagen-1.48.1.tar.gz", hash = "sha256:8f95637ab9f6f305cec6bd1294e197debe207998e3e068596563c74f86b0a173", size = 1276978, upload-time = "2026-06-25T09:47:32.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/d8/a29e4e3991765e7ce4ed1f7e4074fe1ba9da03e0048639734de60f9cadb9/mutagen-1.48.1-py3-none-any.whl", hash = "sha256:4f077fe87d3fc7fba259aa63d8c026b18382ca6a42ef37c61e16f1b1b5b82fe7", size = 195706, upload-time = "2026-06-25T09:47:30.296Z" },
+]
+
+[[package]]
 name = "mypy-extensions"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.4.6"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/49/ec46835a70be8fa6446c495126ac84fdb28cb2558e1620ffb87a10c8b64c/numpy-2.4.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0280e0356c0829a18d9de1cb7eee50ec22ca639878d7240307ca0943d73cd2c4", size = 16969194, upload-time = "2026-05-18T23:33:13.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0d/f5957185c0ee2f3e12f78715aa9e3b353fd83633316c8532b38faa37e3f6/numpy-2.4.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:110f8b71aacb688ec69062bb7f6938a0f8acb01b7c1c4beb453c65b6d234584d", size = 14964111, upload-time = "2026-05-18T23:33:17.795Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/40/40a40ee0ddf7ceb782c49af278894b686e586d65d8c1889c8b5da01a3d7d/numpy-2.4.6-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:4cfe66903cc32a9921a6733d96b19bb6abf310397581bbad89c228f5abaf0ee8", size = 5469159, upload-time = "2026-05-18T23:33:20.654Z" },
+    { url = "https://files.pythonhosted.org/packages/63/13/f9a8046535cb21deae82f8d03de9617e08882d274fad2539630761888228/numpy-2.4.6-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:8155154c7c691289fe18f510b5d4657c68c67989f293f0535a91360392ff6538", size = 6798936, upload-time = "2026-05-18T23:33:22.987Z" },
+    { url = "https://files.pythonhosted.org/packages/33/a8/6fa8c1a345a8c85dbb21932c447bee07c30a2c2a3f31e369c0a84b300147/numpy-2.4.6-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ab0a9c4ffb1a6d95ef519fe4247dba8eb6b18ad93999f76b7f657039acabd47", size = 15966692, upload-time = "2026-05-18T23:33:26.62Z" },
+    { url = "https://files.pythonhosted.org/packages/02/03/74fe2a4cb3817d94d86402f2506554130a2f01414e299b5a843e5a8a957f/numpy-2.4.6-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:89cd468399cfd2504718f0ba50e410dca55a170b61a02ad92bb18c8a65186e93", size = 16918164, upload-time = "2026-05-18T23:33:29.955Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/80/3615be3313f7e7696609bc194b9f0101da809df79e859bdb84e0cd043f46/numpy-2.4.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c2d37ab77531417474168eb79d6d80b14f821a966818505d03013d0833edb7a8", size = 17322877, upload-time = "2026-05-18T23:33:34.724Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ac/a691e0fe2675e370d0e08ff905adc49a1c8830e8cae03efe4477e92cd55d/numpy-2.4.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f407cb6b8e9d6d8c626bc73c945db1706035af8fd632295547bf1c9e46d092d6", size = 18651487, upload-time = "2026-05-18T23:33:38.217Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a7/9bc1cd626d7bf6869bfedf27b91b6ab5dd607758bf8e959d6fa80c6a59cb/numpy-2.4.6-cp311-cp311-win32.whl", hash = "sha256:ddea102b48f9e339f3948bf22040944184627a30fdf7f858667673b9c5f033c8", size = 6233945, upload-time = "2026-05-18T23:33:41.331Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/31/7fc6239c12bce7e931463251cca4426c465e1876ba3cc785402ef4dd8f4e/numpy-2.4.6-cp311-cp311-win_amd64.whl", hash = "sha256:1e254a00cdf42b1e4d5b3d68d33af63268d41340d8885df2ab6470f2e1500147", size = 12608406, upload-time = "2026-05-18T23:33:44.131Z" },
+    { url = "https://files.pythonhosted.org/packages/27/83/140f85a466595a16382996a1bf06b2b54bcd597488921b0c9daaeeda72af/numpy-2.4.6-cp311-cp311-win_arm64.whl", hash = "sha256:ed9749eef4cbd126da3dc1d6bcb3a57f5eb7ac6a6484146bdbf743f552dfc577", size = 10479528, upload-time = "2026-05-18T23:33:50.725Z" },
+    { url = "https://files.pythonhosted.org/packages/95/2a/3d7b5ac8aac24feaf9ad7ed58f45b0bbc06d37e4338ae84c9f2298b570f9/numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1", size = 16689119, upload-time = "2026-05-18T23:33:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/12/92c4c131527599e8288d6918e888d88726f84d805d784b771f32408aeaef/numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb", size = 14699246, upload-time = "2026-05-18T23:33:57.621Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fe/c0a6b7b2ca128a8fb228575147073b660656734b8ebe4d76c8fd748dcc79/numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41", size = 5204410, upload-time = "2026-05-18T23:34:00.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d4/9770d14ba719432bb90a421bfd443872ed0f70f7264b64bec12ea363d5fd/numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698", size = 6551240, upload-time = "2026-05-18T23:34:02.852Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c6/50a46a6205feba2343f1d6d17438107c5dc491ed1c736e6ea68689fd906b/numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f", size = 15671012, upload-time = "2026-05-18T23:34:05.485Z" },
+    { url = "https://files.pythonhosted.org/packages/99/60/14115e6364fa676c5397c2ad3004e527e9aa487abf5d0706ec81bbd08529/numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853", size = 16645538, upload-time = "2026-05-18T23:34:09.265Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/c5/693cbe59e57db94d2231fa519ca3978dc9e19da5a8f088588f5c6e947ff2/numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a", size = 17020706, upload-time = "2026-05-18T23:34:13.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/fc/85b7c4eff9b4966ade25c2273cf7e7012e92366c032058653934b37de044/numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2", size = 18368541, upload-time = "2026-05-18T23:34:17.024Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/e1b27545deedce7f4a0b348618c6b62d74e36a4dc9ccd42f3eb2f85eee32/numpy-2.4.6-cp312-cp312-win32.whl", hash = "sha256:e3eeb0aabd6bd5ce64faae67e9935203a6991b4bc2a485a767fbafb2c5125f45", size = 5962825, upload-time = "2026-05-18T23:34:20.3Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ca/feab00bd44aa5fe1ad2c18f08b4d3bb92e26484b0b1d1443897809ed528c/numpy-2.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751", size = 12321687, upload-time = "2026-05-18T23:34:23.095Z" },
+    { url = "https://files.pythonhosted.org/packages/63/cf/5a6d34850a39d1093558564f77ee8e8e0bee5061151b8f05a55711001ec7/numpy-2.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8", size = 10221482, upload-time = "2026-05-18T23:34:25.876Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/82/bdab26d7438c6791ca31b7c024ca37c1eab8b726ba236129005cd4a06e45/numpy-2.4.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:511dbaf848decaaaf4b4ca48032619fb3138710c4bf7da7617765edad1ef96b0", size = 16684648, upload-time = "2026-05-18T23:34:29.41Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/30/a80189bcc7f5e4258b3fbc3968d909d1756f54d023299ecc39ad6fdb9ef8/numpy-2.4.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bf162abab1c1a736333192707cef898e735a5ca00f38f27eeedf44b39d9e85eb", size = 14693902, upload-time = "2026-05-18T23:34:33.013Z" },
+    { url = "https://files.pythonhosted.org/packages/97/12/70b5d0d7c15e1ebb8a6a84a8caa1d19e181d84fb58bb6d70aca29099dec1/numpy-2.4.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:043191bfa8eab18c776647b62723ac9dddece59743b13f49b2016094129c2b3f", size = 5198992, upload-time = "2026-05-18T23:34:36.132Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/ebd2a8f8a83541f8d38cc5667e8c2b69cecfd30da6e45693e8158857d44b/numpy-2.4.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:6180d8b35af935aed8ece3a85e0a43f87393ae0ac87c8d2c8bd2c993f7270ef3", size = 6546944, upload-time = "2026-05-18T23:34:38.484Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/c5/7b863a97a91671a0338f4253bd3b5a3d3852f0692dae91711c9f4a10e787/numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b", size = 15669392, upload-time = "2026-05-18T23:34:41.257Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9d/3584b9984ca4c047aea75214ce1a4c4c73d849bd71b604264b7f5653f8a8/numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089", size = 16633220, upload-time = "2026-05-18T23:34:45.075Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ae/7c67fba23bd98caec7c99261f3a16072ade14813486b0282cb29846de832/numpy-2.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ef4aea96ce4d3b074422cb4f2f64e216bf9e213004bb58ecfdf50ea02ea8eb9a", size = 17020800, upload-time = "2026-05-18T23:34:49.065Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/5d/3b6725cb31d983c5e66916f5d36f6d7e5521129e4c4404d64f918292a5b6/numpy-2.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfa20cc6ca228e6b155b11da03825975ce66aea520985dbbddf0f2a5a495c605", size = 18357600, upload-time = "2026-05-18T23:34:52.709Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/da/2ccc6c2fe8898dee01d90c75c5f5f914a23daf99e3e0f59516a08760c8b5/numpy-2.4.6-cp313-cp313-win32.whl", hash = "sha256:56b39e5e0622a09a25bf5baf62f4bcf0cb8a41ae6e2819cf49bbc5a74c083f91", size = 5961134, upload-time = "2026-05-18T23:34:55.618Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/cd/9cc4dc876fb065d5c220aae4d5e14826b2715331bb7618ce1fb07a679d99/numpy-2.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:c4fc99836233ea196540b17ab0983aff60ed07941751930f5f4d05bc3b3b7359", size = 12318598, upload-time = "2026-05-18T23:34:58.928Z" },
+    { url = "https://files.pythonhosted.org/packages/39/1e/c0bcba1f8694116485fe28fd1be698c278fcda4141c5b0e53a2aed8b12a8/numpy-2.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a7c711e21628b52034bb5ab8d1bce291f752fcc5e92accc615778acee1ff4778", size = 10222272, upload-time = "2026-05-18T23:35:02.167Z" },
+    { url = "https://files.pythonhosted.org/packages/63/6d/cc5619247c8f4204e507f5883528372e4ac4bb189e579fb859a12e480b1f/numpy-2.4.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:112b06a867b235ef466ed3508ddf0238050df9c727cafb5301ac385b899189a1", size = 14821197, upload-time = "2026-05-18T23:35:05.468Z" },
+    { url = "https://files.pythonhosted.org/packages/00/58/f1c39161c87d9e9bed660f1ed4bafc0e403d5ec9650b6dd77aead07d489b/numpy-2.4.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:eaf7fa2de5c0be8ae6ff8e9bea2ccd725e980541244521d8d4b5f3354a27babe", size = 5326287, upload-time = "2026-05-18T23:35:08.693Z" },
+    { url = "https://files.pythonhosted.org/packages/af/57/3917ab0fd97f271a8694513581b8a36c655f111c446852c302f04ccdb6fc/numpy-2.4.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:7265a2f3d436e54ef9f2b52b5c937e6be778781bd97a590319d7348f1c1ca997", size = 6646763, upload-time = "2026-05-18T23:35:11.459Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0f/037e64c494b67581ae18193d770adef354c41f3f2c8ebf865602d949bf8f/numpy-2.4.6-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f74a575920ab21fe304421a3fc28793d82e299cae9eccb37084e9fc7f3617c20", size = 15728070, upload-time = "2026-05-18T23:35:14.79Z" },
+    { url = "https://files.pythonhosted.org/packages/21/a6/5d2bae9c9542eb4df16dc9c46dc79c186e9bad53805dfa5399a6023c6db0/numpy-2.4.6-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ede83e07a75dd06bc501566c1eca2afc0d61677c1472ac9ad93fdee6e638a48d", size = 16681752, upload-time = "2026-05-18T23:35:18.836Z" },
+    { url = "https://files.pythonhosted.org/packages/92/14/23d1dfb410ae362cd59ce53e936b1513d545eb40db3949ced632e19a459e/numpy-2.4.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:68bb27509ac1b9a3443094260f6326150663b06abe40b73a2f81160623da5b67", size = 17086024, upload-time = "2026-05-18T23:35:22.52Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/23595a2c642cdf3bc567877064bdd7f91c8b0038a4453cf2daf7248eafe9/numpy-2.4.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a0df0043bdb289bde1f62da130d20df23d58b45429f752bc7a8fc5325a225ecd", size = 18403398, upload-time = "2026-05-18T23:35:26.398Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/90/0ac3bc947217e66dec77e7cbc6a1979d1af70b6461b82f620d3bccd5e4c8/numpy-2.4.6-cp313-cp313t-win32.whl", hash = "sha256:29a287e0cf63ff528da061de6b9f64a4618da591ca1046aafc54062e40ca7eab", size = 6084971, upload-time = "2026-05-18T23:35:29.387Z" },
+    { url = "https://files.pythonhosted.org/packages/77/71/5673e351671a1d2bd6063b91b44f70c0affea7d1516fa7a6572941ba4aa1/numpy-2.4.6-cp313-cp313t-win_amd64.whl", hash = "sha256:25c692919ac5a01f170a3bfcd62d745b24fd095c353d50812637d6fcab442e75", size = 12458532, upload-time = "2026-05-18T23:35:32.175Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/88/19d3503c5046e688f049274b27a3ef3d771152fa80d3ba3d01a3dff61abe/numpy-2.4.6-cp313-cp313t-win_arm64.whl", hash = "sha256:1e978ec1e8bd0e0e4de6bb75de9d30cbb74db6b6a2bb727618613703ca0167dd", size = 10291881, upload-time = "2026-05-18T23:35:35.465Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/3ab2044d05fd16d343c5ac2e69b127f1b2854040dd20b193257c78028bd3/numpy-2.4.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06ca2f61ec4385a07a6977c55ba998a4466c123642b4a32694d3128fce18c079", size = 16683458, upload-time = "2026-05-18T23:35:38.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/62/764ce66fa4147ae6d73071a3abf804ffe606f174618697c571acdf26a7c9/numpy-2.4.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:38efbc8de75c7a0fc1ac190162d892787f3f47b57cc291231aafee36b80982b7", size = 14704559, upload-time = "2026-05-18T23:35:42.14Z" },
+    { url = "https://files.pythonhosted.org/packages/60/61/23f27c172f022e04025b7dc2367f4d63c1a398120607ec896228649a6f48/numpy-2.4.6-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d581b735e177fdcdce6fed8e7e8880a3fb6ee4e3653a3ac6af01c6f4c03effc5", size = 5209716, upload-time = "2026-05-18T23:35:45.377Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/21cf70dc6ea3e3acb95fc53a265b2fc248b981f0194ceb5b475271b8809d/numpy-2.4.6-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:0a041d3d761dc3c35cc56ce0351506a02bcbc25f7b169f652435141a17db9096", size = 6543947, upload-time = "2026-05-18T23:35:47.926Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/91/64288395ee1799bd2e0b04a305dce9666da90c961e1f3fe982a05ee1c036/numpy-2.4.6-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40fdc1ae7125e518ea98e53e69a4ebc27e1fd50510c47b7ea130cf21e5e1d42b", size = 15685197, upload-time = "2026-05-18T23:35:50.863Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/eb/ebffaa97dc55502df69584a8f0dcf07f69a3e0b3e2323670a2722db9aa39/numpy-2.4.6-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2c306dea656c12c68f51f4cea133cbe78ca7435eb28c735eac1d3ebe73be6e8", size = 16638245, upload-time = "2026-05-18T23:35:54.752Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0b/54f9da33128d7e350fab89c7455902eeae70349ee52bddb448dc4a576f45/numpy-2.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:33111801a01c12a8a1e3721f0a9232f8cfc8ae2c6b7098167e6f623c6073f402", size = 17036587, upload-time = "2026-05-18T23:35:58.355Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f0/fdebc1052db1cc37c64beb22072d67cd6d1c71adca1299f53dec2b5e20d3/numpy-2.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ae506e6902902557576a26ff33eda8695e7ecb3cb36c3b573a0765dee114ebdb", size = 18363226, upload-time = "2026-05-18T23:36:02.845Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b4/298628d98c72b57e57f7165ae6a481a1deaf6f3c28262a6e4c739c275930/numpy-2.4.6-cp314-cp314-win32.whl", hash = "sha256:aaf159caa35993cb1f56fb9b8e4610d35758e7ca005412eb1daa856a78c9c4b1", size = 6010196, upload-time = "2026-05-18T23:36:05.92Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ac/46de6dda46478f7942f839e094970be2d4a861e005c4b3bf07c92e291a09/numpy-2.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:b507f5c4c1d508876d1819b6bf9a49d365b96320b5d4993426b33a23ca4b8261", size = 12450334, upload-time = "2026-05-18T23:36:09.107Z" },
+    { url = "https://files.pythonhosted.org/packages/78/92/b8b798ac784102c0da830d2257d59358e3d3d90d1e2b3f2575dad976c5cf/numpy-2.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:6f41ae150c4e32db4f3310cdaf64b1593a03dbabe29eec77fc9b50fe64061df6", size = 10495678, upload-time = "2026-05-18T23:36:12.766Z" },
+    { url = "https://files.pythonhosted.org/packages/30/34/ec28d1aa8115971537c01469ab2011ee96827930f0a124de1000cc2a7ed7/numpy-2.4.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ece3d2cfe132e7d51f44a832b303895e6f2d499c5e74dfbdb06ee246147a304a", size = 14823672, upload-time = "2026-05-18T23:36:16.473Z" },
+    { url = "https://files.pythonhosted.org/packages/16/bd/f6d1fede4e54e8042a7ff97bb495510f3c220f94bcd9e8b228e87c92cc0d/numpy-2.4.6-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:e3e5193ef5a3dc73bceee50f7fdc2c90dbb76c42df8d8fae3d1067a583df579e", size = 5328731, upload-time = "2026-05-18T23:36:19.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f0/e105b9e2fd728a9910103884decd6951d9dd73896b914a98d9a231de02ee/numpy-2.4.6-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:17f9ade344e7d9b464a084d69bcf18fc691cb1db67c62ed80820bf4926d78f0e", size = 6649805, upload-time = "2026-05-18T23:36:22.266Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/1206a7ca6ab15e3f02069707ca96222e202af681bb73756da7527f3cb837/numpy-2.4.6-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cd5ffd25db4e7ba6a375693b3fc0fc1791ec636c17db3720da19bde7180ec43", size = 15730496, upload-time = "2026-05-18T23:36:25.713Z" },
+    { url = "https://files.pythonhosted.org/packages/51/e7/38d3ea825dcab85a591734decb2f6c67caa7c8367d374df1a1c3842f9b07/numpy-2.4.6-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d92c3819208a60205a12a245c91ad70cb0a85336659b19b834205573ac8456e", size = 16679616, upload-time = "2026-05-18T23:36:29.652Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b7/caabfdf53edf663e0b4eb74d7d405d83baef09eb5e83bcd32d601d72b93e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e85b752a1e912b70eaad4fafbd4d1238007ab221de2009b9a2f5ae7461239895", size = 17085145, upload-time = "2026-05-18T23:36:33.449Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/45/68d7c33a6bcf3e5aa3bdbd57a367e6f615286dfd6482f97e8ffeb734306e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:29cb7f67d10b479ff07c17d33e39f78c07f71c40ef30d63c153d340e96cd3fb4", size = 18403813, upload-time = "2026-05-18T23:36:37.369Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/50/0753655aa844c99cd9e018aacf76f130f1bd81d881bb74bc0aef5d73a8ba/numpy-2.4.6-cp314-cp314t-win32.whl", hash = "sha256:260a5d70215b61ab4fadf5c7baacd64821842975eea312125ed3c39a6391b063", size = 6156982, upload-time = "2026-05-18T23:36:40.817Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/d4/7c67becf668f973cb490cec3e98dfd799d866f9c989a54d355672cfa0db6/numpy-2.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:81a1cca95ed5bb92aa8b10dd2cdc9a0d3853a50fad926c28b5d7e8ea54389627", size = 12638908, upload-time = "2026-05-18T23:36:43.996Z" },
+    { url = "https://files.pythonhosted.org/packages/43/bb/e1c71a4295b1b1d1393d50dbb4f2a36283c6859d9d3892e84f00ec5a91d5/numpy-2.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:0c9136e14ed34a9e343a31c533d78a9813a69a3148332bce5e9821cb2f996e66", size = 10565867, upload-time = "2026-05-18T23:36:47.114Z" },
+    { url = "https://files.pythonhosted.org/packages/de/12/b422cc84439adc0d00de605bf4a308890ae5c26f2c71fbd73e5d08fbb0dd/numpy-2.4.6-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:55cced7c52e981362f708ad635198e97a752dfba412cc03c23bbf3bd8d5cd662", size = 16847511, upload-time = "2026-05-18T23:36:50.673Z" },
+    { url = "https://files.pythonhosted.org/packages/44/53/f481bef68011740f8849418d82db07230e825013f31f4eef5ba5b805316a/numpy-2.4.6-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d6da64deb6b8ed903e7560180a92f2d804ee1ba5eeb849ac2748b8c1aba1f6d7", size = 14889064, upload-time = "2026-05-18T23:36:53.879Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/57/42ed575c10ced8af951d426bc4e1f8aff16fd851db33f067036215a7f860/numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_arm64.whl", hash = "sha256:68a5124b13fa6cc2086764a20005d30bc0548146f7f5322f02fce212ca14317f", size = 5394157, upload-time = "2026-05-18T23:36:57.194Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/ef/f66cc724fcc36c1e364c67f51ae9146090b8b584f27d58b97fdae3edd737/numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_x86_64.whl", hash = "sha256:948424b06129ce883307e8cff868c31396d8dc7630a59c61d70d98dbe70f222c", size = 6708728, upload-time = "2026-05-18T23:36:59.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/9c/c531f2293b91265d8b48e9b329f54fdd7ffae73cb4134ea10cca4237e9cc/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5dbbdb29840ca3d91ee0fece42fc29278886d908280bfec0a5846c6f901a3eb0", size = 15798374, upload-time = "2026-05-18T23:37:02.674Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b0/413077f6b1153ed3cba361401c6783bbad6114804a000cc22eb71c13e190/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ad03c0965fb3c692200e74d458ca28c1dbb4ce96f9a479a8aa041ad5fabca02", size = 16747286, upload-time = "2026-05-18T23:37:06.327Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ce/e5ec180bc41812edcd8daeb8639d205622c0e8c02259d8ab25a0201b3c2a/numpy-2.4.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:2803abfebfc990042cd494d8ce2d5f82e9d847af6d35ec486923aa19dbad5e73", size = 12504263, upload-time = "2026-05-18T23:37:09.715Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/7b/14687aa674250e5e546f616f486b0d56d3631cd5b2415739141ce40bdcea/numpy-2.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c889b56fe48b1018f764b0eec8df59ab654e9148aa91faa12596043500de277", size = 16801574, upload-time = "2026-07-04T17:06:12.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/19/cc5bb2a3f2913d27d6dbb2c78d25921fabaedc6741d4a5a615a11f3c5bf3/numpy-2.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab451b59c5643c570974c43aef780703ef1d3b4965d2be07afd530615a9358d1", size = 11772250, upload-time = "2026-07-04T17:06:15.726Z" },
+    { url = "https://files.pythonhosted.org/packages/42/77/fdf34a71dd30f54979b18603bee915e0aaf825b07afe79acd60b04b691e2/numpy-2.5.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:78798bd5b9ad744056af8efa90e3b9ddaa53272a0848a483084a1cc0a13b2dc0", size = 5331516, upload-time = "2026-07-04T17:06:17.913Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e2/eb7efa015b4cce41e2517bf182a7fce0d7d5b9d9ed76a29bfa0f4fe4505c/numpy-2.5.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:2ae0ca40bcb22d6ba59c1dfd5446f49940b0f2d821fde133f10dda11f816b84e", size = 6664863, upload-time = "2026-07-04T17:06:20.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/4b/a2b32dd94ee9ffbeecb28152240042a3949db33b1c834d44090b80e1b3b8/numpy-2.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61ac47e772e6b8ea489e1d2f441a34c5c3ac17327e7ce294cbdf535795ad4e75", size = 15167977, upload-time = "2026-07-04T17:06:21.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/6e73d68500f80773f65f0654ea932019d6694329a0eb0ed0533de38df376/numpy-2.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59fda5e192b570217ec2580c96f00e9a7e12ef6866a900eb089b62c1a32545ca", size = 16672469, upload-time = "2026-07-04T17:06:24.064Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7d/ad3e59015135f5261c95fd4cafeff159c955febd83a99a1d9250c4233815/numpy-2.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f7119ebff1a9829e9f431a4f9d28e703023bb6b9fe7c8f724467dbfc27c94ab3", size = 16527531, upload-time = "2026-07-04T17:06:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d0/a39b2fbcde9cb17a1dac678f254b33a6336298af9df338824c685425d5e8/numpy-2.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e824c2acf8862052246be5a44c15da1777940c60d010dd2aab897824d9c430f9", size = 18431940, upload-time = "2026-07-04T17:06:29.521Z" },
+    { url = "https://files.pythonhosted.org/packages/04/12/cff070947791c1ed425ff76413189adbdc2fbe215eba7ce7fa454a03c7f8/numpy-2.5.1-cp312-cp312-win32.whl", hash = "sha256:08d60c810432eb83360958dea0999ac4cfb94531ea8efcbf0b7f277c2068aeb2", size = 6066764, upload-time = "2026-07-04T17:06:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/65/66/53f31807a48a750f9d748da273bc3fcedd12b27ff1f3e373bfec55ef2dc0/numpy-2.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:f7d60026c0bdb1380e83bfa7a0419c4577ee4b9a08880afcb6dadeb74c649fa2", size = 12430966, upload-time = "2026-07-04T17:06:34.926Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/2a/d1a88066b1c14186f5d3c0d18c94f17b064511982bab0578d49ee9d43c29/numpy-2.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:17a25e09640602e10bc8de0e6fa2b3fd68eedd84ba6d7842dc8f32f9ab87bd0b", size = 10350488, upload-time = "2026-07-04T17:06:37.785Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/07/ec2a3f0c91761581d4b7104a740791800025983f9a4dc4e73f91a99aeac4/numpy-2.5.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0bfebd8695f9863592fe744be833a258120b14a9f39da255e8aa8fade2c0ddd1", size = 16796419, upload-time = "2026-07-04T17:06:40.37Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ab/ddb499fc4f8780354395face5b65c7fd107bcd6e1d667a5f07d046956f6f/numpy-2.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:30b44a6b53a7ae63c54c089a8726e5563ed302716c5b7ccc85afade40b0e7ff6", size = 11765832, upload-time = "2026-07-04T17:06:42.768Z" },
+    { url = "https://files.pythonhosted.org/packages/88/b3/3c28c558a09fc72100c646dac6d2fce8e834c471b0edca01a29996706117/numpy-2.5.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:6165343f81b56ef8f514f396989e529b61d9dc709b99421b07e9f3e698e2287d", size = 5325143, upload-time = "2026-07-04T17:06:45.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/0e/ce19b985bb15c596f4f05954e76cccc77c845083b3b8f938a6c68e523128/numpy-2.5.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4939237038ada79308dda3204ac6462df056b5672b2e25db1149cf873668b3e1", size = 6659749, upload-time = "2026-07-04T17:06:47.288Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/20/1ee6614d64332a1bba6411f38e68cb79eec1b2459e20a623777c5c5492a2/numpy-2.5.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c6759f538fb912fc46de0a6b1758ccf7b57bc7c7ebebc23974fdac3de8db0cd", size = 15164716, upload-time = "2026-07-04T17:06:49.494Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a7/2bcd3fdbb87804755c35b729bf8709d62025c5f4cfd7d5b2415997097515/numpy-2.5.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9726558e8db4a5bf7929a70ae50f63abda4daf0efe810e3bfbab95976f75fc1a", size = 16661440, upload-time = "2026-07-04T17:06:52.061Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d7/a41e3310c886fe457d36e670bbf24fae411aca8a7b6ad92a32afd924077c/numpy-2.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3935f3b419b244a02732676fa5317a9193cc596a4c0646db07e5b421229ac9f7", size = 16526305, upload-time = "2026-07-04T17:06:54.605Z" },
+    { url = "https://files.pythonhosted.org/packages/53/75/4333a9a707c1edd3a4e1a0c58eca52c0f31e55089fa80db02b5565b24df7/numpy-2.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dc932a65ded7ce9013d120845a2514dcccb1a67bfc8deb8d37633762951904a6", size = 18423008, upload-time = "2026-07-04T17:06:57.54Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/e314a32b1c11a2ffe818ddad3a57b50b4b6e1b6c487192eb50cdef0415d0/numpy-2.5.1-cp313-cp313-win32.whl", hash = "sha256:4b4ff1608417eb7a59da7b967bbb798cacfe071d2caf526a24281cd562072ed9", size = 6063885, upload-time = "2026-07-04T17:07:00.14Z" },
+    { url = "https://files.pythonhosted.org/packages/10/70/800b3fca480af32df9e8ea9f3d4a0c8feb4b32d7f195d174eabbda4829ad/numpy-2.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:6c3fe51bc6a16453d452997053454f309e8e0ed7b42d6b361ce4ac8c32913d74", size = 12425674, upload-time = "2026-07-04T17:07:02.387Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/0b/196350c122f50f6ca56846f2d71efd5e0d24b7b2e07355e019b2e2c7a11e/numpy-2.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:f7feb014281029e628ba2d5a007407443b06e418b6fe451d1e2adcbc8eba0107", size = 10350256, upload-time = "2026-07-04T17:07:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/db/f4/731b6085a83faf6ca843394cbd5e217280c214399f7e8b21b9f552af0ae2/numpy-2.5.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:7c786fe9a5bbe360022e584c5a34cf6b54265c71bd7ec8ac3d8fec38968071f8", size = 16795063, upload-time = "2026-07-04T17:07:07.374Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/64/0e215f2048dd11a55bb989ed41b3585ef57452404e638d703a211a3e4157/numpy-2.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:32985c896d897419ef8da6917872d80b78ad0ea26d85b23245c7366ffde76d75", size = 11776652, upload-time = "2026-07-04T17:07:09.907Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/59/2b844c7a6e9deff69b404a66221e1542937734f65d5e6e39411876053862/numpy-2.5.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:efd736408cc97c79b9e6917338dfc8f06013b2274f992e96b1d9a81a71e2a2c2", size = 5335944, upload-time = "2026-07-04T17:07:12.227Z" },
+    { url = "https://files.pythonhosted.org/packages/86/51/9bf7cb2cabcebc9e017e4ec7e6322b378317a542c08b4cb68479c1efc716/numpy-2.5.1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:ab84dc6b074fa881cae55bea94cc4f68e285181ba7f32497bf7dee6b1496165b", size = 6656266, upload-time = "2026-07-04T17:07:14.368Z" },
+    { url = "https://files.pythonhosted.org/packages/83/3e/fb7615b211b82a32f44d5180a6d421b61f84d4fadd578b48ba4ac34e189f/numpy-2.5.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caf3e317d33d60c37986b452613f4ab51246d0691350c03d0cb4a898627f4a95", size = 15179720, upload-time = "2026-07-04T17:07:16.272Z" },
+    { url = "https://files.pythonhosted.org/packages/41/5f/0f992cb24560673496c5d68de61913b57166ce530ffda07c1f280e0cc464/numpy-2.5.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:54ad769f17bc2d833b620851989f62054fb9ab93c969d9e1dc3c8e3d56beea21", size = 16664835, upload-time = "2026-07-04T17:07:19.021Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/2f/97d6475ee91afe2587797d09446f9d3e475ad4cb681662d824809327b75a/numpy-2.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c12afb53450fa976d4c681c50a7423729a4c51c0465ed9f32b8a9cabbc472373", size = 16539135, upload-time = "2026-07-04T17:07:22.015Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/5b/4db81e4ba0be7e2776b1de68c82aa862c7f8ec27e1b4927d4ae075e20678/numpy-2.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e8c11c405efc5ff6816d5983c96cdfa215bab3428961243af3ff59b228490438", size = 18426684, upload-time = "2026-07-04T17:07:24.941Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/64/c0ba2d90724d450279a7df8f32057241070250a26a7e2b5337d77347f481/numpy-2.5.1-cp314-cp314-win32.whl", hash = "sha256:f2479a47f8d5932d1718168a681ad6e536a9df484c83cfcf9de365e164537ace", size = 6116103, upload-time = "2026-07-04T17:07:27.622Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/1a/837f9ed7405adcd7a40538792eb169eddd8fa5630c16a1ef49dae71a30f4/numpy-2.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:24d0eb82c0541d3415a33425db64ae439dffccd7b4dbcb30e7c35120205c506a", size = 12562177, upload-time = "2026-07-04T17:07:29.887Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/49707938b6dd0a78a9178dd93227dc89e4c11af47f5c798d70366e8d0483/numpy-2.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:5a4c988b38d261deeeaad9954e3deb091ad905c94e8bb6708654ef1d97f286b0", size = 10627739, upload-time = "2026-07-04T17:07:32.568Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c7/bb4b882cfe7f299cbc8b66e42e7dd78cf9d14e40f9469fc5e3db7e15b3bd/numpy-2.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a33276be12fa045805f477f22482088b66bb758ffbe89a9d21457de863a32e22", size = 11894709, upload-time = "2026-07-04T17:07:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/40/3f/5af7f4a7f6224aef48017aa82bb6174c7a659d724be0c75017b7e64a55b4/numpy-2.5.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:f089d7b00756190aacf1f5d34bdf38c3c430ac82b4f868f8cede73380460fce7", size = 5453810, upload-time = "2026-07-04T17:07:37.495Z" },
+    { url = "https://files.pythonhosted.org/packages/20/c9/3474309bc94d634d3f9c3eddf03250ecb8c22cd948ef16fef69a77cc5d7b/numpy-2.5.1-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:09e9bfd8d2cf479c7d174804fb3811c53a8e9f20a37444008606b57d6b7a826d", size = 6761189, upload-time = "2026-07-04T17:07:39.563Z" },
+    { url = "https://files.pythonhosted.org/packages/90/8a/558ae39fdd55d7e7f7fef9a84a6e964ac6b23edbd2a07e52bb084500507d/numpy-2.5.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e68d8dd1e7eba712948f2053a29ec86917bc70ba1358df869d9f06649ef9cf09", size = 15225039, upload-time = "2026-07-04T17:07:41.682Z" },
+    { url = "https://files.pythonhosted.org/packages/63/27/ca7392b2d030277bdf0273e7d23255b3ee57d57a7c170a6f4fb3981e1e5d/numpy-2.5.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:99d5095fa265a0c4152e7bb12759e14381ef5496152f1ce58f44bdf55c44beb4", size = 16701306, upload-time = "2026-07-04T17:07:44.611Z" },
+    { url = "https://files.pythonhosted.org/packages/02/42/03d53ae7996c44d4374a8262e9dc41671fd56cbb98f7d47ef85cf5da4c6b/numpy-2.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ab87a91b3cc3382b8956095bd8f95e00cf679bb81554339be1a2ba404a1473c1", size = 16589955, upload-time = "2026-07-04T17:07:47.694Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/15/6c1784ae469640e65db111e9a34b3d0f14d91e8a38b9ce34810ced370dbb/numpy-2.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:224ca51130ef7da85bea2191625181cb4f337f9cb64b471f10c1a12aa8b60077", size = 18464252, upload-time = "2026-07-04T17:07:50.684Z" },
+    { url = "https://files.pythonhosted.org/packages/94/a8/f98e50356cf167df656c526c2dfeec2d7dde182f2a3da4b458a5938e2776/numpy-2.5.1-cp314-cp314t-win32.whl", hash = "sha256:6eab239876581b2b3c5a242281b6007bbdbcd1c7085d7709bb57c5929b11e6bf", size = 6263298, upload-time = "2026-07-04T17:07:53.445Z" },
+    { url = "https://files.pythonhosted.org/packages/72/ac/96ae880cdecad0b3275d9359fcec72667b49a4863c9f12942e43679dda02/numpy-2.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:83ce9c80d5b521b0d77ddcbe5447c218d247929b6cc056ca5351342accfff0af", size = 12748623, upload-time = "2026-07-04T17:07:55.384Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/5a/4d2b1601df3602dba7a14f3348ba9bfe94a18adb428e693df6154c293831/numpy-2.5.1-cp314-cp314t-win_arm64.whl", hash = "sha256:5a6db61f9aaa57e369905c67d852045d3c4f7126405b29d09b19dec118e9c9cb", size = 10697674, upload-time = "2026-07-04T17:07:58.506Z" },
 ]
 
 [[package]]
@@ -836,6 +1212,58 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "preshed"
+version = "3.0.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cymem" },
+    { name = "murmurhash" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/75/fe6b7bbd0dea530a001b0e24c331b21a0be2786e402abf3c57f5dce43d4b/preshed-3.0.13.tar.gz", hash = "sha256:d75f718bbfd97e992f7827e0fa7faf6a91bdd9c922d5baa4b50d62731396cb89", size = 18338, upload-time = "2026-03-23T08:57:31.378Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/d1/7bc39738388b38ff48cecbb326a9b2bb3f422bb32097be92e010f3162395/preshed-3.0.13-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5268c0e6fa96f50cdf87f516c2d4b32563c12706ee768e75c00e8d0098acd545", size = 136718, upload-time = "2026-03-23T08:56:23.889Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/65/de465b6801740140c2b5d2db6c312ca7937dcfd0442f1ae7d50dee529544/preshed-3.0.13-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:df642547a1a94079978a0ea8f4593ab4b8d3bd43f767bef0ef64d9a214f8c4c9", size = 137261, upload-time = "2026-03-23T08:56:25.303Z" },
+    { url = "https://files.pythonhosted.org/packages/89/83/478ee078746a4a413c841542caebd2ea74b659475b8bf5f2e3724b6fe655/preshed-3.0.13-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:09397592d333a77f88454e72b7f1f941b2afaf040b392b9e74898dbc4648cdf5", size = 821010, upload-time = "2026-03-23T08:56:26.455Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/2e/1ac761e973966893cd3a0ad3256360365276e2d1e779e351448981a1156a/preshed-3.0.13-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f8e6fe0620ed0f96a246d46447055c447e071cd8222731a045c235e8a758c918", size = 823096, upload-time = "2026-03-23T08:56:28.126Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/51/7824cfd85dd7fe547888de20228ebd87d9acd3708206d30b82211e382d23/preshed-3.0.13-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:502f93f49a22788203f02d3067d4ea077a0cca3864de6a792eae12e7ce589e14", size = 1812148, upload-time = "2026-03-23T08:56:29.755Z" },
+    { url = "https://files.pythonhosted.org/packages/34/48/32160a24705d56179de6af838c10a0c735c955dae5f9e4bb344750b79bc2/preshed-3.0.13-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:acd4d89abeca3678c5d8c89b3cd351314465bc67c7fa053d2644f8513e543386", size = 1881154, upload-time = "2026-03-23T08:56:31.49Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/22/0344b50f8b1ad9e3aac08099c47e1aba91c81602fd117d2673f6606ecae6/preshed-3.0.13-cp311-cp311-win_amd64.whl", hash = "sha256:de87fbabb0f37c3c92d4dd9b94fc82ab73cdab4247cdfbd57ab3926caa983919", size = 122219, upload-time = "2026-03-23T08:56:32.74Z" },
+    { url = "https://files.pythonhosted.org/packages/33/c4/812eeaa568510f396e27edab01100ca71418f032fd7098b107f12e572361/preshed-3.0.13-cp311-cp311-win_arm64.whl", hash = "sha256:5e2753779832e411e93eb727f3d409c0a6b7408e5ce4dd868076d8ece48c7693", size = 109308, upload-time = "2026-03-23T08:56:33.839Z" },
+    { url = "https://files.pythonhosted.org/packages/39/fb/ccff23c44c04088c248539005fcda78b9014512a34d170c5360f02ad908b/preshed-3.0.13-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5d14eea14bd01291388928991d7df7d60b9fd19ae970e55006eb4d29b0c1e8eb", size = 138497, upload-time = "2026-03-23T08:56:35.321Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ce/cad5a8145881a771e6c0d002f2e585fc19b962f120860b54d32af5baa342/preshed-3.0.13-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f05b08ce92399c0655b5e0eb5a1cc1f9e295703ed3aabdfaf6538dfa8ae23d57", size = 138010, upload-time = "2026-03-23T08:56:36.399Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/a2/c5fed4fb3e946699259d11e4036a3cfdd8c89b3e542e3077d46781642425/preshed-3.0.13-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:62cf7f3113132891d6bba70ff547ad81c6fe50a31930bbbb8499f1d47cd122b7", size = 861498, upload-time = "2026-03-23T08:56:37.67Z" },
+    { url = "https://files.pythonhosted.org/packages/51/94/8c9bc48a6ea4903f53a1a0031ce8e35687526949f25821762ef21493c007/preshed-3.0.13-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8b8de3f58043070a354477995acdd98626ce43e4193c708ebd0f694e467f5155", size = 868988, upload-time = "2026-03-23T08:56:39.324Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/df/ecd2f40055ff52527ca117ffbfafb888c1a3079b59fbabe03c5b8f9b7240/preshed-3.0.13-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:183b339956a9e1d7a4a00038a3b9587a734db9e8bd915939a49791bd1b372156", size = 1847382, upload-time = "2026-03-23T08:56:40.89Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/88/bdb244e40284ded3632a9f88c23bc80230bd7b2ae4a8b7f2cc91adead7a8/preshed-3.0.13-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2e77bed56aded7cbe5d28d6bd2178bc5b13eda0e0e464dab205fb578fa915000", size = 1919236, upload-time = "2026-03-23T08:56:42.616Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/c9/c91ea56342e6c364fc69b444a1ac5432327857199c44032c9cc9dc4c3a23/preshed-3.0.13-cp312-cp312-win_amd64.whl", hash = "sha256:04d8f13f2986e5d11af5ac51f55ce3106c70c41b483d20ea392e6180bdd0f870", size = 122938, upload-time = "2026-03-23T08:56:44.271Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/0b/6a99d99619fd83b14c696e2489caed7070647488d4d3ac0b723d35db2de0/preshed-3.0.13-cp312-cp312-win_arm64.whl", hash = "sha256:19318dc1cd8cac6663c6c830bf7e0002d2de853769fb03e056774e97c21bedfd", size = 109194, upload-time = "2026-03-23T08:56:45.346Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/2a/401158195d6dc7f6aef0b354d74d0e95c9da124499448c2b3dbb95b71204/preshed-3.0.13-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c0d0c14187dc0078d8a63bf190ec045a4d13e7748b6caeb557a7d575e411410b", size = 137289, upload-time = "2026-03-23T08:56:46.516Z" },
+    { url = "https://files.pythonhosted.org/packages/88/8f/e20e64573988528785447a6893b2e7ab287ecfd85b3888e978b28812fd20/preshed-3.0.13-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7770987c2e57497cd26124a9be5f652b5b3ccd0def89859ab0da8bca6144a3de", size = 136847, upload-time = "2026-03-23T08:56:47.572Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/72/18168f881359c4482d312f8dc196371bdd61c1583a52b34390da4c88bbea/preshed-3.0.13-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4a7bc48220de579be6bdb0a8715482cf36e2a625a6fd5ad26c9f43485a4a23b5", size = 831478, upload-time = "2026-03-23T08:56:48.769Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/3a/3543476091087102775568cea9885dde3453569e9aeee365809108de572f/preshed-3.0.13-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e5c8462472f790c16708306aef3a102a762bd19dfe3d2f8ee08bd5e12f51b835", size = 839913, upload-time = "2026-03-23T08:56:49.937Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/65/b13f01329decc44ef53cfb6b4601ba85382dcb2a4ec78d9250f03a418066/preshed-3.0.13-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c046736239cc8d72670749b79b526e4111839a2fc461a58545d212797649129c", size = 1816452, upload-time = "2026-03-23T08:56:51.233Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/c7/f1a996c6832234efd4d543041b582418d41ac480ee55c557ec9e65344637/preshed-3.0.13-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7c333f18e9a81c8a6de0603fd8781e17115324b117c445ca91abdf7bfb1abe49", size = 1888978, upload-time = "2026-03-23T08:56:52.591Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/b9/96fb71499049885ce19545903fdd38877bbc2be0da47e37c04d01f3e9f66/preshed-3.0.13-cp313-cp313-win_amd64.whl", hash = "sha256:461327f8dd36520dcf1fd55a671e0c3c2c97a2d95e22fc85faa31173f4785dda", size = 122134, upload-time = "2026-03-23T08:56:54.392Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/a7/32a4903019d936a2316fdd330bedddac287ac26326107d24fb76a1fbc60a/preshed-3.0.13-cp313-cp313-win_arm64.whl", hash = "sha256:35d6c5acb3ee3b12b87a551913063f0cec784055c2af16e028c19fe875f079d0", size = 108497, upload-time = "2026-03-23T08:56:55.816Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/b5/993886c98f5caaa6f07a648cac97a7c62a3093091cad65e1e43a1bd41cc4/preshed-3.0.13-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d2f1efae396cadab5f3890a2fd43d2ee65373ef9096ccbb805e51e8d8bcc563b", size = 137882, upload-time = "2026-03-23T08:56:56.878Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/86/b7fd137cbf140afd6c45e895946068a15f5b55642916de0075e6eb18581c/preshed-3.0.13-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8d6acc1f5031a535a55a6f7148e2f274554a8343a16309c700cebea0fe7aee8c", size = 138233, upload-time = "2026-03-23T08:56:58.318Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ca/21a7e79625614134273dfed32bca5bb4c2ec1313e33fbd12d41657536f1f/preshed-3.0.13-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7da9d931e7660dcdd757e5870269f0c159126d682ed73ed313971d199eb0f334", size = 834835, upload-time = "2026-03-23T08:56:59.48Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/3a/2dbd299516461831ae90e0d5b0637137bf28520c4e6dd0b01d6f1886659a/preshed-3.0.13-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d4ae5cfe075bb7a07982e382bca44f41ddf041f4d24cbd358e8cccfc049259b8", size = 834928, upload-time = "2026-03-23T08:57:01.075Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/d3/af654eba4f6587c4ee02c5043e62c194b0a1c4431ffef0c67b9518f6b61c/preshed-3.0.13-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7557963d0125a3a7bcdb2eb6948f3e45da31b5a7f066b55320de3dea22d7557f", size = 1820368, upload-time = "2026-03-23T08:57:02.351Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/9b/ebcb2b9e8cb881e40b55b0bf450f8a6b187e2ef3ae0c685cce81d2d85026/preshed-3.0.13-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c4bc60dc994864095d784b7e4d77dba3e64188d169ac88722b699d175561fddb", size = 1888251, upload-time = "2026-03-23T08:57:04.158Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f7/c6c012779edcaa6e2cd092c554e98dc53e77f41205b07208655ba77e2327/preshed-3.0.13-cp314-cp314-win_amd64.whl", hash = "sha256:208dcebbe294bf1881ce33fb015d56ab2a7587aece85a09147727174207892e4", size = 125211, upload-time = "2026-03-23T08:57:05.83Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/82/390ef87d732ef64e673ef6bf9e5d898453986e979efa50fb3a400e2c0766/preshed-3.0.13-cp314-cp314-win_arm64.whl", hash = "sha256:cf8e1a7a1823b2a7765121446c630140ac6e8650c07a6efbf375e168d1fef4f7", size = 111942, upload-time = "2026-03-23T08:57:06.996Z" },
+    { url = "https://files.pythonhosted.org/packages/80/3a/a9dde3167bcecb27ae82ce4567b5ab1aa3989113ae6814c092ce223cc4ef/preshed-3.0.13-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:9ca43ecbc3783eda4d6ab3416ae2ecd9ef23dca5f53995843f69f7457bcd0677", size = 144997, upload-time = "2026-03-23T08:57:08.064Z" },
+    { url = "https://files.pythonhosted.org/packages/74/d4/22d9355b50b6a13b407dcad0a81df83fb1d5602092d1f05834674dde8fda/preshed-3.0.13-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c8596e41a258ff213553a441e0bb3eb388fd8158e84a7bf3aae6d8ede2c166d3", size = 147294, upload-time = "2026-03-23T08:57:09.411Z" },
+    { url = "https://files.pythonhosted.org/packages/70/42/a225ee83fdb306d2a503f21a627953b820f4e079c90c8a84338957cb8ff5/preshed-3.0.13-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4f8856ca3d88e9b250630d70abb4f260d8933151ddfb413024784b25b009868e", size = 952110, upload-time = "2026-03-23T08:57:10.592Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ba/09a9dfe3d22d7e745483fd5d7f2a82cd4d39c161f7d2daa0faa4bd6402be/preshed-3.0.13-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e5b2865aecbd2e1e10e5d19bb8bfad765863c1307c6c3e51f2a08bd64122409", size = 932217, upload-time = "2026-03-23T08:57:12.124Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/5c/e10e2e05133e7fcbd7c40536af1148c82dd24357b8f5726e2c7bc51cfd53/preshed-3.0.13-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:09f96b477c987755b3c945df214ea1c1c80bfb350e9f34e78da89585535b77e8", size = 1896542, upload-time = "2026-03-23T08:57:13.525Z" },
+    { url = "https://files.pythonhosted.org/packages/37/aa/51e5b4109a4cdfae28c3613eeeb10764a3794ebef8de93ffbb109465bea3/preshed-3.0.13-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:670db59a52e1823b5f088c764df474e65b686592d4093adbeef14581c95ee2cb", size = 1959473, upload-time = "2026-03-23T08:57:15.706Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/6a/1d966f367a14c703dde629d150d996c1b727d442f620300b21c9ec1a24d1/preshed-3.0.13-cp314-cp314t-win_amd64.whl", hash = "sha256:b03e21b0bf95eb56e23973f32cabb930e94f352228652f81c0955dbd6967d904", size = 146229, upload-time = "2026-03-23T08:57:17.457Z" },
+    { url = "https://files.pythonhosted.org/packages/22/80/368139067603e590a000122355f9c8576c8ebed4fb0b8849feaa2698489d/preshed-3.0.13-cp314-cp314t-win_arm64.whl", hash = "sha256:b980f3ea9bb74b7f94464bc3d6eb3c9162b6b79b531febd14c6465c24344d2cc", size = 119339, upload-time = "2026-03-23T08:57:18.882Z" },
 ]
 
 [[package]]
@@ -1267,12 +1695,55 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "83.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "smart-open"
+version = "8.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/3e/79fd5fd2375a8a500b9ec2f6a0762fc1ac33e35582d4a87483a78d19408f/smart_open-8.0.0.tar.gz", hash = "sha256:5a2008d60688bd3b33c52e2ef666d3c60cf956e73e215de8c7b242cf56fdd1b2", size = 61520, upload-time = "2026-06-27T16:28:11.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/bd/1c92e69a1daff70118f21e18ef3a100c114f00f08b64a1074484f12d9020/smart_open-8.0.0-py3-none-any.whl", hash = "sha256:ff4f395c9e86f23e27771dc4ba756ad4bd145f181859a782c50d64168485761b", size = 73029, upload-time = "2026-06-27T16:28:10.589Z" },
 ]
 
 [[package]]
@@ -1291,6 +1762,76 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
+]
+
+[[package]]
+name = "spacy"
+version = "3.8.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "catalogue" },
+    { name = "confection" },
+    { name = "cymem" },
+    { name = "jinja2" },
+    { name = "murmurhash" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "packaging" },
+    { name = "preshed" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "setuptools" },
+    { name = "spacy-legacy" },
+    { name = "spacy-loggers" },
+    { name = "srsly" },
+    { name = "thinc" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "wasabi" },
+    { name = "weasel" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/8c/0ccf32d9a6b4fd8737bba33d599ddb98934399c1d523f825a4beb4bd1495/spacy-3.8.14-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8c55cb123c3edfba8c252ce6ae27ffb3d7f60a53ba5e108c3534421586c5fdda", size = 6617470, upload-time = "2026-03-29T10:40:25.572Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/61/7f7d38e71daac7f91ffd362fb15645b6f9a68ad231e0ed6ff5c1dc6f6930/spacy-3.8.14-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ab6c1ace316338dac334fc93c849994bbd717f9ebf59d2bc4158e978b2f542ee", size = 6441524, upload-time = "2026-03-29T10:40:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ef/18385aa5aeb9bcb299e8074da162b24e5c8bea5aa4d1dfa3dbafb35e9d1f/spacy-3.8.14-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7bece0450cd8ab841cfa8527fcc0ce18c4454f28e3b9fca42a450803a067355b", size = 32050591, upload-time = "2026-03-29T10:40:29.704Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/67/5c4a65ed2cedc598ad000a2b9f45afc76bb8d17a592cc01082dffa8bbc50/spacy-3.8.14-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc5e5f2ed121d57d819d247bb59253dc320a58acbd237b85f86c2aa38cab6bd1", size = 32296467, upload-time = "2026-03-29T10:40:32.557Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a7/28c118879791b3a7ffa81796d22203daac428e6f75572f1b8da1539e1ac6/spacy-3.8.14-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3c4e5bc5cdefe39ea139985776a2e8eae05e7ff2bf51ca1bd65247dc45feeb8e", size = 32288404, upload-time = "2026-03-29T10:40:35.583Z" },
+    { url = "https://files.pythonhosted.org/packages/72/1c/32aefcea2468782fcdb994f2f96cac93dc74f6589ce01047db42d9a299a2/spacy-3.8.14-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:2c228f4c9ae618173334c17adb748d66b574b6594bc3575233e15cd5ad1cb26b", size = 33113476, upload-time = "2026-03-29T10:40:38.577Z" },
+    { url = "https://files.pythonhosted.org/packages/86/32/fc00532eabeace451175dd9b152ddd636e8f6a42248b5d90141f98be2af5/spacy-3.8.14-cp311-cp311-win_amd64.whl", hash = "sha256:6f51d1ce8b1ba30123f6bef6e795c4bc5466608e6e8a015dc828bd21d399aa9c", size = 15359704, upload-time = "2026-03-29T10:40:41.25Z" },
+    { url = "https://files.pythonhosted.org/packages/de/31/89ff6722ec91f328dc717932849c6f57249c8a9d429d8670a6c8f70e576b/spacy-3.8.14-cp311-cp311-win_arm64.whl", hash = "sha256:c0c6c9d8771cc3708e309b07310d330fc8443a6bca34f4ff20b0f22751d8faf9", size = 14717168, upload-time = "2026-03-29T10:40:43.916Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/78/e4f2ae19a791cae756cd0e801204953eaec4e9ab75a60ad39f671dbb8d5a/spacy-3.8.14-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:726f02c60a2c6b0029167370d22d51731172a053d29c7e2ea6190db6de3ab483", size = 6218335, upload-time = "2026-03-29T10:40:46.298Z" },
+    { url = "https://files.pythonhosted.org/packages/06/df/178bbab47fa209c8baf2f1e609cbddc6b18a985200be1ceee22bd5b89beb/spacy-3.8.14-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e3ebe50b93f2d40e8ec3451255528bb622ccb12be39fd140bb87668ce8d1075b", size = 6033860, upload-time = "2026-03-29T10:40:47.861Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/e8/048d83b73b28686307bd9a60878a58de7b7b21b562ca4de8b5bd558031e9/spacy-3.8.14-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:daeb64b048f12c059997281aed53eb8776d26416dd313cf17ad6f63124b2b564", size = 32725099, upload-time = "2026-03-29T10:40:50.194Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3f/1799af5f4ccc8eb7500e4a20ca301488134429dba08cda5be68ce6ab2992/spacy-3.8.14-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6d45715a24446f23b98ec3f09409a1d4111983d1d64613250ee38c3270e21853", size = 33205838, upload-time = "2026-03-29T10:40:53.029Z" },
+    { url = "https://files.pythonhosted.org/packages/78/07/81ab9acd0ec64bfdd7339acfc4cf35f5fb74bbbb0b2be7e64d717c416bac/spacy-3.8.14-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1069a8be34940809f8462eb69f09a3f0ce59bf8b9cb82475f2a8e3580f50ece0", size = 32090380, upload-time = "2026-03-29T10:40:56.115Z" },
+    { url = "https://files.pythonhosted.org/packages/74/a5/b081b5bd3cedb2634c23eb470b5e24c65c894c57646567f47627291c2b3f/spacy-3.8.14-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2dfa77aec7fdebac0455d8afd4ce1d92d6f868b03d507ed1976179a63db7b374", size = 32991946, upload-time = "2026-03-29T10:40:58.852Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/55/4371413a6dfc1fa837282a365498165f828c2f3fe018dfb35336acc869e0/spacy-3.8.14-cp312-cp312-win_amd64.whl", hash = "sha256:9def18c76a4472b326cb91a195623c9ca38a2b86999ad2df9e00b49ba8c63734", size = 14226946, upload-time = "2026-03-29T10:41:01.63Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/5e/12ac876017da6c1e6b72afcc3c8b309996227fd3aa15382cd3311aee21b8/spacy-3.8.14-cp312-cp312-win_arm64.whl", hash = "sha256:d6257133357e4801c9c5d011925af5439b0a015aacf3c16528aa0009982431c7", size = 13628765, upload-time = "2026-03-29T10:41:03.806Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/e5/822bbdfa459fee863ef2e9879a34b0ae5db7cd1e3eb76d32c766f19222e9/spacy-3.8.14-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2b4f60fa8b9641a5e93e7a96db0cdd106d05d61756bf1d0ddcd1705ad347909a", size = 6202114, upload-time = "2026-03-29T10:41:06.119Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/de/0e512154113e1f341567f2b9341835775e4180c180221e60faedaebb2f65/spacy-3.8.14-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0860c57220c633ccb20468bcd64bfb0d28908990c371a8857951d093a148dc8e", size = 6015458, upload-time = "2026-03-29T10:41:07.79Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/4f/29c7e56afc7db07348a9e0efe0243b5eef465d5dc3d56433f164378c3fa6/spacy-3.8.14-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c24620b7dba879c69cebc51ef3b1107d4d4e44a1e0d4baa439372887d00c3fd9", size = 32510659, upload-time = "2026-03-29T10:41:09.88Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/ce/cae678f664d5467016819253f5d6e52f8e68a12d8e799b651d73ec2a9a4b/spacy-3.8.14-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9699c1248d115d5825987c287a6f6acd66386ef3ebee7994ee67ba093e932c59", size = 32841057, upload-time = "2026-03-29T10:41:12.585Z" },
+    { url = "https://files.pythonhosted.org/packages/04/d4/419868afd449bdd367df005932537eea66c71e97c899ba278f3124933f3c/spacy-3.8.14-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:042d799e342fdb6bb5b02a4213a95acc9116c40ed3c849bb0a8296fbe648ec22", size = 31763252, upload-time = "2026-03-29T10:41:15.569Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/53/df5c1fee45f200b749ba72eeb536fbb2c545fc56230324954263b2f3be00/spacy-3.8.14-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:69b2264294097336e86832e8663f1ab3a7215621184863c96c082ab17ee11937", size = 32717872, upload-time = "2026-03-29T10:41:18.193Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c2/f1882ec2f5cc9c4e73cf2132997a03c397d7ceeb5ee7f7bb878b51a16365/spacy-3.8.14-cp313-cp313-win_amd64.whl", hash = "sha256:4b6d4f20e291a7c70e37de2f246622b44a0ce82efaa710c9801c6bd599e75177", size = 14220335, upload-time = "2026-03-29T10:41:20.89Z" },
+]
+
+[[package]]
+name = "spacy-legacy"
+version = "3.0.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/79/91f9d7cc8db5642acad830dcc4b49ba65a7790152832c4eceb305e46d681/spacy-legacy-3.0.12.tar.gz", hash = "sha256:b37d6e0c9b6e1d7ca1cf5bc7152ab64a4c4671f59c85adaf7a3fcb870357a774", size = 23806, upload-time = "2023-01-23T09:04:15.104Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/55/12e842c70ff8828e34e543a2c7176dac4da006ca6901c9e8b43efab8bc6b/spacy_legacy-3.0.12-py2.py3-none-any.whl", hash = "sha256:476e3bd0d05f8c339ed60f40986c07387c0a71479245d6d0f4298dbd52cda55f", size = 29971, upload-time = "2023-01-23T09:04:13.45Z" },
+]
+
+[[package]]
+name = "spacy-loggers"
+version = "1.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/67/3d/926db774c9c98acf66cb4ed7faf6c377746f3e00b84b700d0868b95d0712/spacy-loggers-1.0.5.tar.gz", hash = "sha256:d60b0bdbf915a60e516cc2e653baeff946f0cfc461b452d11a4d5458c6fe5f24", size = 20811, upload-time = "2023-09-11T12:26:52.323Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/78/d1a1a026ef3af911159398c939b1509d5c36fe524c7b644f34a5146c4e16/spacy_loggers-1.0.5-py3-none-any.whl", hash = "sha256:196284c9c446cc0cdb944005384270d775fdeaf4f494d8e269466cfa497ef645", size = 22343, upload-time = "2023-09-11T12:26:50.586Z" },
 ]
 
 [[package]]
@@ -1347,6 +1888,57 @@ wheels = [
 ]
 
 [[package]]
+name = "srsly"
+version = "2.5.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "catalogue" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2b/db/f794f219a6c788b881252d2536a8c4a97d2bdaadc690391e1cb53d123d71/srsly-2.5.3.tar.gz", hash = "sha256:08f98dbecbff3a31466c4ae7c833131f59d3655a0ad8ac749e6e2c149e2b0680", size = 490881, upload-time = "2026-03-23T11:56:59.865Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/36/5d7bb412d52e9cca787f9bfe838b596367189b254e50bf90f234a97184bf/srsly-2.5.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:785a09216ac31570fb301ddb9f61ee73d1f18f8b9561f712dce0b8ac8628bc88", size = 656760, upload-time = "2026-03-23T11:55:47.155Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/dc/124f008cd2be3e887e972cbdeb17c5aee0f42093eca02c7cfd63bb5daf19/srsly-2.5.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0017c7d2a0cd9a4f1bdc00d946b45edcf90bb0e271e8f084c1ce542bf6708c32", size = 657503, upload-time = "2026-03-23T11:55:48.681Z" },
+    { url = "https://files.pythonhosted.org/packages/35/8a/2c97244ebab125d55f1bfb7bb94e9572b3e819410dffd6a040eca1112350/srsly-2.5.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:66ebae2c70305987341519ec1a720072a3cb3e4b1d52ac0e9e841f4d02658d3d", size = 1139161, upload-time = "2026-03-23T11:55:50.179Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/ea/ecd396188f7591d80b89665f7af9e3ae02e42683daef57033ad7993ad3f9/srsly-2.5.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4ca4a068f6e14d84113a02fcb875c6b50a6285a12938c0e7a157eb3a63c50a86", size = 1142438, upload-time = "2026-03-23T11:55:52.607Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/65/143e2e143c53d498ad0956f69d0e09189aa7a6e0ee6017758c285ba1ab2d/srsly-2.5.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e283fa2a8f7350fb9fb70ecdee28d59d39c92f4c7f1cc90a44d6b86db3b3a8b3", size = 1101783, upload-time = "2026-03-23T11:55:53.906Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/86/1392a5593de0cd3d08c2d6c071b877c84358a37f63172c4e9cb71706842d/srsly-2.5.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9ffc97e22730ea97b00f7c303ccc60b1305e786afadb2a4a46578dafa4d29da0", size = 1115876, upload-time = "2026-03-23T11:55:55.624Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/a5/6193aa4c08e488821538fcbce2282449e228fd2183ed67d118bb5ccd8b54/srsly-2.5.3-cp311-cp311-win_amd64.whl", hash = "sha256:f09b551f6c3e334652831ac68c770ee4284741ce0a3895bf1ccf2a1178d66cdd", size = 651733, upload-time = "2026-03-23T11:55:56.964Z" },
+    { url = "https://files.pythonhosted.org/packages/66/a8/a73181743b6d237026615ca75c3fb3e4780736f1390550a7350d0c7f1149/srsly-2.5.3-cp311-cp311-win_arm64.whl", hash = "sha256:21cf09e417d3e4f3fbf7dd337fd6d948c97abd01896b9b4cb80e81cd9778a73a", size = 639124, upload-time = "2026-03-23T11:55:58.532Z" },
+    { url = "https://files.pythonhosted.org/packages/02/cc/e9f7fcec4cc92ad8bad6316c4241638b8cf7380382d4489d94ec6c436452/srsly-2.5.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:71e51c046ccbeefb86524c6b1e17574f579c6ac4dc8ea4a09437d3e8f88342d3", size = 658379, upload-time = "2026-03-23T11:55:59.85Z" },
+    { url = "https://files.pythonhosted.org/packages/21/e4/fea4512e9785f58509b2cf67d993323848e583161b5fcfdc7dd9d7c1f3df/srsly-2.5.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2f73c0db911552e94fe2016e1759d261d2f47926f68826664cada3723c87006a", size = 658513, upload-time = "2026-03-23T11:56:01.239Z" },
+    { url = "https://files.pythonhosted.org/packages/20/b1/53591681b6ff2699a4f97b2d5552ba196eaa6a979b0873605f4c04b5f7ee/srsly-2.5.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c1ac27ae5f4bb9163c7d2c45fc8ec173aac3d92e32086d9472b326c5c6e570e", size = 1172265, upload-time = "2026-03-23T11:56:02.589Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/c9/741e29f534919a944a16da4184924b1d3404c4bf60716ab2b91be771d1e3/srsly-2.5.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:99026bcd9cbd3211cc36517400b04ca0fc5d3e412b14daf84ee6e65f67d9a2d8", size = 1180873, upload-time = "2026-03-23T11:56:03.944Z" },
+    { url = "https://files.pythonhosted.org/packages/89/57/5554f786eccf78b2750d6ac63be126e1b67badec2cb409dd611cf6f8c52b/srsly-2.5.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:07d682679e639eb46ff7e6da4a92714f4d5ffe351d088ee66f221e9b1f8865bb", size = 1120437, upload-time = "2026-03-23T11:56:05.283Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/95/9b4f73b1be3692f86d72ccc131c8e50f26f824d5c8830a59390bcc5b60ef/srsly-2.5.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8e0542d85d6b55cf2934050d6ffcb1cd76c768dcf9572e7467002cf087bb366d", size = 1137376, upload-time = "2026-03-23T11:56:06.613Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/de/89ca640ca1953c4612279ce515d0af35658df3c06cdb324329bc91b4a7e1/srsly-2.5.3-cp312-cp312-win_amd64.whl", hash = "sha256:598f1e494c18cacb978299d77125415a586417081959f8ec3f068b32d97f8933", size = 652459, upload-time = "2026-03-23T11:56:07.994Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/4f/7ab6d49e36d9cc72ee15746cabd116eb6f338be8a06c1882968ee9d6c7d7/srsly-2.5.3-cp312-cp312-win_arm64.whl", hash = "sha256:4b1b721cd3ad1a9b2343519aadc786a4d09d5c0666962d49852eb12d6ec3fe26", size = 638411, upload-time = "2026-03-23T11:56:09.31Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/5c/12901e3794f4158abc6da750725aad6c2afddb1e4227b300fe7c71f66957/srsly-2.5.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e67b6bbacbfadea5e100266d2797f2d4cec9883ea4dc84a5537673850036a8d8", size = 656750, upload-time = "2026-03-23T11:56:10.708Z" },
+    { url = "https://files.pythonhosted.org/packages/04/61/181c26370995f96f56f1b64b801e3ca1e0d703fc36506ae28606d62369fb/srsly-2.5.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:348c231b4477d8fe86603131d0f166d2feac9c372704dfc4398be71cc5b6fb07", size = 656746, upload-time = "2026-03-23T11:56:12.28Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c6/35876c78889f8ffe11ed3521644e666c3aef20ea31527b70f47456cf35c2/srsly-2.5.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b0938c2978c91ae1ef9c1f2ba35abb86330e198fb23469e356eba311e02233ee", size = 1155762, upload-time = "2026-03-23T11:56:14.075Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/da/40b71ca9906c8eb8f8feb6ac11d33dad458c85a56e1de764b96d402168a0/srsly-2.5.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5f6a837954429ecbe6dcdd27390d2fb4c7d01a3f99c9ffcf9ce66b2a6dd1b738", size = 1161092, upload-time = "2026-03-23T11:56:15.778Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/14/c0dd30cc8b93ce8137ff4766f743c882440ce49195fffc5d50eaeef311a6/srsly-2.5.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3576c125c486ce2958c2047e8858fe3cfc9ea877adfa05203b0986f9badee355", size = 1109984, upload-time = "2026-03-23T11:56:17.056Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f3/34354f183d8faafc631585571224b54d1b4b67e796972c36519c074ca355/srsly-2.5.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5fb59c42922e095d1ea36085c55bc16e2adb06a7bfe57b24d381e0194ae699f2", size = 1128409, upload-time = "2026-03-23T11:56:18.761Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/d9/5531f8a19492060b4e76e4ab06aca6f096fb5128fe18cc813d1772daf653/srsly-2.5.3-cp313-cp313-win_amd64.whl", hash = "sha256:111805927f05f5db440aeeacb85ce43da0b19ce7b2a09567a9ef8d30f3cc4d83", size = 650820, upload-time = "2026-03-23T11:56:20.096Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/8a/62fb7a971eca29e12f03fb9ddacb058548c14d33e5b5675ff0f85839cc7b/srsly-2.5.3-cp313-cp313-win_arm64.whl", hash = "sha256:0f106b0a700ab56e4a7c431b0f1444009ab6cb332edc7bbf6811c2a43f4722cb", size = 637278, upload-time = "2026-03-23T11:56:21.439Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5b/e4ef43c2a381711230af98d4c94a5323df48d6a7899ee652e05bf889290e/srsly-2.5.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:39c13d552a9f9674a12cdcdc66b0c2f02f3430d0cd04c5f9cf598824c2bd3d65", size = 661294, upload-time = "2026-03-23T11:56:23.29Z" },
+    { url = "https://files.pythonhosted.org/packages/92/2d/ebce7f3717e52cd0a01f4ec570f388f3b7098526794fcf1ad734e0b8f852/srsly-2.5.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:14c930767cc169611a2dc14e23bc7638cfb616d6f79029700ade033607343540", size = 660952, upload-time = "2026-03-23T11:56:24.908Z" },
+    { url = "https://files.pythonhosted.org/packages/22/47/a8f3e9b214be2624c8e8a78d38ca7b1d4e26b92d57018412e4bfc4abe89a/srsly-2.5.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2f2d464f0d0237e32fb53f0ec6f05418652c550e772b50e9918e83a1577cba4d", size = 1154554, upload-time = "2026-03-23T11:56:26.608Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/71/2a89dc3180a51e633a87a079ca064225f4aaf46c7b2a5fc720e28f261d98/srsly-2.5.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d18933248a5bb0ad56a1bae6003a9a7f37daac2ecb0c5bcbfaaf081b317e1c84", size = 1155746, upload-time = "2026-03-23T11:56:28.102Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/36/72e5ce3153927ca404b6f5bf5280e6ff3399c11557df472b153945468e0a/srsly-2.5.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7ea5412ea229e571ac9738cbe14f845cc06c8e4e956afb5f42061ccd087ef31f", size = 1112374, upload-time = "2026-03-23T11:56:29.591Z" },
+    { url = "https://files.pythonhosted.org/packages/04/b2/0895de109c28eca0d41a811ab7c076d4e4a505e8466f06bae22f5180a1dd/srsly-2.5.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8d3988970b4cf7d03bdd5b5169302ff84562dd2e1e0f84aeb34df3e5b5dc19bf", size = 1127732, upload-time = "2026-03-23T11:56:31.458Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/79/a37fa7759797fbdfe0a2e029ab13e78b1e81e191220d2bb8ff57d869aefb/srsly-2.5.3-cp314-cp314-win_amd64.whl", hash = "sha256:6a02d7dcc16126c8fae1c1c09b2072798a1dc482ab5f9c52b12c7114dac47325", size = 656467, upload-time = "2026-03-23T11:56:33.14Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/25/0dae019b3b90ad9037f91de4c390555cdaac9460a93ad62b02b03babdff5/srsly-2.5.3-cp314-cp314-win_arm64.whl", hash = "sha256:1c9129c4abe31903ff7996904a51afdd5428060de6c3d12af49a4da5e8df2821", size = 643040, upload-time = "2026-03-23T11:56:34.448Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/44/72dd5285b2e05435d98b0797f101d91d9b345d491ddc1fdb9bd09e27ccb8/srsly-2.5.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:29d5d01ba4c2e9c01f936e5e6d5babc4a47b38c9cbd6e1ec23f6d5a49df32605", size = 666200, upload-time = "2026-03-23T11:56:35.753Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ad/002c71b87fc3f648c9bf0ec47de0c3822bf2c95c8896a589dd03e7fd3977/srsly-2.5.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5c8df4039426d99f0148b5743542842ab96b82daded0b342555e15a639927757", size = 667409, upload-time = "2026-03-23T11:56:37.172Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/35/2cea3d5e80aeecfc4ece9e7e1783e7792cc3bad7ab85ab585882e1db4e38/srsly-2.5.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:06a43d63bde2e8cccadb953d7fff70b18196ca286b65dd2ad16006d65f3f8166", size = 1265941, upload-time = "2026-03-23T11:56:38.825Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/38/8a4d7e86dd0370a2e5af251b646000197bb5b7e0f9aa360c71bbfb253d0d/srsly-2.5.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:808cfafc047f0dec507a34c8fa8e4cda5722737fd33577df73452f52f7aca644", size = 1250693, upload-time = "2026-03-23T11:56:40.449Z" },
+    { url = "https://files.pythonhosted.org/packages/99/05/340129de5ea7b237271b12f8a6962cfa7eb0c5a3056794626d348c5ae7c7/srsly-2.5.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:71d4cbe2b2a1335c76ed0acae2dc862163787d8b01a705e1949796907ed94ccd", size = 1242408, upload-time = "2026-03-23T11:56:41.8Z" },
+    { url = "https://files.pythonhosted.org/packages/01/cb/d7fee7ab27c6aa2e3f865fb7b50ba18c81a4c763bba12bdf53df246441bc/srsly-2.5.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:565f69083d33cb329cfc74317da937fb3270c0f40fabc1b4488702d8074b4a3e", size = 1242749, upload-time = "2026-03-23T11:56:43.246Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/d1/9bad3a0f2fa7b72f4e0cf1d267b00513092d20ef538c47f72823ae4f7656/srsly-2.5.3-cp314-cp314t-win_amd64.whl", hash = "sha256:8ac016ffaeac35bc010992b71bf8afdd39d458f201c8138d84cf78778a936e6c", size = 673783, upload-time = "2026-03-23T11:56:44.875Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/ae/57d1d7af907e20c077e113e0e4976f87b82c0a415403d99284a262229dd0/srsly-2.5.3-cp314-cp314t-win_arm64.whl", hash = "sha256:d822083fe26ec6728bd8c273ac121fc4ab3864a0fdf0cf0ff3efb188fcd209ed", size = 650229, upload-time = "2026-03-23T11:56:46.148Z" },
+]
+
+[[package]]
 name = "starlette"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1384,8 +1976,10 @@ dependencies = [
     { name = "html5lib" },
     { name = "httpcore" },
     { name = "httptools" },
+    { name = "httpx2" },
     { name = "idna" },
     { name = "lxml" },
+    { name = "mutagen" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
     { name = "pydantic-core" },
@@ -1398,6 +1992,7 @@ dependencies = [
     { name = "six" },
     { name = "sniffio" },
     { name = "soupsieve" },
+    { name = "spacy" },
     { name = "sqlalchemy" },
     { name = "starlette" },
     { name = "typing-extensions" },
@@ -1416,7 +2011,6 @@ dev = [
     { name = "autoflake" },
     { name = "black" },
     { name = "flake8" },
-    { name = "httpx2" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
@@ -1453,10 +2047,11 @@ requires-dist = [
     { name = "html5lib", specifier = "==1.1" },
     { name = "httpcore", specifier = "==1.0.9" },
     { name = "httptools", specifier = "==0.7.1" },
-    { name = "httpx2", marker = "extra == 'dev'", specifier = "==2.5.0" },
+    { name = "httpx2", specifier = "==2.5.0" },
     { name = "idna", specifier = "==3.18" },
     { name = "iniconfig", marker = "extra == 'dev'", specifier = "==2.3.0" },
     { name = "lxml", specifier = "==6.1.1" },
+    { name = "mutagen", specifier = ">=1.47,<2" },
     { name = "packaging", marker = "extra == 'dev'", specifier = "==26.1" },
     { name = "pluggy", marker = "extra == 'dev'", specifier = "==1.6.0" },
     { name = "psycopg", extras = ["binary"], specifier = "==3.3.3" },
@@ -1476,6 +2071,7 @@ requires-dist = [
     { name = "six", specifier = "==1.17.0" },
     { name = "sniffio", specifier = "==1.3.1" },
     { name = "soupsieve", specifier = "==2.8.4" },
+    { name = "spacy", specifier = ">=3.7,<4" },
     { name = "sqlalchemy", specifier = "==2.0.49" },
     { name = "starlette", specifier = "==1.3.1" },
     { name = "typing-extensions", specifier = "==4.15.0" },
@@ -1490,12 +2086,94 @@ requires-dist = [
 provides-extras = ["dev"]
 
 [[package]]
+name = "thinc"
+version = "8.3.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "blis" },
+    { name = "catalogue" },
+    { name = "confection" },
+    { name = "cymem" },
+    { name = "murmurhash" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "packaging" },
+    { name = "preshed" },
+    { name = "pydantic" },
+    { name = "setuptools" },
+    { name = "srsly" },
+    { name = "wasabi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/46/76df95f2c327f9a9cef30c1523bf285627897097163584dcf5f77b2ebce2/thinc-8.3.13.tar.gz", hash = "sha256:68e658549fc1eb3ff92aed5147fcbb9c15d6e9cc0e623b4d0998d16522ffb4f9", size = 194640, upload-time = "2026-03-23T07:22:36.41Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/72/ca06842a007e8c794e8c59462f242cdfd6167d7cc9d0155ad004b194b015/thinc-8.3.13-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4565102638038a01a2193c7f5d41ccbd6233fbdcb1f1b184322a06add4f51f18", size = 844359, upload-time = "2026-03-23T07:21:43.017Z" },
+    { url = "https://files.pythonhosted.org/packages/48/44/e6aef092f478d263f72eb3933b55a6f37ba97c6a0ea0a61d13fbf9bf0c19/thinc-8.3.13-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:859fbd9d9b16af5278da23589b4afbe2ab6b0dd615df4d3229b7c4e67cd3107e", size = 812089, upload-time = "2026-03-23T07:21:44.618Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8a/9ce0424d456cd3580cc3a855b23a7ff86b81d5299fceb496a2f56f06c1c0/thinc-8.3.13-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a518d5c761a0f2341e530e867de133dc3ed814558365b2a68ec53b89c482a43f", size = 4101388, upload-time = "2026-03-23T07:21:46.135Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/51/ec91c0434bd9a1096ab874bbd6dc110c5089d7fc513137e6af59bd051eec/thinc-8.3.13-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:81337dfbee37f58f36c0c70f9a819dce1b32cdc13d959181e10de079621f6ac6", size = 4131972, upload-time = "2026-03-23T07:21:48.403Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/67/e30dea753c90cff5cb9e5feb34948fdb89a6774b84d849585b49e16a730e/thinc-8.3.13-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:fbc0ee16edd260c6a4a9e365ff36d0a682c9e7ca6d7b985682659ef2e3e73826", size = 5101283, upload-time = "2026-03-23T07:21:49.991Z" },
+    { url = "https://files.pythonhosted.org/packages/00/e9/b7544eddababa16e548b26a96fff29eeb307ce938df5fa4af9371fe8ed5d/thinc-8.3.13-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0355c37e40d1a9fc2a1b8e9c2e294d8586f6baa97bcac6b9002f2dddb4b82ae9", size = 5264488, upload-time = "2026-03-23T07:21:51.747Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/a9/49391a40d703efc0f7a451310373261835f71fd3e6e2e8cfc08ee02f78ad/thinc-8.3.13-cp311-cp311-win_amd64.whl", hash = "sha256:0a0fa13dcfe4b319c3a396432c1dbff30d3de37dbbdee559e76600ee2b9486df", size = 1795058, upload-time = "2026-03-23T07:21:53.424Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/31/fd5348d44beda12a3ee415cbba9ed4fd0b17ce65db1d473c38a29a8d6153/thinc-8.3.13-cp311-cp311-win_arm64.whl", hash = "sha256:cd8a2b714c061969eee65802965167a6ada1fe708d82fe176d98dcb95ebe182a", size = 1721215, upload-time = "2026-03-23T07:21:55.027Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/af/f7c1ebfe92eb5d27d7f2f3da67a11e2eb57bc30ab1553279af6dc65b65a8/thinc-8.3.13-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:77a41f66285321d20aaedaea1e87d7cd48dca6d2427bed1867ec7cba7109fc8d", size = 821097, upload-time = "2026-03-23T07:21:56.698Z" },
+    { url = "https://files.pythonhosted.org/packages/45/8f/69d7338575d98df85d0b54c0f5fc277dba72587fe9ab846ecdd12a998bcb/thinc-8.3.13-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3710d318b4e5460cf366a6f7b5ddbefb5d39dbd4cfa408222750fdc6c27c4411", size = 791932, upload-time = "2026-03-23T07:21:58.38Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/a5/21d010c81e81e1589e5ccb4950e521804d13726e541e87f644c51815673b/thinc-8.3.13-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5a08c87143a6d20177652dca1ec0dc815d88216d8fc62594a57e8bc45bf5ed49", size = 3854219, upload-time = "2026-03-23T07:21:59.819Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ff/6914bf370bd1d604d89e6dfb46b97d10cd9b00d42ff8c036283e92314a8c/thinc-8.3.13-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4b5ec9ff313819e7d8667794a3559463fa89ff45aaa73e3fd8d6273b1e0d7a7f", size = 3903307, upload-time = "2026-03-23T07:22:01.652Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/3d/5572b47fa155fb3388c071515b74024fa17a6efd1df9406da378f0aa84ef/thinc-8.3.13-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5c9a48f2bc1e04f138240ed5f9b815a9141a5de26accd0f08fa0137fcefed258", size = 4836882, upload-time = "2026-03-23T07:22:03.565Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/f0/a8d77c7bac089697c6df302cc3c936a1ab36a4720deae889e6f1dbcbd0eb/thinc-8.3.13-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:79a29a44d76bd02f5ac0624268c6e42b3576ae472c791a8ae9c2d813ae789b59", size = 5033398, upload-time = "2026-03-23T07:22:05.045Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/5651bb1f904d04220fc7670035ada921bf0638e2cff6444d67c12887a968/thinc-8.3.13-cp312-cp312-win_amd64.whl", hash = "sha256:ed1dc709ac4f2f03b710457889e4e02f05de51bc8456980c241d0b28798bc7cb", size = 1721248, upload-time = "2026-03-23T07:22:06.749Z" },
+    { url = "https://files.pythonhosted.org/packages/94/8d/683703de021ffbe46833d722b70f49ffbbca8e5bd6876256977555d92d7d/thinc-8.3.13-cp312-cp312-win_arm64.whl", hash = "sha256:c6a049703a6011c8fe26ee41af7e70272145594140d82f79bb23de619c6a6525", size = 1645777, upload-time = "2026-03-23T07:22:08.104Z" },
+    { url = "https://files.pythonhosted.org/packages/af/b9/7b46942176df459d1804a9e77b0976f7c56f3abf3ec7485d0e5f836a0382/thinc-8.3.13-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c2811dfd8d46d8b5d3b39051b23e64006b2994a5143b1978b436938018792af8", size = 817337, upload-time = "2026-03-23T07:22:09.538Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/79/53085a72cd8f4fc4e6e313d05ea5aa98e870684f4a0fb318a9875fc0a964/thinc-8.3.13-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5593e6300cb1ebe0c0e546e9c9fb49e7c2627a0aa688795cd4f995a8b820d2ec", size = 788120, upload-time = "2026-03-23T07:22:11.215Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/3e/d61b462b16da95ac6885f95bb395e672040ee594833e571a6edcffd234f5/thinc-8.3.13-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f697174d3fb474966ce50b430bbafa101a6d2f7ffb559dac4b5c59389ef72d22", size = 3844666, upload-time = "2026-03-23T07:22:12.67Z" },
+    { url = "https://files.pythonhosted.org/packages/78/4c/898cc654bb123734c71ec5a425c02ca34439517d01ce1c95a6563295580e/thinc-8.3.13-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e9c7c5c104737b414c8c4ec578e67d78b6c859afe25cbc0684402e721415bd7f", size = 3890658, upload-time = "2026-03-23T07:22:14.668Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/56/1abdbf0a4ad628e8a05d6516fe0745969649d805367a3dccad8ee872981b/thinc-8.3.13-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7a99d0e242d1ccd23f9ae6bea7cd502f8626efa65c156b91d84581d0356696c3", size = 4819933, upload-time = "2026-03-23T07:22:16.85Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/22/b84dbdc6be5055bbdb2a7352e2c393f67e8593c137f1b83c82bf1e062b6e/thinc-8.3.13-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e676edd21a747afbe3e6b9f3fca8b962e36d146ded03b070cb0c28e2dfbe9499", size = 5018099, upload-time = "2026-03-23T07:22:18.356Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/a8/763cd7ba949334c9d2cddc92dadb68b344cb9546dc01b8d4a733dcaa16c1/thinc-8.3.13-cp313-cp313-win_amd64.whl", hash = "sha256:8ad40307f20e83f77af28ff5c6be0b86af7a8b251d1231c545508d2763157d8f", size = 1720309, upload-time = "2026-03-23T07:22:19.81Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/15/a11f7bb3cbc97dfecf32a90552f5a8f8a5c99316a99c6c17bdabf5baf256/thinc-8.3.13-cp313-cp313-win_arm64.whl", hash = "sha256:723949cab11d1925c15447928513a718276316cec6e0de28337cca0a62be0521", size = 1644606, upload-time = "2026-03-23T07:22:21.339Z" },
+    { url = "https://files.pythonhosted.org/packages/80/40/f4937d113912c6d669ffe982356ab29dcb6c7fe3be926a15981dbbb6a91c/thinc-8.3.13-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:7badb0be4825535e6362c19e8a41872b65409e9da46d3453a391b843a0720865", size = 817024, upload-time = "2026-03-23T07:22:23.005Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/00/4d4ed1a11ba2920b85a03a0683b16d97dc5beb2e78078dbf0e13e43bcea7/thinc-8.3.13-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:565300b7e13de799e5abff00d445f537e9256cf7da4dcb0d0f005fc16748a29e", size = 792096, upload-time = "2026-03-23T07:22:24.349Z" },
+    { url = "https://files.pythonhosted.org/packages/44/5d/dc33d6932be8721af2ef76b4a3a6e8020648630eabae61fb916d2a861d1d/thinc-8.3.13-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c17cef1900a1aba7e1487493d16b8aa0a8633116f1b2a51c6649a4000697f17b", size = 3842215, upload-time = "2026-03-23T07:22:25.836Z" },
+    { url = "https://files.pythonhosted.org/packages/af/bc/a6d37d8dadc2c5b524f51192413481160c42c9dd6105e8d5551531623225/thinc-8.3.13-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f4f26d1eec9b2a6a8f2e0298a5515d13eb06d70730d0d9e1040bb329e12bf3fb", size = 3849253, upload-time = "2026-03-23T07:22:27.845Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/59/ce9c7067f1dfe5985875927de9cf7a79f9dae3e69487fd650dfba558029d/thinc-8.3.13-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a61a31fd0ce3c2771cf4901ba6df70e774ffe32febf1024c5b43d63575cd58fe", size = 4831163, upload-time = "2026-03-23T07:22:29.395Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/a8/f57819347fc4d8bef2204d15fcbb9d7dff2d6cdd5f83d5ed91456ddacc55/thinc-8.3.13-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ba8119daf84a12259ae4d251d36426417bafa0b34108890b4b7e2b50966bd990", size = 4986051, upload-time = "2026-03-23T07:22:30.933Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ef/a82214bb7c7c1e2d92b69e1a7654be90cfab180082c6108e45a98af2422c/thinc-8.3.13-cp314-cp314-win_amd64.whl", hash = "sha256:433e3826e018da489f1a8068e6de677f6eff3cc93991a599d90f12cd1bc26cdc", size = 1740382, upload-time = "2026-03-23T07:22:32.869Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ef/1648fda54e9689058335ff54f650a7a314db2a42e21af1b83949b2dc748e/thinc-8.3.13-cp314-cp314-win_arm64.whl", hash = "sha256:11754fada9ad5ba2e02d5f3f234f940e24015b82333db58372f4a6aedad9b43f", size = 1667687, upload-time = "2026-03-23T07:22:34.967Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.68.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/5f/57ff8b434839e70dab45601284ea413e947a63799891b7553e5960a793a8/tqdm-4.68.4.tar.gz", hash = "sha256:19829c9673638f2a0b8617da4cdcb927e831cd88bcfcb6e78d42a4d1af131520", size = 792418, upload-time = "2026-07-07T09:58:18.369Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/2a/5e5e750890ada51017d18d0d4c30da696e5b5bd3180947729927628fc3cb/tqdm-4.68.4-py3-none-any.whl", hash = "sha256:5168118b2368f48c561afda8020fd79195b1bdb0bdf8086b88442c267a315dc2", size = 676612, upload-time = "2026-07-07T09:58:16.256Z" },
+]
+
+[[package]]
 name = "truststore"
 version = "0.10.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.26.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/f7/68adc395201b20b872d68e975386832e8005ffeacedd43a1d837a32815be/typer-0.26.8.tar.gz", hash = "sha256:c244a6bd558886fe3f8780efb6bdd28bb9aff005a94eedebaa5cb32926fe2f7e", size = 202097, upload-time = "2026-06-26T09:22:45.705Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/87/b9fd69c92c6102a066e1b86a35243f53e70bd4c709f2a26d9f4fee4f4dc0/typer-0.26.8-py3-none-any.whl", hash = "sha256:3512ca79ac5c11113414b36e80281b872884477722440691c89d1112e321a49c", size = 122564, upload-time = "2026-06-26T09:22:44.72Z" },
 ]
 
 [[package]]
@@ -1601,6 +2279,18 @@ wheels = [
 ]
 
 [[package]]
+name = "wasabi"
+version = "1.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/f9/054e6e2f1071e963b5e746b48d1e3727470b2a490834d18ad92364929db3/wasabi-1.1.3.tar.gz", hash = "sha256:4bb3008f003809db0c3e28b4daf20906ea871a2bb43f9914197d540f4f2e0878", size = 30391, upload-time = "2024-05-31T16:56:18.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/7c/34330a89da55610daa5f245ddce5aab81244321101614751e7537f125133/wasabi-1.1.3-py3-none-any.whl", hash = "sha256:f76e16e8f7e79f8c4c8be49b4024ac725713ab10cd7f19350ad18a8e3f71728c", size = 27880, upload-time = "2024-05-31T16:56:16.699Z" },
+]
+
+[[package]]
 name = "watchfiles"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1688,6 +2378,26 @@ wheels = [
 ]
 
 [[package]]
+name = "weasel"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpathlib" },
+    { name = "confection" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "smart-open" },
+    { name = "srsly" },
+    { name = "typer" },
+    { name = "wasabi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/e5/e272bb9a045105a1fdf4b798d8086f5932a178f4d738f17a74f5c9e0ae9a/weasel-1.0.0.tar.gz", hash = "sha256:7b129b44c90cc543b760532974ca1e4eb30dad2aa2026f57bdce66354ae610fc", size = 38682, upload-time = "2026-03-20T08:10:25.266Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/07/57ebf7a6798b016c064bd0ca81b4c6a99daa4dc377b898bc7b41eb6b5af0/weasel-1.0.0-py3-none-any.whl", hash = "sha256:89518acee027f49d743126c3502d35e6dd14f5768be5c37c9af47c171b6005cc", size = 50713, upload-time = "2026-03-20T08:10:23.637Z" },
+]
+
+[[package]]
 name = "webencodings"
 version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1753,4 +2463,79 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
     { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/a4/282c8e64300a59fc834518a54bf0afabb4ff9218b5fa76958b450459a844/wrapt-2.2.2.tar.gz", hash = "sha256:0788e321027c999bf221b667bd4a54aaefd1a36283749a860ac3eb77daed0302", size = 129068, upload-time = "2026-06-20T23:49:44.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/15/0c2d55168707465abfc41f33c0b23d792a5fa9b65c26983606940900a120/wrapt-2.2.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f1a2ff355ece6a111ca7a20dc86df6659c9205d3fcee674ca34f2a2854fd4e73", size = 80782, upload-time = "2026-06-20T23:47:44.367Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/b5/5c0b093eb48f8a062ef6267d3cb36e9bb1b88440181f6545a383c60efdf8/wrapt-2.2.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:55b9a899e6fff5444f229d30aa6e9ac92d2216d9d60f33c771b5d76a760d5f8e", size = 81678, upload-time = "2026-06-20T23:47:45.857Z" },
+    { url = "https://files.pythonhosted.org/packages/34/f3/de70937472dd3e8a4e6811192f9c6075efdffd4a2cd9b4596bf160f89668/wrapt-2.2.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a2d78c363f97d8bd718ee40432c66395685e9e98528ccaa423c3355d1715a26d", size = 159671, upload-time = "2026-06-20T23:47:47.345Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ec/40aed2330e7f02ecf74386ffcfef9ccb7108c6a430f15b6a252b663b1bed/wrapt-2.2.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d619e1eed9bd4f6ed9f24cd61971aa086fa86505289628d464bcf8a2c2e3f328", size = 160785, upload-time = "2026-06-20T23:47:48.759Z" },
+    { url = "https://files.pythonhosted.org/packages/45/04/aa5309beed5344b00220ae6b3b24055852192656194c27947bee1736306a/wrapt-2.2.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:518b0c5e323511ec56a38894802ddd5e1222626484e68efe63f201854ad788e5", size = 153699, upload-time = "2026-06-20T23:47:50.177Z" },
+    { url = "https://files.pythonhosted.org/packages/01/df/2def7e99d1fe87eea413f95f671924cdddcb08823b1ffd212748dfa6d062/wrapt-2.2.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4bccea5cdecffa9dd70e343741f0e41e0a16619313d04b72f78bb525162ebcd0", size = 159695, upload-time = "2026-06-20T23:47:51.602Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f6/a906d01a2ce12157bad2404957b3e2140da354b8a70b2fa48bbf282871c0/wrapt-2.2.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:209112cafd963710a05d199aae431d79a28bc76eb8e6d1bbbb8ad24340722cae", size = 152813, upload-time = "2026-06-20T23:47:53.03Z" },
+    { url = "https://files.pythonhosted.org/packages/02/49/bc0086292d239575b4c08f4cf8a4079fa58abbad58ec23abf84833a283ed/wrapt-2.2.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e5a5290e4bf2f332fc29ce72ffb9a2fff678aaac047e2e9f5f7165cd7792e099", size = 158809, upload-time = "2026-06-20T23:47:54.391Z" },
+    { url = "https://files.pythonhosted.org/packages/55/83/8fbd034de1f3e907edaa18786d5dd8f6932874edee0826c7cecb5cab03a1/wrapt-2.2.2-cp311-cp311-win32.whl", hash = "sha256:5499236ad1dc116012e2a5dd943f3f31af12fce452128e2bbcbd55a7d3d4d14c", size = 77414, upload-time = "2026-06-20T23:47:55.882Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/9c/23695baa331c6de4e874c3d78b8e0bed92e1d2a274e665b29858f6841672/wrapt-2.2.2-cp311-cp311-win_amd64.whl", hash = "sha256:8636809939152be6ae20a6cef0fed9fe60f411b47847d0426a826884b469e971", size = 80368, upload-time = "2026-06-20T23:47:57.237Z" },
+    { url = "https://files.pythonhosted.org/packages/08/49/40cefc342bf89b234a4490d741290fce781774b831aefb39c25471da96c9/wrapt-2.2.2-cp311-cp311-win_arm64.whl", hash = "sha256:5d0a142f7af07caeb5e5da87493162a7b8efa19ba919e550a746f7446e13fb30", size = 79489, upload-time = "2026-06-20T23:47:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/85/180b40628b23772692a0c76e8030114e1c0ae068470ed531919f0a5f2a4a/wrapt-2.2.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8417fd3c674d3c8023d080292d29301531a12daf8bd938dd419710dd2f464f2b", size = 81484, upload-time = "2026-06-20T23:47:59.924Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f2/21c90f2a16689702e2aaff45795b11018dff2c9b1242bac10d225483f676/wrapt-2.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e7070c7472582e31af3dfc2622b2381a0df7435110a9388ed8db5ffbce67efb", size = 82151, upload-time = "2026-06-20T23:48:01.303Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/b3/7e6e9fcf4fe7e1b69a49fe6cc5a44e8224bab6283c5233c97e132f14908e/wrapt-2.2.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2e096c9d39a59b35b63c9aacfbbbec2088ff51ff1fc31051acc60a07f42f273a", size = 169828, upload-time = "2026-06-20T23:48:02.719Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/43/894f132d857ed5a9904d937baf368badcbe5ea9e436e2f1930fe21c9f1f0/wrapt-2.2.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d1a6050405bf334be33bf66296f113563622972a34900ae6fa60fd283a1a900", size = 171544, upload-time = "2026-06-20T23:48:04.266Z" },
+    { url = "https://files.pythonhosted.org/packages/29/de/3c833e03725b477e9ea34028224dd21a48781830101e4e036f77e8b6b102/wrapt-2.2.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10adb01371408c6de504a6658b9886480f1a4919a83752748a387a504a21df79", size = 160663, upload-time = "2026-06-20T23:48:05.708Z" },
+    { url = "https://files.pythonhosted.org/packages/33/be/27edce350b24e3054d9d047f65f16d4c4d4c1f3f31c4278a1f8a95c723c8/wrapt-2.2.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3442eee2a5798f9b451f1b2cd7518ce8b7e28a2a364696c414460a0e295c012a", size = 169387, upload-time = "2026-06-20T23:48:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c4/9fd9679af8bf38e146652c7f47b6b352c3e5795b4ad1c0b7f94e15ac2aa7/wrapt-2.2.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6c99012a22f735a85eed7c4b86a3e99c30fdd57d9e115b2b45f796264b58d0bf", size = 158849, upload-time = "2026-06-20T23:48:08.91Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/c2/aa6c0c2206803068c6859dabe01f8c84c43744da93d4c67b8946d21655ee/wrapt-2.2.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3b686cfc008776a3952d6213cb296ed7f45d782a8453936406faa89eac0835ab", size = 168147, upload-time = "2026-06-20T23:48:10.374Z" },
+    { url = "https://files.pythonhosted.org/packages/42/63/3eb25da41049d20ae18fcab2dd8b056e02387c4bfa626cbdfb7c3b872e4f/wrapt-2.2.2-cp312-cp312-win32.whl", hash = "sha256:ef2cce266b5b0b07e19fa82e59673b81142b7a3607c8ed1254113d048ed668da", size = 77734, upload-time = "2026-06-20T23:48:11.769Z" },
+    { url = "https://files.pythonhosted.org/packages/da/09/0390e008a305360948fa9ce69507d041ac12cb2ee5d28e34467e2ee79391/wrapt-2.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:abf8c20a2d72ee69e16328b3c91342c446e723bfe48bfcc4dded3b9722ac027f", size = 80585, upload-time = "2026-06-20T23:48:13.117Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b3/84c445c66969f2d3457276b183a48c91097d59bbef9af6c075366b0f8c36/wrapt-2.2.2-cp312-cp312-win_arm64.whl", hash = "sha256:c6c64c5d02578bc4c4bca4f0aef1504de933c1d5b4ac2710b9131111459506c8", size = 79553, upload-time = "2026-06-20T23:48:14.5Z" },
+    { url = "https://files.pythonhosted.org/packages/43/fc/f32f4b22c6511173c11d9e541ab4e7d8467a0f1b3455acaf784115d31ff8/wrapt-2.2.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9e8b648270c613720a202d9a45ebabc33261b22c3a839b115ac5bce8c0bb0d69", size = 81296, upload-time = "2026-06-20T23:48:15.881Z" },
+    { url = "https://files.pythonhosted.org/packages/72/06/4d117d5d77a9344776c0248b24dae3d3dd2f58e5f765fa08cf887072e719/wrapt-2.2.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6fb7e94e8fe3e4c3067bb1653a91cce7c5e83acc119fdd41501b1bf74654617", size = 81841, upload-time = "2026-06-20T23:48:17.262Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ff/63ad96f98eb58a742b1a20d80f21da88924405910149950b912368150468/wrapt-2.2.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fb18fc51e813df0d9c98049e3bf2298a5495a648602040e21fa3c7329371159e", size = 167882, upload-time = "2026-06-20T23:48:18.764Z" },
+    { url = "https://files.pythonhosted.org/packages/20/1f/8bb62d8933df7acf3247194e6e9fc68edf9d2fa203252c89c94b319dd472/wrapt-2.2.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94b00b00f806eb3ef2abe9049ed45994a81ee9284884d96e6b8314927c6cea3d", size = 167411, upload-time = "2026-06-20T23:48:20.315Z" },
+    { url = "https://files.pythonhosted.org/packages/17/09/8789dcb09ee1de715727db7521aabbb68ffa68dfade3a49468440cfced49/wrapt-2.2.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:62415fd095bc590b842b6d092f2b5d9ccbaeb7e0b28535c03dcea2718b48636b", size = 158607, upload-time = "2026-06-20T23:48:21.728Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/66e02562d53ee67d841f175e38e3c993c2d78a3e104c576cad61c028b43c/wrapt-2.2.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a41e758d80dc0ab8c210f641ac892009d356cf1f955d97db544c8dd317b4d14c", size = 166367, upload-time = "2026-06-20T23:48:23.177Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a3/832ac4e41222fb263b3042d42c2f08d305db7d0f0c9b1d3a271a9eede8f6/wrapt-2.2.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b84cd4058001c9727b0e9980b7a9e66325b5ca748b1b578e822cade1bc6b304f", size = 157176, upload-time = "2026-06-20T23:48:24.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/01/1bd5e4d2df9c0178989ac8da9186543465388588ee2ef153e2591accebef/wrapt-2.2.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:26fc73a1b15e0946d2942b9a4426d162b51676338327dc067ccd8d2d76385f94", size = 167025, upload-time = "2026-06-20T23:48:26.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/69/583ed25291ab53e1ec117135fb1c33425e2f46d2bc8f29c17f7a94cf4274/wrapt-2.2.2-cp313-cp313-win32.whl", hash = "sha256:3c4095803491f6ef72128914c28ec05bbad9758433bb35f6715a3e9c8e46fb2d", size = 77605, upload-time = "2026-06-20T23:48:27.643Z" },
+    { url = "https://files.pythonhosted.org/packages/29/68/e69fc6d06e1523c68e0d00f95c9aed1158ce9908ee41603f7f2eae3d5db6/wrapt-2.2.2-cp313-cp313-win_amd64.whl", hash = "sha256:2cb07f414fab25dbe6b5c7398e1491423a5c81a6209533639969a6c928d474a4", size = 80508, upload-time = "2026-06-20T23:48:29.013Z" },
+    { url = "https://files.pythonhosted.org/packages/55/21/fe7a393d9e5dc0923bed8f5d857e9dcff210f1fa0888c02cc8f3ffaa55aa/wrapt-2.2.2-cp313-cp313-win_arm64.whl", hash = "sha256:1fc7691f070220215cccb2a20836b9adbaecb8ff22ad47abe63de5f110994fac", size = 79565, upload-time = "2026-06-20T23:48:30.429Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e5/c120d13bf5091164f68c3c1657e84f16f57e71d978421b626393ac5bd7eb/wrapt-2.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ec8f83949028366531383603139403cac7a826e4011955813cdd640017845ce5", size = 83264, upload-time = "2026-06-20T23:48:31.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b0/d4a1eb97e0e286625bdf21bc7f702637f9607787ffbbdb5ec14d50c79dbf/wrapt-2.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4b481fb0c40d9fd90a5809911208da700987d373a20a4709dc9e3944af7a6bec", size = 83791, upload-time = "2026-06-20T23:48:33.482Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1e/f060df47755e87b57684cee7bfc1362b204df55fac96ffebc0631b697b79/wrapt-2.2.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0065a3b657cec06813b4241d2462ccec287f6863103d7445b725fb3a889736f9", size = 203399, upload-time = "2026-06-20T23:48:34.97Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/de/2316a757a1abb6453700b79d83e532146dcef2611348282d4d8889792161/wrapt-2.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30f7424af5c5c345b7f26490e097f74a2ef45b3d08b664dc33571aee3bd3b56c", size = 210461, upload-time = "2026-06-20T23:48:36.569Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/29/d1160785ae18ca2495a6d82a21154103d74f656c9fd457fb35f6b11b965a/wrapt-2.2.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:07fdcb012821859168641acf68afad61ef9783cf37100af85f152550e9677194", size = 195313, upload-time = "2026-06-20T23:48:38.175Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/2d/7caa9598ae61a9cf0989cc501739cbeeb7d650ab3193cca1407b9af0c6ab/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f90038ab58fafb584801ca62d72384d7d5225d93c76f7b773c22fae545bd8066", size = 206116, upload-time = "2026-06-20T23:48:39.804Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/02/281ea1088b8650d865f311b35cf86fd21df89128e2909714f1161e01c9d0/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:c5d7825491bfa2d08b97e9557768987952c7b9ae687d06c3320b40a37ccb7f20", size = 192668, upload-time = "2026-06-20T23:48:41.346Z" },
+    { url = "https://files.pythonhosted.org/packages/be/7d/976e2d5b4b5c5babda40974edd54d0a5585cb60132ed86b46f4b80239b16/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ad520e6daa9bbf136f14de735474dbec7dcc0891f718e1d274ce8dc92e645af", size = 198891, upload-time = "2026-06-20T23:48:43.056Z" },
+    { url = "https://files.pythonhosted.org/packages/59/b7/e47651797c097f75a37e2ce86dcf04048ff576f3a674f7c558df7b5e9622/wrapt-2.2.2-cp313-cp313t-win32.whl", hash = "sha256:25904acb9475f46c24fe0423dbc8fda8cc5fbc282ab3dc6e72e919748c53f4e9", size = 78537, upload-time = "2026-06-20T23:48:44.509Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/6f/9fa5d59fb06d890defb5a8f727ce6a14d2932c8760153f96956628559fee/wrapt-2.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:305d4c247d61c4115794a169141823c62f719525ddb90b23aa332741c77d2c28", size = 82005, upload-time = "2026-06-20T23:48:46.391Z" },
+    { url = "https://files.pythonhosted.org/packages/15/80/4c7bd9873d1f9f7d138d93556b500469dbe24f42710b877519c2b9eb380d/wrapt-2.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c20279cd1a29800815d7b2d6338b60a6c6e78263f9d6e62e0eda251ba9cae2d0", size = 80762, upload-time = "2026-06-20T23:48:47.964Z" },
+    { url = "https://files.pythonhosted.org/packages/24/05/7fd9c3f83b2c74cbfc572a0b88aa37431e04bd8aed70d2c0efd3464206de/wrapt-2.2.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0e64826f920c42d9d9f87e8cc09ffae66c51ede12d59061a5a426deb9aa71745", size = 81341, upload-time = "2026-06-20T23:48:49.39Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/68/1bfa43100dd90d4ef74a05897b86275cf57e1313ca14aae2545bc9f872c9/wrapt-2.2.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:dcaa5e1451bd8751d7bd1568dfa3321c78092a52a7ecb5d1a0f18a5791e1fd00", size = 81921, upload-time = "2026-06-20T23:48:50.986Z" },
+    { url = "https://files.pythonhosted.org/packages/74/eb/df7b7f0b631dbbc750f39be27d8b55f65777d8ac86da80e12be41a644c4b/wrapt-2.2.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0abfd648dac9ac9c5b3aa9b523d27f1789046640b58dcd5652a720ddb325e1fc", size = 167713, upload-time = "2026-06-20T23:48:52.598Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/9a/d1bd36f6d088c8e652a9383cabbd49af30b8c576302a7eccddbab6963e3f/wrapt-2.2.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f4bfd8d1eb438153eff8b8cfe87f032ba65731e1ce06138b5090f745a33f6f95", size = 166779, upload-time = "2026-06-20T23:48:54.33Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ae/24ffacd4187fac2740a1972093929e836dea092d42c87d728cd98fee11a6/wrapt-2.2.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c427c9d06d859848a69f0d928fe28b5c33a941b2265d10a0e1f15cd244f1ee33", size = 158407, upload-time = "2026-06-20T23:48:55.944Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ed/974427668249a356051e8d67d47fa54ef6c777f0fcf3bae9d292c047d4b6/wrapt-2.2.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4250b43d1a129d947e083c4dc6baf333c9bb34edd26f912d5b0457841fc858ab", size = 166594, upload-time = "2026-06-20T23:48:57.617Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/5f/e1d7c6e4523f78db2fbd7826babd0348da1d5e0834c4f918b9ab5757dfae/wrapt-2.2.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:173e5bb5ca350a6e0abab60b7ec7cdd7992a814cb14b4de670a28f067f105663", size = 157068, upload-time = "2026-06-20T23:48:59.171Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c1/7ebd1027f00700c0b0233b20aceef2b4784294ed64971424c4a78e069e34/wrapt-2.2.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:aa14b01804bce36c6d63d7b6a4f55df390f29f8648cc13a1f40b166f4d54680d", size = 166470, upload-time = "2026-06-20T23:49:00.737Z" },
+    { url = "https://files.pythonhosted.org/packages/99/eb/974e471a6a978b8180186b8a9dc5ae3361ce269a967190b709b8ce17abfb/wrapt-2.2.2-cp314-cp314-win32.whl", hash = "sha256:58f9f8d637c9a6e245c6ef5b109b67ec187d2faed23d1405656b51d96e0a5b56", size = 78062, upload-time = "2026-06-20T23:49:02.327Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ec/e1281156cdc7a66693838ad7a0865ad641c74abd337a957d668b575aaffb/wrapt-2.2.2-cp314-cp314-win_amd64.whl", hash = "sha256:385cb1866f20479e83299af585375bfa0a4b0c6c9907a981483ea782ea8ae406", size = 80832, upload-time = "2026-06-20T23:49:03.837Z" },
+    { url = "https://files.pythonhosted.org/packages/45/7d/1b6b5ddd94005a2dac97a4490c9838f3154977850d633abcb65b30089437/wrapt-2.2.2-cp314-cp314-win_arm64.whl", hash = "sha256:8ffbeaea6771a6eba6e6eeb09767864995726bc8240bb54baf88a9bb1db34d5c", size = 80029, upload-time = "2026-06-20T23:49:05.237Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/33/9ebcf8aafe91c601127cbd93708c16aa8f688f34a10bf004046803ecdc4f/wrapt-2.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:09f811d43f6f33ec7515f0be76b159569f4057ab54d3e079c3204dddb90afa2a", size = 83357, upload-time = "2026-06-20T23:49:06.632Z" },
+    { url = "https://files.pythonhosted.org/packages/39/38/ec45b635153327b52e52732a0ea980e5f00b7efba65f9e018828f1e69daa/wrapt-2.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a795d3c06e5fbf9ea2f13196180b77aeab1b4685917256ee0d014cc163d90063", size = 83794, upload-time = "2026-06-20T23:49:08.098Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ea/1a89e6d3b7a83c3affe5c09cde77792c947e63e4bc85ad84cd5bb9abb0d8/wrapt-2.2.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:45c2f2768e790c9f8db90f239ef23a2af8e7570f25a35619ef902df4a738447f", size = 203362, upload-time = "2026-06-20T23:49:09.811Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d8/3b58763d9863b5a73771c0d97110f9595d248db454009e07e1535ee905a4/wrapt-2.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbf00ee0cb55ec24e2b0995a71942b85b21a066db8f3f46e1dbfdb9433ffba81", size = 210449, upload-time = "2026-06-20T23:49:11.521Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/6f/17fd9e053103d8be148d20d5d7505facc72d5fe1f9127973904ceaed79cf/wrapt-2.2.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2252f77663651b89255895f58cc6ac08fcb206d4371813e5af61bb62d4f7689c", size = 195349, upload-time = "2026-06-20T23:49:13.346Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/04/d0d1ccaaa12cb7dccf28a23f0279a608ba498f71e81d949d5ed54bcfd5c1/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2cd7181ab1c31192ff5219269830744b5a62020b3a6d433588c4f1c95b8f8bff", size = 206099, upload-time = "2026-06-20T23:49:15.051Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/e8aa07b619890a2aa6cde1931b1887abb08820721b564a5f80b7ca3f3aa0/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:6fe35fd51b74867d8b80174c277bd6bbf6a73e443f908129dc531c4b688a20d5", size = 192728, upload-time = "2026-06-20T23:49:16.854Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f0/1819fb50f0d3c9bd758d8a83b56f1b470dee8b5b8eac8702b7c137cea9d4/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:11d95fc2fbad3163596c39d440e6f21ca9fccece74b56e30a37ac2fca786a07c", size = 198842, upload-time = "2026-06-20T23:49:18.504Z" },
+    { url = "https://files.pythonhosted.org/packages/67/7c/e88313f16a99930b899ef970d91c281544a470749a359decad994483bbda/wrapt-2.2.2-cp314-cp314t-win32.whl", hash = "sha256:d8a15813215f33fa83667bfc978b300e35669ea8bb424e970a1426bcb7bc6cca", size = 79059, upload-time = "2026-06-20T23:49:20.107Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/4f/ac12fda57a55068a094ec42851fb0a40e8489d8941863d517452de62e507/wrapt-2.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d09db0f7e8357060d3c38fc22a018aba683a796bf184360fd1a58f6fc180dc77", size = 82462, upload-time = "2026-06-20T23:49:21.631Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/df732dac86d9b2027c56bd163dbc883e037b16c3469614752e148d219c61/wrapt-2.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:f32fe639c39561ccc187bcae17e9271be0eb45f1c2952510d2f29b33ab577347", size = 81182, upload-time = "2026-06-20T23:49:23.199Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d2/6317eb6d4554855bbf12d61857774af34747bf88a42c19bf306de67e2fa3/wrapt-2.2.2-py3-none-any.whl", hash = "sha256:5bad217350f19ce99ca5b5e71d406765ea86fe541628426772b657375ee1c048", size = 61460, upload-time = "2026-06-20T23:49:42.966Z" },
 ]


### PR DESCRIPTION
## Summary

Adds an opt-in, stoppable EPUB-to-audiobook pipeline that produces EPUB 3 Media Overlay audiobooks with sentence-level state, resumable processing, shared series voice profiles, manual chapter previews, and listen/read playback.

The pipeline is practical to run locally: Ollama `qwen3.5:9b` is the recommended analysis model, official OmniVoice produces local speech, and a deterministic harness remains available for fast development and CI.

## What changed

- Adds audiobook tables and observability fields through Alembic revisions `0018`–`0021`.
- Ingests EPUB spine documents while preserving nested markup and stable sentence anchors.
- Adds Ollama structured-output integration plus OpenAI-compatible and Anthropic providers.
- Builds character rosters from story excerpts, whole-book dialogue/name evidence, and existing series context.
- Stores canonical character and voice profiles at the series level while retaining book-local character IDs for sentence assignments.
- Propagates profile edits across sibling books, reconciles rosters when series metadata changes, and safely merges renamed identities.
- Persists summaries, character evidence, speaker confidence, attribution rationale, job progress, and recoverable errors.
- Adds cooperative pause, single-stage stepping, one-batch execution, resume/retry, and roster-only regeneration.
- Adds explicit per-sentence and per-chapter preview generation; voice edits invalidate affected clips but do not automatically start expensive TTS work.
- Shows durable `Audio queued` / `Generating audio` row states and swaps the manual sentence action for an inline player when speech is ready.
- Adds a Listen & Read view with playable preview chapters, navigation, summaries, and transcript text.
- Adds library audiobook badges, series enabled counts, enabled/not-enabled filtering, and audiobook-enabled sorting across grouped series, standalone EPUBs, and web books.
- Generates chapter MP3/SMIL output and a packaged audiobook EPUB.
- Includes the official local OmniVoice adapter and deterministic silent-TTS/offline harness.

## Real-book validation

Tested locally with John Scalzi's *Old Man's War* (93,191 words; 9,156 narratable sentences):

- Ingestion completed across 30 narratable spine documents.
- Ollama `qwen3.5:9b` generated the working roster and story analysis; the job is paused durably at 121 / 9,156 analyzed sentences.
- The roster was promoted into the new Old Man's War series-level profile store.
- Manual sentence previews ran from both the API and the Script Editor through the real local OmniVoice model on Apple MPS.
- The chapter preview produced a valid 1.64-second MP3 plus SMIL, reached durable `ready` state, and supports HTTP byte-range playback.
- The Script Editor action visibly transitioned from `Generating audio` / `Working…` to `Audio generated` with an inline player, without advancing the paused full-book pipeline.
- The browser UI exposed the playable chapter in Listen & Read while leaving the incomplete first story chapter disabled at 80 / 320 analyzed sentences.
- Model-generated summaries and character descriptions remain explicitly labeled review-required because a local 9B model can still hallucinate details.

## Validation

- Backend: 260 passed.
- Frontend: 38 passed.
- Black, Flake8, ESLint, production Vite build, and diff checks passed.
- PostgreSQL migration `0021` passed clean upgrade, existing-data upgrade, downgrade, and re-upgrade checks.
- In-app browser walkthrough passed against the real 925-book library and 9,156-sentence job: audiobook-enabled ordering works in series and standalone views, the 1,280 px Script Editor has no document overflow, and no console errors were recorded.
- Real Ollama and OmniVoice health/inference paths were exercised locally.

## Local setup

```bash
make pull-ollama-model
make run-db
make run-api
make run-ui
make run-omnivoice
```

In **Audio Settings**, choose the Ollama preset (`http://127.0.0.1:11434`, `qwen3.5:9b`) and use **Save & Test LLM**. Use **Run Next Stage** or **Run One Batch** for analysis checkpoints. Once a chapter is fully analyzed, use **Generate Preview** in Chapter Assembly, then evaluate it in **Listen & Read** before continuing the full book.