### PR TITLE
[codex] Strip unused paragraph classes during epub normalization

### DIFF
--- a/backend/app/epub_editor.py
+++ b/backend/app/epub_editor.py
@@ -9,7 +9,7 @@ from bs4 import BeautifulSoup
 import re
 
 from . import models
-from .services.epub_utils import normalize_xhtml_prose_blocks
+from .services.epub_utils import collect_epub_book_styled_classes, normalize_xhtml_prose_blocks
 
 logger = logging.getLogger(__name__)
 
@@ -167,6 +167,7 @@ def process_epub(
     """Process an epub, returning the new word count if changed, or None if unchanged."""
     book = epub.read_epub(immutable_path)
     new_book = epub.EpubBook()
+    styled_classes = collect_epub_book_styled_classes(book) if normalize_prose_blocks else None
 
     # Copy metadata, filtering out Calibre custom columns (e.g. "user_metadata:#sort")
     # that cause ValueError in ebooklib when serialising to XML.
@@ -195,7 +196,7 @@ def process_epub(
                     for elem in soup.select(selector):
                         elem.decompose()
                 if normalize_prose_blocks:
-                    normalized_content, _ = normalize_xhtml_prose_blocks(str(soup))
+                    normalized_content, _ = normalize_xhtml_prose_blocks(str(soup), styled_classes=styled_classes)
                     soup = BeautifulSoup(normalized_content, "html.parser")
                 item.set_content(str(soup).encode("utf-8"))
             new_book.add_item(item)

--- a/backend/app/services/epub_utils.py
+++ b/backend/app/services/epub_utils.py
@@ -57,6 +57,8 @@ RISKY_PROSE_DESCENDANTS = {
     "video",
 }
 SENTENCE_END_RE = re.compile(r"(?<=[.!?])\s+")
+CSS_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+CSS_CLASS_SELECTOR_RE = re.compile(r"(?<![\w-])\.(-?[_a-zA-Z][\w-]*)")
 # Intentionally duplicated in migration 0015 — migrations must be self-contained.
 SCRIBBLEHUB_GENRES = {
     "Action",
@@ -111,6 +113,25 @@ def _clone_empty_tag(soup: BeautifulSoup, source: Tag) -> Tag:
     clone = soup.new_tag(source.name)
     clone.attrs = copy.deepcopy(source.attrs)
     return clone
+
+
+def _strip_unstyled_classes(tag: Tag, styled_classes: set[str] | None) -> bool:
+    if styled_classes is None:
+        return False
+
+    classes = tag.get("class") or []
+    if not classes:
+        return False
+
+    kept_classes = [class_name for class_name in classes if class_name in styled_classes]
+    if kept_classes == classes:
+        return False
+
+    if kept_classes:
+        tag["class"] = kept_classes
+    else:
+        del tag["class"]
+    return True
 
 
 def _append_copied_children(target: Tag, children: list) -> None:
@@ -236,12 +257,49 @@ def _split_oversized_paragraph(soup: BeautifulSoup, paragraph: Tag) -> bool:
     return True
 
 
-def normalize_xhtml_prose_blocks(content: str | bytes) -> tuple[bytes, bool]:
+def _styled_classes_from_css(css: str | bytes) -> set[str]:
+    css_text = css.decode("utf-8", "ignore") if isinstance(css, bytes) else css
+    css_text = CSS_COMMENT_RE.sub("", css_text)
+    return set(CSS_CLASS_SELECTOR_RE.findall(css_text))
+
+
+def _styled_classes_from_style_tags(content: str | bytes) -> set[str]:
+    soup = BeautifulSoup(content, "html.parser")
+    return set().union(*(_styled_classes_from_css(style.get_text()) for style in soup.find_all("style")))
+
+
+def _collect_zip_styled_classes(src: zipfile.ZipFile) -> set[str]:
+    styled_classes: set[str] = set()
+    for info in src.infolist():
+        filename = info.filename.lower()
+        if filename.endswith(".css"):
+            styled_classes.update(_styled_classes_from_css(src.read(info.filename)))
+        elif filename.endswith((".xhtml", ".html", ".htm")):
+            styled_classes.update(_styled_classes_from_style_tags(src.read(info.filename)))
+    return styled_classes
+
+
+def collect_epub_book_styled_classes(book: epub.EpubBook) -> set[str]:
+    styled_classes: set[str] = set()
+    for item in book.items:
+        if item is None:
+            continue
+        name = item.get_name().lower()
+        if name.endswith(".css") or getattr(item, "media_type", None) == "text/css":
+            styled_classes.update(_styled_classes_from_css(item.get_content()))
+        elif item.get_type() == ebooklib.ITEM_DOCUMENT:
+            styled_classes.update(_styled_classes_from_style_tags(item.get_content()))
+    return styled_classes
+
+
+def normalize_xhtml_prose_blocks(content: str | bytes, styled_classes: set[str] | None = None) -> tuple[bytes, bool]:
     """Split oversized prose paragraphs into smaller XHTML block elements."""
     soup = BeautifulSoup(content, "html.parser")
     changed = False
 
     for paragraph in list(soup.find_all("p")):
+        if _strip_unstyled_classes(paragraph, styled_classes):
+            changed = True
         if _split_oversized_paragraph(soup, paragraph):
             changed = True
 
@@ -254,10 +312,11 @@ def normalize_epub_prose_blocks(epub_path: Path) -> bool:
     changed = False
 
     with zipfile.ZipFile(epub_path) as src, zipfile.ZipFile(temp_path, "w") as dst:
+        styled_classes = _collect_zip_styled_classes(src)
         for info in src.infolist():
             data = src.read(info.filename)
             if info.filename.lower().endswith((".xhtml", ".html", ".htm")):
-                normalized, entry_changed = normalize_xhtml_prose_blocks(data)
+                normalized, entry_changed = normalize_xhtml_prose_blocks(data, styled_classes=styled_classes)
                 if entry_changed:
                     data = normalized
                     changed = True

--- a/backend/tests/test_epub_utils.py
+++ b/backend/tests/test_epub_utils.py
@@ -8,6 +8,7 @@ from backend.app.services.epub_utils import (
     get_and_save_epub_cover,
     get_epub_genre_tags,
     get_epub_source_tags,
+    normalize_epub_prose_blocks,
     normalize_xhtml_prose_blocks,
 )
 
@@ -64,6 +65,35 @@ def test_normalize_xhtml_prose_blocks_splits_double_br_paragraph_breaks():
     assert all(len(text) <= PROSE_BLOCK_MAX_CHARS for text in _paragraph_texts(normalized))
 
 
+def test_normalize_xhtml_prose_blocks_does_not_copy_unstyled_classes_to_split_paragraphs():
+    parts = [
+        "First sentence. " * 80,
+        "Second sentence. " * 80,
+        "Third sentence. " * 80,
+    ]
+    html = f"<html><body><p class='web-hash'>{'<br/><br/>'.join(parts)}</p></body></html>"
+
+    normalized, changed = normalize_xhtml_prose_blocks(html, styled_classes=set())
+
+    soup = BeautifulSoup(normalized, "html.parser")
+    paragraphs = soup.find_all("p")
+    assert changed is True
+    assert len(paragraphs) == 3
+    assert all(p.get("class") is None for p in paragraphs)
+
+
+def test_normalize_xhtml_prose_blocks_preserves_styled_paragraph_classes():
+    html = b"<html><body><p class='web-hash keep'>Styled paragraph.</p><p class='web-hash'>Plain paragraph.</p></body></html>"
+
+    normalized, changed = normalize_xhtml_prose_blocks(html, styled_classes={"keep"})
+
+    soup = BeautifulSoup(normalized, "html.parser")
+    paragraphs = soup.find_all("p")
+    assert changed is True
+    assert paragraphs[0].get("class") == ["keep"]
+    assert paragraphs[1].get("class") is None
+
+
 def test_normalize_xhtml_prose_blocks_splits_simple_prose_at_sentence_boundaries():
     text = " ".join(f"This is sentence number {index} with enough words to make the paragraph long." for index in range(180))
     html = f"<html><body><p>{text}</p></body></html>"
@@ -109,6 +139,40 @@ def test_normalize_xhtml_prose_blocks_skips_risky_and_non_prose_structures():
     assert len(soup.find_all("p")) == 2
     assert len(soup.find_all("pre")) == 1
     assert len(soup.find_all("table")) == 1
+
+
+def test_normalize_epub_prose_blocks_strips_unstyled_paragraph_classes_from_stylesheet_context(tmp_path):
+    epub_path = tmp_path / "web-classes.epub"
+    write_minimal_epub(
+        epub_path,
+        """<?xml version="1.0" encoding="UTF-8"?>
+<package version="3.0" xmlns="http://www.idpf.org/2007/opf">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Web Classes</dc:title>
+  </metadata>
+</package>
+""",
+        {
+            "EPUB/OEBPS/stylesheet.css": b".keep { text-align: center; }",
+            "EPUB/OEBPS/chapter.xhtml": (
+                b"<html><body>"
+                b"<p class='web-hash keep'>Styled paragraph.</p>"
+                b"<p class='web-hash'>Plain paragraph.</p>"
+                b"<h3 class='web-hash'>Heading class is not prose.</h3>"
+                b"</body></html>"
+            ),
+        },
+    )
+
+    changed = normalize_epub_prose_blocks(epub_path)
+
+    with zipfile.ZipFile(epub_path) as archive:
+        soup = BeautifulSoup(archive.read("EPUB/OEBPS/chapter.xhtml"), "html.parser")
+    paragraphs = soup.find_all("p")
+    assert changed is True
+    assert paragraphs[0].get("class") == ["keep"]
+    assert paragraphs[1].get("class") is None
+    assert soup.find("h3").get("class") == ["web-hash"]
 
 
 def test_get_and_save_epub_cover_uses_epub3_cover_image_property(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- collect class selectors from EPUB stylesheets and inline style tags before prose normalization
- strip unused classes from paragraph tags while preserving classes that are actually referenced by CSS
- apply the same stylesheet-aware normalization path in the EPUB editor flow

## Why
Web-imported EPUBs can contain hash-like paragraph classes that are not used for styling. When oversized paragraphs are split for better Readium locator granularity, copying those unused classes onto each generated paragraph can still leave Readium with poor or ambiguous selectors for later TTS starts.

This keeps the useful split paragraph structure while removing unstyled paragraph class noise from normalized EPUB content.

## Validation
- `PYTHONPATH=. uv run pytest backend/tests/test_epub_utils.py backend/tests/test_epub_editor.py`
- `uv run black --check backend/app/services/epub_utils.py backend/app/epub_editor.py backend/tests/test_epub_utils.py`
- sample EPUB copy check: `p_classes=0`, heading classes preserved
