### PR TITLE
Add core offline EPUB audiobook pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,12 @@ COPY run-container.sh run-container.sh
 
 RUN chmod +x run-container.sh
 
+RUN rm -f /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends ffmpeg \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
     && /root/.local/bin/uv export --quiet --frozen --no-dev --no-emit-project --format requirements-txt -o /tmp/requirements.txt \
     && /root/.local/bin/uv pip install --system --no-cache -r /tmp/requirements.txt \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
     && /root/.local/bin/uv pip install --system --no-cache -r /tmp/requirements.txt \
     && /root/.local/bin/uv pip install --system --no-cache --no-deps .
 
+RUN python -m spacy download en_core_web_sm
+
 RUN npm --prefix frontend ci && npm --prefix frontend run build
 
 EXPOSE 8000

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,7 +1,7 @@
 FROM python:3.13-slim
 
 # Install PostgreSQL and Node.js
-RUN apt-get update && apt-get install -y curl ffmpeg postgresql postgresql-contrib \
+RUN apt-get update && apt-get install -y curl postgresql postgresql-contrib \
     && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y nodejs \
     && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,7 +1,7 @@
 FROM python:3.13-slim
 
 # Install PostgreSQL and Node.js
-RUN apt-get update && apt-get install -y curl postgresql postgresql-contrib \
+RUN apt-get update && apt-get install -y curl ffmpeg postgresql postgresql-contrib \
     && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y nodejs \
     && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/backend/alembic/versions/0018_audiobook_pipeline.py
+++ b/backend/alembic/versions/0018_audiobook_pipeline.py
@@ -1,0 +1,85 @@
+"""audiobook pipeline tables and book pipeline status column
+
+Revision ID: 0018
+Revises: 0017
+Create Date: 2026-05-07 00:00:00
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0018"
+down_revision = "0017"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "audiobook_settings",
+        sa.Column("id", sa.Integer, primary_key=True, index=True),
+        sa.Column("llm_provider", sa.String, nullable=True),
+        sa.Column("llm_api_key", sa.String, nullable=True),
+        sa.Column("llm_base_url", sa.String, nullable=True),
+        sa.Column("llm_model", sa.String, nullable=True),
+        sa.Column("omnivoice_endpoint", sa.String, nullable=True),
+        sa.Column("roster_prompt_template", sa.Text, nullable=True),
+        sa.Column("diarization_prompt_template", sa.Text, nullable=True),
+    )
+
+    op.create_table(
+        "audiobook_chapters",
+        sa.Column("id", sa.Integer, primary_key=True, index=True),
+        sa.Column("book_id", sa.Integer, sa.ForeignKey("books.id", ondelete="CASCADE"), nullable=False, index=True),
+        sa.Column("chapter_number", sa.Integer, nullable=False),
+        sa.Column("smil_file_path", sa.String, nullable=True),
+        sa.Column("audio_file_path", sa.String, nullable=True),
+        sa.Column("needs_reassembly", sa.Boolean, nullable=False, server_default="false"),
+    )
+
+    op.create_table(
+        "audiobook_characters",
+        sa.Column("id", sa.Integer, primary_key=True, index=True),
+        sa.Column("book_id", sa.Integer, sa.ForeignKey("books.id", ondelete="CASCADE"), nullable=False, index=True),
+        sa.Column("name", sa.String, nullable=False),
+        sa.Column("description", sa.Text, nullable=True),
+        sa.Column("voice_design_prompt", sa.String, nullable=True),
+        sa.Column("is_narrator", sa.Boolean, nullable=False, server_default="false"),
+    )
+
+    op.create_table(
+        "audiobook_sentences",
+        sa.Column("id", sa.Integer, primary_key=True, index=True),
+        sa.Column(
+            "chapter_id",
+            sa.Integer,
+            sa.ForeignKey("audiobook_chapters.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "character_id",
+            sa.Integer,
+            sa.ForeignKey("audiobook_characters.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("html_element_id", sa.String, nullable=False),
+        sa.Column("sequence_order", sa.Integer, nullable=False),
+        sa.Column("original_text", sa.Text, nullable=False),
+        sa.Column("tagged_text", sa.Text, nullable=True),
+        sa.Column("audio_file_path", sa.String, nullable=True),
+        sa.Column("audio_duration_ms", sa.Integer, nullable=True),
+        sa.Column("status", sa.String, nullable=False, server_default="pending_diarization"),
+    )
+    op.create_index("ix_audiobook_sentences_status", "audiobook_sentences", ["status"])
+
+    op.add_column("books", sa.Column("audiobook_pipeline_status", sa.String, nullable=True))
+
+
+def downgrade():
+    op.drop_column("books", "audiobook_pipeline_status")
+    op.drop_index("ix_audiobook_sentences_status", table_name="audiobook_sentences")
+    op.drop_table("audiobook_sentences")
+    op.drop_table("audiobook_characters")
+    op.drop_table("audiobook_chapters")
+    op.drop_table("audiobook_settings")

--- a/backend/alembic/versions/0018_audiobook_pipeline.py
+++ b/backend/alembic/versions/0018_audiobook_pipeline.py
@@ -32,6 +32,7 @@ def upgrade():
         sa.Column("id", sa.Integer, primary_key=True, index=True),
         sa.Column("book_id", sa.Integer, sa.ForeignKey("books.id", ondelete="CASCADE"), nullable=False, index=True),
         sa.Column("chapter_number", sa.Integer, nullable=False),
+        sa.Column("content_file_name", sa.String, nullable=True),
         sa.Column("smil_file_path", sa.String, nullable=True),
         sa.Column("audio_file_path", sa.String, nullable=True),
         sa.Column("needs_reassembly", sa.Boolean, nullable=False, server_default="false"),
@@ -73,11 +74,16 @@ def upgrade():
     )
     op.create_index("ix_audiobook_sentences_status", "audiobook_sentences", ["status"])
 
+    op.add_column(
+        "books",
+        sa.Column("audiobook_enabled", sa.Boolean, nullable=False, server_default="false"),
+    )
     op.add_column("books", sa.Column("audiobook_pipeline_status", sa.String, nullable=True))
 
 
 def downgrade():
     op.drop_column("books", "audiobook_pipeline_status")
+    op.drop_column("books", "audiobook_enabled")
     op.drop_index("ix_audiobook_sentences_status", table_name="audiobook_sentences")
     op.drop_table("audiobook_sentences")
     op.drop_table("audiobook_characters")

--- a/backend/app/admin_auth_middleware.py
+++ b/backend/app/admin_auth_middleware.py
@@ -27,4 +27,6 @@ class AdminAuthMiddleware(BaseHTTPMiddleware):
         if not is_admin_auth_enabled():
             return False
         path = request.url.path
-        return path.startswith("/api/") and not path.startswith("/api/auth/")
+        protected_api = path.startswith("/api/") and not path.startswith("/api/auth/")
+        protected_audiobook = path == "/library/audiobooks" or path.startswith("/library/audiobooks/")
+        return protected_api or protected_audiobook

--- a/backend/app/crud/__init__.py
+++ b/backend/app/crud/__init__.py
@@ -1,5 +1,7 @@
 """CRUD operations package — re-exports all functions for backward compatibility."""
 
+from . import audiobook  # noqa: F401
+
 from .books import (  # noqa: F401
     count_books,
     create_book,

--- a/backend/app/crud/audiobook.py
+++ b/backend/app/crud/audiobook.py
@@ -1,0 +1,340 @@
+"""CRUD operations for the audiobook pipeline tables."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlalchemy import select, update, func
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..models import AudiobookSettings, AudiobookChapter, AudiobookCharacter, AudiobookSentence, Book
+
+
+# ---------------------------------------------------------------------------
+# Settings
+# ---------------------------------------------------------------------------
+
+
+async def get_audiobook_settings(db: AsyncSession) -> Optional[AudiobookSettings]:
+    result = await db.execute(select(AudiobookSettings).limit(1))
+    return result.scalar_one_or_none()
+
+
+async def upsert_audiobook_settings(db: AsyncSession, data: dict) -> AudiobookSettings:
+    settings = await get_audiobook_settings(db)
+    if settings is None:
+        settings = AudiobookSettings(**data)
+        db.add(settings)
+    else:
+        for key, value in data.items():
+            setattr(settings, key, value)
+    await db.commit()
+    await db.refresh(settings)
+    return settings
+
+
+# ---------------------------------------------------------------------------
+# Book pipeline status
+# ---------------------------------------------------------------------------
+
+
+async def set_book_pipeline_status(db: AsyncSession, book_id: int, status: Optional[str]) -> None:
+    await db.execute(update(Book).where(Book.id == book_id).values(audiobook_pipeline_status=status))
+    await db.commit()
+
+
+async def get_in_progress_audiobook_books(db: AsyncSession) -> list[Book]:
+    active_statuses = ["ingesting", "roster_gen", "diarizing", "audio_gen", "assembling"]
+    result = await db.execute(select(Book).where(Book.audiobook_pipeline_status.in_(active_statuses)))
+    return list(result.scalars().all())
+
+
+# ---------------------------------------------------------------------------
+# Chapters
+# ---------------------------------------------------------------------------
+
+
+async def create_chapter(db: AsyncSession, book_id: int, chapter_number: int) -> AudiobookChapter:
+    chapter = AudiobookChapter(book_id=book_id, chapter_number=chapter_number)
+    db.add(chapter)
+    await db.flush()
+    return chapter
+
+
+async def get_chapters_for_book(db: AsyncSession, book_id: int) -> list[AudiobookChapter]:
+    result = await db.execute(
+        select(AudiobookChapter)
+        .where(AudiobookChapter.book_id == book_id)
+        .order_by(AudiobookChapter.chapter_number)
+    )
+    return list(result.scalars().all())
+
+
+async def get_chapters_needing_reassembly(db: AsyncSession, book_id: int) -> list[AudiobookChapter]:
+    result = await db.execute(
+        select(AudiobookChapter)
+        .where(AudiobookChapter.book_id == book_id, AudiobookChapter.needs_reassembly.is_(True))
+        .order_by(AudiobookChapter.chapter_number)
+    )
+    return list(result.scalars().all())
+
+
+async def update_chapter_assembly(
+    db: AsyncSession,
+    chapter_id: int,
+    audio_file_path: str,
+    smil_file_path: str,
+) -> None:
+    await db.execute(
+        update(AudiobookChapter)
+        .where(AudiobookChapter.id == chapter_id)
+        .values(audio_file_path=audio_file_path, smil_file_path=smil_file_path, needs_reassembly=False)
+    )
+    await db.commit()
+
+
+async def flag_chapter_for_reassembly(db: AsyncSession, chapter_id: int) -> None:
+    await db.execute(
+        update(AudiobookChapter).where(AudiobookChapter.id == chapter_id).values(needs_reassembly=True)
+    )
+    await db.commit()
+
+
+async def delete_chapters_for_book(db: AsyncSession, book_id: int) -> None:
+    chapters = await get_chapters_for_book(db, book_id)
+    for ch in chapters:
+        await db.delete(ch)
+    await db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Characters
+# ---------------------------------------------------------------------------
+
+
+async def create_characters_bulk(db: AsyncSession, book_id: int, characters_data: list[dict]) -> list[AudiobookCharacter]:
+    chars = [AudiobookCharacter(book_id=book_id, **c) for c in characters_data]
+    db.add_all(chars)
+    await db.commit()
+    for c in chars:
+        await db.refresh(c)
+    return chars
+
+
+async def get_characters_for_book(db: AsyncSession, book_id: int) -> list[AudiobookCharacter]:
+    result = await db.execute(
+        select(AudiobookCharacter)
+        .where(AudiobookCharacter.book_id == book_id)
+        .order_by(AudiobookCharacter.is_narrator.desc(), AudiobookCharacter.name)
+    )
+    return list(result.scalars().all())
+
+
+async def get_character(db: AsyncSession, char_id: int) -> Optional[AudiobookCharacter]:
+    return await db.get(AudiobookCharacter, char_id)
+
+
+async def update_character(db: AsyncSession, char_id: int, data: dict) -> Optional[AudiobookCharacter]:
+    char = await db.get(AudiobookCharacter, char_id)
+    if char is None:
+        return None
+    for key, value in data.items():
+        setattr(char, key, value)
+    await db.commit()
+    await db.refresh(char)
+    return char
+
+
+async def cascade_voice_change(db: AsyncSession, char_id: int) -> None:
+    """Reset audio for all sentences by this character and flag affected chapters."""
+    await db.execute(
+        update(AudiobookSentence)
+        .where(AudiobookSentence.character_id == char_id)
+        .values(status="ready_for_audio", audio_file_path=None, audio_duration_ms=None)
+    )
+    result = await db.execute(
+        select(AudiobookSentence.chapter_id)
+        .where(AudiobookSentence.character_id == char_id)
+        .distinct()
+    )
+    chapter_ids = [row[0] for row in result.all()]
+    if chapter_ids:
+        await db.execute(
+            update(AudiobookChapter)
+            .where(AudiobookChapter.id.in_(chapter_ids))
+            .values(needs_reassembly=True)
+        )
+    await db.commit()
+
+
+async def delete_characters_for_book(db: AsyncSession, book_id: int) -> None:
+    chars = await get_characters_for_book(db, book_id)
+    for c in chars:
+        await db.delete(c)
+    await db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Sentences
+# ---------------------------------------------------------------------------
+
+
+async def create_sentences_bulk(db: AsyncSession, chapter_id: int, sentences_data: list[dict]) -> int:
+    sentences = [AudiobookSentence(chapter_id=chapter_id, **s) for s in sentences_data]
+    db.add_all(sentences)
+    await db.commit()
+    return len(sentences)
+
+
+async def get_sentences_for_chapter(db: AsyncSession, chapter_id: int) -> list[AudiobookSentence]:
+    result = await db.execute(
+        select(AudiobookSentence)
+        .where(AudiobookSentence.chapter_id == chapter_id)
+        .order_by(AudiobookSentence.sequence_order)
+    )
+    return list(result.scalars().all())
+
+
+async def get_sentences_paginated(
+    db: AsyncSession,
+    book_id: int,
+    page: int = 1,
+    limit: int = 50,
+    chapter_id: Optional[int] = None,
+) -> tuple[list[AudiobookSentence], int]:
+    base_query = (
+        select(AudiobookSentence)
+        .join(AudiobookChapter, AudiobookSentence.chapter_id == AudiobookChapter.id)
+        .where(AudiobookChapter.book_id == book_id)
+    )
+    count_query = (
+        select(func.count())
+        .select_from(AudiobookSentence)
+        .join(AudiobookChapter, AudiobookSentence.chapter_id == AudiobookChapter.id)
+        .where(AudiobookChapter.book_id == book_id)
+    )
+    if chapter_id is not None:
+        base_query = base_query.where(AudiobookSentence.chapter_id == chapter_id)
+        count_query = count_query.where(AudiobookSentence.chapter_id == chapter_id)
+
+    total_result = await db.execute(count_query)
+    total = total_result.scalar_one()
+
+    result = await db.execute(
+        base_query
+        .order_by(AudiobookChapter.chapter_number, AudiobookSentence.sequence_order)
+        .offset((page - 1) * limit)
+        .limit(limit)
+    )
+    return list(result.scalars().all()), total
+
+
+async def get_sentences_pending_diarization(
+    db: AsyncSession, book_id: int, limit: int = 50
+) -> list[AudiobookSentence]:
+    result = await db.execute(
+        select(AudiobookSentence)
+        .join(AudiobookChapter, AudiobookSentence.chapter_id == AudiobookChapter.id)
+        .where(
+            AudiobookChapter.book_id == book_id,
+            AudiobookSentence.status == "pending_diarization",
+        )
+        .order_by(AudiobookChapter.chapter_number, AudiobookSentence.sequence_order)
+        .limit(limit)
+    )
+    return list(result.scalars().all())
+
+
+async def get_sentences_ready_for_audio(
+    db: AsyncSession, book_id: int, limit: int = 20
+) -> list[AudiobookSentence]:
+    result = await db.execute(
+        select(AudiobookSentence)
+        .join(AudiobookChapter, AudiobookSentence.chapter_id == AudiobookChapter.id)
+        .where(
+            AudiobookChapter.book_id == book_id,
+            AudiobookSentence.status == "ready_for_audio",
+        )
+        .order_by(AudiobookChapter.chapter_number, AudiobookSentence.sequence_order)
+        .limit(limit)
+    )
+    return list(result.scalars().all())
+
+
+async def update_sentence_diarization(
+    db: AsyncSession, sentence_id: int, character_id: Optional[int], tagged_text: str
+) -> None:
+    await db.execute(
+        update(AudiobookSentence)
+        .where(AudiobookSentence.id == sentence_id)
+        .values(character_id=character_id, tagged_text=tagged_text, status="ready_for_audio")
+    )
+    await db.commit()
+
+
+async def update_sentence_audio(
+    db: AsyncSession, sentence_id: int, audio_file_path: str, audio_duration_ms: int
+) -> None:
+    await db.execute(
+        update(AudiobookSentence)
+        .where(AudiobookSentence.id == sentence_id)
+        .values(audio_file_path=audio_file_path, audio_duration_ms=audio_duration_ms, status="audio_generated")
+    )
+    await db.commit()
+
+
+async def update_sentence_speaker(
+    db: AsyncSession, sentence_id: int, character_id: Optional[int], tagged_text: str
+) -> Optional[AudiobookSentence]:
+    """Update sentence speaker/tags and cascade invalidation to the parent chapter."""
+    sentence = await db.get(AudiobookSentence, sentence_id)
+    if sentence is None:
+        return None
+    sentence.character_id = character_id
+    sentence.tagged_text = tagged_text
+    sentence.status = "ready_for_audio"
+    sentence.audio_file_path = None
+    sentence.audio_duration_ms = None
+    await db.execute(
+        update(AudiobookChapter)
+        .where(AudiobookChapter.id == sentence.chapter_id)
+        .values(needs_reassembly=True)
+    )
+    await db.commit()
+    await db.refresh(sentence)
+    return sentence
+
+
+async def count_sentences_by_status(db: AsyncSession, book_id: int) -> dict[str, int]:
+    result = await db.execute(
+        select(AudiobookSentence.status, func.count())
+        .join(AudiobookChapter, AudiobookSentence.chapter_id == AudiobookChapter.id)
+        .where(AudiobookChapter.book_id == book_id)
+        .group_by(AudiobookSentence.status)
+    )
+    return {row[0]: row[1] for row in result.all()}
+
+
+async def chapter_all_audio_generated(db: AsyncSession, chapter_id: int) -> bool:
+    result = await db.execute(
+        select(func.count())
+        .select_from(AudiobookSentence)
+        .where(
+            AudiobookSentence.chapter_id == chapter_id,
+            AudiobookSentence.status != "audio_generated",
+        )
+    )
+    return result.scalar_one() == 0
+
+
+async def all_sentences_audio_generated(db: AsyncSession, book_id: int) -> bool:
+    result = await db.execute(
+        select(func.count())
+        .select_from(AudiobookSentence)
+        .join(AudiobookChapter, AudiobookSentence.chapter_id == AudiobookChapter.id)
+        .where(
+            AudiobookChapter.book_id == book_id,
+            AudiobookSentence.status != "audio_generated",
+        )
+    )
+    return result.scalar_one() == 0

--- a/backend/app/crud/audiobook.py
+++ b/backend/app/crud/audiobook.py
@@ -7,6 +7,7 @@ from typing import Optional
 from sqlalchemy import func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from ..config import LIBRARY_PATH
 from ..models import AudiobookSettings, AudiobookChapter, AudiobookCharacter, AudiobookSentence, Book
 
 # ---------------------------------------------------------------------------
@@ -373,7 +374,8 @@ async def infer_audiobook_resume_status(db: AsyncSession, book_id: int) -> str:
     total = sum(counts.values())
     if total > 0 and counts.get("audio_generated", 0) == total:
         pending_chapters = await get_chapters_pending_assembly(db, book_id)
-        return "assembling" if pending_chapters else "complete"
+        packaged_epub = LIBRARY_PATH / "audiobooks" / str(book_id) / "audiobook.epub"
+        return "assembling" if pending_chapters or not packaged_epub.is_file() else "complete"
 
     return "ingesting"
 

--- a/backend/app/crud/audiobook.py
+++ b/backend/app/crud/audiobook.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Optional
 
-from sqlalchemy import select, update, func
+from sqlalchemy import func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..models import AudiobookSettings, AudiobookChapter, AudiobookCharacter, AudiobookSentence, Book
@@ -44,7 +44,12 @@ async def set_book_pipeline_status(db: AsyncSession, book_id: int, status: Optio
 
 async def get_in_progress_audiobook_books(db: AsyncSession) -> list[Book]:
     active_statuses = ["ingesting", "roster_gen", "diarizing", "audio_gen", "assembling"]
-    result = await db.execute(select(Book).where(Book.audiobook_pipeline_status.in_(active_statuses)))
+    result = await db.execute(
+        select(Book).where(
+            Book.audiobook_enabled.is_(True),
+            Book.audiobook_pipeline_status.in_(active_statuses),
+        )
+    )
     return list(result.scalars().all())
 
 
@@ -53,8 +58,13 @@ async def get_in_progress_audiobook_books(db: AsyncSession) -> list[Book]:
 # ---------------------------------------------------------------------------
 
 
-async def create_chapter(db: AsyncSession, book_id: int, chapter_number: int) -> AudiobookChapter:
-    chapter = AudiobookChapter(book_id=book_id, chapter_number=chapter_number)
+async def create_chapter(
+    db: AsyncSession,
+    book_id: int,
+    chapter_number: int,
+    content_file_name: Optional[str] = None,
+) -> AudiobookChapter:
+    chapter = AudiobookChapter(book_id=book_id, chapter_number=chapter_number, content_file_name=content_file_name)
     db.add(chapter)
     await db.flush()
     return chapter
@@ -71,6 +81,22 @@ async def get_chapters_needing_reassembly(db: AsyncSession, book_id: int) -> lis
     result = await db.execute(
         select(AudiobookChapter)
         .where(AudiobookChapter.book_id == book_id, AudiobookChapter.needs_reassembly.is_(True))
+        .order_by(AudiobookChapter.chapter_number)
+    )
+    return list(result.scalars().all())
+
+
+async def get_chapters_pending_assembly(db: AsyncSession, book_id: int) -> list[AudiobookChapter]:
+    result = await db.execute(
+        select(AudiobookChapter)
+        .where(
+            AudiobookChapter.book_id == book_id,
+            or_(
+                AudiobookChapter.needs_reassembly.is_(True),
+                AudiobookChapter.audio_file_path.is_(None),
+                AudiobookChapter.smil_file_path.is_(None),
+            ),
+        )
         .order_by(AudiobookChapter.chapter_number)
     )
     return list(result.scalars().all())
@@ -261,6 +287,26 @@ async def update_sentence_audio(db: AsyncSession, sentence_id: int, audio_file_p
     await db.commit()
 
 
+async def mark_sentence_error(db: AsyncSession, sentence_id: int) -> None:
+    await db.execute(update(AudiobookSentence).where(AudiobookSentence.id == sentence_id).values(status="error"))
+    await db.commit()
+
+
+async def reset_error_sentences_for_book(db: AsyncSession, book_id: int) -> int:
+    chapter_ids = select(AudiobookChapter.id).where(AudiobookChapter.book_id == book_id)
+    result = await db.execute(
+        update(AudiobookSentence)
+        .where(
+            AudiobookSentence.chapter_id.in_(chapter_ids),
+            AudiobookSentence.status == "error",
+        )
+        .values(status="ready_for_audio", audio_file_path=None, audio_duration_ms=None)
+    )
+    await db.execute(update(AudiobookChapter).where(AudiobookChapter.book_id == book_id).values(needs_reassembly=True))
+    await db.commit()
+    return result.rowcount or 0
+
+
 async def update_sentence_speaker(
     db: AsyncSession, sentence_id: int, character_id: Optional[int], tagged_text: str
 ) -> Optional[AudiobookSentence]:
@@ -287,6 +333,49 @@ async def count_sentences_by_status(db: AsyncSession, book_id: int) -> dict[str,
         .group_by(AudiobookSentence.status)
     )
     return {row[0]: row[1] for row in result.all()}
+
+
+async def has_sentence_status(db: AsyncSession, book_id: int, statuses: str | list[str]) -> bool:
+    status_values = [statuses] if isinstance(statuses, str) else statuses
+    result = await db.execute(
+        select(func.count())
+        .select_from(AudiobookSentence)
+        .join(AudiobookChapter, AudiobookSentence.chapter_id == AudiobookChapter.id)
+        .where(
+            AudiobookChapter.book_id == book_id,
+            AudiobookSentence.status.in_(status_values),
+        )
+    )
+    return result.scalar_one() > 0
+
+
+async def get_book_pipeline_status(db: AsyncSession, book_id: int) -> Optional[str]:
+    result = await db.execute(select(Book.audiobook_pipeline_status).where(Book.id == book_id))
+    return result.scalar_one_or_none()
+
+
+async def infer_audiobook_resume_status(db: AsyncSession, book_id: int) -> str:
+    """Infer the earliest safe phase from durable chapter/sentence state."""
+    chapters = await get_chapters_for_book(db, book_id)
+    if not chapters:
+        return "ingesting"
+
+    characters = await get_characters_for_book(db, book_id)
+    if not characters:
+        return "roster_gen"
+
+    counts = await count_sentences_by_status(db, book_id)
+    if counts.get("pending_diarization", 0) > 0:
+        return "diarizing"
+    if counts.get("ready_for_audio", 0) > 0 or counts.get("error", 0) > 0:
+        return "audio_gen"
+
+    total = sum(counts.values())
+    if total > 0 and counts.get("audio_generated", 0) == total:
+        pending_chapters = await get_chapters_pending_assembly(db, book_id)
+        return "assembling" if pending_chapters else "complete"
+
+    return "ingesting"
 
 
 async def chapter_all_audio_generated(db: AsyncSession, chapter_id: int) -> bool:

--- a/backend/app/crud/audiobook.py
+++ b/backend/app/crud/audiobook.py
@@ -9,7 +9,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..models import AudiobookSettings, AudiobookChapter, AudiobookCharacter, AudiobookSentence, Book
 
-
 # ---------------------------------------------------------------------------
 # Settings
 # ---------------------------------------------------------------------------
@@ -63,9 +62,7 @@ async def create_chapter(db: AsyncSession, book_id: int, chapter_number: int) ->
 
 async def get_chapters_for_book(db: AsyncSession, book_id: int) -> list[AudiobookChapter]:
     result = await db.execute(
-        select(AudiobookChapter)
-        .where(AudiobookChapter.book_id == book_id)
-        .order_by(AudiobookChapter.chapter_number)
+        select(AudiobookChapter).where(AudiobookChapter.book_id == book_id).order_by(AudiobookChapter.chapter_number)
     )
     return list(result.scalars().all())
 
@@ -94,9 +91,7 @@ async def update_chapter_assembly(
 
 
 async def flag_chapter_for_reassembly(db: AsyncSession, chapter_id: int) -> None:
-    await db.execute(
-        update(AudiobookChapter).where(AudiobookChapter.id == chapter_id).values(needs_reassembly=True)
-    )
+    await db.execute(update(AudiobookChapter).where(AudiobookChapter.id == chapter_id).values(needs_reassembly=True))
     await db.commit()
 
 
@@ -152,18 +147,10 @@ async def cascade_voice_change(db: AsyncSession, char_id: int) -> None:
         .where(AudiobookSentence.character_id == char_id)
         .values(status="ready_for_audio", audio_file_path=None, audio_duration_ms=None)
     )
-    result = await db.execute(
-        select(AudiobookSentence.chapter_id)
-        .where(AudiobookSentence.character_id == char_id)
-        .distinct()
-    )
+    result = await db.execute(select(AudiobookSentence.chapter_id).where(AudiobookSentence.character_id == char_id).distinct())
     chapter_ids = [row[0] for row in result.all()]
     if chapter_ids:
-        await db.execute(
-            update(AudiobookChapter)
-            .where(AudiobookChapter.id.in_(chapter_ids))
-            .values(needs_reassembly=True)
-        )
+        await db.execute(update(AudiobookChapter).where(AudiobookChapter.id.in_(chapter_ids)).values(needs_reassembly=True))
     await db.commit()
 
 
@@ -188,9 +175,7 @@ async def create_sentences_bulk(db: AsyncSession, chapter_id: int, sentences_dat
 
 async def get_sentences_for_chapter(db: AsyncSession, chapter_id: int) -> list[AudiobookSentence]:
     result = await db.execute(
-        select(AudiobookSentence)
-        .where(AudiobookSentence.chapter_id == chapter_id)
-        .order_by(AudiobookSentence.sequence_order)
+        select(AudiobookSentence).where(AudiobookSentence.chapter_id == chapter_id).order_by(AudiobookSentence.sequence_order)
     )
     return list(result.scalars().all())
 
@@ -221,17 +206,14 @@ async def get_sentences_paginated(
     total = total_result.scalar_one()
 
     result = await db.execute(
-        base_query
-        .order_by(AudiobookChapter.chapter_number, AudiobookSentence.sequence_order)
+        base_query.order_by(AudiobookChapter.chapter_number, AudiobookSentence.sequence_order)
         .offset((page - 1) * limit)
         .limit(limit)
     )
     return list(result.scalars().all()), total
 
 
-async def get_sentences_pending_diarization(
-    db: AsyncSession, book_id: int, limit: int = 50
-) -> list[AudiobookSentence]:
+async def get_sentences_pending_diarization(db: AsyncSession, book_id: int, limit: int = 50) -> list[AudiobookSentence]:
     result = await db.execute(
         select(AudiobookSentence)
         .join(AudiobookChapter, AudiobookSentence.chapter_id == AudiobookChapter.id)
@@ -245,9 +227,7 @@ async def get_sentences_pending_diarization(
     return list(result.scalars().all())
 
 
-async def get_sentences_ready_for_audio(
-    db: AsyncSession, book_id: int, limit: int = 20
-) -> list[AudiobookSentence]:
+async def get_sentences_ready_for_audio(db: AsyncSession, book_id: int, limit: int = 20) -> list[AudiobookSentence]:
     result = await db.execute(
         select(AudiobookSentence)
         .join(AudiobookChapter, AudiobookSentence.chapter_id == AudiobookChapter.id)
@@ -272,9 +252,7 @@ async def update_sentence_diarization(
     await db.commit()
 
 
-async def update_sentence_audio(
-    db: AsyncSession, sentence_id: int, audio_file_path: str, audio_duration_ms: int
-) -> None:
+async def update_sentence_audio(db: AsyncSession, sentence_id: int, audio_file_path: str, audio_duration_ms: int) -> None:
     await db.execute(
         update(AudiobookSentence)
         .where(AudiobookSentence.id == sentence_id)
@@ -295,11 +273,7 @@ async def update_sentence_speaker(
     sentence.status = "ready_for_audio"
     sentence.audio_file_path = None
     sentence.audio_duration_ms = None
-    await db.execute(
-        update(AudiobookChapter)
-        .where(AudiobookChapter.id == sentence.chapter_id)
-        .values(needs_reassembly=True)
-    )
+    await db.execute(update(AudiobookChapter).where(AudiobookChapter.id == sentence.chapter_id).values(needs_reassembly=True))
     await db.commit()
     await db.refresh(sentence)
     return sentence

--- a/backend/app/crud/audiobook.py
+++ b/backend/app/crud/audiobook.py
@@ -380,24 +380,20 @@ async def infer_audiobook_resume_status(db: AsyncSession, book_id: int) -> str:
 
 async def chapter_all_audio_generated(db: AsyncSession, chapter_id: int) -> bool:
     result = await db.execute(
-        select(func.count())
+        select(func.count(), func.count().filter(AudiobookSentence.status != "audio_generated"))
         .select_from(AudiobookSentence)
-        .where(
-            AudiobookSentence.chapter_id == chapter_id,
-            AudiobookSentence.status != "audio_generated",
-        )
+        .where(AudiobookSentence.chapter_id == chapter_id)
     )
-    return result.scalar_one() == 0
+    total, pending = result.one()
+    return total > 0 and pending == 0
 
 
 async def all_sentences_audio_generated(db: AsyncSession, book_id: int) -> bool:
     result = await db.execute(
-        select(func.count())
+        select(func.count(), func.count().filter(AudiobookSentence.status != "audio_generated"))
         .select_from(AudiobookSentence)
         .join(AudiobookChapter, AudiobookSentence.chapter_id == AudiobookChapter.id)
-        .where(
-            AudiobookChapter.book_id == book_id,
-            AudiobookSentence.status != "audio_generated",
-        )
+        .where(AudiobookChapter.book_id == book_id)
     )
-    return result.scalar_one() == 0
+    total, pending = result.one()
+    return total > 0 and pending == 0

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,7 +20,8 @@ from .errors import install_error_handlers
 from .middleware import RequestIdMiddleware
 from .database import SessionLocal, get_db
 from .logging_config import setup_logging
-from .routers import api_keys, auth, books, cleaning, covers, metadata, reader, scheduler, storage, upload, web_novels
+from .routers import api_keys, auth, audiobook, books, cleaning, covers, metadata, reader, scheduler, storage, upload, web_novels
+from .services.audiobook_queue import get_audiobook_queue
 from .services.metadata_sync_queue import get_metadata_sync_queue
 from .services.refresh_queue import get_refresh_queue
 from .services.update_scheduler import get_scheduler, schedule_next_metadata_recheck, schedule_next_web_novel_update
@@ -48,6 +49,7 @@ _scheduler = get_scheduler()
 _web_import_queue = get_web_import_queue()
 _refresh_queue = get_refresh_queue()
 _metadata_sync_queue = get_metadata_sync_queue()
+_audiobook_queue = get_audiobook_queue()
 
 
 @asynccontextmanager
@@ -65,11 +67,15 @@ async def lifespan(app: FastAPI):
         await crud.reset_stuck_update_tasks(db)
     await _web_import_queue.start()
     await _refresh_queue.start()
+    await _audiobook_queue.start()
     if not is_test_app:
         await _metadata_sync_queue.start()
     requeued = await _web_import_queue.requeue_pending_books()
     if requeued:
         logger.info("Re-queued %s pending web novel imports.", requeued)
+    audiobook_requeued = await _audiobook_queue.requeue_in_progress()
+    if audiobook_requeued:
+        logger.info("Re-queued %s in-flight audiobook pipeline jobs.", audiobook_requeued)
     refresh_requeued = await _refresh_queue.requeue_pending_books()
     if refresh_requeued:
         logger.info("Re-queued %s in-flight book refreshes.", refresh_requeued)
@@ -85,6 +91,7 @@ async def lifespan(app: FastAPI):
     yield
     await _web_import_queue.stop()
     await _refresh_queue.stop()
+    await _audiobook_queue.stop()
     if not is_test_app:
         await _metadata_sync_queue.stop()
     if _scheduler.running:
@@ -100,7 +107,15 @@ app.mount(
     RasterCoverStaticFiles(directory=str((LIBRARY_PATH / "covers").resolve()), check_dir=False),
     name="cover-files",
 )
+_AUDIOBOOK_DIR = LIBRARY_PATH / "audiobooks"
+_AUDIOBOOK_DIR.mkdir(parents=True, exist_ok=True)
+app.mount(
+    "/library/audiobooks",
+    StaticFiles(directory=str(_AUDIOBOOK_DIR.resolve()), check_dir=False),
+    name="audiobook-files",
+)
 
+app.include_router(audiobook.router)
 app.include_router(books.router)
 app.include_router(upload.router)
 app.include_router(web_novels.router)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,7 +20,20 @@ from .errors import install_error_handlers
 from .middleware import RequestIdMiddleware
 from .database import SessionLocal, get_db
 from .logging_config import setup_logging
-from .routers import api_keys, auth, audiobook, books, cleaning, covers, metadata, reader, scheduler, storage, upload, web_novels
+from .routers import (
+    api_keys,
+    auth,
+    audiobook,
+    books,
+    cleaning,
+    covers,
+    metadata,
+    reader,
+    scheduler,
+    storage,
+    upload,
+    web_novels,
+)
 from .services.audiobook_queue import get_audiobook_queue
 from .services.metadata_sync_queue import get_metadata_sync_queue
 from .services.refresh_queue import get_refresh_queue

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, Enum, JSON, Numeric
+from sqlalchemy import Boolean, Column, Integer, String, DateTime, ForeignKey, Enum, JSON, Numeric, Text
 from sqlalchemy.sql import func
 from .database import Base
 import enum
@@ -38,6 +38,9 @@ class Book(Base):
     # Tracks the lifecycle of a "refresh from source" job independently from the
     # initial download state. Values: None (idle), "queued", "processing", "error".
     refresh_status = Column(String, nullable=True)
+    # Audiobook pipeline state. Values: None (idle), "ingesting", "roster_gen",
+    # "diarizing", "audio_gen", "assembling", "complete", "error", "paused".
+    audiobook_pipeline_status = Column(String, nullable=True)
 
     # Timestamps
     created_at = Column(DateTime(timezone=True), server_default=func.now())
@@ -160,3 +163,54 @@ class ApiKey(Base):
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     last_used_at = Column(DateTime(timezone=True), nullable=True)
     revoked_at = Column(DateTime(timezone=True), nullable=True)
+
+
+class AudiobookSettings(Base):
+    __tablename__ = "audiobook_settings"
+
+    id = Column(Integer, primary_key=True, index=True)
+    llm_provider = Column(String, nullable=True)
+    llm_api_key = Column(String, nullable=True)
+    llm_base_url = Column(String, nullable=True)
+    llm_model = Column(String, nullable=True)
+    omnivoice_endpoint = Column(String, nullable=True)
+    roster_prompt_template = Column(Text, nullable=True)
+    diarization_prompt_template = Column(Text, nullable=True)
+
+
+class AudiobookChapter(Base):
+    __tablename__ = "audiobook_chapters"
+
+    id = Column(Integer, primary_key=True, index=True)
+    book_id = Column(Integer, ForeignKey("books.id", ondelete="CASCADE"), nullable=False, index=True)
+    chapter_number = Column(Integer, nullable=False)
+    smil_file_path = Column(String, nullable=True)
+    audio_file_path = Column(String, nullable=True)
+    needs_reassembly = Column(Boolean, nullable=False, server_default="false")
+
+
+class AudiobookCharacter(Base):
+    __tablename__ = "audiobook_characters"
+
+    id = Column(Integer, primary_key=True, index=True)
+    book_id = Column(Integer, ForeignKey("books.id", ondelete="CASCADE"), nullable=False, index=True)
+    name = Column(String, nullable=False)
+    description = Column(Text, nullable=True)
+    voice_design_prompt = Column(String, nullable=True)
+    is_narrator = Column(Boolean, nullable=False, server_default="false")
+
+
+class AudiobookSentence(Base):
+    __tablename__ = "audiobook_sentences"
+
+    id = Column(Integer, primary_key=True, index=True)
+    chapter_id = Column(Integer, ForeignKey("audiobook_chapters.id", ondelete="CASCADE"), nullable=False, index=True)
+    character_id = Column(Integer, ForeignKey("audiobook_characters.id", ondelete="SET NULL"), nullable=True)
+    html_element_id = Column(String, nullable=False)
+    sequence_order = Column(Integer, nullable=False)
+    original_text = Column(Text, nullable=False)
+    tagged_text = Column(Text, nullable=True)
+    audio_file_path = Column(String, nullable=True)
+    audio_duration_ms = Column(Integer, nullable=True)
+    # Status values: pending_diarization, ready_for_audio, audio_generated, error
+    status = Column(String, nullable=False, server_default="pending_diarization")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -38,6 +38,9 @@ class Book(Base):
     # Tracks the lifecycle of a "refresh from source" job independently from the
     # initial download state. Values: None (idle), "queued", "processing", "error".
     refresh_status = Column(String, nullable=True)
+    # Audiobook generation is opt-in per book. Keep it disabled by default so
+    # normal library books do not show or run the heavier pipeline.
+    audiobook_enabled = Column(Boolean, nullable=False, default=False, server_default="false")
     # Audiobook pipeline state. Values: None (idle), "ingesting", "roster_gen",
     # "diarizing", "audio_gen", "assembling", "complete", "error", "paused".
     audiobook_pipeline_status = Column(String, nullable=True)
@@ -184,6 +187,7 @@ class AudiobookChapter(Base):
     id = Column(Integer, primary_key=True, index=True)
     book_id = Column(Integer, ForeignKey("books.id", ondelete="CASCADE"), nullable=False, index=True)
     chapter_number = Column(Integer, nullable=False)
+    content_file_name = Column(String, nullable=True)
     smil_file_path = Column(String, nullable=True)
     audio_file_path = Column(String, nullable=True)
     needs_reassembly = Column(Boolean, nullable=False, server_default="false")

--- a/backend/app/routers/audiobook.py
+++ b/backend/app/routers/audiobook.py
@@ -196,9 +196,7 @@ async def list_characters(book_id: int, db: AsyncSession = Depends(get_db)) -> l
 
 
 @router.put("/api/audiobook/characters/{char_id}", response_model=CharacterResponse)
-async def update_character(
-    char_id: int, body: CharacterUpdate, db: AsyncSession = Depends(get_db)
-) -> CharacterResponse:
+async def update_character(char_id: int, body: CharacterUpdate, db: AsyncSession = Depends(get_db)) -> CharacterResponse:
     data = body.model_dump(exclude_none=True)
     voice_changed = "voice_design_prompt" in data
 
@@ -240,9 +238,7 @@ async def list_sentences(
 
 
 @router.put("/api/audiobook/sentences/{sentence_id}", response_model=SentenceResponse)
-async def update_sentence(
-    sentence_id: int, body: SentenceUpdate, db: AsyncSession = Depends(get_db)
-) -> SentenceResponse:
+async def update_sentence(sentence_id: int, body: SentenceUpdate, db: AsyncSession = Depends(get_db)) -> SentenceResponse:
     sentence = await crud.audiobook.update_sentence_speaker(
         db,
         sentence_id=sentence_id,

--- a/backend/app/routers/audiobook.py
+++ b/backend/app/routers/audiobook.py
@@ -14,7 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from .. import crud
 from ..config import LIBRARY_PATH
 from ..database import get_db
-from ..models import AudiobookChapter, AudiobookSentence, Book
+from ..models import AudiobookChapter, AudiobookCharacter, AudiobookSentence, Book
 from ..services.audiobook_queue import get_audiobook_queue
 
 logger = logging.getLogger(__name__)
@@ -175,12 +175,20 @@ async def pause_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> di
 
 @router.post("/api/books/{book_id}/audiobook/rebuild")
 async def rebuild_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> dict[str, Any]:
-    await _get_audiobook_book_or_404(book_id, db)
+    book = await _get_audiobook_book_or_404(book_id, db)
+    queue = get_audiobook_queue()
+    if book.audiobook_pipeline_status in (
+        "ingesting",
+        "roster_gen",
+        "diarizing",
+        "audio_gen",
+        "assembling",
+    ) or queue.has_book_job(book_id):
+        raise HTTPException(status_code=409, detail="Pause the active pipeline before rebuilding it")
     # Delete existing pipeline data so ingestion runs fresh
     await crud.audiobook.delete_chapters_for_book(db, book_id)
     await crud.audiobook.delete_characters_for_book(db, book_id)
     await crud.audiobook.set_book_pipeline_status(db, book_id, "ingesting")
-    queue = get_audiobook_queue()
     await queue.enqueue(book_id)
     return {"status": "ingesting", "queued": True}
 
@@ -260,6 +268,10 @@ async def update_sentence(sentence_id: int, body: SentenceUpdate, db: AsyncSessi
     chapter = await db.get(AudiobookChapter, existing.chapter_id)
     if chapter:
         await _get_audiobook_book_or_404(chapter.book_id, db)
+    if body.character_id is not None:
+        character = await db.get(AudiobookCharacter, body.character_id)
+        if chapter is None or character is None or character.book_id != chapter.book_id:
+            raise HTTPException(status_code=404, detail="Character not found for this book")
 
     sentence = await crud.audiobook.update_sentence_speaker(
         db,

--- a/backend/app/routers/audiobook.py
+++ b/backend/app/routers/audiobook.py
@@ -74,6 +74,7 @@ class ChapterResponse(BaseModel):
     id: int
     book_id: int
     chapter_number: int
+    content_file_name: Optional[str]
     smil_file_path: Optional[str]
     audio_file_path: Optional[str]
     needs_reassembly: bool
@@ -121,6 +122,13 @@ async def _get_book_or_404(book_id: int, db: AsyncSession) -> Book:
     return book
 
 
+async def _get_audiobook_book_or_404(book_id: int, db: AsyncSession) -> Book:
+    book = await _get_book_or_404(book_id, db)
+    if not book.audiobook_enabled:
+        raise HTTPException(status_code=403, detail="Audiobook pipeline is not enabled for this book")
+    return book
+
+
 def _resolve_path(relative_path: Optional[str]) -> Optional[Path]:
     if not relative_path:
         return None
@@ -134,19 +142,22 @@ def _resolve_path(relative_path: Optional[str]) -> Optional[Path]:
 
 @router.post("/api/books/{book_id}/audiobook/start")
 async def start_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> dict[str, Any]:
-    book = await _get_book_or_404(book_id, db)
+    book = await _get_audiobook_book_or_404(book_id, db)
     status = book.audiobook_pipeline_status
 
     if status in ("ingesting", "roster_gen", "diarizing", "audio_gen", "assembling"):
         # Already running; idempotent
         return {"status": status, "queued": False}
 
-    if status == "complete":
-        # Resume from audio_gen to re-generate only chapters with needs_reassembly
-        await crud.audiobook.set_book_pipeline_status(db, book_id, "audio_gen")
-    elif status != "paused":
-        # Fresh start or reset
-        await crud.audiobook.set_book_pipeline_status(db, book_id, "ingesting")
+    if status == "error" and await crud.audiobook.has_sentence_status(db, book_id, "error"):
+        await crud.audiobook.reset_error_sentences_for_book(db, book_id)
+
+    resume_status = await crud.audiobook.infer_audiobook_resume_status(db, book_id)
+    if resume_status == "complete":
+        await crud.audiobook.set_book_pipeline_status(db, book_id, "complete")
+        return {"status": "complete", "queued": False}
+
+    await crud.audiobook.set_book_pipeline_status(db, book_id, resume_status)
 
     queue = get_audiobook_queue()
     queued = await queue.enqueue(book_id)
@@ -156,14 +167,14 @@ async def start_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> di
 
 @router.post("/api/books/{book_id}/audiobook/pause")
 async def pause_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> dict[str, Any]:
-    await _get_book_or_404(book_id, db)
+    await _get_audiobook_book_or_404(book_id, db)
     await crud.audiobook.set_book_pipeline_status(db, book_id, "paused")
     return {"status": "paused"}
 
 
 @router.post("/api/books/{book_id}/audiobook/rebuild")
 async def rebuild_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> dict[str, Any]:
-    await _get_book_or_404(book_id, db)
+    await _get_audiobook_book_or_404(book_id, db)
     # Delete existing pipeline data so ingestion runs fresh
     await crud.audiobook.delete_chapters_for_book(db, book_id)
     await crud.audiobook.delete_characters_for_book(db, book_id)
@@ -175,7 +186,7 @@ async def rebuild_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> 
 
 @router.get("/api/books/{book_id}/audiobook/status", response_model=AudiobookStatusResponse)
 async def get_pipeline_status(book_id: int, db: AsyncSession = Depends(get_db)) -> AudiobookStatusResponse:
-    book = await _get_book_or_404(book_id, db)
+    book = await _get_audiobook_book_or_404(book_id, db)
     counts = await crud.audiobook.count_sentences_by_status(db, book_id)
     return AudiobookStatusResponse(
         pipeline_status=book.audiobook_pipeline_status,
@@ -190,7 +201,7 @@ async def get_pipeline_status(book_id: int, db: AsyncSession = Depends(get_db)) 
 
 @router.get("/api/books/{book_id}/audiobook/characters", response_model=list[CharacterResponse])
 async def list_characters(book_id: int, db: AsyncSession = Depends(get_db)) -> list[CharacterResponse]:
-    await _get_book_or_404(book_id, db)
+    await _get_audiobook_book_or_404(book_id, db)
     chars = await crud.audiobook.get_characters_for_book(db, book_id)
     return [CharacterResponse.model_validate(c) for c in chars]
 
@@ -200,9 +211,12 @@ async def update_character(char_id: int, body: CharacterUpdate, db: AsyncSession
     data = body.model_dump(exclude_none=True)
     voice_changed = "voice_design_prompt" in data
 
-    char = await crud.audiobook.update_character(db, char_id, data)
-    if char is None:
+    existing = await crud.audiobook.get_character(db, char_id)
+    if existing is None:
         raise HTTPException(status_code=404, detail="Character not found")
+    await _get_audiobook_book_or_404(existing.book_id, db)
+
+    char = await crud.audiobook.update_character(db, char_id, data)
 
     if voice_changed:
         await crud.audiobook.cascade_voice_change(db, char_id)
@@ -227,7 +241,7 @@ async def list_sentences(
     chapter_id: Optional[int] = Query(None),
     db: AsyncSession = Depends(get_db),
 ) -> SentenceListResponse:
-    await _get_book_or_404(book_id, db)
+    await _get_audiobook_book_or_404(book_id, db)
     sentences, total = await crud.audiobook.get_sentences_paginated(db, book_id, page=page, limit=limit, chapter_id=chapter_id)
     return SentenceListResponse(
         items=[SentenceResponse.model_validate(s) for s in sentences],
@@ -239,17 +253,21 @@ async def list_sentences(
 
 @router.put("/api/audiobook/sentences/{sentence_id}", response_model=SentenceResponse)
 async def update_sentence(sentence_id: int, body: SentenceUpdate, db: AsyncSession = Depends(get_db)) -> SentenceResponse:
+    existing = await db.get(AudiobookSentence, sentence_id)
+    if existing is None:
+        raise HTTPException(status_code=404, detail="Sentence not found")
+    chapter = await db.get(AudiobookChapter, existing.chapter_id)
+    if chapter:
+        await _get_audiobook_book_or_404(chapter.book_id, db)
+
     sentence = await crud.audiobook.update_sentence_speaker(
         db,
         sentence_id=sentence_id,
         character_id=body.character_id,
         tagged_text=body.tagged_text or "",
     )
-    if sentence is None:
-        raise HTTPException(status_code=404, detail="Sentence not found")
 
     # Re-enqueue for TTS
-    chapter = await db.get(AudiobookChapter, sentence.chapter_id)
     if chapter:
         queue = get_audiobook_queue()
         await crud.audiobook.set_book_pipeline_status(db, chapter.book_id, "audio_gen")
@@ -263,6 +281,9 @@ async def get_sentence_audio(sentence_id: int, db: AsyncSession = Depends(get_db
     sentence = await db.get(AudiobookSentence, sentence_id)
     if sentence is None or not sentence.audio_file_path:
         raise HTTPException(status_code=404, detail="Audio not available")
+    chapter = await db.get(AudiobookChapter, sentence.chapter_id)
+    if chapter:
+        await _get_audiobook_book_or_404(chapter.book_id, db)
     full_path = _resolve_path(sentence.audio_file_path)
     if not full_path or not full_path.exists():
         raise HTTPException(status_code=404, detail="Audio file not found on disk")
@@ -276,7 +297,7 @@ async def get_sentence_audio(sentence_id: int, db: AsyncSession = Depends(get_db
 
 @router.get("/api/books/{book_id}/audiobook/chapters", response_model=list[ChapterResponse])
 async def list_chapters(book_id: int, db: AsyncSession = Depends(get_db)) -> list[ChapterResponse]:
-    await _get_book_or_404(book_id, db)
+    await _get_audiobook_book_or_404(book_id, db)
     chapters = await crud.audiobook.get_chapters_for_book(db, book_id)
     return [ChapterResponse.model_validate(c) for c in chapters]
 
@@ -286,6 +307,7 @@ async def get_chapter_audio(book_id: int, chapter_id: int, db: AsyncSession = De
     chapter = await db.get(AudiobookChapter, chapter_id)
     if chapter is None or chapter.book_id != book_id or not chapter.audio_file_path:
         raise HTTPException(status_code=404, detail="Audio not available")
+    await _get_audiobook_book_or_404(book_id, db)
     full_path = _resolve_path(chapter.audio_file_path)
     if not full_path or not full_path.exists():
         raise HTTPException(status_code=404, detail="Audio file not found on disk")

--- a/backend/app/routers/audiobook.py
+++ b/backend/app/routers/audiobook.py
@@ -132,7 +132,8 @@ async def _get_audiobook_book_or_404(book_id: int, db: AsyncSession) -> Book:
 def _resolve_path(relative_path: Optional[str]) -> Optional[Path]:
     if not relative_path:
         return None
-    return (LIBRARY_PATH.parent / relative_path).resolve()
+    path = (LIBRARY_PATH.parent / relative_path).resolve()
+    return path if path.is_relative_to(LIBRARY_PATH.resolve()) else None
 
 
 # ---------------------------------------------------------------------------
@@ -312,6 +313,18 @@ async def get_chapter_audio(book_id: int, chapter_id: int, db: AsyncSession = De
     if not full_path or not full_path.exists():
         raise HTTPException(status_code=404, detail="Audio file not found on disk")
     return FileResponse(str(full_path), media_type="audio/mpeg")
+
+
+@router.get("/api/books/{book_id}/audiobook/download")
+async def download_audiobook(book_id: int, db: AsyncSession = Depends(get_db)) -> FileResponse:
+    book = await _get_audiobook_book_or_404(book_id, db)
+    if book.audiobook_pipeline_status != "complete":
+        raise HTTPException(status_code=409, detail="Audiobook generation is not complete")
+    full_path = (LIBRARY_PATH / "audiobooks" / str(book_id) / "audiobook.epub").resolve()
+    if not full_path.exists():
+        raise HTTPException(status_code=404, detail="Audiobook EPUB not found on disk")
+    filename = f"{book.title or 'audiobook'}-audiobook.epub"
+    return FileResponse(str(full_path), media_type="application/epub+zip", filename=filename)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/routers/audiobook.py
+++ b/backend/app/routers/audiobook.py
@@ -1,0 +1,343 @@
+"""Audiobook pipeline API endpoints."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import FileResponse
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import crud
+from ..config import LIBRARY_PATH
+from ..database import get_db
+from ..models import AudiobookChapter, AudiobookSentence, Book
+from ..services.audiobook_queue import get_audiobook_queue
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class AudiobookStatusResponse(BaseModel):
+    pipeline_status: Optional[str]
+    sentence_counts: dict[str, int]
+
+
+class CharacterResponse(BaseModel):
+    id: int
+    book_id: int
+    name: str
+    description: Optional[str]
+    voice_design_prompt: Optional[str]
+    is_narrator: bool
+
+    model_config = {"from_attributes": True}
+
+
+class CharacterUpdate(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
+    voice_design_prompt: Optional[str] = None
+    is_narrator: Optional[bool] = None
+
+
+class SentenceResponse(BaseModel):
+    id: int
+    chapter_id: int
+    character_id: Optional[int]
+    html_element_id: str
+    sequence_order: int
+    original_text: str
+    tagged_text: Optional[str]
+    audio_file_path: Optional[str]
+    audio_duration_ms: Optional[int]
+    status: str
+
+    model_config = {"from_attributes": True}
+
+
+class SentenceUpdate(BaseModel):
+    character_id: Optional[int] = None
+    tagged_text: Optional[str] = None
+
+
+class ChapterResponse(BaseModel):
+    id: int
+    book_id: int
+    chapter_number: int
+    smil_file_path: Optional[str]
+    audio_file_path: Optional[str]
+    needs_reassembly: bool
+
+    model_config = {"from_attributes": True}
+
+
+class SettingsResponse(BaseModel):
+    id: Optional[int]
+    llm_provider: Optional[str]
+    llm_api_key_set: bool
+    llm_base_url: Optional[str]
+    llm_model: Optional[str]
+    omnivoice_endpoint: Optional[str]
+    roster_prompt_template: Optional[str]
+    diarization_prompt_template: Optional[str]
+
+
+class SettingsUpdate(BaseModel):
+    llm_provider: Optional[str] = None
+    llm_api_key: Optional[str] = None
+    llm_base_url: Optional[str] = None
+    llm_model: Optional[str] = None
+    omnivoice_endpoint: Optional[str] = None
+    roster_prompt_template: Optional[str] = None
+    diarization_prompt_template: Optional[str] = None
+
+
+class SentenceListResponse(BaseModel):
+    items: list[SentenceResponse]
+    total: int
+    page: int
+    limit: int
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _get_book_or_404(book_id: int, db: AsyncSession) -> Book:
+    book = await db.get(Book, book_id)
+    if book is None:
+        raise HTTPException(status_code=404, detail="Book not found")
+    return book
+
+
+def _resolve_path(relative_path: Optional[str]) -> Optional[Path]:
+    if not relative_path:
+        return None
+    return (LIBRARY_PATH.parent / relative_path).resolve()
+
+
+# ---------------------------------------------------------------------------
+# Pipeline control
+# ---------------------------------------------------------------------------
+
+
+@router.post("/api/books/{book_id}/audiobook/start")
+async def start_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> dict[str, Any]:
+    book = await _get_book_or_404(book_id, db)
+    status = book.audiobook_pipeline_status
+
+    if status in ("ingesting", "roster_gen", "diarizing", "audio_gen", "assembling"):
+        # Already running; idempotent
+        return {"status": status, "queued": False}
+
+    if status == "complete":
+        # Resume from audio_gen to re-generate only chapters with needs_reassembly
+        await crud.audiobook.set_book_pipeline_status(db, book_id, "audio_gen")
+    elif status != "paused":
+        # Fresh start or reset
+        await crud.audiobook.set_book_pipeline_status(db, book_id, "ingesting")
+
+    queue = get_audiobook_queue()
+    queued = await queue.enqueue(book_id)
+    current_status = (await db.get(Book, book_id)).audiobook_pipeline_status
+    return {"status": current_status, "queued": queued}
+
+
+@router.post("/api/books/{book_id}/audiobook/pause")
+async def pause_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> dict[str, Any]:
+    await _get_book_or_404(book_id, db)
+    await crud.audiobook.set_book_pipeline_status(db, book_id, "paused")
+    return {"status": "paused"}
+
+
+@router.post("/api/books/{book_id}/audiobook/rebuild")
+async def rebuild_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> dict[str, Any]:
+    await _get_book_or_404(book_id, db)
+    # Delete existing pipeline data so ingestion runs fresh
+    await crud.audiobook.delete_chapters_for_book(db, book_id)
+    await crud.audiobook.delete_characters_for_book(db, book_id)
+    await crud.audiobook.set_book_pipeline_status(db, book_id, "ingesting")
+    queue = get_audiobook_queue()
+    await queue.enqueue(book_id)
+    return {"status": "ingesting", "queued": True}
+
+
+@router.get("/api/books/{book_id}/audiobook/status", response_model=AudiobookStatusResponse)
+async def get_pipeline_status(book_id: int, db: AsyncSession = Depends(get_db)) -> AudiobookStatusResponse:
+    book = await _get_book_or_404(book_id, db)
+    counts = await crud.audiobook.count_sentences_by_status(db, book_id)
+    return AudiobookStatusResponse(
+        pipeline_status=book.audiobook_pipeline_status,
+        sentence_counts=counts,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Characters
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/books/{book_id}/audiobook/characters", response_model=list[CharacterResponse])
+async def list_characters(book_id: int, db: AsyncSession = Depends(get_db)) -> list[CharacterResponse]:
+    await _get_book_or_404(book_id, db)
+    chars = await crud.audiobook.get_characters_for_book(db, book_id)
+    return [CharacterResponse.model_validate(c) for c in chars]
+
+
+@router.put("/api/audiobook/characters/{char_id}", response_model=CharacterResponse)
+async def update_character(
+    char_id: int, body: CharacterUpdate, db: AsyncSession = Depends(get_db)
+) -> CharacterResponse:
+    data = body.model_dump(exclude_none=True)
+    voice_changed = "voice_design_prompt" in data
+
+    char = await crud.audiobook.update_character(db, char_id, data)
+    if char is None:
+        raise HTTPException(status_code=404, detail="Character not found")
+
+    if voice_changed:
+        await crud.audiobook.cascade_voice_change(db, char_id)
+        # Re-enqueue for TTS phase
+        queue = get_audiobook_queue()
+        await crud.audiobook.set_book_pipeline_status(db, char.book_id, "audio_gen")
+        await queue.enqueue(char.book_id)
+
+    return CharacterResponse.model_validate(char)
+
+
+# ---------------------------------------------------------------------------
+# Sentences
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/books/{book_id}/audiobook/sentences", response_model=SentenceListResponse)
+async def list_sentences(
+    book_id: int,
+    page: int = Query(1, ge=1),
+    limit: int = Query(50, ge=1, le=200),
+    chapter_id: Optional[int] = Query(None),
+    db: AsyncSession = Depends(get_db),
+) -> SentenceListResponse:
+    await _get_book_or_404(book_id, db)
+    sentences, total = await crud.audiobook.get_sentences_paginated(db, book_id, page=page, limit=limit, chapter_id=chapter_id)
+    return SentenceListResponse(
+        items=[SentenceResponse.model_validate(s) for s in sentences],
+        total=total,
+        page=page,
+        limit=limit,
+    )
+
+
+@router.put("/api/audiobook/sentences/{sentence_id}", response_model=SentenceResponse)
+async def update_sentence(
+    sentence_id: int, body: SentenceUpdate, db: AsyncSession = Depends(get_db)
+) -> SentenceResponse:
+    sentence = await crud.audiobook.update_sentence_speaker(
+        db,
+        sentence_id=sentence_id,
+        character_id=body.character_id,
+        tagged_text=body.tagged_text or "",
+    )
+    if sentence is None:
+        raise HTTPException(status_code=404, detail="Sentence not found")
+
+    # Re-enqueue for TTS
+    chapter = await db.get(AudiobookChapter, sentence.chapter_id)
+    if chapter:
+        queue = get_audiobook_queue()
+        await crud.audiobook.set_book_pipeline_status(db, chapter.book_id, "audio_gen")
+        await queue.enqueue(chapter.book_id)
+
+    return SentenceResponse.model_validate(sentence)
+
+
+@router.get("/api/audiobook/sentences/{sentence_id}/audio")
+async def get_sentence_audio(sentence_id: int, db: AsyncSession = Depends(get_db)) -> FileResponse:
+    sentence = await db.get(AudiobookSentence, sentence_id)
+    if sentence is None or not sentence.audio_file_path:
+        raise HTTPException(status_code=404, detail="Audio not available")
+    full_path = _resolve_path(sentence.audio_file_path)
+    if not full_path or not full_path.exists():
+        raise HTTPException(status_code=404, detail="Audio file not found on disk")
+    return FileResponse(str(full_path), media_type="audio/mpeg")
+
+
+# ---------------------------------------------------------------------------
+# Chapters
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/books/{book_id}/audiobook/chapters", response_model=list[ChapterResponse])
+async def list_chapters(book_id: int, db: AsyncSession = Depends(get_db)) -> list[ChapterResponse]:
+    await _get_book_or_404(book_id, db)
+    chapters = await crud.audiobook.get_chapters_for_book(db, book_id)
+    return [ChapterResponse.model_validate(c) for c in chapters]
+
+
+@router.get("/api/books/{book_id}/audiobook/chapters/{chapter_id}/audio")
+async def get_chapter_audio(book_id: int, chapter_id: int, db: AsyncSession = Depends(get_db)) -> FileResponse:
+    chapter = await db.get(AudiobookChapter, chapter_id)
+    if chapter is None or chapter.book_id != book_id or not chapter.audio_file_path:
+        raise HTTPException(status_code=404, detail="Audio not available")
+    full_path = _resolve_path(chapter.audio_file_path)
+    if not full_path or not full_path.exists():
+        raise HTTPException(status_code=404, detail="Audio file not found on disk")
+    return FileResponse(str(full_path), media_type="audio/mpeg")
+
+
+# ---------------------------------------------------------------------------
+# Settings
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/audiobook/settings", response_model=SettingsResponse)
+async def get_settings(db: AsyncSession = Depends(get_db)) -> SettingsResponse:
+    settings = await crud.audiobook.get_audiobook_settings(db)
+    if settings is None:
+        return SettingsResponse(
+            id=None,
+            llm_provider=None,
+            llm_api_key_set=False,
+            llm_base_url=None,
+            llm_model=None,
+            omnivoice_endpoint=None,
+            roster_prompt_template=None,
+            diarization_prompt_template=None,
+        )
+    return SettingsResponse(
+        id=settings.id,
+        llm_provider=settings.llm_provider,
+        llm_api_key_set=bool(settings.llm_api_key),
+        llm_base_url=settings.llm_base_url,
+        llm_model=settings.llm_model,
+        omnivoice_endpoint=settings.omnivoice_endpoint,
+        roster_prompt_template=settings.roster_prompt_template,
+        diarization_prompt_template=settings.diarization_prompt_template,
+    )
+
+
+@router.put("/api/audiobook/settings", response_model=SettingsResponse)
+async def update_settings(body: SettingsUpdate, db: AsyncSession = Depends(get_db)) -> SettingsResponse:
+    data = body.model_dump(exclude_none=True)
+    settings = await crud.audiobook.upsert_audiobook_settings(db, data)
+    return SettingsResponse(
+        id=settings.id,
+        llm_provider=settings.llm_provider,
+        llm_api_key_set=bool(settings.llm_api_key),
+        llm_base_url=settings.llm_base_url,
+        llm_model=settings.llm_model,
+        omnivoice_endpoint=settings.omnivoice_endpoint,
+        roster_prompt_template=settings.roster_prompt_template,
+        diarization_prompt_template=settings.diarization_prompt_template,
+    )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -31,6 +31,8 @@ class BookBase(BaseModel):
     notes: Optional[str] = None
     download_status: Optional[str] = None
     refresh_status: Optional[str] = None
+    audiobook_enabled: bool = False
+    audiobook_pipeline_status: Optional[str] = None
 
 
 # Pydantic model for creating a new book.
@@ -48,6 +50,7 @@ class BookUpdate(BaseModel):
     user_genre_tags: Optional[List[str]] = None
     source_tags: Optional[List[str]] = None
     metadata_remote_ids: Optional[dict] = None
+    audiobook_enabled: Optional[bool] = None
     removed_chapters: Optional[List[str]] = None
     content_selectors: Optional[List[str]] = None
     notes: Optional[str] = None
@@ -81,6 +84,8 @@ class BookCatalogEntry(BaseModel):
     updated_at: Optional[datetime] = None
     download_status: Optional[str] = None
     refresh_status: Optional[str] = None
+    audiobook_enabled: bool = False
+    audiobook_pipeline_status: Optional[str] = None
 
 
 # Pydantic model for creating a new book log.

--- a/backend/app/services/audiobook_assembly.py
+++ b/backend/app/services/audiobook_assembly.py
@@ -161,11 +161,15 @@ async def assemble_book(book_id: int, db: AsyncSession) -> None:
         await crud.audiobook.set_book_pipeline_status(db, book_id, "error")
         raise RuntimeError(f"Cannot assemble book {book_id}: not all sentences have generated audio.")
 
+    audiobook_epub_path = output_dir / "audiobook.epub"
     chapters = await crud.audiobook.get_chapters_pending_assembly(db, book_id)
-    if not chapters:
-        logger.info("No chapters need reassembly for book %s.", book_id)
-        await crud.audiobook.set_book_pipeline_status(db, book_id, "complete")
-        return
+    if chapters:
+        # Once chapter state changes, an older package is no longer a valid
+        # completion marker. Removing it makes an interrupted package step
+        # resume at assembly on the next run.
+        audiobook_epub_path.unlink(missing_ok=True)
+    else:
+        logger.info("No chapters need reassembly for book %s; rebuilding the EPUB package.", book_id)
 
     for chapter in chapters:
         sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
@@ -174,19 +178,18 @@ async def assemble_book(book_id: int, db: AsyncSession) -> None:
     # Repackage the EPUB with updated media-overlay references
     working_epub_path = output_dir / "working.epub"
     if not working_epub_path.exists():
-        logger.warning("Working EPUB not found for book %s; skipping repackage.", book_id)
-        await crud.audiobook.set_book_pipeline_status(db, book_id, "complete")
-        return
+        await crud.audiobook.set_book_pipeline_status(db, book_id, "error")
+        raise RuntimeError(f"Working EPUB not found for book {book_id}; run ingestion again.")
 
     ebook = epub.read_epub(str(working_epub_path))
 
     all_chapters = await crud.audiobook.get_chapters_for_book(db, book_id)
     for chapter in all_chapters:
         if not chapter.smil_file_path:
-            continue
+            raise RuntimeError(f"Missing SMIL path for book {book_id}, chapter {chapter.id}.")
         smil_full = LIBRARY_PATH.parent / chapter.smil_file_path
         if not smil_full.exists():
-            continue
+            raise RuntimeError(f"Missing SMIL file for book {book_id}, chapter {chapter.id}.")
         audio_full = LIBRARY_PATH.parent / chapter.audio_file_path if chapter.audio_file_path else None
         if audio_full is None or not audio_full.exists():
             raise RuntimeError(f"Missing chapter audio for book {book_id}, chapter {chapter.id}.")
@@ -212,9 +215,11 @@ async def assemble_book(book_id: int, db: AsyncSession) -> None:
                 item.media_overlay = smil_item.id
                 break
 
-    audiobook_epub_path = output_dir / "audiobook.epub"
+    temporary_epub_path = output_dir / "audiobook.tmp.epub"
+    temporary_epub_path.unlink(missing_ok=True)
     _ensure_toc_link_ids(ebook.toc)
-    epub.write_epub(str(audiobook_epub_path), ebook)
+    epub.write_epub(str(temporary_epub_path), ebook)
+    temporary_epub_path.replace(audiobook_epub_path)
     logger.info("Repackaged audiobook EPUB: %s", audiobook_epub_path)
 
     if await crud.audiobook.get_book_pipeline_status(db, book_id) != "paused":

--- a/backend/app/services/audiobook_assembly.py
+++ b/backend/app/services/audiobook_assembly.py
@@ -27,8 +27,22 @@ def _ms_to_clock(ms: int) -> str:
     return f"{hours:02d}:{mins:02d}:{secs:02d}.{millis:03d}"
 
 
-def _build_smil(chapter_num: int, sentences: list, audio_filename: str) -> str:
+def _ensure_toc_link_ids(toc_items, prefix: str = "toc") -> None:
+    for index, item in enumerate(toc_items or []):
+        uid = f"{prefix}_{index}"
+        if isinstance(item, epub.Link) and not item.uid:
+            item.uid = uid
+        elif isinstance(item, (tuple, list)) and item:
+            section = item[0]
+            if isinstance(section, epub.Link) and not section.uid:
+                section.uid = uid
+            if len(item) > 1:
+                _ensure_toc_link_ids(item[1], uid)
+
+
+def _build_smil(chapter, sentences: list, audio_filename: str) -> str:
     """Generate EPUB 3 Media Overlay SMIL XML for a chapter."""
+    text_file_name = chapter.content_file_name or f"chapter{chapter.chapter_number:04d}.xhtml"
     root = ET.Element(
         "smil",
         {
@@ -38,7 +52,7 @@ def _build_smil(chapter_num: int, sentences: list, audio_filename: str) -> str:
         },
     )
     body = ET.SubElement(root, "body")
-    seq = ET.SubElement(body, "seq", {"epub:textref": f"chapter{chapter_num:04d}.xhtml", "epub:type": "chapter"})
+    seq = ET.SubElement(body, "seq", {"epub:textref": text_file_name, "epub:type": "chapter"})
 
     cumulative_ms = 0
     for sentence in sentences:
@@ -47,7 +61,7 @@ def _build_smil(chapter_num: int, sentences: list, audio_filename: str) -> str:
         ET.SubElement(
             par,
             "text",
-            {"src": f"chapter{chapter_num:04d}.xhtml#{sentence.html_element_id}"},
+            {"src": f"{text_file_name}#{sentence.html_element_id}"},
         )
         ET.SubElement(
             par,
@@ -74,15 +88,10 @@ async def _assemble_chapter(book_id: int, chapter, sentences: list, output_dir: 
     combined = AudioSegment.empty()
     for sentence in sentences:
         if not sentence.audio_file_path:
-            logger.warning("Sentence %s missing audio; inserting silence.", sentence.id)
-            duration_ms = sentence.audio_duration_ms or 500
-            combined += AudioSegment.silent(duration=duration_ms)
-            continue
+            raise RuntimeError(f"Sentence {sentence.id} is missing audio path during assembly.")
         snippet_full = LIBRARY_PATH.parent / sentence.audio_file_path
         if not snippet_full.exists():
-            logger.warning("Snippet file missing for sentence %s; inserting silence.", sentence.id)
-            combined += AudioSegment.silent(duration=sentence.audio_duration_ms or 500)
-            continue
+            raise RuntimeError(f"Snippet file missing for sentence {sentence.id}: {snippet_full}")
         combined += AudioSegment.from_mp3(str(snippet_full))
 
     audio_filename = f"ch{chapter.chapter_number:04d}.mp3"
@@ -90,7 +99,7 @@ async def _assemble_chapter(book_id: int, chapter, sentences: list, output_dir: 
     combined.export(str(audio_path), format="mp3")
     logger.info("Assembled chapter audio: %s (%d ms)", audio_path, len(combined))
 
-    smil_xml = _build_smil(chapter.chapter_number, sentences, audio_filename)
+    smil_xml = _build_smil(chapter, sentences, audio_filename)
     smil_filename = f"ch{chapter.chapter_number:04d}.smil"
     smil_path = output_dir / smil_filename
     smil_path.write_text(smil_xml, encoding="utf-8")
@@ -108,7 +117,19 @@ async def assemble_book(book_id: int, db: AsyncSession) -> None:
     output_dir = LIBRARY_PATH.parent / "library" / "audiobooks" / str(book_id)
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    chapters = await crud.audiobook.get_chapters_needing_reassembly(db, book_id)
+    if await crud.audiobook.get_book_pipeline_status(db, book_id) == "paused":
+        logger.info("Book %s paused before assembly.", book_id)
+        return
+
+    if await crud.audiobook.has_sentence_status(db, book_id, "error"):
+        await crud.audiobook.set_book_pipeline_status(db, book_id, "error")
+        raise RuntimeError(f"Cannot assemble book {book_id}: sentence audio generation has errors.")
+
+    if not await crud.audiobook.all_sentences_audio_generated(db, book_id):
+        await crud.audiobook.set_book_pipeline_status(db, book_id, "error")
+        raise RuntimeError(f"Cannot assemble book {book_id}: not all sentences have generated audio.")
+
+    chapters = await crud.audiobook.get_chapters_pending_assembly(db, book_id)
     if not chapters:
         logger.info("No chapters need reassembly for book %s.", book_id)
         await crud.audiobook.set_book_pipeline_status(db, book_id, "complete")
@@ -134,6 +155,18 @@ async def assemble_book(book_id: int, db: AsyncSession) -> None:
         smil_full = LIBRARY_PATH.parent / chapter.smil_file_path
         if not smil_full.exists():
             continue
+        audio_full = LIBRARY_PATH.parent / chapter.audio_file_path if chapter.audio_file_path else None
+        if audio_full is None or not audio_full.exists():
+            raise RuntimeError(f"Missing chapter audio for book {book_id}, chapter {chapter.id}.")
+
+        audio_item = epub.EpubItem(
+            uid=f"audio_ch{chapter.chapter_number:04d}",
+            file_name=f"ch{chapter.chapter_number:04d}.mp3",
+            media_type="audio/mpeg",
+            content=audio_full.read_bytes(),
+        )
+        ebook.add_item(audio_item)
+
         smil_item = epub.EpubSMIL(
             uid=f"smil_ch{chapter.chapter_number:04d}",
             file_name=f"ch{chapter.chapter_number:04d}.smil",
@@ -143,15 +176,17 @@ async def assemble_book(book_id: int, db: AsyncSession) -> None:
 
         # Attach media-overlay to the matching spine item
         for item in ebook.get_items_of_type(ebooklib.ITEM_DOCUMENT):
-            if f"chapter{chapter.chapter_number:04d}" in item.get_name():
+            if item.get_name() == chapter.content_file_name:
                 item.media_overlay = smil_item.id
                 break
 
     audiobook_epub_path = output_dir / "audiobook.epub"
+    _ensure_toc_link_ids(ebook.toc)
     epub.write_epub(str(audiobook_epub_path), ebook)
     logger.info("Repackaged audiobook EPUB: %s", audiobook_epub_path)
 
-    await crud.audiobook.set_book_pipeline_status(db, book_id, "complete")
+    if await crud.audiobook.get_book_pipeline_status(db, book_id) != "paused":
+        await crud.audiobook.set_book_pipeline_status(db, book_id, "complete")
     logger.info("Assembly complete for book %s.", book_id)
 
 

--- a/backend/app/services/audiobook_assembly.py
+++ b/backend/app/services/audiobook_assembly.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from pathlib import Path
+import shutil
+import tempfile
 from xml.etree import ElementTree as ET
 
 from ebooklib import epub
@@ -79,25 +82,54 @@ def _build_smil(chapter, sentences: list, audio_filename: str) -> str:
 
 
 async def _assemble_chapter(book_id: int, chapter, sentences: list, output_dir: Path, db: AsyncSession) -> None:
-    from pydub import AudioSegment
-
     if not sentences:
         logger.warning("Chapter %s has no sentences with audio; skipping assembly.", chapter.id)
         return
 
-    combined = AudioSegment.empty()
+    snippet_paths: list[Path] = []
     for sentence in sentences:
         if not sentence.audio_file_path:
             raise RuntimeError(f"Sentence {sentence.id} is missing audio path during assembly.")
         snippet_full = LIBRARY_PATH.parent / sentence.audio_file_path
         if not snippet_full.exists():
             raise RuntimeError(f"Snippet file missing for sentence {sentence.id}: {snippet_full}")
-        combined += AudioSegment.from_mp3(str(snippet_full))
+        snippet_paths.append(snippet_full)
 
     audio_filename = f"ch{chapter.chapter_number:04d}.mp3"
     audio_path = output_dir / audio_filename
-    combined.export(str(audio_path), format="mp3")
-    logger.info("Assembled chapter audio: %s (%d ms)", audio_path, len(combined))
+    ffmpeg = shutil.which("ffmpeg")
+    if not ffmpeg:
+        raise RuntimeError("ffmpeg is required to assemble audiobook chapters.")
+    with tempfile.NamedTemporaryFile("w", suffix=".txt", dir=output_dir, encoding="utf-8") as manifest:
+        for snippet_path in snippet_paths:
+            escaped_path = str(snippet_path).replace("'", "'\\''")
+            manifest.write(f"file '{escaped_path}'\n")
+        manifest.flush()
+        process = await asyncio.create_subprocess_exec(
+            ffmpeg,
+            "-v",
+            "error",
+            "-f",
+            "concat",
+            "-safe",
+            "0",
+            "-i",
+            manifest.name,
+            "-codec:a",
+            "libmp3lame",
+            "-b:a",
+            "64k",
+            "-y",
+            str(audio_path),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        _, stderr = await process.communicate()
+        if process.returncode:
+            message = stderr.decode("utf-8", errors="replace")[:500]
+            raise RuntimeError(f"ffmpeg chapter assembly failed: {message}")
+    total_duration_ms = sum(sentence.audio_duration_ms or 0 for sentence in sentences)
+    logger.info("Assembled chapter audio: %s (%d ms)", audio_path, total_duration_ms)
 
     smil_xml = _build_smil(chapter, sentences, audio_filename)
     smil_filename = f"ch{chapter.chapter_number:04d}.smil"

--- a/backend/app/services/audiobook_assembly.py
+++ b/backend/app/services/audiobook_assembly.py
@@ -1,0 +1,159 @@
+"""Phase 5: MP3 concatenation, SMIL generation, and EPUB 3 Media Overlay packaging."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+from ebooklib import epub
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import crud
+from ..config import LIBRARY_PATH
+
+logger = logging.getLogger(__name__)
+
+
+def _relative_path(full_path: Path) -> str:
+    return str(full_path.relative_to(LIBRARY_PATH.parent))
+
+
+def _ms_to_clock(ms: int) -> str:
+    """Convert milliseconds to SMIL clock value hh:mm:ss.mmm."""
+    total_s, millis = divmod(ms, 1000)
+    total_m, secs = divmod(total_s, 60)
+    hours, mins = divmod(total_m, 60)
+    return f"{hours:02d}:{mins:02d}:{secs:02d}.{millis:03d}"
+
+
+def _build_smil(chapter_num: int, sentences: list, audio_filename: str) -> str:
+    """Generate EPUB 3 Media Overlay SMIL XML for a chapter."""
+    root = ET.Element(
+        "smil",
+        {
+            "xmlns": "http://www.w3.org/ns/SMIL",
+            "xmlns:epub": "http://www.idpf.org/2007/ops",
+            "version": "3.0",
+        },
+    )
+    body = ET.SubElement(root, "body")
+    seq = ET.SubElement(body, "seq", {"epub:textref": f"chapter{chapter_num:04d}.xhtml", "epub:type": "chapter"})
+
+    cumulative_ms = 0
+    for sentence in sentences:
+        duration_ms = sentence.audio_duration_ms or 0
+        par = ET.SubElement(seq, "par", {"id": f"par_{sentence.html_element_id}"})
+        ET.SubElement(
+            par,
+            "text",
+            {"src": f"chapter{chapter_num:04d}.xhtml#{sentence.html_element_id}"},
+        )
+        ET.SubElement(
+            par,
+            "audio",
+            {
+                "src": audio_filename,
+                "clipBegin": _ms_to_clock(cumulative_ms),
+                "clipEnd": _ms_to_clock(cumulative_ms + duration_ms),
+            },
+        )
+        cumulative_ms += duration_ms
+
+    ET.indent(root, space="  ")
+    return '<?xml version="1.0" encoding="UTF-8"?>\n' + ET.tostring(root, encoding="unicode")
+
+
+async def _assemble_chapter(book_id: int, chapter, sentences: list, output_dir: Path, db: AsyncSession) -> None:
+    from pydub import AudioSegment
+
+    if not sentences:
+        logger.warning("Chapter %s has no sentences with audio; skipping assembly.", chapter.id)
+        return
+
+    combined = AudioSegment.empty()
+    for sentence in sentences:
+        if not sentence.audio_file_path:
+            logger.warning("Sentence %s missing audio; inserting silence.", sentence.id)
+            duration_ms = sentence.audio_duration_ms or 500
+            combined += AudioSegment.silent(duration=duration_ms)
+            continue
+        snippet_full = LIBRARY_PATH.parent / sentence.audio_file_path
+        if not snippet_full.exists():
+            logger.warning("Snippet file missing for sentence %s; inserting silence.", sentence.id)
+            combined += AudioSegment.silent(duration=sentence.audio_duration_ms or 500)
+            continue
+        combined += AudioSegment.from_mp3(str(snippet_full))
+
+    audio_filename = f"ch{chapter.chapter_number:04d}.mp3"
+    audio_path = output_dir / audio_filename
+    combined.export(str(audio_path), format="mp3")
+    logger.info("Assembled chapter audio: %s (%d ms)", audio_path, len(combined))
+
+    smil_xml = _build_smil(chapter.chapter_number, sentences, audio_filename)
+    smil_filename = f"ch{chapter.chapter_number:04d}.smil"
+    smil_path = output_dir / smil_filename
+    smil_path.write_text(smil_xml, encoding="utf-8")
+
+    await crud.audiobook.update_chapter_assembly(
+        db,
+        chapter_id=chapter.id,
+        audio_file_path=_relative_path(audio_path),
+        smil_file_path=_relative_path(smil_path),
+    )
+
+
+async def assemble_book(book_id: int, db: AsyncSession) -> None:
+    """Phase 5: assemble all chapters that need reassembly and repackage the EPUB."""
+    output_dir = LIBRARY_PATH.parent / "library" / "audiobooks" / str(book_id)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    chapters = await crud.audiobook.get_chapters_needing_reassembly(db, book_id)
+    if not chapters:
+        logger.info("No chapters need reassembly for book %s.", book_id)
+        await crud.audiobook.set_book_pipeline_status(db, book_id, "complete")
+        return
+
+    for chapter in chapters:
+        sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
+        await _assemble_chapter(book_id, chapter, sentences, output_dir, db)
+
+    # Repackage the EPUB with updated media-overlay references
+    working_epub_path = output_dir / "working.epub"
+    if not working_epub_path.exists():
+        logger.warning("Working EPUB not found for book %s; skipping repackage.", book_id)
+        await crud.audiobook.set_book_pipeline_status(db, book_id, "complete")
+        return
+
+    ebook = epub.read_epub(str(working_epub_path))
+
+    all_chapters = await crud.audiobook.get_chapters_for_book(db, book_id)
+    for chapter in all_chapters:
+        if not chapter.smil_file_path:
+            continue
+        smil_full = LIBRARY_PATH.parent / chapter.smil_file_path
+        if not smil_full.exists():
+            continue
+        smil_item = epub.EpubSMIL(
+            uid=f"smil_ch{chapter.chapter_number:04d}",
+            file_name=f"ch{chapter.chapter_number:04d}.smil",
+            content=smil_full.read_bytes(),
+        )
+        ebook.add_item(smil_item)
+
+        # Attach media-overlay to the matching spine item
+        for item in ebook.get_items_of_type(ebooklib.ITEM_DOCUMENT):
+            if f"chapter{chapter.chapter_number:04d}" in item.get_name():
+                item.media_overlay = smil_item.id
+                break
+
+    audiobook_epub_path = output_dir / "audiobook.epub"
+    epub.write_epub(str(audiobook_epub_path), ebook)
+    logger.info("Repackaged audiobook EPUB: %s", audiobook_epub_path)
+
+    await crud.audiobook.set_book_pipeline_status(db, book_id, "complete")
+    logger.info("Assembly complete for book %s.", book_id)
+
+
+# ebooklib constant needed above
+import ebooklib  # noqa: E402

--- a/backend/app/services/audiobook_ingestion.py
+++ b/backend/app/services/audiobook_ingestion.py
@@ -23,6 +23,7 @@ def _get_nlp():
     global _NLP
     if _NLP is None:
         import spacy
+
         _NLP = spacy.load("en_core_web_sm", disable=["ner", "parser"])
         _NLP.add_pipe("sentencizer")
     return _NLP

--- a/backend/app/services/audiobook_ingestion.py
+++ b/backend/app/services/audiobook_ingestion.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 
 import ebooklib
 from ebooklib import epub

--- a/backend/app/services/audiobook_ingestion.py
+++ b/backend/app/services/audiobook_ingestion.py
@@ -24,8 +24,13 @@ def _get_nlp():
     if _NLP is None:
         import spacy
 
-        _NLP = spacy.load("en_core_web_sm", disable=["ner", "parser"])
-        _NLP.add_pipe("sentencizer")
+        try:
+            _NLP = spacy.load("en_core_web_sm", disable=["ner", "parser"])
+        except OSError:
+            logger.warning("spaCy model en_core_web_sm is unavailable; using the built-in English tokenizer.")
+            _NLP = spacy.blank("en")
+        if "sentencizer" not in _NLP.pipe_names:
+            _NLP.add_pipe("sentencizer")
     return _NLP
 
 
@@ -172,6 +177,7 @@ async def ingest_epub(book_id: int, db: AsyncSession) -> None:
     logger.info("Wrote span-injected EPUB to %s", working_epub_path)
 
     # Persist to database
+    persisted_chapters = 0
     for chapter_num, item, chapter_sentences in all_chapter_records:
         if not chapter_sentences:
             continue
@@ -182,8 +188,11 @@ async def ingest_epub(book_id: int, db: AsyncSession) -> None:
             content_file_name=item.get_name(),
         )
         await crud.audiobook.create_sentences_bulk(db, chapter_id=chapter.id, sentences_data=chapter_sentences)
+        persisted_chapters += 1
 
     await db.commit()
+    if persisted_chapters == 0:
+        raise RuntimeError(f"EPUB for book {book_id} contains no narratable text.")
     if await crud.audiobook.get_book_pipeline_status(db, book_id) != "paused":
         await crud.audiobook.set_book_pipeline_status(db, book_id, "roster_gen")
-    logger.info("Ingestion complete for book %s: %d chapters processed", book_id, len(all_chapter_records))
+    logger.info("Ingestion complete for book %s: %d chapters processed", book_id, persisted_chapters)

--- a/backend/app/services/audiobook_ingestion.py
+++ b/backend/app/services/audiobook_ingestion.py
@@ -1,0 +1,138 @@
+"""Phase 1: EPUB ingestion, sentence tokenization, and span ID injection."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import ebooklib
+from ebooklib import epub
+from bs4 import BeautifulSoup, NavigableString
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import crud
+from ..config import LIBRARY_PATH
+from ..models import Book
+
+logger = logging.getLogger(__name__)
+
+_NLP = None  # lazy-load spaCy model to avoid startup cost
+
+
+def _get_nlp():
+    global _NLP
+    if _NLP is None:
+        import spacy
+        _NLP = spacy.load("en_core_web_sm", disable=["ner", "parser"])
+        _NLP.add_pipe("sentencizer")
+    return _NLP
+
+
+def _tokenize_text(text: str) -> list[str]:
+    nlp = _get_nlp()
+    doc = nlp(text)
+    return [sent.text.strip() for sent in doc.sents if sent.text.strip()]
+
+
+def _inject_spans_into_element(element, chapter_num: int, start_seq: int) -> tuple[int, list[dict]]:
+    """Replace the text content of block elements with span-wrapped sentences.
+
+    Returns (next_sequence_number, list_of_sentence_dicts).
+    """
+    sentences_data = []
+    seq = start_seq
+
+    # Collect all text nodes that are direct or shallow children
+    raw_text = element.get_text(separator=" ", strip=True)
+    if not raw_text:
+        return seq, sentences_data
+
+    sentences = _tokenize_text(raw_text)
+    if not sentences:
+        return seq, sentences_data
+
+    # Clear existing children and re-build with span-wrapped sentences
+    element.clear()
+    for sent_text in sentences:
+        span_id = f"ch{chapter_num}_s{seq}"
+        span = BeautifulSoup(f'<span id="{span_id}"></span>', "html.parser").find("span")
+        span.string = sent_text
+        element.append(span)
+        element.append(NavigableString(" "))
+
+        sentences_data.append(
+            {
+                "html_element_id": span_id,
+                "sequence_order": seq,
+                "original_text": sent_text,
+                "tagged_text": sent_text,
+                "status": "pending_diarization",
+            }
+        )
+        seq += 1
+
+    return seq, sentences_data
+
+
+async def ingest_epub(book_id: int, db: AsyncSession) -> None:
+    """Parse the book's EPUB, inject span IDs, populate chapters and sentences tables."""
+    book: Book = await db.get(Book, book_id)
+    if book is None:
+        raise ValueError(f"Book {book_id} not found")
+
+    epub_path = (LIBRARY_PATH.parent / book.current_path).resolve()
+    logger.info("Ingesting EPUB for book %s from %s", book_id, epub_path)
+
+    output_dir = LIBRARY_PATH.parent / "library" / "audiobooks" / str(book_id)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    snippets_dir = output_dir / "snippets"
+    snippets_dir.mkdir(exist_ok=True)
+
+    ebook = epub.read_epub(str(epub_path))
+
+    # Collect spine items in order
+    spine_items = []
+    for item_id, _linear in ebook.spine:
+        item = ebook.get_item_with_id(item_id)
+        if item and item.get_type() == ebooklib.ITEM_DOCUMENT:
+            spine_items.append(item)
+
+    all_chapter_records = []
+
+    for chapter_num, item in enumerate(spine_items, start=1):
+        content = item.get_content()
+        soup = BeautifulSoup(content, "html.parser")
+
+        chapter_sentences: list[dict] = []
+        seq = 0
+
+        # Process block-level text elements
+        for tag in soup.find_all(["p", "div", "h1", "h2", "h3", "h4", "h5", "h6", "li"]):
+            # Skip elements with no direct text (only child elements)
+            if not tag.get_text(strip=True):
+                continue
+            # Skip if already contains span children from a previous run
+            if tag.find("span", id=True):
+                continue
+            seq, new_sentences = _inject_spans_into_element(tag, chapter_num, seq)
+            chapter_sentences.extend(new_sentences)
+
+        # Save modified XHTML back into the ebook item
+        item.set_content(str(soup).encode("utf-8"))
+        all_chapter_records.append((chapter_num, item, chapter_sentences))
+
+    # Write modified EPUB to working copy
+    working_epub_path = output_dir / "working.epub"
+    epub.write_epub(str(working_epub_path), ebook)
+    logger.info("Wrote span-injected EPUB to %s", working_epub_path)
+
+    # Persist to database
+    for chapter_num, _item, chapter_sentences in all_chapter_records:
+        if not chapter_sentences:
+            continue
+        chapter = await crud.audiobook.create_chapter(db, book_id=book_id, chapter_number=chapter_num)
+        await crud.audiobook.create_sentences_bulk(db, chapter_id=chapter.id, sentences_data=chapter_sentences)
+
+    await db.commit()
+    await crud.audiobook.set_book_pipeline_status(db, book_id, "roster_gen")
+    logger.info("Ingestion complete for book %s: %d chapters processed", book_id, len(all_chapter_records))

--- a/backend/app/services/audiobook_ingestion.py
+++ b/backend/app/services/audiobook_ingestion.py
@@ -16,6 +16,7 @@ from ..models import Book
 logger = logging.getLogger(__name__)
 
 _NLP = None  # lazy-load spaCy model to avoid startup cost
+_SKIP_TEXT_ANCESTORS = {"script", "style", "head", "title", "svg", "math", "audio", "video"}
 
 
 def _get_nlp():
@@ -34,31 +35,72 @@ def _tokenize_text(text: str) -> list[str]:
     return [sent.text.strip() for sent in doc.sents if sent.text.strip()]
 
 
-def _inject_spans_into_element(element, chapter_num: int, start_seq: int) -> tuple[int, list[dict]]:
-    """Replace the text content of block elements with span-wrapped sentences.
+def _span_for_sentence(span_id: str, text: str):
+    span = BeautifulSoup(f'<span id="{span_id}"></span>', "html.parser").find("span")
+    span.string = text
+    return span
+
+
+def _replace_text_node(text_node: NavigableString, replacement_nodes: list) -> None:
+    first, *rest = replacement_nodes
+    text_node.replace_with(first)
+    previous = first
+    for node in rest:
+        previous.insert_after(node)
+        previous = node
+
+
+def _should_skip_text_node(text_node: NavigableString) -> bool:
+    for parent in text_node.parents:
+        if parent.name in _SKIP_TEXT_ANCESTORS:
+            return True
+        if parent.name == "span" and parent.get("id"):
+            return True
+    return False
+
+
+def _ensure_toc_link_ids(toc_items, prefix: str = "toc") -> None:
+    for index, item in enumerate(toc_items or []):
+        uid = f"{prefix}_{index}"
+        if isinstance(item, epub.Link) and not item.uid:
+            item.uid = uid
+        elif isinstance(item, (tuple, list)) and item:
+            section = item[0]
+            if isinstance(section, epub.Link) and not section.uid:
+                section.uid = uid
+            if len(item) > 1:
+                _ensure_toc_link_ids(item[1], uid)
+
+
+def _inject_spans_into_text_node(text_node: NavigableString, chapter_num: int, start_seq: int) -> tuple[int, list[dict]]:
+    """Wrap one text node's sentences without disturbing surrounding markup.
 
     Returns (next_sequence_number, list_of_sentence_dicts).
     """
     sentences_data = []
     seq = start_seq
 
-    # Collect all text nodes that are direct or shallow children
-    raw_text = element.get_text(separator=" ", strip=True)
-    if not raw_text:
+    raw_text = str(text_node)
+    stripped = raw_text.strip()
+    if not stripped or _should_skip_text_node(text_node):
         return seq, sentences_data
 
-    sentences = _tokenize_text(raw_text)
+    sentences = _tokenize_text(stripped)
     if not sentences:
         return seq, sentences_data
 
-    # Clear existing children and re-build with span-wrapped sentences
-    element.clear()
-    for sent_text in sentences:
+    leading_whitespace = raw_text[: len(raw_text) - len(raw_text.lstrip())]
+    trailing_start = len(raw_text.rstrip())
+    trailing_whitespace = raw_text[trailing_start:]
+    replacement_nodes: list = []
+    if leading_whitespace:
+        replacement_nodes.append(NavigableString(leading_whitespace))
+
+    for index, sent_text in enumerate(sentences):
+        if index > 0:
+            replacement_nodes.append(NavigableString(" "))
         span_id = f"ch{chapter_num}_s{seq}"
-        span = BeautifulSoup(f'<span id="{span_id}"></span>', "html.parser").find("span")
-        span.string = sent_text
-        element.append(span)
-        element.append(NavigableString(" "))
+        replacement_nodes.append(_span_for_sentence(span_id, sent_text))
 
         sentences_data.append(
             {
@@ -71,6 +113,10 @@ def _inject_spans_into_element(element, chapter_num: int, start_seq: int) -> tup
         )
         seq += 1
 
+    if trailing_whitespace:
+        replacement_nodes.append(NavigableString(trailing_whitespace))
+
+    _replace_text_node(text_node, replacement_nodes)
     return seq, sentences_data
 
 
@@ -89,12 +135,14 @@ async def ingest_epub(book_id: int, db: AsyncSession) -> None:
     snippets_dir.mkdir(exist_ok=True)
 
     ebook = epub.read_epub(str(epub_path))
+    await crud.audiobook.delete_chapters_for_book(db, book_id)
+    await crud.audiobook.delete_characters_for_book(db, book_id)
 
     # Collect spine items in order
     spine_items = []
     for item_id, _linear in ebook.spine:
         item = ebook.get_item_with_id(item_id)
-        if item and item.get_type() == ebooklib.ITEM_DOCUMENT:
+        if item and item.get_type() == ebooklib.ITEM_DOCUMENT and not isinstance(item, epub.EpubNav):
             spine_items.append(item)
 
     all_chapter_records = []
@@ -106,15 +154,11 @@ async def ingest_epub(book_id: int, db: AsyncSession) -> None:
         chapter_sentences: list[dict] = []
         seq = 0
 
-        # Process block-level text elements
-        for tag in soup.find_all(["p", "div", "h1", "h2", "h3", "h4", "h5", "h6", "li"]):
-            # Skip elements with no direct text (only child elements)
-            if not tag.get_text(strip=True):
-                continue
-            # Skip if already contains span children from a previous run
-            if tag.find("span", id=True):
-                continue
-            seq, new_sentences = _inject_spans_into_element(tag, chapter_num, seq)
+        # Process text nodes in document order. This preserves existing block and
+        # inline structure while adding stable sentence-level anchors.
+        container = soup.body or soup
+        for text_node in list(container.find_all(string=True)):
+            seq, new_sentences = _inject_spans_into_text_node(text_node, chapter_num, seq)
             chapter_sentences.extend(new_sentences)
 
         # Save modified XHTML back into the ebook item
@@ -123,16 +167,23 @@ async def ingest_epub(book_id: int, db: AsyncSession) -> None:
 
     # Write modified EPUB to working copy
     working_epub_path = output_dir / "working.epub"
+    _ensure_toc_link_ids(ebook.toc)
     epub.write_epub(str(working_epub_path), ebook)
     logger.info("Wrote span-injected EPUB to %s", working_epub_path)
 
     # Persist to database
-    for chapter_num, _item, chapter_sentences in all_chapter_records:
+    for chapter_num, item, chapter_sentences in all_chapter_records:
         if not chapter_sentences:
             continue
-        chapter = await crud.audiobook.create_chapter(db, book_id=book_id, chapter_number=chapter_num)
+        chapter = await crud.audiobook.create_chapter(
+            db,
+            book_id=book_id,
+            chapter_number=chapter_num,
+            content_file_name=item.get_name(),
+        )
         await crud.audiobook.create_sentences_bulk(db, chapter_id=chapter.id, sentences_data=chapter_sentences)
 
     await db.commit()
-    await crud.audiobook.set_book_pipeline_status(db, book_id, "roster_gen")
+    if await crud.audiobook.get_book_pipeline_status(db, book_id) != "paused":
+        await crud.audiobook.set_book_pipeline_status(db, book_id, "roster_gen")
     logger.info("Ingestion complete for book %s: %d chapters processed", book_id, len(all_chapter_records))

--- a/backend/app/services/audiobook_llm.py
+++ b/backend/app/services/audiobook_llm.py
@@ -1,0 +1,215 @@
+"""Phases 2 & 3: LLM-based character roster generation and sentence diarization."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import httpx
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import crud
+from ..models import AudiobookSettings
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_ROSTER_PROMPT = """\
+You are a literary analyst. Analyze the following text excerpt from a book and extract a list of all named \
+characters (including the narrator if the text uses first person).
+
+For each character produce:
+- name: their name (use "Narrator" for first-person narrators)
+- description: a 1-2 sentence description of their personality and role
+- voice_design_prompt: an OmniVoice voice parameter string using ONLY these tokens:
+  [gender-{male|female|neutral}] [pitch-{low|medium|high}] [speed-{slow|normal|fast}]
+  Optional: [accent-{british|american|australian}] [age-{young|middle|old}]
+  Example: [gender-male][pitch-low][speed-normal][age-middle]
+- is_narrator: true only for the primary narrator
+
+Return ONLY a valid JSON array of objects. No markdown, no explanation.
+
+Text:
+{text}
+"""
+
+DEFAULT_DIARIZATION_PROMPT = """\
+You are a script editor. Assign each sentence to a speaker from the character roster and add non-verbal \
+expression tags where appropriate.
+
+Character roster (JSON):
+{roster_json}
+
+Previous context (last 5 sentences):
+{context}
+
+Sentences to process (JSON array with id and text):
+{sentences_json}
+
+For each sentence return:
+- id: the sentence id (integer)
+- character_id: the character id from the roster (use the narrator's id for narration; null if uncertain)
+- tagged_text: the sentence text with optional non-verbal tags like [laughter], [sigh], [whisper], [shout]
+
+Return ONLY a valid JSON array. No markdown, no explanation.
+"""
+
+
+async def _call_llm(settings: AudiobookSettings, messages: list[dict[str, Any]]) -> str:
+    """Route to the configured LLM provider and return the text response."""
+    if not settings.llm_api_key and not settings.llm_base_url:
+        raise RuntimeError("LLM not configured: set llm_api_key or llm_base_url in Audio Settings.")
+
+    provider = (settings.llm_provider or "openai").lower()
+    model = settings.llm_model or "gpt-4o"
+
+    headers = {"Content-Type": "application/json"}
+
+    if provider == "anthropic":
+        url = (settings.llm_base_url or "https://api.anthropic.com").rstrip("/") + "/v1/messages"
+        headers["x-api-key"] = settings.llm_api_key or ""
+        headers["anthropic-version"] = "2023-06-01"
+        payload: dict[str, Any] = {
+            "model": model,
+            "max_tokens": 4096,
+            "messages": messages,
+        }
+        async with httpx.AsyncClient(timeout=120.0) as client:
+            resp = await client.post(url, json=payload, headers=headers)
+            resp.raise_for_status()
+            data = resp.json()
+        return data["content"][0]["text"]
+
+    else:
+        # OpenAI-compatible (openai, custom, local)
+        base = settings.llm_base_url or "https://api.openai.com"
+        url = base.rstrip("/") + "/v1/chat/completions"
+        if settings.llm_api_key:
+            headers["Authorization"] = f"Bearer {settings.llm_api_key}"
+        payload = {
+            "model": model,
+            "messages": messages,
+            "temperature": 0.2,
+        }
+        async with httpx.AsyncClient(timeout=120.0) as client:
+            resp = await client.post(url, json=payload, headers=headers)
+            resp.raise_for_status()
+            data = resp.json()
+        return data["choices"][0]["message"]["content"]
+
+
+def _extract_json(raw: str) -> Any:
+    """Strip markdown code fences if present and parse JSON."""
+    text = raw.strip()
+    if text.startswith("```"):
+        lines = text.splitlines()
+        # Drop first and last fence lines
+        text = "\n".join(lines[1:-1] if lines[-1].strip() == "```" else lines[1:])
+    return json.loads(text)
+
+
+async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
+    """Phase 2: extract characters from book text and persist to audiobook_characters."""
+    settings = await crud.audiobook.get_audiobook_settings(db)
+    if settings is None:
+        raise RuntimeError("Audiobook settings not found.")
+
+    chapters = await crud.audiobook.get_chapters_for_book(db, book_id)
+    if not chapters:
+        logger.warning("No chapters found for book %s during roster generation.", book_id)
+        await crud.audiobook.set_book_pipeline_status(db, book_id, "diarizing")
+        return
+
+    # Collect text from up to 5 chapters (keeps prompt size manageable)
+    text_chunks: list[str] = []
+    for chapter in chapters[:5]:
+        sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
+        text_chunks.append(" ".join(s.original_text for s in sentences))
+    combined_text = "\n\n".join(text_chunks)[:12000]  # ~10k tokens safety cap
+
+    prompt_template = settings.roster_prompt_template or DEFAULT_ROSTER_PROMPT
+    prompt = prompt_template.format(text=combined_text)
+
+    logger.info("Calling LLM for character roster (book %s).", book_id)
+    raw = await _call_llm(settings, [{"role": "user", "content": prompt}])
+
+    try:
+        characters_data = _extract_json(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"LLM returned invalid JSON for roster: {exc}\nRaw: {raw[:500]}") from exc
+
+    if not isinstance(characters_data, list):
+        raise RuntimeError(f"Expected a JSON array from LLM, got: {type(characters_data)}")
+
+    # Normalise keys to match our model
+    normalised: list[dict] = []
+    for c in characters_data:
+        normalised.append(
+            {
+                "name": str(c.get("name", "Unknown")),
+                "description": c.get("description"),
+                "voice_design_prompt": c.get("voice_design_prompt"),
+                "is_narrator": bool(c.get("is_narrator", False)),
+            }
+        )
+
+    await crud.audiobook.create_characters_bulk(db, book_id=book_id, characters_data=normalised)
+    logger.info("Created %d characters for book %s.", len(normalised), book_id)
+    await crud.audiobook.set_book_pipeline_status(db, book_id, "diarizing")
+
+
+async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
+    """Phase 3: batch-assign speakers and expression tags to all pending sentences."""
+    settings = await crud.audiobook.get_audiobook_settings(db)
+    if settings is None:
+        raise RuntimeError("Audiobook settings not found.")
+
+    characters = await crud.audiobook.get_characters_for_book(db, book_id)
+    roster_json = json.dumps(
+        [
+            {"id": c.id, "name": c.name, "description": c.description, "is_narrator": c.is_narrator}
+            for c in characters
+        ],
+        ensure_ascii=False,
+    )
+
+    context_window: list[str] = []
+    batch_size = 50
+
+    while True:
+        batch = await crud.audiobook.get_sentences_pending_diarization(db, book_id, limit=batch_size)
+        if not batch:
+            break
+
+        sentences_json = json.dumps(
+            [{"id": s.id, "text": s.original_text} for s in batch],
+            ensure_ascii=False,
+        )
+        context_str = "\n".join(context_window[-5:]) if context_window else "(none)"
+
+        prompt_template = settings.diarization_prompt_template or DEFAULT_DIARIZATION_PROMPT
+        prompt = prompt_template.format(
+            roster_json=roster_json,
+            context=context_str,
+            sentences_json=sentences_json,
+        )
+
+        logger.debug("Diarizing %d sentences for book %s.", len(batch), book_id)
+        raw = await _call_llm(settings, [{"role": "user", "content": prompt}])
+
+        try:
+            results = _extract_json(raw)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"LLM returned invalid JSON for diarization: {exc}\nRaw: {raw[:500]}") from exc
+
+        result_map = {r["id"]: r for r in results if isinstance(r, dict)}
+
+        for sentence in batch:
+            result = result_map.get(sentence.id, {})
+            char_id = result.get("character_id")
+            tagged = result.get("tagged_text") or sentence.original_text
+            await crud.audiobook.update_sentence_diarization(db, sentence.id, char_id, tagged)
+            context_window.append(sentence.original_text)
+
+    logger.info("Diarization complete for book %s.", book_id)
+    await crud.audiobook.set_book_pipeline_status(db, book_id, "audio_gen")

--- a/backend/app/services/audiobook_llm.py
+++ b/backend/app/services/audiobook_llm.py
@@ -117,7 +117,8 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
     chapters = await crud.audiobook.get_chapters_for_book(db, book_id)
     if not chapters:
         logger.warning("No chapters found for book %s during roster generation.", book_id)
-        await crud.audiobook.set_book_pipeline_status(db, book_id, "diarizing")
+        if await crud.audiobook.get_book_pipeline_status(db, book_id) != "paused":
+            await crud.audiobook.set_book_pipeline_status(db, book_id, "diarizing")
         return
 
     # Collect text from up to 5 chapters (keeps prompt size manageable)
@@ -155,7 +156,8 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
 
     await crud.audiobook.create_characters_bulk(db, book_id=book_id, characters_data=normalised)
     logger.info("Created %d characters for book %s.", len(normalised), book_id)
-    await crud.audiobook.set_book_pipeline_status(db, book_id, "diarizing")
+    if await crud.audiobook.get_book_pipeline_status(db, book_id) != "paused":
+        await crud.audiobook.set_book_pipeline_status(db, book_id, "diarizing")
 
 
 async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
@@ -174,6 +176,10 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
     batch_size = 50
 
     while True:
+        if await crud.audiobook.get_book_pipeline_status(db, book_id) == "paused":
+            logger.info("Book %s paused during diarization.", book_id)
+            return
+
         batch = await crud.audiobook.get_sentences_pending_diarization(db, book_id, limit=batch_size)
         if not batch:
             break
@@ -209,4 +215,5 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
             context_window.append(sentence.original_text)
 
     logger.info("Diarization complete for book %s.", book_id)
-    await crud.audiobook.set_book_pipeline_status(db, book_id, "audio_gen")
+    if await crud.audiobook.get_book_pipeline_status(db, book_id) != "paused":
+        await crud.audiobook.set_book_pipeline_status(db, book_id, "audio_gen")

--- a/backend/app/services/audiobook_llm.py
+++ b/backend/app/services/audiobook_llm.py
@@ -166,10 +166,7 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
 
     characters = await crud.audiobook.get_characters_for_book(db, book_id)
     roster_json = json.dumps(
-        [
-            {"id": c.id, "name": c.name, "description": c.description, "is_narrator": c.is_narrator}
-            for c in characters
-        ],
+        [{"id": c.id, "name": c.name, "description": c.description, "is_narrator": c.is_narrator} for c in characters],
         ensure_ascii=False,
     )
 

--- a/backend/app/services/audiobook_llm.py
+++ b/backend/app/services/audiobook_llm.py
@@ -14,6 +14,8 @@ from ..models import AudiobookSettings
 
 logger = logging.getLogger(__name__)
 
+STUB_PROVIDER = "stub"
+
 DEFAULT_ROSTER_PROMPT = """\
 You are a literary analyst. Analyze the following text excerpt from a book and extract a list of all named \
 characters (including the narrator if the text uses first person).
@@ -111,15 +113,11 @@ def _extract_json(raw: str) -> Any:
 async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
     """Phase 2: extract characters from book text and persist to audiobook_characters."""
     settings = await crud.audiobook.get_audiobook_settings(db)
-    if settings is None:
-        raise RuntimeError("Audiobook settings not found.")
+    provider = (settings.llm_provider or STUB_PROVIDER).lower() if settings else STUB_PROVIDER
 
     chapters = await crud.audiobook.get_chapters_for_book(db, book_id)
     if not chapters:
-        logger.warning("No chapters found for book %s during roster generation.", book_id)
-        if await crud.audiobook.get_book_pipeline_status(db, book_id) != "paused":
-            await crud.audiobook.set_book_pipeline_status(db, book_id, "diarizing")
-        return
+        raise RuntimeError(f"No narratable chapters found for book {book_id} during roster generation.")
 
     # Collect text from up to 5 chapters (keeps prompt size manageable)
     text_chunks: list[str] = []
@@ -128,16 +126,24 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
         text_chunks.append(" ".join(s.original_text for s in sentences))
     combined_text = "\n\n".join(text_chunks)[:12000]  # ~10k tokens safety cap
 
-    prompt_template = settings.roster_prompt_template or DEFAULT_ROSTER_PROMPT
-    prompt = prompt_template.format(text=combined_text)
-
-    logger.info("Calling LLM for character roster (book %s).", book_id)
-    raw = await _call_llm(settings, [{"role": "user", "content": prompt}])
-
-    try:
-        characters_data = _extract_json(raw)
-    except json.JSONDecodeError as exc:
-        raise RuntimeError(f"LLM returned invalid JSON for roster: {exc}\nRaw: {raw[:500]}") from exc
+    if provider == STUB_PROVIDER:
+        characters_data = [
+            {
+                "name": "Narrator",
+                "description": "Deterministic local harness narrator.",
+                "voice_design_prompt": "[gender-neutral][pitch-medium][speed-normal]",
+                "is_narrator": True,
+            }
+        ]
+    else:
+        prompt_template = settings.roster_prompt_template or DEFAULT_ROSTER_PROMPT
+        prompt = prompt_template.format(text=combined_text)
+        logger.info("Calling LLM for character roster (book %s).", book_id)
+        raw = await _call_llm(settings, [{"role": "user", "content": prompt}])
+        try:
+            characters_data = _extract_json(raw)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"LLM returned invalid JSON for roster: {exc}\nRaw: {raw[:500]}") from exc
 
     if not isinstance(characters_data, list):
         raise RuntimeError(f"Expected a JSON array from LLM, got: {type(characters_data)}")
@@ -145,6 +151,8 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
     # Normalise keys to match our model
     normalised: list[dict] = []
     for c in characters_data:
+        if not isinstance(c, dict):
+            continue
         normalised.append(
             {
                 "name": str(c.get("name", "Unknown")),
@@ -152,6 +160,18 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
                 "voice_design_prompt": c.get("voice_design_prompt"),
                 "is_narrator": bool(c.get("is_narrator", False)),
             }
+        )
+    if not normalised:
+        raise RuntimeError("LLM returned an empty character roster.")
+    if not any(character["is_narrator"] for character in normalised):
+        normalised.insert(
+            0,
+            {
+                "name": "Narrator",
+                "description": "Primary narrative voice.",
+                "voice_design_prompt": "[gender-neutral][pitch-medium][speed-normal]",
+                "is_narrator": True,
+            },
         )
 
     await crud.audiobook.create_characters_bulk(db, book_id=book_id, characters_data=normalised)
@@ -163,10 +183,11 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
 async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
     """Phase 3: batch-assign speakers and expression tags to all pending sentences."""
     settings = await crud.audiobook.get_audiobook_settings(db)
-    if settings is None:
-        raise RuntimeError("Audiobook settings not found.")
+    provider = (settings.llm_provider or STUB_PROVIDER).lower() if settings else STUB_PROVIDER
 
     characters = await crud.audiobook.get_characters_for_book(db, book_id)
+    character_ids = {character.id for character in characters}
+    narrator_id = next((character.id for character in characters if character.is_narrator), None)
     roster_json = json.dumps(
         [{"id": c.id, "name": c.name, "description": c.description, "is_narrator": c.is_narrator} for c in characters],
         ensure_ascii=False,
@@ -190,26 +211,34 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
         )
         context_str = "\n".join(context_window[-5:]) if context_window else "(none)"
 
-        prompt_template = settings.diarization_prompt_template or DEFAULT_DIARIZATION_PROMPT
-        prompt = prompt_template.format(
-            roster_json=roster_json,
-            context=context_str,
-            sentences_json=sentences_json,
-        )
+        if provider == STUB_PROVIDER:
+            results = [
+                {"id": sentence.id, "character_id": narrator_id, "tagged_text": sentence.original_text} for sentence in batch
+            ]
+        else:
+            prompt_template = settings.diarization_prompt_template or DEFAULT_DIARIZATION_PROMPT
+            prompt = prompt_template.format(
+                roster_json=roster_json,
+                context=context_str,
+                sentences_json=sentences_json,
+            )
+            logger.debug("Diarizing %d sentences for book %s.", len(batch), book_id)
+            raw = await _call_llm(settings, [{"role": "user", "content": prompt}])
+            try:
+                results = _extract_json(raw)
+            except json.JSONDecodeError as exc:
+                raise RuntimeError(f"LLM returned invalid JSON for diarization: {exc}\nRaw: {raw[:500]}") from exc
 
-        logger.debug("Diarizing %d sentences for book %s.", len(batch), book_id)
-        raw = await _call_llm(settings, [{"role": "user", "content": prompt}])
+        if not isinstance(results, list):
+            raise RuntimeError(f"Expected a JSON array from diarization, got: {type(results)}")
 
-        try:
-            results = _extract_json(raw)
-        except json.JSONDecodeError as exc:
-            raise RuntimeError(f"LLM returned invalid JSON for diarization: {exc}\nRaw: {raw[:500]}") from exc
-
-        result_map = {r["id"]: r for r in results if isinstance(r, dict)}
+        result_map = {r["id"]: r for r in results if isinstance(r, dict) and isinstance(r.get("id"), int)}
 
         for sentence in batch:
             result = result_map.get(sentence.id, {})
             char_id = result.get("character_id")
+            if char_id not in character_ids:
+                char_id = narrator_id
             tagged = result.get("tagged_text") or sentence.original_text
             await crud.audiobook.update_sentence_diarization(db, sentence.id, char_id, tagged)
             context_window.append(sentence.original_text)

--- a/backend/app/services/audiobook_queue.py
+++ b/backend/app/services/audiobook_queue.py
@@ -1,0 +1,134 @@
+"""Single-worker queue for the audiobook pipeline."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Optional
+
+from .. import crud
+from ..database import SessionLocal
+from .audiobook_ingestion import ingest_epub
+from .audiobook_llm import generate_character_roster, diarize_sentences
+from .audiobook_tts import generate_audio_for_book
+from .audiobook_assembly import assemble_book
+
+logger = logging.getLogger(__name__)
+
+# Ordered pipeline phases; the worker resumes from wherever the book's status is.
+_PHASE_ORDER = [
+    "ingesting",
+    "roster_gen",
+    "diarizing",
+    "audio_gen",
+    "assembling",
+]
+
+
+class AudiobookQueue:
+    """App-scoped queue that processes one audiobook pipeline job at a time."""
+
+    def __init__(self) -> None:
+        self._queue: asyncio.Queue[Optional[int]] = asyncio.Queue()
+        self._queued_book_ids: set[int] = set()
+        self._worker_task: Optional[asyncio.Task[None]] = None
+
+    async def start(self) -> None:
+        if self._worker_task and not self._worker_task.done():
+            return
+        self._worker_task = asyncio.create_task(self._run(), name="audiobook-worker")
+
+    async def stop(self) -> None:
+        if not self._worker_task:
+            return
+        await self._queue.put(None)
+        await self._worker_task
+        self._worker_task = None
+        self._queued_book_ids.clear()
+
+    async def enqueue(self, book_id: int) -> bool:
+        if book_id in self._queued_book_ids:
+            return False
+        self._queued_book_ids.add(book_id)
+        await self._queue.put(book_id)
+        return True
+
+    async def requeue_in_progress(self) -> int:
+        async with SessionLocal() as db:
+            books = await crud.audiobook.get_in_progress_audiobook_books(db)
+        queued = 0
+        for book in books:
+            if await self.enqueue(book.id):
+                queued += 1
+        return queued
+
+    async def _run(self) -> None:
+        while True:
+            item = await self._queue.get()
+            try:
+                if item is None:
+                    return
+                book_id = item
+                try:
+                    await self._process(book_id)
+                except Exception:
+                    logger.exception("Unhandled exception in audiobook pipeline for book %s.", book_id)
+                    async with SessionLocal() as db:
+                        await crud.audiobook.set_book_pipeline_status(db, book_id, "error")
+                finally:
+                    self._queued_book_ids.discard(book_id)
+            finally:
+                self._queue.task_done()
+
+    async def _process(self, book_id: int) -> None:
+        """Run the pipeline from the book's current status to completion."""
+        async with SessionLocal() as db:
+            from ..models import Book
+            book = await db.get(Book, book_id)
+            if book is None:
+                logger.warning("Book %s not found; skipping pipeline.", book_id)
+                return
+            current_status = book.audiobook_pipeline_status
+
+        if current_status == "paused":
+            logger.info("Book %s is paused; skipping pipeline.", book_id)
+            return
+
+        if current_status not in _PHASE_ORDER and current_status != "ingesting":
+            # Default: start from the beginning
+            current_status = "ingesting"
+            async with SessionLocal() as db:
+                await crud.audiobook.set_book_pipeline_status(db, book_id, "ingesting")
+
+        start_idx = _PHASE_ORDER.index(current_status) if current_status in _PHASE_ORDER else 0
+
+        for phase in _PHASE_ORDER[start_idx:]:
+            logger.info("Book %s: running phase '%s'.", book_id, phase)
+            async with SessionLocal() as db:
+                if phase == "ingesting":
+                    await ingest_epub(book_id, db)
+                elif phase == "roster_gen":
+                    await generate_character_roster(book_id, db)
+                elif phase == "diarizing":
+                    await diarize_sentences(book_id, db)
+                elif phase == "audio_gen":
+                    await generate_audio_for_book(book_id, db)
+                elif phase == "assembling":
+                    await assemble_book(book_id, db)
+
+            # Check if the book was paused mid-pipeline
+            async with SessionLocal() as db:
+                from ..models import Book
+                book = await db.get(Book, book_id)
+                if book and book.audiobook_pipeline_status == "paused":
+                    logger.info("Book %s paused after phase '%s'.", book_id, phase)
+                    return
+
+        logger.info("Audiobook pipeline complete for book %s.", book_id)
+
+
+_audiobook_queue = AudiobookQueue()
+
+
+def get_audiobook_queue() -> AudiobookQueue:
+    return _audiobook_queue

--- a/backend/app/services/audiobook_queue.py
+++ b/backend/app/services/audiobook_queue.py
@@ -84,6 +84,7 @@ class AudiobookQueue:
         """Run the pipeline from the book's current status to completion."""
         async with SessionLocal() as db:
             from ..models import Book
+
             book = await db.get(Book, book_id)
             if book is None:
                 logger.warning("Book %s not found; skipping pipeline.", book_id)
@@ -119,6 +120,7 @@ class AudiobookQueue:
             # Check if the book was paused mid-pipeline
             async with SessionLocal() as db:
                 from ..models import Book
+
                 book = await db.get(Book, book_id)
                 if book and book.audiobook_pipeline_status == "paused":
                     logger.info("Book %s paused after phase '%s'.", book_id, phase)

--- a/backend/app/services/audiobook_queue.py
+++ b/backend/app/services/audiobook_queue.py
@@ -31,6 +31,10 @@ class AudiobookQueue:
     def __init__(self) -> None:
         self._queue: asyncio.Queue[Optional[int]] = asyncio.Queue()
         self._queued_book_ids: set[int] = set()
+        # A pipeline mutation may arrive while a book is already running. Keep
+        # one follow-up job so the mutation is not lost when the current worker
+        # finishes.
+        self._rerun_book_ids: set[int] = set()
         self._worker_task: Optional[asyncio.Task[None]] = None
 
     async def start(self) -> None:
@@ -45,9 +49,11 @@ class AudiobookQueue:
         await self._worker_task
         self._worker_task = None
         self._queued_book_ids.clear()
+        self._rerun_book_ids.clear()
 
     async def enqueue(self, book_id: int) -> bool:
         if book_id in self._queued_book_ids:
+            self._rerun_book_ids.add(book_id)
             return False
         self._queued_book_ids.add(book_id)
         await self._queue.put(book_id)
@@ -77,6 +83,9 @@ class AudiobookQueue:
                         await crud.audiobook.set_book_pipeline_status(db, book_id, "error")
                 finally:
                     self._queued_book_ids.discard(book_id)
+                    if book_id in self._rerun_book_ids:
+                        self._rerun_book_ids.discard(book_id)
+                        await self.enqueue(book_id)
             finally:
                 self._queue.task_done()
 

--- a/backend/app/services/audiobook_queue.py
+++ b/backend/app/services/audiobook_queue.py
@@ -59,6 +59,10 @@ class AudiobookQueue:
         await self._queue.put(book_id)
         return True
 
+    def has_book_job(self, book_id: int) -> bool:
+        """Return whether a book is queued or currently being processed."""
+        return book_id in self._queued_book_ids
+
     async def requeue_in_progress(self) -> int:
         async with SessionLocal() as db:
             books = await crud.audiobook.get_in_progress_audiobook_books(db)

--- a/backend/app/services/audiobook_tts.py
+++ b/backend/app/services/audiobook_tts.py
@@ -1,0 +1,110 @@
+"""Phase 4: OmniVoice TTS — generate a per-sentence MP3 snippet."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import httpx
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import crud
+from ..config import LIBRARY_PATH
+from ..models import AudiobookCharacter, AudiobookSentence
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_VOICE_PROMPT = "[gender-neutral][pitch-medium][speed-normal]"
+
+
+def _snippet_path(book_id: int, sentence_id: int) -> Path:
+    return LIBRARY_PATH.parent / "library" / "audiobooks" / str(book_id) / "snippets" / f"{sentence_id}.mp3"
+
+
+def _relative_path(full_path: Path) -> str:
+    return str(full_path.relative_to(LIBRARY_PATH.parent))
+
+
+def _get_mp3_duration_ms(path: Path) -> int:
+    from mutagen.mp3 import MP3
+    audio = MP3(str(path))
+    return int(audio.info.length * 1000)
+
+
+async def _call_omnivoice(endpoint: str, voice_prompt: str, tagged_text: str) -> bytes:
+    url = endpoint.rstrip("/") + "/generate"
+    async with httpx.AsyncClient(timeout=120.0) as client:
+        resp = await client.post(
+            url,
+            json={"voice": voice_prompt, "text": tagged_text},
+            headers={"Accept": "audio/mpeg"},
+        )
+        resp.raise_for_status()
+    return resp.content
+
+
+async def generate_audio_for_book(book_id: int, db: AsyncSession) -> None:
+    """Phase 4: iterate ready_for_audio sentences and call OmniVoice for each."""
+    settings = await crud.audiobook.get_audiobook_settings(db)
+    if not settings or not settings.omnivoice_endpoint:
+        raise RuntimeError("OmniVoice endpoint not configured. Set it in Audio Settings.")
+
+    endpoint = settings.omnivoice_endpoint
+
+    # Ensure snippets directory exists
+    snippets_dir = LIBRARY_PATH.parent / "library" / "audiobooks" / str(book_id) / "snippets"
+    snippets_dir.mkdir(parents=True, exist_ok=True)
+
+    processed = 0
+    while True:
+        batch = await crud.audiobook.get_sentences_ready_for_audio(db, book_id, limit=20)
+        if not batch:
+            break
+
+        for sentence in batch:
+            # Resolve voice prompt from the assigned character
+            voice_prompt = DEFAULT_VOICE_PROMPT
+            if sentence.character_id is not None:
+                char = await db.get(AudiobookCharacter, sentence.character_id)
+                if char and char.voice_design_prompt:
+                    voice_prompt = char.voice_design_prompt
+
+            text_to_speak = sentence.tagged_text or sentence.original_text
+
+            logger.debug("Generating audio for sentence %s (book %s).", sentence.id, book_id)
+            try:
+                audio_bytes = await _call_omnivoice(endpoint, voice_prompt, text_to_speak)
+            except httpx.HTTPStatusError as exc:
+                logger.error(
+                    "OmniVoice error for sentence %s: %s %s",
+                    sentence.id,
+                    exc.response.status_code,
+                    exc.response.text[:200],
+                )
+                # Mark as error but continue with remaining sentences
+                from sqlalchemy import update
+                from ..database import SessionLocal
+                async with SessionLocal() as err_db:
+                    await err_db.execute(
+                        update(AudiobookSentence)
+                        .where(AudiobookSentence.id == sentence.id)
+                        .values(status="error")
+                    )
+                    await err_db.commit()
+                continue
+
+            out_path = _snippet_path(book_id, sentence.id)
+            out_path.write_bytes(audio_bytes)
+
+            duration_ms = _get_mp3_duration_ms(out_path)
+            await crud.audiobook.update_sentence_audio(
+                db, sentence.id, _relative_path(out_path), duration_ms
+            )
+            processed += 1
+
+            # Flag chapter for reassembly if all its sentences are done
+            if await crud.audiobook.chapter_all_audio_generated(db, sentence.chapter_id):
+                await crud.audiobook.flag_chapter_for_reassembly(db, sentence.chapter_id)
+
+    logger.info("TTS complete for book %s: %d sentences generated.", book_id, processed)
+    await crud.audiobook.set_book_pipeline_status(db, book_id, "assembling")

--- a/backend/app/services/audiobook_tts.py
+++ b/backend/app/services/audiobook_tts.py
@@ -27,6 +27,7 @@ def _relative_path(full_path: Path) -> str:
 
 def _get_mp3_duration_ms(path: Path) -> int:
     from mutagen.mp3 import MP3
+
     audio = MP3(str(path))
     return int(audio.info.length * 1000)
 
@@ -84,11 +85,10 @@ async def generate_audio_for_book(book_id: int, db: AsyncSession) -> None:
                 # Mark as error but continue with remaining sentences
                 from sqlalchemy import update
                 from ..database import SessionLocal
+
                 async with SessionLocal() as err_db:
                     await err_db.execute(
-                        update(AudiobookSentence)
-                        .where(AudiobookSentence.id == sentence.id)
-                        .values(status="error")
+                        update(AudiobookSentence).where(AudiobookSentence.id == sentence.id).values(status="error")
                     )
                     await err_db.commit()
                 continue
@@ -97,9 +97,7 @@ async def generate_audio_for_book(book_id: int, db: AsyncSession) -> None:
             out_path.write_bytes(audio_bytes)
 
             duration_ms = _get_mp3_duration_ms(out_path)
-            await crud.audiobook.update_sentence_audio(
-                db, sentence.id, _relative_path(out_path), duration_ms
-            )
+            await crud.audiobook.update_sentence_audio(db, sentence.id, _relative_path(out_path), duration_ms)
             processed += 1
 
             # Flag chapter for reassembly if all its sentences are done

--- a/backend/app/services/audiobook_tts.py
+++ b/backend/app/services/audiobook_tts.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from pathlib import Path
+import shutil
 
 import httpx
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -33,6 +35,37 @@ def _get_mp3_duration_ms(path: Path) -> int:
 
 
 async def _call_omnivoice(endpoint: str, voice_prompt: str, tagged_text: str) -> bytes:
+    if endpoint.startswith("stub://"):
+        duration_ms = max(350, min(5000, len(tagged_text.split()) * 260))
+        ffmpeg = shutil.which("ffmpeg")
+        if not ffmpeg:
+            raise RuntimeError("ffmpeg is required by the local audiobook TTS harness.")
+        process = await asyncio.create_subprocess_exec(
+            ffmpeg,
+            "-v",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "anullsrc=r=22050:cl=mono",
+            "-t",
+            f"{duration_ms / 1000:.3f}",
+            "-codec:a",
+            "libmp3lame",
+            "-b:a",
+            "64k",
+            "-f",
+            "mp3",
+            "pipe:1",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await process.communicate()
+        if process.returncode:
+            message = stderr.decode("utf-8", errors="replace")[:500]
+            raise RuntimeError(f"Local TTS harness failed: {message}")
+        return stdout
+
     url = endpoint.rstrip("/") + "/generate"
     async with httpx.AsyncClient(timeout=120.0) as client:
         resp = await client.post(
@@ -47,10 +80,11 @@ async def _call_omnivoice(endpoint: str, voice_prompt: str, tagged_text: str) ->
 async def generate_audio_for_book(book_id: int, db: AsyncSession) -> None:
     """Phase 4: iterate ready_for_audio sentences and call OmniVoice for each."""
     settings = await crud.audiobook.get_audiobook_settings(db)
-    if not settings or not settings.omnivoice_endpoint:
+    endpoint = settings.omnivoice_endpoint if settings else None
+    if not endpoint and (settings is None or (settings.llm_provider or "stub").lower() == "stub"):
+        endpoint = "stub://local"
+    if not endpoint:
         raise RuntimeError("OmniVoice endpoint not configured. Set it in Audio Settings.")
-
-    endpoint = settings.omnivoice_endpoint
 
     # Ensure snippets directory exists
     snippets_dir = LIBRARY_PATH.parent / "library" / "audiobooks" / str(book_id) / "snippets"

--- a/backend/app/services/audiobook_tts.py
+++ b/backend/app/services/audiobook_tts.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import crud
 from ..config import LIBRARY_PATH
-from ..models import AudiobookCharacter, AudiobookSentence
+from ..models import AudiobookCharacter
 
 logger = logging.getLogger(__name__)
 
@@ -57,12 +57,21 @@ async def generate_audio_for_book(book_id: int, db: AsyncSession) -> None:
     snippets_dir.mkdir(parents=True, exist_ok=True)
 
     processed = 0
+    failed = 0
     while True:
+        if await crud.audiobook.get_book_pipeline_status(db, book_id) == "paused":
+            logger.info("Book %s paused during TTS generation.", book_id)
+            return
+
         batch = await crud.audiobook.get_sentences_ready_for_audio(db, book_id, limit=20)
         if not batch:
             break
 
         for sentence in batch:
+            if await crud.audiobook.get_book_pipeline_status(db, book_id) == "paused":
+                logger.info("Book %s paused during TTS generation.", book_id)
+                return
+
             # Resolve voice prompt from the assigned character
             voice_prompt = DEFAULT_VOICE_PROMPT
             if sentence.character_id is not None:
@@ -75,34 +84,49 @@ async def generate_audio_for_book(book_id: int, db: AsyncSession) -> None:
             logger.debug("Generating audio for sentence %s (book %s).", sentence.id, book_id)
             try:
                 audio_bytes = await _call_omnivoice(endpoint, voice_prompt, text_to_speak)
+                out_path = _snippet_path(book_id, sentence.id)
+                out_path.write_bytes(audio_bytes)
+
+                duration_ms = _get_mp3_duration_ms(out_path)
             except httpx.HTTPStatusError as exc:
+                response_text = exc.response.text[:200] if exc.response is not None else ""
                 logger.error(
                     "OmniVoice error for sentence %s: %s %s",
                     sentence.id,
-                    exc.response.status_code,
-                    exc.response.text[:200],
+                    exc.response.status_code if exc.response is not None else "unknown",
+                    response_text,
                 )
-                # Mark as error but continue with remaining sentences
-                from sqlalchemy import update
-                from ..database import SessionLocal
-
-                async with SessionLocal() as err_db:
-                    await err_db.execute(
-                        update(AudiobookSentence).where(AudiobookSentence.id == sentence.id).values(status="error")
-                    )
-                    await err_db.commit()
+                await crud.audiobook.mark_sentence_error(db, sentence.id)
+                failed += 1
+                continue
+            except Exception as exc:
+                logger.exception(
+                    "Unable to generate or inspect audio for sentence %s: %s",
+                    sentence.id,
+                    exc,
+                )
+                await crud.audiobook.mark_sentence_error(db, sentence.id)
+                failed += 1
                 continue
 
-            out_path = _snippet_path(book_id, sentence.id)
-            out_path.write_bytes(audio_bytes)
-
-            duration_ms = _get_mp3_duration_ms(out_path)
             await crud.audiobook.update_sentence_audio(db, sentence.id, _relative_path(out_path), duration_ms)
             processed += 1
 
             # Flag chapter for reassembly if all its sentences are done
             if await crud.audiobook.chapter_all_audio_generated(db, sentence.chapter_id):
                 await crud.audiobook.flag_chapter_for_reassembly(db, sentence.chapter_id)
+
+    if failed or await crud.audiobook.has_sentence_status(db, book_id, "error"):
+        await crud.audiobook.set_book_pipeline_status(db, book_id, "error")
+        raise RuntimeError(f"TTS failed for {failed} sentence(s) in book {book_id}.")
+
+    if not await crud.audiobook.all_sentences_audio_generated(db, book_id):
+        await crud.audiobook.set_book_pipeline_status(db, book_id, "error")
+        raise RuntimeError(f"TTS finished before all sentences had audio for book {book_id}.")
+
+    if await crud.audiobook.get_book_pipeline_status(db, book_id) == "paused":
+        logger.info("Book %s paused after TTS generation.", book_id)
+        return
 
     logger.info("TTS complete for book %s: %d sentences generated.", book_id, processed)
     await crud.audiobook.set_book_pipeline_status(db, book_id, "assembling")

--- a/backend/tests/test_audiobook_pipeline.py
+++ b/backend/tests/test_audiobook_pipeline.py
@@ -70,12 +70,16 @@ async def _seed_audio_chapter(db, book_id: int, *, sentence_status: str = "ready
 
 
 class _FakeQueue:
-    def __init__(self):
+    def __init__(self, *, active_book_ids: set[int] | None = None):
         self.enqueued: list[int] = []
+        self.active_book_ids = active_book_ids or set()
 
     async def enqueue(self, book_id: int) -> bool:
         self.enqueued.append(book_id)
         return True
+
+    def has_book_job(self, book_id: int) -> bool:
+        return book_id in self.active_book_ids
 
 
 @pytest.mark.asyncio
@@ -176,6 +180,54 @@ async def test_error_pipeline_resets_failed_sentences_before_retry(db, monkeypat
     assert sentence.status == "ready_for_audio"
     assert sentence.audio_file_path is None
     assert chapter.needs_reassembly is True
+
+
+@pytest.mark.asyncio
+async def test_rebuild_rejects_an_active_pipeline(db, monkeypatch):
+    book = await _make_book(db, audiobook_enabled=True, audiobook_pipeline_status="diarizing")
+    queue = _FakeQueue()
+    monkeypatch.setattr(audiobook_router, "get_audiobook_queue", lambda: queue)
+
+    with pytest.raises(audiobook_router.HTTPException) as exc_info:
+        await audiobook_router.rebuild_pipeline(book.id, db)
+
+    assert exc_info.value.status_code == 409
+    assert queue.enqueued == []
+
+
+@pytest.mark.asyncio
+async def test_rebuild_waits_for_a_paused_worker_to_exit(db, monkeypatch):
+    book = await _make_book(db, audiobook_enabled=True, audiobook_pipeline_status="paused")
+    queue = _FakeQueue(active_book_ids={book.id})
+    monkeypatch.setattr(audiobook_router, "get_audiobook_queue", lambda: queue)
+
+    with pytest.raises(audiobook_router.HTTPException) as exc_info:
+        await audiobook_router.rebuild_pipeline(book.id, db)
+
+    assert exc_info.value.status_code == 409
+    assert queue.enqueued == []
+
+
+@pytest.mark.asyncio
+async def test_sentence_speaker_must_belong_to_the_same_book(db, monkeypatch):
+    book = await _make_book(db, audiobook_enabled=True)
+    other_book = await _make_book(db, title="Other Audio", audiobook_enabled=True)
+    _chapter, _character, sentence = await _seed_audio_chapter(db, book.id)
+    _other_chapter, other_character, _other_sentence = await _seed_audio_chapter(db, other_book.id)
+    queue = _FakeQueue()
+    monkeypatch.setattr(audiobook_router, "get_audiobook_queue", lambda: queue)
+
+    with pytest.raises(audiobook_router.HTTPException) as exc_info:
+        await audiobook_router.update_sentence(
+            sentence.id,
+            audiobook_router.SentenceUpdate(character_id=other_character.id, tagged_text=sentence.original_text),
+            db,
+        )
+
+    await db.refresh(sentence)
+    assert exc_info.value.status_code == 404
+    assert sentence.character_id != other_character.id
+    assert queue.enqueued == []
 
 
 @pytest.mark.asyncio
@@ -338,3 +390,15 @@ async def test_offline_harness_builds_downloadable_media_overlay_epub(db, tmp_pa
     response = await audiobook_router.download_audiobook(book.id, db)
     assert Path(response.path) == output_path
     assert response.media_type == "application/epub+zip"
+
+    # A crash or cleanup after chapter assembly must resume packaging rather
+    # than leaving a false complete state with a missing download.
+    output_path.unlink()
+    monkeypatch.setattr(crud.audiobook, "LIBRARY_PATH", library_path)
+    assert await crud.audiobook.infer_audiobook_resume_status(db, book.id) == "assembling"
+
+    await audiobook_assembly.assemble_book(book.id, db)
+
+    await db.refresh(book)
+    assert output_path.exists()
+    assert book.audiobook_pipeline_status == "complete"

--- a/backend/tests/test_audiobook_pipeline.py
+++ b/backend/tests/test_audiobook_pipeline.py
@@ -1,0 +1,254 @@
+from pathlib import Path
+
+import httpx
+import pytest
+from bs4 import BeautifulSoup
+from ebooklib import epub
+
+from backend.app import crud, models
+from backend.app.routers import audiobook as audiobook_router
+from backend.app.services import audiobook_assembly, audiobook_ingestion, audiobook_tts
+
+
+async def _make_book(db, **overrides):
+    title = overrides.get("title", "Audio Book")
+    slug = title.lower().replace(" ", "-")
+    payload = {
+        "title": title,
+        "author": "Reader",
+        "source_type": models.SourceType.epub,
+        "immutable_path": f"library/{slug}-immutable.epub",
+        "current_path": f"library/{slug}.epub",
+    }
+    payload.update(overrides)
+    book = models.Book(**payload)
+    db.add(book)
+    await db.commit()
+    await db.refresh(book)
+    return book
+
+
+async def _seed_audio_chapter(db, book_id: int, *, sentence_status: str = "ready_for_audio"):
+    chapter = await crud.audiobook.create_chapter(
+        db,
+        book_id=book_id,
+        chapter_number=1,
+        content_file_name="Text/chapter_1.xhtml",
+    )
+    characters = await crud.audiobook.create_characters_bulk(
+        db,
+        book_id=book_id,
+        characters_data=[
+            {
+                "name": "Narrator",
+                "description": "Primary narrator",
+                "voice_design_prompt": "[gender-neutral][pitch-medium][speed-normal]",
+                "is_narrator": True,
+            }
+        ],
+    )
+    await crud.audiobook.create_sentences_bulk(
+        db,
+        chapter_id=chapter.id,
+        sentences_data=[
+            {
+                "html_element_id": "ch1_s0",
+                "sequence_order": 0,
+                "original_text": "One sentence.",
+                "tagged_text": "One sentence.",
+                "character_id": characters[0].id,
+                "status": sentence_status,
+            }
+        ],
+    )
+    sentence = (await crud.audiobook.get_sentences_for_chapter(db, chapter.id))[0]
+    return chapter, characters[0], sentence
+
+
+class _FakeQueue:
+    def __init__(self):
+        self.enqueued: list[int] = []
+
+    async def enqueue(self, book_id: int) -> bool:
+        self.enqueued.append(book_id)
+        return True
+
+
+@pytest.mark.asyncio
+async def test_books_default_audiobook_pipeline_disabled(db, monkeypatch):
+    book = await _make_book(db)
+    queue = _FakeQueue()
+    monkeypatch.setattr(audiobook_router, "get_audiobook_queue", lambda: queue)
+
+    with pytest.raises(audiobook_router.HTTPException) as exc_info:
+        await audiobook_router.start_pipeline(book.id, db)
+
+    await db.refresh(book)
+    assert book.audiobook_enabled is False
+    assert exc_info.value.status_code == 403
+    assert queue.enqueued == []
+
+
+@pytest.mark.asyncio
+async def test_requeue_candidates_only_include_enabled_audiobooks(db):
+    disabled = await _make_book(db)
+    disabled.audiobook_pipeline_status = "audio_gen"
+    enabled = await _make_book(db, title="Enabled Audio", audiobook_enabled=True)
+    enabled.audiobook_pipeline_status = "audio_gen"
+    await db.commit()
+
+    pending = await crud.audiobook.get_in_progress_audiobook_books(db)
+
+    assert [book.id for book in pending] == [enabled.id]
+
+
+@pytest.mark.asyncio
+async def test_paused_pipeline_resumes_from_persisted_audio_state(db, monkeypatch):
+    book = await _make_book(db, audiobook_enabled=True)
+    await _seed_audio_chapter(db, book.id, sentence_status="ready_for_audio")
+    await crud.audiobook.set_book_pipeline_status(db, book.id, "paused")
+    queue = _FakeQueue()
+    monkeypatch.setattr(audiobook_router, "get_audiobook_queue", lambda: queue)
+
+    response = await audiobook_router.start_pipeline(book.id, db)
+
+    await db.refresh(book)
+    assert response == {"status": "audio_gen", "queued": True}
+    assert book.audiobook_pipeline_status == "audio_gen"
+    assert queue.enqueued == [book.id]
+
+
+@pytest.mark.asyncio
+async def test_error_pipeline_resets_failed_sentences_before_retry(db, monkeypatch):
+    book = await _make_book(db, audiobook_enabled=True)
+    chapter, _character, sentence = await _seed_audio_chapter(db, book.id, sentence_status="error")
+    await crud.audiobook.set_book_pipeline_status(db, book.id, "error")
+    queue = _FakeQueue()
+    monkeypatch.setattr(audiobook_router, "get_audiobook_queue", lambda: queue)
+
+    response = await audiobook_router.start_pipeline(book.id, db)
+
+    await db.refresh(book)
+    await db.refresh(chapter)
+    await db.refresh(sentence)
+    assert response == {"status": "audio_gen", "queued": True}
+    assert book.audiobook_pipeline_status == "audio_gen"
+    assert sentence.status == "ready_for_audio"
+    assert sentence.audio_file_path is None
+    assert chapter.needs_reassembly is True
+
+
+@pytest.mark.asyncio
+async def test_tts_failure_marks_book_error_instead_of_advancing_to_assembly(db, monkeypatch):
+    book = await _make_book(db)
+    chapter, _character, _sentence = await _seed_audio_chapter(db, book.id, sentence_status="ready_for_audio")
+    settings = models.AudiobookSettings(omnivoice_endpoint="http://tts.example.test")
+    db.add(settings)
+    await db.commit()
+
+    async def fail_omnivoice(endpoint, voice_prompt, tagged_text):
+        request = httpx.Request("POST", endpoint)
+        raise httpx.ConnectError("connection failed", request=request)
+
+    monkeypatch.setattr(audiobook_tts, "_call_omnivoice", fail_omnivoice)
+
+    with pytest.raises(RuntimeError, match="TTS failed"):
+        await audiobook_tts.generate_audio_for_book(book.id, db)
+
+    sentence = (await crud.audiobook.get_sentences_for_chapter(db, chapter.id))[0]
+    await db.refresh(book)
+    await db.refresh(sentence)
+    assert book.audiobook_pipeline_status == "error"
+    assert sentence.status == "error"
+    assert sentence.audio_file_path is None
+
+
+def test_smil_uses_real_epub_content_file_name():
+    chapter = models.AudiobookChapter(
+        chapter_number=1,
+        content_file_name="Text/real_chapter.xhtml",
+    )
+    sentence = models.AudiobookSentence(
+        html_element_id="ch1_s0",
+        audio_duration_ms=1250,
+    )
+
+    smil = audiobook_assembly._build_smil(chapter, [sentence], "ch0001.mp3")
+
+    assert 'epub:textref="Text/real_chapter.xhtml"' in smil
+    assert 'src="Text/real_chapter.xhtml#ch1_s0"' in smil
+    assert 'src="ch0001.mp3"' in smil
+    assert 'clipEnd="00:00:01.250"' in smil
+
+
+def _write_nested_epub(path: Path) -> None:
+    book = epub.EpubBook()
+    book.set_identifier("nested-test")
+    book.set_title("Nested")
+    book.set_language("en")
+    book.add_author("Author")
+    chapter = epub.EpubHtml(title="One", file_name="Text/chapter_1.xhtml", lang="en")
+    chapter.content = """
+    <html xmlns="http://www.w3.org/1999/xhtml">
+      <body>
+        <div class="chapter">
+          <h1>Chapter One</h1>
+          <p>First sentence. <em>Second sentence.</em></p>
+          <p><a href="next.xhtml">Linked sentence.</a></p>
+        </div>
+      </body>
+    </html>
+    """
+    chapter_two = epub.EpubHtml(title="Two", file_name="Text/chapter_2.xhtml", lang="en")
+    chapter_two.content = "<p>Third sentence.</p>"
+    book.add_item(chapter)
+    book.add_item(chapter_two)
+    book.add_item(epub.EpubNcx())
+    book.add_item(epub.EpubNav())
+    book.spine = ["nav", chapter, chapter_two]
+    book.toc = (
+        epub.Link("Text/chapter_1.xhtml", "One", "one"),
+        epub.Link("Text/chapter_2.xhtml", "Two", "two"),
+    )
+    epub.write_epub(path, book, {})
+
+
+def _simple_sentence_split(text: str) -> list[str]:
+    if "." not in text:
+        return [text.strip()]
+    return [f"{chunk.strip()}." for chunk in text.split(".") if chunk.strip()]
+
+
+@pytest.mark.asyncio
+async def test_ingestion_preserves_nested_markup_and_records_spine_file(db, tmp_path, monkeypatch):
+    library_path = tmp_path / "library"
+    library_path.mkdir()
+    epub_path = library_path / "nested.epub"
+    _write_nested_epub(epub_path)
+    book = await _make_book(
+        db,
+        immutable_path=str(epub_path.relative_to(library_path.parent)),
+        current_path=str(epub_path.relative_to(library_path.parent)),
+    )
+    monkeypatch.setattr(audiobook_ingestion, "LIBRARY_PATH", library_path)
+    monkeypatch.setattr(audiobook_ingestion, "_tokenize_text", _simple_sentence_split)
+
+    await audiobook_ingestion.ingest_epub(book.id, db)
+
+    chapters = await crud.audiobook.get_chapters_for_book(db, book.id)
+    assert [chapter.content_file_name for chapter in chapters] == [
+        "Text/chapter_1.xhtml",
+        "Text/chapter_2.xhtml",
+    ]
+
+    working_epub = library_path / "audiobooks" / str(book.id) / "working.epub"
+    parsed = epub.read_epub(str(working_epub))
+    item = parsed.get_item_with_href("Text/chapter_1.xhtml")
+    soup = BeautifulSoup(item.get_content(), "html.parser")
+
+    assert soup.find("div", class_="chapter") is not None
+    assert soup.find("p") is not None
+    assert soup.find("em") is not None
+    assert soup.find("a", href="next.xhtml") is not None
+    assert soup.find("span", id="ch1_s0") is not None
+    assert soup.find("span", id="ch1_s1") is not None

--- a/backend/tests/test_audiobook_pipeline.py
+++ b/backend/tests/test_audiobook_pipeline.py
@@ -1,3 +1,4 @@
+import asyncio
 from pathlib import Path
 
 import httpx
@@ -8,6 +9,7 @@ from ebooklib import epub
 from backend.app import crud, models
 from backend.app.routers import audiobook as audiobook_router
 from backend.app.services import audiobook_assembly, audiobook_ingestion, audiobook_tts
+from backend.app.services.audiobook_queue import AudiobookQueue
 
 
 async def _make_book(db, **overrides):
@@ -72,6 +74,35 @@ class _FakeQueue:
     async def enqueue(self, book_id: int) -> bool:
         self.enqueued.append(book_id)
         return True
+
+
+@pytest.mark.asyncio
+async def test_queue_schedules_one_rerun_for_changes_during_processing(monkeypatch):
+    queue = AudiobookQueue()
+    processed: list[int] = []
+    first_run_started = asyncio.Event()
+    release_first_run = asyncio.Event()
+
+    async def process(book_id: int) -> None:
+        processed.append(book_id)
+        if len(processed) == 1:
+            first_run_started.set()
+            await release_first_run.wait()
+
+    monkeypatch.setattr(queue, "_process", process)
+    await queue.start()
+    try:
+        assert await queue.enqueue(42) is True
+        await first_run_started.wait()
+
+        assert await queue.enqueue(42) is False
+        assert await queue.enqueue(42) is False
+        release_first_run.set()
+        await queue._queue.join()
+
+        assert processed == [42, 42]
+    finally:
+        await queue.stop()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_audiobook_pipeline.py
+++ b/backend/tests/test_audiobook_pipeline.py
@@ -1,4 +1,6 @@
 import asyncio
+import shutil
+import zipfile
 from pathlib import Path
 
 import httpx
@@ -8,7 +10,7 @@ from ebooklib import epub
 
 from backend.app import crud, models
 from backend.app.routers import audiobook as audiobook_router
-from backend.app.services import audiobook_assembly, audiobook_ingestion, audiobook_tts
+from backend.app.services import audiobook_assembly, audiobook_ingestion, audiobook_llm, audiobook_tts
 from backend.app.services.audiobook_queue import AudiobookQueue
 
 
@@ -131,6 +133,13 @@ async def test_requeue_candidates_only_include_enabled_audiobooks(db):
     pending = await crud.audiobook.get_in_progress_audiobook_books(db)
 
     assert [book.id for book in pending] == [enabled.id]
+
+
+@pytest.mark.asyncio
+async def test_empty_audio_state_is_not_considered_complete(db):
+    book = await _make_book(db, audiobook_enabled=True)
+
+    assert await crud.audiobook.all_sentences_audio_generated(db, book.id) is False
 
 
 @pytest.mark.asyncio
@@ -283,3 +292,49 @@ async def test_ingestion_preserves_nested_markup_and_records_spine_file(db, tmp_
     assert soup.find("a", href="next.xhtml") is not None
     assert soup.find("span", id="ch1_s0") is not None
     assert soup.find("span", id="ch1_s1") is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg is required for MP3 assembly")
+async def test_offline_harness_builds_downloadable_media_overlay_epub(db, tmp_path, monkeypatch):
+    library_path = tmp_path / "library"
+    library_path.mkdir()
+    epub_path = library_path / "offline.epub"
+    _write_nested_epub(epub_path)
+    book = await _make_book(
+        db,
+        audiobook_enabled=True,
+        immutable_path=str(epub_path.relative_to(library_path.parent)),
+        current_path=str(epub_path.relative_to(library_path.parent)),
+    )
+    for module in (audiobook_ingestion, audiobook_tts, audiobook_assembly):
+        monkeypatch.setattr(module, "LIBRARY_PATH", library_path)
+    monkeypatch.setattr(audiobook_ingestion, "_tokenize_text", _simple_sentence_split)
+
+    await audiobook_ingestion.ingest_epub(book.id, db)
+    await audiobook_llm.generate_character_roster(book.id, db)
+    await audiobook_llm.diarize_sentences(book.id, db)
+    await audiobook_tts.generate_audio_for_book(book.id, db)
+    await audiobook_assembly.assemble_book(book.id, db)
+
+    await db.refresh(book)
+    characters = await crud.audiobook.get_characters_for_book(db, book.id)
+    counts = await crud.audiobook.count_sentences_by_status(db, book.id)
+    output_path = library_path / "audiobooks" / str(book.id) / "audiobook.epub"
+
+    assert book.audiobook_pipeline_status == "complete"
+    assert [(character.name, character.is_narrator) for character in characters] == [("Narrator", True)]
+    assert counts == {"audio_generated": 5}
+    assert output_path.exists()
+    with zipfile.ZipFile(output_path) as archive:
+        names = archive.namelist()
+        assert "EPUB/ch0001.mp3" in names
+        assert "EPUB/ch0001.smil" in names
+        package = archive.read("EPUB/content.opf").decode("utf-8")
+        assert 'media-type="application/smil+xml"' in package
+        assert 'media-overlay="smil_ch0001"' in package
+
+    monkeypatch.setattr(audiobook_router, "LIBRARY_PATH", library_path)
+    response = await audiobook_router.download_audiobook(book.id, db)
+    assert Path(response.path) == output_path
+    assert response.media_type == "application/epub+zip"

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -13,6 +13,7 @@ from backend.app.auth import (
     validate_admin_session_token,
     verify_admin_password,
 )
+from backend.app.admin_auth_middleware import AdminAuthMiddleware
 
 
 class TestGenerateReaderToken:
@@ -70,6 +71,16 @@ class TestExtractPrefix:
 
 
 class TestAdminAuth:
+    def test_audiobook_files_require_admin_auth(self, monkeypatch):
+        monkeypatch.setenv("STORY_MANAGER_ADMIN_PASSWORD", "secret")
+        audiobook_request = Request(
+            {"type": "http", "method": "GET", "path": "/library/audiobooks/1/working.epub", "headers": []}
+        )
+        cover_request = Request({"type": "http", "method": "GET", "path": "/library/covers/1.jpg", "headers": []})
+
+        assert AdminAuthMiddleware._requires_admin_auth(audiobook_request) is True
+        assert AdminAuthMiddleware._requires_admin_auth(cover_request) is False
+
     def test_verify_admin_password_uses_env(self, monkeypatch):
         monkeypatch.setenv("STORY_MANAGER_ADMIN_PASSWORD", "secret")
 

--- a/docs/AUDIOBOOK_PIPELINE.md
+++ b/docs/AUDIOBOOK_PIPELINE.md
@@ -121,6 +121,7 @@ PUT /api/audiobook/sentences/{id}
 | id | Integer PK | |
 | book_id | FK → books CASCADE | |
 | chapter_number | Integer | Spine order |
+| content_file_name | String | Original EPUB spine document path used by SMIL text refs |
 | smil_file_path | String | Relative path to generated `.smil` |
 | audio_file_path | String | Relative path to concatenated chapter MP3 |
 | needs_reassembly | Boolean | Worker polls for `True` |
@@ -149,7 +150,9 @@ PUT /api/audiobook/sentences/{id}
 | audio_duration_ms | Integer | Used for SMIL timestamp calculation |
 | status | String | `pending_diarization` → `ready_for_audio` → `audio_generated` / `error` |
 
-**New column on `books`**: `audiobook_pipeline_status` (String, nullable)
+**New columns on `books`**:
+- `audiobook_enabled` (Boolean, default `false`) — per-book opt-in gate for this pipeline
+- `audiobook_pipeline_status` (String, nullable)
 Values: `None` (idle), `ingesting`, `roster_gen`, `diarizing`, `audio_gen`, `assembling`, `complete`, `error`, `paused`
 
 ---
@@ -271,6 +274,9 @@ All paths stored in the database as relative to `LIBRARY_PATH.parent`, matching 
 - `httpx>=0.27` — HTTP client for LLM and OmniVoice calls (moved from dev)
 - `pydub>=0.25` — MP3 concatenation
 - `mutagen>=1.47` — MP3 duration extraction
+
+**`Dockerfile.base`**:
+- `ffmpeg` — required by `pydub` for MP3 decode/export
 
 **`Dockerfile`** — after `uv pip install`:
 ```dockerfile

--- a/docs/AUDIOBOOK_PIPELINE.md
+++ b/docs/AUDIOBOOK_PIPELINE.md
@@ -1,0 +1,278 @@
+# EPUB-to-Audiobook Pipeline
+
+## Overview
+
+This pipeline converts any stored EPUB into an EPUB 3 Media Overlay audiobook. The system is a **sentence-level state machine**: each sentence in the book is independently tracked through diarization → TTS → assembly, enabling surgical regeneration of specific audio snippets without full rebuilds.
+
+The five pipeline phases are:
+1. **Ingestion** — parse EPUB, inject sentence `<span>` IDs, seed the database
+2. **Roster Generation** — LLM extracts named characters and assigns OmniVoice voice profiles
+3. **Diarization** — LLM assigns a speaker and non-verbal tags to every sentence
+4. **Audio Generation** — OmniVoice TTS produces an MP3 snippet per sentence
+5. **Assembly** — MP3 snippets are concatenated per chapter; SMIL timing files and the final EPUB 3 Media Overlay package are generated
+
+---
+
+## Architecture Flow
+
+```
+User: "Start Pipeline"
+        │
+        ▼
+POST /api/books/{id}/audiobook/start
+        │  sets books.audiobook_pipeline_status = "ingesting"
+        ▼
+AudiobookQueue.enqueue(book_id)
+        │
+        ▼
+┌──────────────────────────────────────────────────────────┐
+│  AudiobookQueue worker (_run loop)                        │
+│                                                          │
+│  Phase 1 – Ingestion (status="ingesting")                │
+│    audiobook_ingestion.ingest_epub(book_id)              │
+│    • parse EPUB via ebooklib                             │
+│    • tokenize with spaCy en_core_web_sm                  │
+│    • inject <span id="ch{N}_s{M}"> around each sentence  │
+│    • write modified EPUB to library/audiobooks/{id}/      │
+│    • INSERT audiobook_chapters + audiobook_sentences     │
+│    • set status = "roster_gen"                           │
+│                                                          │
+│  Phase 2 – Roster Gen (status="roster_gen")              │
+│    audiobook_llm.generate_character_roster(book_id)      │
+│    • chunk chapter text → LLM (provider from settings)   │
+│    • parse characters + voice params                     │
+│    • INSERT audiobook_characters (incl. Narrator)        │
+│    • set status = "diarizing"                            │
+│                                                          │
+│  Phase 3 – Diarization (status="diarizing")              │
+│    audiobook_llm.diarize_sentences(book_id)              │
+│    • batch 50 sentences + 5-sentence context window      │
+│    • LLM assigns character_id + tagged_text              │
+│    • UPDATE sentence status → "ready_for_audio"          │
+│    • set status = "audio_gen" when all done              │
+│                                                          │
+│  Phase 4 – TTS (status="audio_gen")                      │
+│    audiobook_tts.generate_audio_for_book(book_id)        │
+│    • for each "ready_for_audio" sentence:                │
+│      POST omnivoice_endpoint {voice_prompt, tagged_text} │
+│      save mp3 to library/audiobooks/{id}/snippets/       │
+│      UPDATE sentence: audio_file_path, duration_ms,     │
+│                        status="audio_generated"          │
+│    • when chapter complete → chapter.needs_reassembly=T  │
+│    • set status = "assembling" when all done             │
+│                                                          │
+│  Phase 5 – Assembly (status="assembling")                │
+│    audiobook_assembly.assemble_book(book_id)             │
+│    • for each chapter where needs_reassembly=True:       │
+│      concat snippets → ch{N}.mp3 (pydub)                │
+│      generate .smil from html_element_id + timestamps   │
+│      chapter.needs_reassembly = False                    │
+│    • patch content.opf media-overlay attributes          │
+│    • repackage modified EPUB                             │
+│    • set status = "complete"                             │
+└──────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Surgical Rebuild Logic
+
+Changes propagate via cascades without requiring full rebuilds.
+
+**Character voice profile updated:**
+```
+PUT /api/audiobook/characters/{id}
+  → UPDATE sentences SET status="ready_for_audio", audio_file_path=NULL
+      WHERE character_id = {id}
+  → UPDATE chapters SET needs_reassembly=TRUE
+      WHERE id IN (SELECT chapter_id FROM audiobook_sentences WHERE character_id = {id})
+  → Re-enqueue book starting at "audio_gen" phase
+```
+
+**Sentence speaker or tags changed:**
+```
+PUT /api/audiobook/sentences/{id}
+  → UPDATE sentence: character_id, tagged_text, status="ready_for_audio", audio_file_path=NULL
+  → UPDATE chapter SET needs_reassembly=TRUE WHERE id = sentence.chapter_id
+  → Re-enqueue book starting at "audio_gen" phase
+```
+
+---
+
+## Database Schema
+
+### New tables (migration 0018)
+
+**`audiobook_settings`** — global LLM and TTS configuration
+| Column | Type | Notes |
+|---|---|---|
+| id | Integer PK | |
+| llm_provider | String | `"openai"`, `"anthropic"`, `"custom"` |
+| llm_api_key | String | Stored plaintext; masked on GET |
+| llm_base_url | String | Override for custom/local LLMs |
+| llm_model | String | e.g. `"gpt-4o"`, `"claude-opus-4-7"` |
+| omnivoice_endpoint | String | Base URL of OmniVoice worker |
+| roster_prompt_template | Text | Override default roster extraction prompt |
+| diarization_prompt_template | Text | Override default diarization prompt |
+
+**`audiobook_chapters`**
+| Column | Type | Notes |
+|---|---|---|
+| id | Integer PK | |
+| book_id | FK → books CASCADE | |
+| chapter_number | Integer | Spine order |
+| smil_file_path | String | Relative path to generated `.smil` |
+| audio_file_path | String | Relative path to concatenated chapter MP3 |
+| needs_reassembly | Boolean | Worker polls for `True` |
+
+**`audiobook_characters`**
+| Column | Type | Notes |
+|---|---|---|
+| id | Integer PK | |
+| book_id | FK → books CASCADE | |
+| name | String | |
+| description | Text | LLM-generated summary |
+| voice_design_prompt | String | OmniVoice params e.g. `[gender-male][pitch-low]` |
+| is_narrator | Boolean | |
+
+**`audiobook_sentences`** — the state engine
+| Column | Type | Notes |
+|---|---|---|
+| id | Integer PK | |
+| chapter_id | FK → audiobook_chapters CASCADE | |
+| character_id | FK → audiobook_characters SET NULL | Nullable |
+| html_element_id | String | Matches injected span ID e.g. `ch1_s42` |
+| sequence_order | Integer | Absolute order within chapter |
+| original_text | Text | Pure extracted text |
+| tagged_text | Text | Text with non-verbal tags e.g. `[laughter]` |
+| audio_file_path | String | Path to snippet MP3 |
+| audio_duration_ms | Integer | Used for SMIL timestamp calculation |
+| status | String | `pending_diarization` → `ready_for_audio` → `audio_generated` / `error` |
+
+**New column on `books`**: `audiobook_pipeline_status` (String, nullable)
+Values: `None` (idle), `ingesting`, `roster_gen`, `diarizing`, `audio_gen`, `assembling`, `complete`, `error`, `paused`
+
+---
+
+## OmniVoice TTS Integration
+
+OmniVoice is a self-hosted TTS worker. The endpoint URL is configured in `audiobook_settings`.
+
+### HTTP Contract
+```
+POST {omnivoice_endpoint}/generate
+Content-Type: application/json
+Accept: audio/mpeg
+
+{
+  "voice": "[gender-female][pitch-high][speed-normal]",
+  "text": "She laughed. [laughter] \"I can't believe it,\" she said."
+}
+
+Response: 200 OK
+Content-Type: audio/mpeg
+Body: raw MP3 bytes
+```
+
+### Voice Design Prompt Schema
+The LLM roster prompt instructs the model to produce voice design strings using these parameters:
+
+```
+[gender-{male|female|neutral}]
+[pitch-{low|medium|high}]
+[speed-{slow|normal|fast}]
+[accent-{british|american|australian|...}]   # optional
+[age-{young|middle|old}]                     # optional
+```
+
+Examples:
+- Narrator: `[gender-male][pitch-low][speed-normal][age-middle]`
+- Child character: `[gender-female][pitch-high][speed-fast][age-young]`
+
+Users can manually edit these values in the Character Roster UI.
+
+---
+
+## File Storage Layout
+
+```
+library/
+└── audiobooks/
+    └── {book_id}/
+        ├── working.epub          # span-injected working copy of the EPUB
+        ├── snippets/
+        │   └── {sentence_id}.mp3 # per-sentence TTS output
+        ├── ch1.mp3               # assembled chapter audio
+        ├── ch1.smil              # EPUB 3 Media Overlay timing file
+        ├── ch2.mp3
+        ├── ch2.smil
+        └── audiobook.epub        # final repackaged EPUB 3 MO
+```
+
+All paths stored in the database as relative to `LIBRARY_PATH.parent`, matching the existing pattern for `immutable_path` and `current_path`.
+
+---
+
+## API Endpoints
+
+| Method | Path | Description |
+|---|---|---|
+| POST | `/api/books/{id}/audiobook/start` | Start or resume pipeline |
+| POST | `/api/books/{id}/audiobook/pause` | Pause workers (set status=paused) |
+| POST | `/api/books/{id}/audiobook/rebuild` | Force full rebuild |
+| GET | `/api/books/{id}/audiobook/status` | Pipeline status + sentence counts by status |
+| GET | `/api/books/{id}/audiobook/characters` | List characters |
+| PUT | `/api/audiobook/characters/{char_id}` | Update voice profile (triggers cascade) |
+| GET | `/api/books/{id}/audiobook/sentences` | Paginated sentence list (`?page=&limit=&chapter_id=`) |
+| PUT | `/api/audiobook/sentences/{id}` | Update speaker/tags (triggers cascade) |
+| GET | `/api/audiobook/sentences/{id}/audio` | Stream sentence snippet MP3 |
+| GET | `/api/books/{id}/audiobook/chapters` | Chapter list with assembly status |
+| GET | `/api/books/{id}/audiobook/chapters/{cid}/audio` | Stream chapter MP3 |
+| GET | `/api/audiobook/settings` | Get LLM/TTS config (API key masked) |
+| PUT | `/api/audiobook/settings` | Upsert LLM/TTS config |
+
+---
+
+## Backend File Map
+
+| File | Purpose |
+|---|---|
+| `backend/app/models.py` | +4 new models, +1 Book column |
+| `backend/alembic/versions/0018_audiobook_pipeline.py` | Schema migration |
+| `backend/app/crud/audiobook.py` | DB queries for all new tables |
+| `backend/app/services/audiobook_ingestion.py` | Phase 1: EPUB parse + span injection |
+| `backend/app/services/audiobook_llm.py` | Phases 2 & 3: character roster + diarization |
+| `backend/app/services/audiobook_tts.py` | Phase 4: OmniVoice TTS per sentence |
+| `backend/app/services/audiobook_assembly.py` | Phase 5: MP3 concat + SMIL + EPUB repackage |
+| `backend/app/services/audiobook_queue.py` | Async worker queue (mirrors `web_import_queue.py`) |
+| `backend/app/routers/audiobook.py` | All API endpoints |
+| `backend/app/main.py` | Wire queue lifecycle + router |
+
+## Frontend File Map
+
+| File | Purpose |
+|---|---|
+| `frontend/src/api/audiobook.js` | HTTP client helpers |
+| `frontend/src/lib/navigation.js` | +Audio Settings tab |
+| `frontend/src/components/AudiobookSettings.jsx` | Global LLM/TTS config page |
+| `frontend/src/components/AudiobookPipeline.jsx` | Pipeline tab container (progress + sub-tabs) |
+| `frontend/src/components/audiobook/CharacterRoster.jsx` | Character card grid with voice editing |
+| `frontend/src/components/audiobook/ScriptEditor.jsx` | Paginated sentence table with inline editing |
+| `frontend/src/components/audiobook/ChapterAssembly.jsx` | Chapter assembly status list |
+| `frontend/src/App.jsx` | +Audio Settings tab routing |
+| `frontend/src/components/BookSettings.jsx` | +Audiobook Pipeline tab |
+
+---
+
+## Dependencies Added
+
+**`pyproject.toml`** (core):
+- `spacy>=3.7,<4` — sentence tokenization
+- `httpx>=0.27` — HTTP client for LLM and OmniVoice calls (moved from dev)
+- `pydub>=0.25` — MP3 concatenation
+- `mutagen>=1.47` — MP3 duration extraction
+
+**`Dockerfile`** — after `uv pip install`:
+```dockerfile
+RUN python -m spacy download en_core_web_sm
+```

--- a/docs/AUDIOBOOK_PIPELINE.md
+++ b/docs/AUDIOBOOK_PIPELINE.md
@@ -64,7 +64,7 @@ AudiobookQueue.enqueue(book_id)
 │  Phase 5 – Assembly (status="assembling")                │
 │    audiobook_assembly.assemble_book(book_id)             │
 │    • for each chapter where needs_reassembly=True:       │
-│      concat snippets → ch{N}.mp3 (pydub)                │
+│      concat snippets → ch{N}.mp3 (ffmpeg)               │
 │      generate .smil from html_element_id + timestamps   │
 │      chapter.needs_reassembly = False                    │
 │    • patch content.opf media-overlay attributes          │
@@ -107,7 +107,7 @@ PUT /api/audiobook/sentences/{id}
 | Column | Type | Notes |
 |---|---|---|
 | id | Integer PK | |
-| llm_provider | String | `"openai"`, `"anthropic"`, `"custom"` |
+| llm_provider | String | `"stub"`, `"openai"`, `"anthropic"`, `"custom"` |
 | llm_api_key | String | Stored plaintext; masked on GET |
 | llm_base_url | String | Override for custom/local LLMs |
 | llm_model | String | e.g. `"gpt-4o"`, `"claude-opus-4-7"` |
@@ -194,6 +194,17 @@ Examples:
 
 Users can manually edit these values in the Character Roster UI.
 
+## Deterministic Local Harness
+
+The pipeline works without API keys or network services. When no settings row exists—or when the LLM provider is
+`stub`—it creates a single Narrator, assigns every sentence to that narrator, and generates timed silent placeholder
+MP3s through the installed `ffmpeg` binary. This exercises ingestion, durable state transitions, surgical rebuilds,
+chapter assembly, SMIL generation, and final EPUB packaging end to end.
+
+Choose **Deterministic local harness** in Audio Settings to make this mode explicit. To switch to real generation,
+choose an LLM provider and configure an OmniVoice-compatible endpoint. The harness is intentionally deterministic;
+it is a validation and UI-development path, not synthetic speech.
+
 ---
 
 ## File Storage Layout
@@ -231,6 +242,7 @@ All paths stored in the database as relative to `LIBRARY_PATH.parent`, matching 
 | GET | `/api/audiobook/sentences/{id}/audio` | Stream sentence snippet MP3 |
 | GET | `/api/books/{id}/audiobook/chapters` | Chapter list with assembly status |
 | GET | `/api/books/{id}/audiobook/chapters/{cid}/audio` | Stream chapter MP3 |
+| GET | `/api/books/{id}/audiobook/download` | Download the completed EPUB 3 Media Overlay audiobook |
 | GET | `/api/audiobook/settings` | Get LLM/TTS config (API key masked) |
 | PUT | `/api/audiobook/settings` | Upsert LLM/TTS config |
 
@@ -271,14 +283,13 @@ All paths stored in the database as relative to `LIBRARY_PATH.parent`, matching 
 
 **`pyproject.toml`** (core):
 - `spacy>=3.7,<4` — sentence tokenization
-- `httpx>=0.27` — HTTP client for LLM and OmniVoice calls (moved from dev)
-- `pydub>=0.25` — MP3 concatenation
+- `httpx2==2.5.0` — HTTP client for LLM and OmniVoice calls (exports the `httpx` module)
 - `mutagen>=1.47` — MP3 duration extraction
 
-**`Dockerfile.base`**:
-- `ffmpeg` — required by `pydub` for MP3 decode/export
+**`Dockerfile`**:
+- `ffmpeg` — placeholder MP3 generation and chapter concatenation
 
-**`Dockerfile`** — after `uv pip install`:
+The application image also downloads the optional higher-quality spaCy English model after installing Python dependencies:
 ```dockerfile
 RUN python -m spacy download en_core_web_sm
 ```

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import AdminLogin from "./components/AdminLogin.jsx";
 import BookList from "./components/BookList";
 import BookSettings from "./components/BookSettings";
 import AddBook from "./components/AddBook.jsx";
+import AudiobookSettings from "./components/AudiobookSettings.jsx";
 import CleaningConfigs from "./components/CleaningConfigs.jsx";
 import SchedulerStatus from "./components/SchedulerStatus.jsx";
 import Logs from "./components/Logs.jsx";
@@ -227,6 +228,8 @@ function App() {
         return <Logs />;
       case "utilities":
         return <Utilities />;
+      case "audio-settings":
+        return <AudiobookSettings />;
       default:
         return (
           <>

--- a/frontend/src/api/audiobook.js
+++ b/frontend/src/api/audiobook.js
@@ -67,6 +67,10 @@ export function getChapterAudioUrl(bookId, chapterId) {
   return `/api/books/${bookId}/audiobook/chapters/${chapterId}/audio`;
 }
 
+export function getAudiobookDownloadUrl(bookId) {
+  return `/api/books/${bookId}/audiobook/download`;
+}
+
 // Settings
 export function getAudiobookSettings() {
   return getJson("/api/audiobook/settings", "Failed to fetch audiobook settings");

--- a/frontend/src/api/audiobook.js
+++ b/frontend/src/api/audiobook.js
@@ -1,0 +1,81 @@
+import { getJson, sendJson, sendWithoutBody } from "./client";
+
+// Pipeline control
+export function getAudiobookStatus(bookId) {
+  return getJson(`/api/books/${bookId}/audiobook/status`, "Failed to fetch audiobook status");
+}
+
+export function startPipeline(bookId) {
+  return sendWithoutBody(`/api/books/${bookId}/audiobook/start`, {
+    method: "POST",
+    fallbackMessage: "Failed to start pipeline",
+  });
+}
+
+export function pausePipeline(bookId) {
+  return sendWithoutBody(`/api/books/${bookId}/audiobook/pause`, {
+    method: "POST",
+    fallbackMessage: "Failed to pause pipeline",
+  });
+}
+
+export function rebuildPipeline(bookId) {
+  return sendWithoutBody(`/api/books/${bookId}/audiobook/rebuild`, {
+    method: "POST",
+    fallbackMessage: "Failed to rebuild pipeline",
+  });
+}
+
+// Characters
+export function getCharacters(bookId) {
+  return getJson(`/api/books/${bookId}/audiobook/characters`, "Failed to fetch characters");
+}
+
+export function updateCharacter(charId, data) {
+  return sendJson(`/api/audiobook/characters/${charId}`, {
+    method: "PUT",
+    body: data,
+    fallbackMessage: "Failed to update character",
+  });
+}
+
+// Sentences
+export function getSentences(bookId, { page = 1, limit = 50, chapterId } = {}) {
+  const params = new URLSearchParams({ page, limit });
+  if (chapterId != null) params.set("chapter_id", chapterId);
+  return getJson(`/api/books/${bookId}/audiobook/sentences?${params}`, "Failed to fetch sentences");
+}
+
+export function updateSentence(sentenceId, data) {
+  return sendJson(`/api/audiobook/sentences/${sentenceId}`, {
+    method: "PUT",
+    body: data,
+    fallbackMessage: "Failed to update sentence",
+  });
+}
+
+export function getSentenceAudioUrl(sentenceId) {
+  return `/api/audiobook/sentences/${sentenceId}/audio`;
+}
+
+// Chapters
+export function getAudiobookChapters(bookId) {
+  return getJson(`/api/books/${bookId}/audiobook/chapters`, "Failed to fetch chapters");
+}
+
+export function getChapterAudioUrl(bookId, chapterId) {
+  return `/api/books/${bookId}/audiobook/chapters/${chapterId}/audio`;
+}
+
+// Settings
+export function getAudiobookSettings() {
+  return getJson("/api/audiobook/settings", "Failed to fetch audiobook settings");
+}
+
+export function updateAudiobookSettings(data) {
+  return sendJson("/api/audiobook/settings", {
+    method: "PUT",
+    body: data,
+    fallbackMessage: "Failed to save audiobook settings",
+  });
+}

--- a/frontend/src/components/AudiobookPipeline.jsx
+++ b/frontend/src/components/AudiobookPipeline.jsx
@@ -1,0 +1,200 @@
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  getAudiobookStatus,
+  getCharacters,
+  getAudiobookChapters,
+  startPipeline,
+  pausePipeline,
+  rebuildPipeline,
+} from "../api/audiobook";
+import CharacterRoster from "./audiobook/CharacterRoster";
+import ScriptEditor from "./audiobook/ScriptEditor";
+import ChapterAssembly from "./audiobook/ChapterAssembly";
+
+const PIPELINE_STEPS = [
+  { status: "ingesting", label: "Ingesting" },
+  { status: "roster_gen", label: "Roster" },
+  { status: "diarizing", label: "Diarizing" },
+  { status: "audio_gen", label: "TTS" },
+  { status: "assembling", label: "Assembly" },
+  { status: "complete", label: "Complete" },
+];
+
+const ACTIVE_STATUSES = new Set(["ingesting", "roster_gen", "diarizing", "audio_gen", "assembling"]);
+
+function PipelineProgress({ status }) {
+  const currentIdx = PIPELINE_STEPS.findIndex((s) => s.status === status);
+  return (
+    <div className="pipeline-progress">
+      {PIPELINE_STEPS.map((step, idx) => {
+        let cls = "pipeline-step";
+        if (idx < currentIdx) cls += " pipeline-step--done";
+        else if (idx === currentIdx) cls += " pipeline-step--active";
+        return (
+          <div key={step.status} className={cls}>
+            <div className="pipeline-step-dot" />
+            <span>{step.label}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+const SUB_TABS = ["Characters", "Script Editor", "Chapter Assembly"];
+
+function AudiobookPipeline({ book }) {
+  const bookId = book.id;
+  const queryClient = useQueryClient();
+  const [subTab, setSubTab] = useState("Characters");
+  const [confirmRebuild, setConfirmRebuild] = useState(false);
+
+  const isActive = (status) => ACTIVE_STATUSES.has(status);
+
+  const { data: statusData } = useQuery({
+    queryKey: ["audiobook-status", bookId],
+    queryFn: () => getAudiobookStatus(bookId),
+    refetchInterval: ({ state }) => {
+      const s = state.data?.pipeline_status;
+      return s && isActive(s) ? 3000 : false;
+    },
+  });
+
+  const { data: characters = [] } = useQuery({
+    queryKey: ["audiobook-characters", bookId],
+    queryFn: () => getCharacters(bookId),
+  });
+
+  const { data: chapters = [] } = useQuery({
+    queryKey: ["audiobook-chapters", bookId],
+    queryFn: () => getAudiobookChapters(bookId),
+    refetchInterval: ({ state: queryState }) => {
+      const s = statusData?.pipeline_status;
+      return s && isActive(s) ? 5000 : false;
+    },
+  });
+
+  const invalidateAll = () => {
+    queryClient.invalidateQueries({ queryKey: ["audiobook-status", bookId] });
+    queryClient.invalidateQueries({ queryKey: ["audiobook-characters", bookId] });
+    queryClient.invalidateQueries({ queryKey: ["audiobook-chapters", bookId] });
+  };
+
+  const startMutation = useMutation({
+    mutationFn: () => startPipeline(bookId),
+    onSuccess: invalidateAll,
+  });
+
+  const pauseMutation = useMutation({
+    mutationFn: () => pausePipeline(bookId),
+    onSuccess: invalidateAll,
+  });
+
+  const rebuildMutation = useMutation({
+    mutationFn: () => rebuildPipeline(bookId),
+    onSuccess: () => {
+      setConfirmRebuild(false);
+      invalidateAll();
+    },
+  });
+
+  const pipelineStatus = statusData?.pipeline_status ?? null;
+  const sentenceCounts = statusData?.sentence_counts ?? {};
+  const totalSentences = Object.values(sentenceCounts).reduce((a, b) => a + b, 0);
+  const doneCount = sentenceCounts["audio_generated"] ?? 0;
+
+  return (
+    <div className="audiobook-pipeline">
+      <div className="pipeline-header">
+        <PipelineProgress status={pipelineStatus} />
+
+        <div className="pipeline-meta">
+          {totalSentences > 0 && (
+            <span className="pipeline-sentence-count">
+              {doneCount} / {totalSentences} sentences with audio
+            </span>
+          )}
+          {pipelineStatus === "error" && (
+            <span className="badge badge--error">Pipeline error — check logs</span>
+          )}
+          {pipelineStatus === "paused" && (
+            <span className="badge badge--warning">Paused</span>
+          )}
+        </div>
+
+        <div className="pipeline-controls">
+          {pipelineStatus !== "complete" && !isActive(pipelineStatus) && (
+            <button
+              onClick={() => startMutation.mutate()}
+              disabled={startMutation.isPending}
+              className="btn-primary"
+            >
+              {pipelineStatus ? "Resume Pipeline" : "Start Pipeline"}
+            </button>
+          )}
+          {isActive(pipelineStatus) && (
+            <button
+              onClick={() => pauseMutation.mutate()}
+              disabled={pauseMutation.isPending}
+            >
+              Pause Workers
+            </button>
+          )}
+          {!confirmRebuild ? (
+            <button className="btn-danger" onClick={() => setConfirmRebuild(true)}>
+              Force Full Rebuild
+            </button>
+          ) : (
+            <span className="confirm-inline">
+              Destroy all audio and re-run from scratch?{" "}
+              <button
+                className="btn-danger"
+                onClick={() => rebuildMutation.mutate()}
+                disabled={rebuildMutation.isPending}
+              >
+                {rebuildMutation.isPending ? "Rebuilding…" : "Yes, rebuild"}
+              </button>{" "}
+              <button className="btn-text" onClick={() => setConfirmRebuild(false)}>
+                Cancel
+              </button>
+            </span>
+          )}
+        </div>
+
+        {(startMutation.isError || pauseMutation.isError || rebuildMutation.isError) && (
+          <p className="error">
+            {(startMutation.error || pauseMutation.error || rebuildMutation.error)?.message ||
+              "Action failed"}
+          </p>
+        )}
+      </div>
+
+      <nav className="sub-tabs">
+        {SUB_TABS.map((t) => (
+          <button
+            key={t}
+            className={`sub-tab${subTab === t ? " sub-tab--active" : ""}`}
+            onClick={() => setSubTab(t)}
+          >
+            {t}
+          </button>
+        ))}
+      </nav>
+
+      <div className="sub-tab-content">
+        {subTab === "Characters" && (
+          <CharacterRoster characters={characters} bookId={bookId} />
+        )}
+        {subTab === "Script Editor" && (
+          <ScriptEditor bookId={bookId} characters={characters} />
+        )}
+        {subTab === "Chapter Assembly" && (
+          <ChapterAssembly chapters={chapters} bookId={bookId} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default AudiobookPipeline;

--- a/frontend/src/components/AudiobookPipeline.jsx
+++ b/frontend/src/components/AudiobookPipeline.jsx
@@ -69,7 +69,7 @@ function AudiobookPipeline({ book }) {
   const { data: chapters = [] } = useQuery({
     queryKey: ["audiobook-chapters", bookId],
     queryFn: () => getAudiobookChapters(bookId),
-    refetchInterval: ({ state: queryState }) => {
+    refetchInterval: () => {
       const s = statusData?.pipeline_status;
       return s && isActive(s) ? 5000 : false;
     },

--- a/frontend/src/components/AudiobookPipeline.jsx
+++ b/frontend/src/components/AudiobookPipeline.jsx
@@ -7,6 +7,7 @@ import {
   startPipeline,
   pausePipeline,
   rebuildPipeline,
+  getAudiobookDownloadUrl,
 } from "../api/audiobook";
 import CharacterRoster from "./audiobook/CharacterRoster";
 import ScriptEditor from "./audiobook/ScriptEditor";
@@ -124,6 +125,11 @@ function AudiobookPipeline({ book }) {
         </div>
 
         <div className="pipeline-controls">
+          {pipelineStatus === "complete" && (
+            <a className="btn btn-primary" href={getAudiobookDownloadUrl(bookId)} download>
+              Download Audiobook EPUB
+            </a>
+          )}
           {pipelineStatus !== "complete" && !isActive(pipelineStatus) && (
             <button
               onClick={() => startMutation.mutate()}

--- a/frontend/src/components/AudiobookPipeline.jsx
+++ b/frontend/src/components/AudiobookPipeline.jsx
@@ -147,25 +147,26 @@ function AudiobookPipeline({ book }) {
               Pause Workers
             </button>
           )}
-          {!confirmRebuild ? (
-            <button className="btn-danger" onClick={() => setConfirmRebuild(true)}>
-              Force Full Rebuild
-            </button>
-          ) : (
-            <span className="confirm-inline">
-              Destroy all audio and re-run from scratch?{" "}
-              <button
-                className="btn-danger"
-                onClick={() => rebuildMutation.mutate()}
-                disabled={rebuildMutation.isPending}
-              >
-                {rebuildMutation.isPending ? "Rebuilding…" : "Yes, rebuild"}
-              </button>{" "}
-              <button className="btn-text" onClick={() => setConfirmRebuild(false)}>
-                Cancel
+          {!isActive(pipelineStatus) &&
+            (!confirmRebuild ? (
+              <button className="btn-danger" onClick={() => setConfirmRebuild(true)}>
+                Force Full Rebuild
               </button>
-            </span>
-          )}
+            ) : (
+              <span className="confirm-inline">
+                Destroy all audio and re-run from scratch?{" "}
+                <button
+                  className="btn-danger"
+                  onClick={() => rebuildMutation.mutate()}
+                  disabled={rebuildMutation.isPending}
+                >
+                  {rebuildMutation.isPending ? "Rebuilding…" : "Yes, rebuild"}
+                </button>{" "}
+                <button className="btn-text" onClick={() => setConfirmRebuild(false)}>
+                  Cancel
+                </button>
+              </span>
+            ))}
         </div>
 
         {(startMutation.isError || pauseMutation.isError || rebuildMutation.isError) && (

--- a/frontend/src/components/AudiobookSettings.jsx
+++ b/frontend/src/components/AudiobookSettings.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { getAudiobookSettings, updateAudiobookSettings } from "../api/audiobook";
 
@@ -22,15 +22,17 @@ function AudiobookSettings() {
   const [diarizationPrompt, setDiarizationPrompt] = useState("");
   const [initialised, setInitialised] = useState(false);
 
-  if (settings && !initialised) {
-    setLlmProvider(settings.llm_provider || "openai");
-    setLlmBaseUrl(settings.llm_base_url || "");
-    setLlmModel(settings.llm_model || "");
-    setOmnivoiceEndpoint(settings.omnivoice_endpoint || "");
-    setRosterPrompt(settings.roster_prompt_template || "");
-    setDiarizationPrompt(settings.diarization_prompt_template || "");
-    setInitialised(true);
-  }
+  useEffect(() => {
+    if (settings && !initialised) {
+      setLlmProvider(settings.llm_provider || "stub");
+      setLlmBaseUrl(settings.llm_base_url || "");
+      setLlmModel(settings.llm_model || "");
+      setOmnivoiceEndpoint(settings.omnivoice_endpoint || "");
+      setRosterPrompt(settings.roster_prompt_template || "");
+      setDiarizationPrompt(settings.diarization_prompt_template || "");
+      setInitialised(true);
+    }
+  }, [initialised, settings]);
 
   const saveMutation = useMutation({
     mutationFn: (data) => updateAudiobookSettings(data),
@@ -69,6 +71,7 @@ function AudiobookSettings() {
               <option value="openai">OpenAI</option>
               <option value="anthropic">Anthropic</option>
               <option value="custom">Custom / Local</option>
+              <option value="stub">Deterministic local harness</option>
             </select>
           </label>
           <label>
@@ -115,6 +118,10 @@ function AudiobookSettings() {
             OmniVoice receives <code>POST /generate</code> with{" "}
             <code>{"{ \"voice\": \"[gender-male][pitch-low]\", \"text\": \"...\" }"}</code> and
             returns raw MP3 bytes.
+          </p>
+          <p className="settings-hint">
+            For offline validation, choose the deterministic local harness and leave this blank.
+            It generates silent placeholder MP3s with realistic timing.
           </p>
         </section>
 

--- a/frontend/src/components/AudiobookSettings.jsx
+++ b/frontend/src/components/AudiobookSettings.jsx
@@ -1,0 +1,156 @@
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { getAudiobookSettings, updateAudiobookSettings } from "../api/audiobook";
+
+const DEFAULT_ROSTER_PROMPT_HINT = "Leave blank to use the built-in roster extraction prompt.";
+const DEFAULT_DIARIZATION_PROMPT_HINT = "Leave blank to use the built-in diarization prompt.";
+
+function AudiobookSettings() {
+  const queryClient = useQueryClient();
+
+  const { data: settings, isLoading } = useQuery({
+    queryKey: ["audiobook-settings"],
+    queryFn: getAudiobookSettings,
+  });
+
+  const [llmProvider, setLlmProvider] = useState("");
+  const [llmApiKey, setLlmApiKey] = useState("");
+  const [llmBaseUrl, setLlmBaseUrl] = useState("");
+  const [llmModel, setLlmModel] = useState("");
+  const [omnivoiceEndpoint, setOmnivoiceEndpoint] = useState("");
+  const [rosterPrompt, setRosterPrompt] = useState("");
+  const [diarizationPrompt, setDiarizationPrompt] = useState("");
+  const [initialised, setInitialised] = useState(false);
+
+  if (settings && !initialised) {
+    setLlmProvider(settings.llm_provider || "openai");
+    setLlmBaseUrl(settings.llm_base_url || "");
+    setLlmModel(settings.llm_model || "");
+    setOmnivoiceEndpoint(settings.omnivoice_endpoint || "");
+    setRosterPrompt(settings.roster_prompt_template || "");
+    setDiarizationPrompt(settings.diarization_prompt_template || "");
+    setInitialised(true);
+  }
+
+  const saveMutation = useMutation({
+    mutationFn: (data) => updateAudiobookSettings(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["audiobook-settings"] });
+    },
+  });
+
+  const handleSave = (e) => {
+    e.preventDefault();
+    const payload = {
+      llm_provider: llmProvider || null,
+      llm_base_url: llmBaseUrl || null,
+      llm_model: llmModel || null,
+      omnivoice_endpoint: omnivoiceEndpoint || null,
+      roster_prompt_template: rosterPrompt || null,
+      diarization_prompt_template: diarizationPrompt || null,
+    };
+    if (llmApiKey) {
+      payload.llm_api_key = llmApiKey;
+    }
+    saveMutation.mutate(payload);
+  };
+
+  if (isLoading) return <p>Loading settings…</p>;
+
+  return (
+    <div className="settings-page">
+      <h2>Audio &amp; AI Configuration</h2>
+      <form onSubmit={handleSave}>
+        <section className="settings-section">
+          <h3>LLM Provider</h3>
+          <label>
+            Provider
+            <select value={llmProvider} onChange={(e) => setLlmProvider(e.target.value)}>
+              <option value="openai">OpenAI</option>
+              <option value="anthropic">Anthropic</option>
+              <option value="custom">Custom / Local</option>
+            </select>
+          </label>
+          <label>
+            API Key
+            <input
+              type="password"
+              value={llmApiKey}
+              onChange={(e) => setLlmApiKey(e.target.value)}
+              placeholder={settings?.llm_api_key_set ? "••••••••  (set — enter new key to change)" : "Enter API key"}
+            />
+          </label>
+          <label>
+            Base URL
+            <input
+              type="url"
+              value={llmBaseUrl}
+              onChange={(e) => setLlmBaseUrl(e.target.value)}
+              placeholder="https://api.openai.com  (leave blank for provider default)"
+            />
+          </label>
+          <label>
+            Model
+            <input
+              type="text"
+              value={llmModel}
+              onChange={(e) => setLlmModel(e.target.value)}
+              placeholder="e.g. gpt-4o or claude-opus-4-7"
+            />
+          </label>
+        </section>
+
+        <section className="settings-section">
+          <h3>OmniVoice TTS</h3>
+          <label>
+            Endpoint URL
+            <input
+              type="url"
+              value={omnivoiceEndpoint}
+              onChange={(e) => setOmnivoiceEndpoint(e.target.value)}
+              placeholder="http://your-omnivoice-server:port"
+            />
+          </label>
+          <p className="settings-hint">
+            OmniVoice receives <code>POST /generate</code> with{" "}
+            <code>{"{ \"voice\": \"[gender-male][pitch-low]\", \"text\": \"...\" }"}</code> and
+            returns raw MP3 bytes.
+          </p>
+        </section>
+
+        <section className="settings-section">
+          <h3>Prompt Templates</h3>
+          <label>
+            Roster Extraction Prompt
+            <textarea
+              rows={6}
+              value={rosterPrompt}
+              onChange={(e) => setRosterPrompt(e.target.value)}
+              placeholder={DEFAULT_ROSTER_PROMPT_HINT}
+            />
+          </label>
+          <label>
+            Diarization Prompt
+            <textarea
+              rows={6}
+              value={diarizationPrompt}
+              onChange={(e) => setDiarizationPrompt(e.target.value)}
+              placeholder={DEFAULT_DIARIZATION_PROMPT_HINT}
+            />
+          </label>
+        </section>
+
+        {saveMutation.isError && (
+          <p className="error">{saveMutation.error?.message || "Save failed"}</p>
+        )}
+        {saveMutation.isSuccess && <p className="success">Settings saved.</p>}
+
+        <button type="submit" disabled={saveMutation.isPending}>
+          {saveMutation.isPending ? "Saving…" : "Save Settings"}
+        </button>
+      </form>
+    </div>
+  );
+}
+
+export default AudiobookSettings;

--- a/frontend/src/components/BookSettings.jsx
+++ b/frontend/src/components/BookSettings.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import AudiobookPipeline from "./AudiobookPipeline";
 

--- a/frontend/src/components/BookSettings.jsx
+++ b/frontend/src/components/BookSettings.jsx
@@ -1,5 +1,6 @@
 import { useState, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import AudiobookPipeline from "./AudiobookPipeline";
 
 import {
   deleteBook,
@@ -135,6 +136,7 @@ function BookSettings({ book: initialBook, onBack }) {
     getUpdatedFields,
   } = useBookSettingsForm(initialBook);
   const [previewedChapter, setPreviewedChapter] = useState(null);
+  const [bookTab, setBookTab] = useState("details");
 
   const { data: chapters = [], isLoading: chaptersLoading } = useQuery({
     queryKey: ["chapters", book.id],
@@ -345,6 +347,25 @@ function BookSettings({ book: initialBook, onBack }) {
         <h2>{book.title}</h2>
       </div>
 
+      <nav className="book-settings-tabs">
+        <button
+          className={`book-settings-tab${bookTab === "details" ? " book-settings-tab--active" : ""}`}
+          onClick={() => setBookTab("details")}
+        >
+          Details
+        </button>
+        <button
+          className={`book-settings-tab${bookTab === "audiobook" ? " book-settings-tab--active" : ""}`}
+          onClick={() => setBookTab("audiobook")}
+        >
+          Audiobook Pipeline
+        </button>
+      </nav>
+
+      {bookTab === "audiobook" && <AudiobookPipeline book={book} />}
+
+      {bookTab === "details" && (
+      <>
       {isRefreshing && (
         <div className="hint" role="status" style={{ marginBottom: "0.75rem" }}>
           {book.refresh_status === "queued"
@@ -770,6 +791,8 @@ function BookSettings({ book: initialBook, onBack }) {
       )}
       {deleteMutation.isError && (
         <p className="error">Delete failed: {deleteMutation.error.message}</p>
+      )}
+      </>
       )}
     </div>
   );

--- a/frontend/src/components/BookSettings.jsx
+++ b/frontend/src/components/BookSettings.jsx
@@ -176,9 +176,19 @@ function BookSettings({ book: initialBook, onBack }) {
 
   const saveMutation = useMutation({
     mutationFn: (data) => updateBook(book.id, data),
-    onSuccess: () => {
+    onSuccess: (updatedBook) => {
+      queryClient.setQueryData(["book", book.id], updatedBook);
       queryClient.invalidateQueries({ queryKey: ["book-catalog"] });
       queryClient.invalidateQueries({ queryKey: ["series"] });
+    },
+  });
+
+  const enableAudiobookMutation = useMutation({
+    mutationFn: () => updateBook(book.id, { audiobook_enabled: true }),
+    onSuccess: (updatedBook) => {
+      queryClient.setQueryData(["book", book.id], updatedBook);
+      queryClient.invalidateQueries({ queryKey: ["book-catalog"] });
+      setBookTab("audiobook");
     },
   });
 
@@ -233,6 +243,12 @@ function BookSettings({ book: initialBook, onBack }) {
   });
 
   const [coverUrl, setCoverUrl] = useState("");
+
+  useEffect(() => {
+    if (!book.audiobook_enabled && bookTab === "audiobook") {
+      setBookTab("details");
+    }
+  }, [book.audiobook_enabled, bookTab]);
 
   // Cover files live at a deterministic URL (/api/covers/{book_id}), so the
   // browser happily caches them. Whenever any cover mutation succeeds we bump
@@ -323,6 +339,7 @@ function BookSettings({ book: initialBook, onBack }) {
     refreshMutation.isPending ||
     detachSourceMutation.isPending ||
     deleteMutation.isPending ||
+    enableAudiobookMutation.isPending ||
     isRefreshing;
   const canDetachWebMarker =
     book.source_type === "web" && book.immutable_path && book.current_path;
@@ -338,7 +355,8 @@ function BookSettings({ book: initialBook, onBack }) {
             processMutation.isPending ||
             refreshMutation.isPending ||
             detachSourceMutation.isPending ||
-            deleteMutation.isPending
+            deleteMutation.isPending ||
+            enableAudiobookMutation.isPending
           }
           style={{ flexShrink: 0 }}
         >
@@ -354,15 +372,19 @@ function BookSettings({ book: initialBook, onBack }) {
         >
           Details
         </button>
-        <button
-          className={`book-settings-tab${bookTab === "audiobook" ? " book-settings-tab--active" : ""}`}
-          onClick={() => setBookTab("audiobook")}
-        >
-          Audiobook Pipeline
-        </button>
+        {book.audiobook_enabled && (
+          <button
+            className={`book-settings-tab${bookTab === "audiobook" ? " book-settings-tab--active" : ""}`}
+            onClick={() => setBookTab("audiobook")}
+          >
+            Audiobook Pipeline
+          </button>
+        )}
       </nav>
 
-      {bookTab === "audiobook" && <AudiobookPipeline book={book} />}
+      {book.audiobook_enabled && bookTab === "audiobook" && (
+        <AudiobookPipeline book={book} />
+      )}
 
       {bookTab === "details" && (
       <>
@@ -539,6 +561,32 @@ function BookSettings({ book: initialBook, onBack }) {
           </div>
         </div>
       </section>
+
+      {!book.audiobook_enabled && (
+        <section className="settings-section">
+          <h3>Audiobook</h3>
+          <p className="hint">
+            Generate an EPUB 3 audiobook with synchronized sentence-level
+            narration. Enabling this creates processing records for this book;
+            it does not start generation until you ask it to.
+          </p>
+          <button
+            type="button"
+            onClick={() => enableAudiobookMutation.mutate()}
+            disabled={enableAudiobookMutation.isPending}
+          >
+            {enableAudiobookMutation.isPending
+              ? "Enabling…"
+              : "Enable Audiobook Pipeline"}
+          </button>
+          {enableAudiobookMutation.isError && (
+            <p className="error">
+              {enableAudiobookMutation.error?.message ||
+                "Failed to enable the audiobook pipeline"}
+            </p>
+          )}
+        </section>
+      )}
 
       <section className="settings-section">
         <h3>Notes</h3>

--- a/frontend/src/components/BookSettings.test.jsx
+++ b/frontend/src/components/BookSettings.test.jsx
@@ -513,4 +513,106 @@ describe("BookSettings", () => {
       });
     });
   });
+
+  it("keeps the audiobook pipeline hidden until the book is enabled", async () => {
+    const fetchMock = vi.fn((url, options) => {
+      if (
+        url === "/api/books/11/chapters" ||
+        url === "/api/books/11/matched-config" ||
+        url === "/api/series" ||
+        url === "/api/books/11/audiobook/characters" ||
+        url === "/api/books/11/audiobook/chapters"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([]),
+        });
+      }
+      if (url === "/api/books/11/audiobook/status") {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              pipeline_status: null,
+              sentence_counts: {},
+            }),
+        });
+      }
+      if (url === "/api/books/11" && options?.method === "PUT") {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              id: 11,
+              title: "Audio Candidate",
+              author: "Author",
+              series: null,
+              series_index: null,
+              source_type: "epub",
+              source_url: null,
+              immutable_path: "library/original.epub",
+              current_path: "library/current.epub",
+              removed_chapters: [],
+              content_selectors: [],
+              created_at: "2026-03-17T00:00:00Z",
+              content_updated_at: "2026-03-17T00:00:00Z",
+              content_version: 1,
+              audiobook_enabled: true,
+              audiobook_pipeline_status: null,
+            }),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([]),
+      });
+    });
+    globalThis.fetch = fetchMock;
+
+    renderWithClient(
+      <BookSettings
+        book={{
+          id: 11,
+          title: "Audio Candidate",
+          author: "Author",
+          series: null,
+          series_index: null,
+          source_type: "epub",
+          source_url: null,
+          immutable_path: "library/original.epub",
+          current_path: "library/current.epub",
+          removed_chapters: [],
+          content_selectors: [],
+          created_at: "2026-03-17T00:00:00Z",
+          content_updated_at: "2026-03-17T00:00:00Z",
+          content_version: 1,
+          audiobook_enabled: false,
+        }}
+        onBack={() => {}}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Audiobook Pipeline" }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Enable Audiobook Pipeline" }),
+    );
+
+    await waitFor(() => {
+      const enableCall = fetchMock.mock.calls.find(
+        ([url, options]) =>
+          url === "/api/books/11" && options?.method === "PUT",
+      );
+      expect(enableCall).toBeTruthy();
+      expect(JSON.parse(enableCall[1].body)).toEqual({
+        audiobook_enabled: true,
+      });
+    });
+
+    expect(
+      await screen.findByRole("button", { name: "Audiobook Pipeline" }),
+    ).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/audiobook/ChapterAssembly.jsx
+++ b/frontend/src/components/audiobook/ChapterAssembly.jsx
@@ -1,0 +1,65 @@
+import { getChapterAudioUrl } from "../../api/audiobook";
+
+function ChapterAssembly({ chapters, bookId }) {
+  if (!chapters || chapters.length === 0) {
+    return (
+      <p className="empty-state">
+        No chapters yet. Start the pipeline to begin processing.
+      </p>
+    );
+  }
+
+  return (
+    <div className="chapter-assembly">
+      <table className="chapter-table">
+        <thead>
+          <tr>
+            <th>Chapter</th>
+            <th>Assembly Status</th>
+            <th>Audio Preview</th>
+            <th>SMIL</th>
+          </tr>
+        </thead>
+        <tbody>
+          {chapters.map((chapter) => (
+            <tr key={chapter.id}>
+              <td>Chapter {chapter.chapter_number}</td>
+              <td>
+                {chapter.needs_reassembly ? (
+                  <span className="badge badge--warning">Rebuild Pending</span>
+                ) : chapter.audio_file_path ? (
+                  <span className="badge badge--success">Assembled</span>
+                ) : (
+                  <span className="badge badge--neutral">Not yet assembled</span>
+                )}
+              </td>
+              <td>
+                {chapter.audio_file_path && !chapter.needs_reassembly && (
+                  <audio
+                    controls
+                    src={getChapterAudioUrl(bookId, chapter.id)}
+                    preload="none"
+                    style={{ height: "28px" }}
+                  />
+                )}
+              </td>
+              <td>
+                {chapter.smil_file_path && !chapter.needs_reassembly && (
+                  <a
+                    href={`/library/audiobooks/${bookId}/${chapter.smil_file_path.split("/").pop()}`}
+                    download
+                    className="btn-text"
+                  >
+                    Download SMIL
+                  </a>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default ChapterAssembly;

--- a/frontend/src/components/audiobook/CharacterRoster.jsx
+++ b/frontend/src/components/audiobook/CharacterRoster.jsx
@@ -1,0 +1,80 @@
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { updateCharacter } from "../../api/audiobook";
+
+function CharacterCard({ character, bookId }) {
+  const queryClient = useQueryClient();
+  const [voicePrompt, setVoicePrompt] = useState(character.voice_design_prompt || "");
+  const [saved, setSaved] = useState(false);
+
+  const mutation = useMutation({
+    mutationFn: (data) => updateCharacter(character.id, data),
+    onSuccess: () => {
+      setSaved(true);
+      setTimeout(() => setSaved(false), 3000);
+      queryClient.invalidateQueries({ queryKey: ["audiobook-characters", bookId] });
+      queryClient.invalidateQueries({ queryKey: ["audiobook-status", bookId] });
+    },
+  });
+
+  const handleSave = () => {
+    mutation.mutate({ voice_design_prompt: voicePrompt });
+  };
+
+  return (
+    <div className="character-card">
+      <div className="character-card-header">
+        <strong>{character.name}</strong>
+        {character.is_narrator && <span className="badge">Narrator</span>}
+      </div>
+      {character.description && (
+        <p className="character-description">{character.description}</p>
+      )}
+      <label className="character-voice-label">
+        Voice Design Prompt
+        <input
+          type="text"
+          value={voicePrompt}
+          onChange={(e) => setVoicePrompt(e.target.value)}
+          placeholder="e.g. [gender-male][pitch-low][speed-normal]"
+        />
+      </label>
+      <p className="character-voice-hint">
+        Tokens: <code>[gender-male|female|neutral]</code>{" "}
+        <code>[pitch-low|medium|high]</code>{" "}
+        <code>[speed-slow|normal|fast]</code>{" "}
+        <code>[age-young|middle|old]</code>{" "}
+        <code>[accent-british|american|…]</code>
+      </p>
+      {mutation.isError && (
+        <p className="error">{mutation.error?.message || "Save failed"}</p>
+      )}
+      {saved && (
+        <p className="success">Saved — audio for this character will be regenerated.</p>
+      )}
+      <button onClick={handleSave} disabled={mutation.isPending}>
+        {mutation.isPending ? "Saving…" : "Save Profile"}
+      </button>
+    </div>
+  );
+}
+
+function CharacterRoster({ characters, bookId }) {
+  if (!characters || characters.length === 0) {
+    return (
+      <p className="empty-state">
+        No characters yet. Start the pipeline to generate the roster.
+      </p>
+    );
+  }
+
+  return (
+    <div className="character-roster">
+      {characters.map((char) => (
+        <CharacterCard key={char.id} character={char} bookId={bookId} />
+      ))}
+    </div>
+  );
+}
+
+export default CharacterRoster;

--- a/frontend/src/components/audiobook/ScriptEditor.jsx
+++ b/frontend/src/components/audiobook/ScriptEditor.jsx
@@ -1,0 +1,175 @@
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { getSentences, updateSentence, getSentenceAudioUrl } from "../../api/audiobook";
+
+const STATUS_ICONS = {
+  pending_diarization: { icon: "⏳", label: "Pending diarization" },
+  ready_for_audio: { icon: "🎙", label: "Ready for audio" },
+  audio_generated: { icon: "✅", label: "Audio generated" },
+  error: { icon: "❌", label: "Error" },
+};
+
+function SentenceRow({ sentence, characters, bookId }) {
+  const queryClient = useQueryClient();
+  const [tags, setTags] = useState(sentence.tagged_text || sentence.original_text);
+  const [characterId, setCharacterId] = useState(sentence.character_id ?? "");
+  const [editing, setEditing] = useState(false);
+
+  const mutation = useMutation({
+    mutationFn: (data) => updateSentence(sentence.id, data),
+    onSuccess: () => {
+      setEditing(false);
+      queryClient.invalidateQueries({ queryKey: ["audiobook-sentences", bookId] });
+      queryClient.invalidateQueries({ queryKey: ["audiobook-status", bookId] });
+    },
+  });
+
+  const handleSave = () => {
+    mutation.mutate({
+      character_id: characterId !== "" ? Number(characterId) : null,
+      tagged_text: tags,
+    });
+  };
+
+  const statusInfo = STATUS_ICONS[sentence.status] || { icon: "?", label: sentence.status };
+  const audioUrl = sentence.status === "audio_generated" ? getSentenceAudioUrl(sentence.id) : null;
+
+  return (
+    <tr className={`sentence-row sentence-row--${sentence.status}`}>
+      <td className="sentence-seq">{sentence.sequence_order}</td>
+      <td className="sentence-text">{sentence.original_text}</td>
+      <td className="sentence-tags">
+        {editing ? (
+          <input
+            type="text"
+            value={tags}
+            onChange={(e) => setTags(e.target.value)}
+            className="sentence-tags-input"
+          />
+        ) : (
+          <span onClick={() => setEditing(true)} title="Click to edit">
+            {tags}
+          </span>
+        )}
+      </td>
+      <td className="sentence-speaker">
+        <select
+          value={characterId}
+          onChange={(e) => {
+            setCharacterId(e.target.value);
+            setEditing(true);
+          }}
+        >
+          <option value="">— unassigned —</option>
+          {characters.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.name}
+            </option>
+          ))}
+        </select>
+      </td>
+      <td className="sentence-status" title={statusInfo.label}>
+        {statusInfo.icon}
+      </td>
+      <td className="sentence-audio">
+        {audioUrl && (
+          <audio controls src={audioUrl} preload="none" style={{ height: "24px" }} />
+        )}
+      </td>
+      <td className="sentence-actions">
+        {editing && (
+          <>
+            <button onClick={handleSave} disabled={mutation.isPending} className="btn-small">
+              {mutation.isPending ? "…" : "Save"}
+            </button>
+            <button
+              onClick={() => {
+                setTags(sentence.tagged_text || sentence.original_text);
+                setCharacterId(sentence.character_id ?? "");
+                setEditing(false);
+              }}
+              className="btn-small btn-text"
+            >
+              Cancel
+            </button>
+          </>
+        )}
+        {mutation.isError && <span className="error">{mutation.error?.message}</span>}
+      </td>
+    </tr>
+  );
+}
+
+function ScriptEditor({ bookId, characters }) {
+  const [page, setPage] = useState(1);
+  const [chapterFilter, setChapterFilter] = useState("");
+  const limit = 50;
+
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: ["audiobook-sentences", bookId, page, chapterFilter],
+    queryFn: () =>
+      getSentences(bookId, {
+        page,
+        limit,
+        chapterId: chapterFilter ? Number(chapterFilter) : undefined,
+      }),
+    keepPreviousData: true,
+  });
+
+  if (isLoading) return <p>Loading sentences…</p>;
+  if (isError) return <p className="error">{error?.message || "Failed to load sentences"}</p>;
+
+  const { items = [], total = 0 } = data || {};
+  const totalPages = Math.max(1, Math.ceil(total / limit));
+
+  return (
+    <div className="script-editor">
+      <div className="script-editor-controls">
+        <span>{total} sentences</span>
+        <div className="pagination">
+          <button onClick={() => setPage((p) => Math.max(1, p - 1))} disabled={page === 1}>
+            ‹ Prev
+          </button>
+          <span>
+            Page {page} / {totalPages}
+          </span>
+          <button onClick={() => setPage((p) => Math.min(totalPages, p + 1))} disabled={page === totalPages}>
+            Next ›
+          </button>
+        </div>
+      </div>
+
+      {items.length === 0 ? (
+        <p className="empty-state">No sentences found. Start the pipeline first.</p>
+      ) : (
+        <div className="script-table-wrap">
+          <table className="script-table">
+            <thead>
+              <tr>
+                <th>#</th>
+                <th>Original Text</th>
+                <th>Tags</th>
+                <th>Speaker</th>
+                <th>Status</th>
+                <th>Audio</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((sentence) => (
+                <SentenceRow
+                  key={sentence.id}
+                  sentence={sentence}
+                  characters={characters}
+                  bookId={bookId}
+                />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default ScriptEditor;

--- a/frontend/src/components/audiobook/ScriptEditor.jsx
+++ b/frontend/src/components/audiobook/ScriptEditor.jsx
@@ -102,7 +102,7 @@ function SentenceRow({ sentence, characters, bookId }) {
 
 function ScriptEditor({ bookId, characters }) {
   const [page, setPage] = useState(1);
-  const [chapterFilter, setChapterFilter] = useState("");
+  const [chapterFilter, _setChapterFilter] = useState("");
   const limit = 50;
 
   const { data, isLoading, isError, error } = useQuery({

--- a/frontend/src/lib/navigation.js
+++ b/frontend/src/lib/navigation.js
@@ -4,6 +4,7 @@ export const TABS = [
   { key: "scheduler", label: "Scheduler", path: "/scheduler" },
   { key: "logs", label: "Logs", path: "/logs" },
   { key: "utilities", label: "Utilities", path: "/utilities" },
+  { key: "audio-settings", label: "Audio Settings", path: "/audio-settings" },
 ];
 
 export const LIBRARY_VIEWS = ["series", "standalone", "web"];

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
     "mutagen>=1.47,<2",
     "idna==3.18",
     "lxml==6.1.1",
-    "pydub>=0.25,<1",
     "pydantic==2.13.2",
     "pydantic-core==2.46.2",
     "python-dotenv==1.2.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "certifi==2026.2.25",
     "chardet==7.4.3",
     "charset-normalizer==3.4.7",
-    "click==8.3.2",
+    "click==8.3.3",
     "cloudscraper==1.2.71",
     "ebooklib==0.20",
     "fanficfare==4.56.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,11 @@ dependencies = [
     "html5lib==1.1",
     "httpcore==1.0.9",
     "httptools==0.7.1",
+    "httpx2==2.5.0",
+    "mutagen>=1.47,<2",
     "idna==3.18",
     "lxml==6.1.1",
+    "pydub>=0.25,<1",
     "pydantic==2.13.2",
     "pydantic-core==2.46.2",
     "python-dotenv==1.2.2",
@@ -36,6 +39,7 @@ dependencies = [
     "requests-file==3.0.1",
     "requests-toolbelt==1.0.0",
     "six==1.17.0",
+    "spacy>=3.7,<4",
     "sniffio==1.3.1",
     "soupsieve==2.8.4",
     "sqlalchemy==2.0.49",
@@ -53,7 +57,6 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "aiosqlite==0.22.1",
-    "httpx2==2.5.0",
     "iniconfig==2.3.0",
     "packaging==26.1",
     "pluggy==1.6.0",

--- a/uv.lock
+++ b/uv.lock
@@ -368,14 +368,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.2"
+version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d", size = 108379, upload-time = "2026-04-03T19:14:43.505Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
 ]
 
 [[package]]
@@ -2035,7 +2035,7 @@ requires-dist = [
     { name = "certifi", specifier = "==2026.2.25" },
     { name = "chardet", specifier = "==7.4.3" },
     { name = "charset-normalizer", specifier = "==3.4.7" },
-    { name = "click", specifier = "==8.3.2" },
+    { name = "click", specifier = "==8.3.3" },
     { name = "cloudscraper", specifier = "==1.2.71" },
     { name = "ebooklib", specifier = "==0.20" },
     { name = "fanficfare", specifier = "==4.56.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version < '3.12'",
+]
 
 [[package]]
 name = "aiosqlite"
@@ -131,6 +135,46 @@ wheels = [
 ]
 
 [[package]]
+name = "blis"
+version = "1.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/d0/d8cc8c9a4488a787e7fa430f6055e5bd1ddb22c340a751d9e901b82e2efe/blis-1.3.3.tar.gz", hash = "sha256:034d4560ff3cc43e8aa37e188451b0440e3261d989bb8a42ceee865607715ecd", size = 2644873, upload-time = "2025-11-17T12:28:30.511Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/0a/a4c8736bc497d386b0ffc76d321f478c03f1a4725e52092f93b38beb3786/blis-1.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e10c8d3e892b1dbdff365b9d00e08291876fc336915bf1a5e9f188ed087e1a91", size = 6925522, upload-time = "2025-11-17T12:27:29.199Z" },
+    { url = "https://files.pythonhosted.org/packages/83/5a/3437009282f23684ecd3963a8b034f9307cdd2bf4484972e5a6b096bf9ac/blis-1.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:66e6249564f1db22e8af1e0513ff64134041fa7e03c8dd73df74db3f4d8415a7", size = 1232787, upload-time = "2025-11-17T12:27:30.996Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/0e/82221910d16259ce3017c1442c468a3f206a4143a96fbba9f5b5b81d62e8/blis-1.3.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7260da065958b4e5475f62f44895ef9d673b0f47dcf61b672b22b7dae1a18505", size = 2844596, upload-time = "2025-11-17T12:27:32.601Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/93/ab547f1a5c23e20bca16fbcf04021c32aac3f969be737ea4980509a7ca90/blis-1.3.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e9327a6ca67de8ae76fe071e8584cc7f3b2e8bfadece4961d40f2826e1cda2df", size = 11377746, upload-time = "2025-11-17T12:27:35.342Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/a6/7733820aa62da32526287a63cd85c103b2b323b186c8ee43b7772ff7017c/blis-1.3.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c4ae70629cf302035d268858a10ca4eb6242a01b2dc8d64422f8e6dcb8a8ee74", size = 3041954, upload-time = "2025-11-17T12:27:37.479Z" },
+    { url = "https://files.pythonhosted.org/packages/87/53/e39d67fd3296b649772780ca6aab081412838ecb54e0b0c6432d01626a50/blis-1.3.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:45866a9027d43b93e8b59980a23c5d7358b6536fc04606286e39fdcfce1101c2", size = 14251222, upload-time = "2025-11-17T12:27:39.705Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/44/b749f8777b020b420bceaaf60f66432fc30cc904ca5b69640ec9cbef11ed/blis-1.3.3-cp311-cp311-win_amd64.whl", hash = "sha256:27f82b8633030f8d095d2b412dffa7eb6dbc8ee43813139909a20012e54422ea", size = 6171233, upload-time = "2025-11-17T12:27:41.921Z" },
+    { url = "https://files.pythonhosted.org/packages/16/d1/429cf0cf693d4c7dc2efed969bd474e315aab636e4a95f66c4ed7264912d/blis-1.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2a1c74e100665f8e918ebdbae2794576adf1f691680b5cdb8b29578432f623ef", size = 6929663, upload-time = "2025-11-17T12:27:44.482Z" },
+    { url = "https://files.pythonhosted.org/packages/11/69/363c8df8d98b3cc97be19aad6aabb2c9c53f372490d79316bdee92d476e7/blis-1.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3f6c595185176ce021316263e1a1d636a3425b6c48366c1fd712d08d0b71849a", size = 1230939, upload-time = "2025-11-17T12:27:46.19Z" },
+    { url = "https://files.pythonhosted.org/packages/96/2a/fbf65d906d823d839076c5150a6f8eb5ecbc5f9135e0b6510609bda1e6b7/blis-1.3.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d734b19fba0be7944f272dfa7b443b37c61f9476d9ab054a9ac53555ceadd2e0", size = 2818835, upload-time = "2025-11-17T12:27:48.167Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ad/58deaa3ad856dd3cc96493e40ffd2ed043d18d4d304f85a65cde1ccbf644/blis-1.3.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ef6d6e2b599a3a2788eb6d9b443533961265aa4ec49d574ed4bb846e548dcdb", size = 11366550, upload-time = "2025-11-17T12:27:49.958Z" },
+    { url = "https://files.pythonhosted.org/packages/78/82/816a7adfe1f7acc8151f01ec86ef64467a3c833932d8f19f8e06613b8a4e/blis-1.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8c888438ae99c500422d50698e3028b65caa8ebb44e24204d87fda2df64058f7", size = 3023686, upload-time = "2025-11-17T12:27:52.062Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/e2/0e93b865f648b5519360846669a35f28ee8f4e1d93d054f6850d8afbabde/blis-1.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8177879fd3590b5eecdd377f9deafb5dc8af6d684f065bd01553302fb3fcf9a7", size = 14250939, upload-time = "2025-11-17T12:27:53.847Z" },
+    { url = "https://files.pythonhosted.org/packages/20/07/fb43edc2ff0a6a367e4a94fc39eb3b85aa1e55e24cc857af2db145ce9f0d/blis-1.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:f20f7ad69aaffd1ce14fe77de557b6df9b61e0c9e582f75a843715d836b5c8af", size = 6192759, upload-time = "2025-11-17T12:27:56.176Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/f7/d26e62d9be3d70473a63e0a5d30bae49c2fe138bebac224adddcdef8a7ce/blis-1.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1e647341f958421a86b028a2efe16ce19c67dba2a05f79e8f7e80b1ff45328aa", size = 6928322, upload-time = "2025-11-17T12:27:57.965Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/78/750d12da388f714958eb2f2fd177652323bbe7ec528365c37129edd6eb84/blis-1.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d563160f874abb78a57e346f07312c5323f7ad67b6370052b6b17087ef234a8e", size = 1229635, upload-time = "2025-11-17T12:28:00.118Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/36/eac4199c5b200a5f3e93cad197da8d26d909f218eb444c4f552647c95240/blis-1.3.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:30b8a5b90cb6cb81d1ada9ae05aa55fb8e70d9a0ae9db40d2401bb9c1c8f14c4", size = 2815650, upload-time = "2025-11-17T12:28:02.544Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/51/472e7b36a6bedb5242a9757e7486f702c3619eff76e256735d0c8b1679c6/blis-1.3.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e9f5c53b277f6ac5b3ca30bc12ebab7ea16c8f8c36b14428abb56924213dc127", size = 11359008, upload-time = "2025-11-17T12:28:04.589Z" },
+    { url = "https://files.pythonhosted.org/packages/84/da/d0dfb6d6e6321ae44df0321384c32c322bd07b15740d7422727a1a49fc5d/blis-1.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6297e7616c158b305c9a8a4e47ca5fc9b0785194dd96c903b1a1591a7ca21ddf", size = 3011959, upload-time = "2025-11-17T12:28:06.862Z" },
+    { url = "https://files.pythonhosted.org/packages/20/c5/2b0b5e556fa0364ed671051ea078a6d6d7b979b1cfef78d64ad3ca5f0c7f/blis-1.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:3f966ca74f89f8a33e568b9a1d71992fc9a0d29a423e047f0a212643e21b5458", size = 14232456, upload-time = "2025-11-17T12:28:08.779Z" },
+    { url = "https://files.pythonhosted.org/packages/31/07/4cdc81a47bf862c0b06d91f1bc6782064e8b69ac9b5d4ff51d97e4ff03da/blis-1.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:7a0fc4b237a3a453bdc3c7ab48d91439fcd2d013b665c46948d9eaf9c3e45a97", size = 6192624, upload-time = "2025-11-17T12:28:14.197Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/8a/80f7c68fbc24a76fc9c18522c46d6d69329c320abb18e26a707a5d874083/blis-1.3.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c3e33cfbf22a418373766816343fcfcd0556012aa3ffdf562c29cddec448a415", size = 6934081, upload-time = "2025-11-17T12:28:16.436Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/52/d1aa3a51a7fc299b0c89dcaa971922714f50b1202769eebbdaadd1b5cff7/blis-1.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6f165930e8d3a85c606d2003211497e28d528c7416fbfeafb6b15600963f7c9b", size = 1231486, upload-time = "2025-11-17T12:28:18.008Z" },
+    { url = "https://files.pythonhosted.org/packages/99/4f/badc7bd7f74861b26c10123bba7b9d16f99cd9535ad0128780360713820f/blis-1.3.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:878d4d96d8f2c7a2459024f013f2e4e5f46d708b23437dae970d998e7bff14a0", size = 2814944, upload-time = "2025-11-17T12:28:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/72/a6/f62a3bd814ca19ec7e29ac889fd354adea1217df3183e10217de51e2eb8b/blis-1.3.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f36c0ca84a05ee5d3dbaa38056c4423c1fc29948b17a7923dd2fed8967375d74", size = 11345825, upload-time = "2025-11-17T12:28:21.354Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/6c/671af79ee42bc4c968cae35c091ac89e8721c795bfa4639100670dc59139/blis-1.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e5a662c48cd4aad5dae1a950345df23957524f071315837a4c6feb7d3b288990", size = 3008771, upload-time = "2025-11-17T12:28:23.637Z" },
+    { url = "https://files.pythonhosted.org/packages/be/92/7cd7f8490da7c98ee01557f2105885cc597217b0e7fd2eeb9e22cdd4ef23/blis-1.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9de26fbd72bac900c273b76d46f0b45b77a28eace2e01f6ac6c2239531a413bb", size = 14219213, upload-time = "2025-11-17T12:28:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/de/acae8e9f9a1f4bb393d41c8265898b0f29772e38eac14e9f69d191e2c006/blis-1.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:9e5fdf4211b1972400f8ff6dafe87cb689c5d84f046b4a76b207c0bd2270faaf", size = 6324695, upload-time = "2025-11-17T12:28:28.401Z" },
+]
+
+[[package]]
 name = "brotli"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -176,6 +220,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/73/3183c9e41ca755713bdf2cc1d0810df742c09484e2e1ddd693bee53877c1/brotli-1.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d2d085ded05278d1c7f65560aae97b3160aeb2ea2c0b3e26204856beccb60888", size = 1488164, upload-time = "2025-11-05T18:38:53.079Z" },
     { url = "https://files.pythonhosted.org/packages/64/6a/0c78d8f3a582859236482fd9fa86a65a60328a00983006bcf6d83b7b2253/brotli-1.2.0-cp314-cp314-win32.whl", hash = "sha256:832c115a020e463c2f67664560449a7bea26b0c1fdd690352addad6d0a08714d", size = 339280, upload-time = "2025-11-05T18:38:54.02Z" },
     { url = "https://files.pythonhosted.org/packages/f5/10/56978295c14794b2c12007b07f3e41ba26acda9257457d7085b0bb3bb90c/brotli-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:e7c0af964e0b4e3412a0ebf341ea26ec767fa0b4cf81abb5e897c9338b5ad6a3", size = 375639, upload-time = "2025-11-05T18:38:55.67Z" },
+]
+
+[[package]]
+name = "catalogue"
+version = "2.0.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/b4/244d58127e1cdf04cf2dc7d9566f0d24ef01d5ce21811bab088ecc62b5ea/catalogue-2.0.10.tar.gz", hash = "sha256:4f56daa940913d3f09d589c191c74e5a6d51762b3a9e37dd53b7437afd6cda15", size = 19561, upload-time = "2023-09-25T06:29:24.962Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/96/d32b941a501ab566a16358d68b6eb4e4acc373fab3c3c4d7d9e649f7b4bb/catalogue-2.0.10-py3-none-any.whl", hash = "sha256:58c2de0020aa90f4a2da7dfad161bf7b3b054c86a5f09fcedc0b2b740c109a9f", size = 17325, upload-time = "2023-09-25T06:29:23.337Z" },
 ]
 
 [[package]]
@@ -326,6 +379,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cloudpathlib"
+version = "0.24.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/19/58bc6b5d7d0f81c7209b05445af477e147c486552f96665a5912211839b9/cloudpathlib-0.24.0.tar.gz", hash = "sha256:c521a984e77b47e656fe78e20a7e3e260e0ab45fc69e33ac01094227c979e34a", size = 53600, upload-time = "2026-04-30T00:54:43.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/5b/ba933f896d9b0b07608d575a8501e2b4e32166b60d84c430a4a7285ebe64/cloudpathlib-0.24.0-py3-none-any.whl", hash = "sha256:b1c51e2d2ec7dc4fed6538991f4aea849d6cf11a7e6b9069f86e461aa1f9b5b4", size = 63214, upload-time = "2026-04-30T00:54:42.06Z" },
+]
+
+[[package]]
 name = "cloudscraper"
 version = "1.2.71"
 source = { registry = "https://pypi.org/simple" }
@@ -346,6 +408,71 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "confection"
+version = "1.3.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/65/efd0fe8a936fc8ca2978cb7b82581fb20d901c6039e746a808f746b7647b/confection-1.3.3.tar.gz", hash = "sha256:f0f6810d567ff73993fe74d218ca5e1ffb6a44fb03f391257fc5d033546cbfaa", size = 54895, upload-time = "2026-03-24T18:45:24.331Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/e4/d66708bdf0d92fb4d49b22cdff4b10cec38aca5dcd7e81d909bb55c65cd7/confection-1.3.3-py3-none-any.whl", hash = "sha256:b9fef9ee84b237ef4611ec3eb5797b70e13063e6310ad9f15536373f5e313c82", size = 35902, upload-time = "2026-03-24T18:45:22.664Z" },
+]
+
+[[package]]
+name = "cymem"
+version = "2.0.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/2f0fbb32535c3731b7c2974c569fb9325e0a38ed5565a08e1139a3b71e82/cymem-2.0.13.tar.gz", hash = "sha256:1c91a92ae8c7104275ac26bd4d29b08ccd3e7faff5893d3858cb6fadf1bc1588", size = 12320, upload-time = "2025-11-14T14:58:36.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/64/1db41f7576a6b69f70367e3c15e968fd775ba7419e12059c9966ceb826f8/cymem-2.0.13-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:673183466b0ff2e060d97ec5116711d44200b8f7be524323e080d215ee2d44a5", size = 43587, upload-time = "2025-11-14T14:57:22.39Z" },
+    { url = "https://files.pythonhosted.org/packages/81/13/57f936fc08551323aab3f92ff6b7f4d4b89d5b4e495c870a67cb8d279757/cymem-2.0.13-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bee2791b3f6fc034ce41268851462bf662ff87e8947e35fb6dd0115b4644a61f", size = 43139, upload-time = "2025-11-14T14:57:23.363Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a6/9345754be51e0479aa387b7b6cffc289d0fd3201aaeb8dade4623abd1e02/cymem-2.0.13-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f3aee3adf16272bca81c5826eed55ba3c938add6d8c9e273f01c6b829ecfde22", size = 245063, upload-time = "2025-11-14T14:57:24.839Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/01/6bc654101526fa86e82bf6b05d99b2cd47c30a333cfe8622c26c0592beb2/cymem-2.0.13-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:30c4e75a3a1d809e89106b0b21803eb78e839881aa1f5b9bd27b454bc73afde3", size = 244496, upload-time = "2025-11-14T14:57:26.42Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/fb/853b7b021e701a1f41687f3704d5f469aeb2a4f898c3fbb8076806885955/cymem-2.0.13-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ec99efa03cf8ec11c8906aa4d4cc0c47df393bc9095c9dd64b89b9b43e220b04", size = 243287, upload-time = "2025-11-14T14:57:27.542Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/2b/0e4664cafc581de2896d75000651fd2ce7094d33263f466185c28ffc96e4/cymem-2.0.13-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c90a6ecba994a15b17a3f45d7ec74d34081df2f73bd1b090e2adc0317e4e01b6", size = 248287, upload-time = "2025-11-14T14:57:29.055Z" },
+    { url = "https://files.pythonhosted.org/packages/21/0f/f94c6950edbfc2aafb81194fc40b6cacc8e994e9359d3cb4328c5705b9b5/cymem-2.0.13-cp311-cp311-win_amd64.whl", hash = "sha256:ce821e6ba59148ed17c4567113b8683a6a0be9c9ac86f14e969919121efb61a5", size = 40116, upload-time = "2025-11-14T14:57:30.592Z" },
+    { url = "https://files.pythonhosted.org/packages/00/df/2455eff6ac0381ff165db6883b311f7016e222e3dd62185517f8e8187ed0/cymem-2.0.13-cp311-cp311-win_arm64.whl", hash = "sha256:0dca715e708e545fd1d97693542378a00394b20a37779c1ae2c8bdbb43acef79", size = 36349, upload-time = "2025-11-14T14:57:31.573Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/52/478a2911ab5028cb710b4900d64aceba6f4f882fcb13fd8d40a456a1b6dc/cymem-2.0.13-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e8afbc5162a0fe14b6463e1c4e45248a1b2fe2cbcecc8a5b9e511117080da0eb", size = 43745, upload-time = "2025-11-14T14:57:32.52Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/71/f0f8adee945524774b16af326bd314a14a478ed369a728a22834e6785a18/cymem-2.0.13-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c9251d889348fe79a75e9b3e4d1b5fa651fca8a64500820685d73a3acc21b6a8", size = 42927, upload-time = "2025-11-14T14:57:33.827Z" },
+    { url = "https://files.pythonhosted.org/packages/62/6d/159780fe162ff715d62b809246e5fc20901cef87ca28b67d255a8d741861/cymem-2.0.13-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:742fc19764467a49ed22e56a4d2134c262d73a6c635409584ae3bf9afa092c33", size = 258346, upload-time = "2025-11-14T14:57:34.917Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/12/678d16f7aa1996f947bf17b8cfb917ea9c9674ef5e2bd3690c04123d5680/cymem-2.0.13-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f190a92fe46197ee64d32560eb121c2809bb843341733227f51538ce77b3410d", size = 260843, upload-time = "2025-11-14T14:57:36.503Z" },
+    { url = "https://files.pythonhosted.org/packages/31/5d/0dd8c167c08cd85e70d274b7235cfe1e31b3cebc99221178eaf4bbb95c6f/cymem-2.0.13-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d670329ee8dbbbf241b7c08069fe3f1d3a1a3e2d69c7d05ea008a7010d826298", size = 254607, upload-time = "2025-11-14T14:57:38.036Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/c9/d6514a412a1160aa65db539836b3d47f9b59f6675f294ec34ae32f867c82/cymem-2.0.13-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a84ba3178d9128b9ffb52ce81ebab456e9fe959125b51109f5b73ebdfc6b60d6", size = 262421, upload-time = "2025-11-14T14:57:39.265Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/fe/3ee37d02ca4040f2fb22d34eb415198f955862b5dd47eee01df4c8f5454c/cymem-2.0.13-cp312-cp312-win_amd64.whl", hash = "sha256:2ff1c41fd59b789579fdace78aa587c5fc091991fa59458c382b116fc36e30dc", size = 40176, upload-time = "2025-11-14T14:57:40.706Z" },
+    { url = "https://files.pythonhosted.org/packages/94/fb/1b681635bfd5f2274d0caa8f934b58435db6c091b97f5593738065ddb786/cymem-2.0.13-cp312-cp312-win_arm64.whl", hash = "sha256:6bbd701338df7bf408648191dff52472a9b334f71bcd31a21a41d83821050f67", size = 35959, upload-time = "2025-11-14T14:57:41.682Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/0f/95a4d1e3bebfdfa7829252369357cf9a764f67569328cd9221f21e2c952e/cymem-2.0.13-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:891fd9030293a8b652dc7fb9fdc79a910a6c76fc679cd775e6741b819ffea476", size = 43478, upload-time = "2025-11-14T14:57:42.682Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/a0/8fc929cc29ae466b7b4efc23ece99cbd3ea34992ccff319089c624d667fd/cymem-2.0.13-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:89c4889bd16513ce1644ccfe1e7c473ba7ca150f0621e66feac3a571bde09e7e", size = 42695, upload-time = "2025-11-14T14:57:43.741Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/b3/deeb01354ebaf384438083ffe0310209ef903db3e7ba5a8f584b06d28387/cymem-2.0.13-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:45dcaba0f48bef9cc3d8b0b92058640244a95a9f12542210b51318da97c2cf28", size = 250573, upload-time = "2025-11-14T14:57:44.81Z" },
+    { url = "https://files.pythonhosted.org/packages/36/36/bc980b9a14409f3356309c45a8d88d58797d02002a9d794dd6c84e809d3a/cymem-2.0.13-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e96848faaafccc0abd631f1c5fb194eac0caee4f5a8777fdbb3e349d3a21741c", size = 254572, upload-time = "2025-11-14T14:57:46.023Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/dd/a12522952624685bd0f8968e26d2ed6d059c967413ce6eb52292f538f1b0/cymem-2.0.13-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e02d3e2c3bfeb21185d5a4a70790d9df40629a87d8d7617dc22b4e864f665fa3", size = 248060, upload-time = "2025-11-14T14:57:47.605Z" },
+    { url = "https://files.pythonhosted.org/packages/08/11/5dc933ddfeb2dfea747a0b935cb965b9a7580b324d96fc5f5a1b5ff8df29/cymem-2.0.13-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fece5229fd5ecdcd7a0738affb8c59890e13073ae5626544e13825f26c019d3c", size = 254601, upload-time = "2025-11-14T14:57:48.861Z" },
+    { url = "https://files.pythonhosted.org/packages/70/66/d23b06166864fa94e13a98e5922986ce774832936473578febce64448d75/cymem-2.0.13-cp313-cp313-win_amd64.whl", hash = "sha256:38aefeb269597c1a0c2ddf1567dd8605489b661fa0369c6406c1acd433b4c7ba", size = 40103, upload-time = "2025-11-14T14:57:50.396Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/9e/c7b21271ab88a21760f3afdec84d2bc09ffa9e6c8d774ad9d4f1afab0416/cymem-2.0.13-cp313-cp313-win_arm64.whl", hash = "sha256:717270dcfd8c8096b479c42708b151002ff98e434a7b6f1f916387a6c791e2ad", size = 36016, upload-time = "2025-11-14T14:57:51.611Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/28/d3b03427edc04ae04910edf1c24b993881c3ba93a9729a42bcbb816a1808/cymem-2.0.13-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:7e1a863a7f144ffb345397813701509cfc74fc9ed360a4d92799805b4b865dd1", size = 46429, upload-time = "2025-11-14T14:57:52.582Z" },
+    { url = "https://files.pythonhosted.org/packages/35/a9/7ed53e481f47ebfb922b0b42e980cec83e98ccb2137dc597ea156642440c/cymem-2.0.13-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:c16cb80efc017b054f78998c6b4b013cef509c7b3d802707ce1f85a1d68361bf", size = 46205, upload-time = "2025-11-14T14:57:53.64Z" },
+    { url = "https://files.pythonhosted.org/packages/61/39/a3d6ad073cf7f0fbbb8bbf09698c3c8fac11be3f791d710239a4e8dd3438/cymem-2.0.13-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0d78a27c88b26c89bd1ece247d1d5939dba05a1dae6305aad8fd8056b17ddb51", size = 296083, upload-time = "2025-11-14T14:57:55.922Z" },
+    { url = "https://files.pythonhosted.org/packages/36/0c/20697c8bc19f624a595833e566f37d7bcb9167b0ce69de896eba7cfc9c2d/cymem-2.0.13-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6d36710760f817194dacb09d9fc45cb6a5062ed75e85f0ef7ad7aeeb13d80cc3", size = 286159, upload-time = "2025-11-14T14:57:57.106Z" },
+    { url = "https://files.pythonhosted.org/packages/82/d4/9326e3422d1c2d2b4a8fb859bdcce80138f6ab721ddafa4cba328a505c71/cymem-2.0.13-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c8f30971cadd5dcf73bcfbbc5849b1f1e1f40db8cd846c4aa7d3b5e035c7b583", size = 288186, upload-time = "2025-11-14T14:57:58.334Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/bc/68da7dd749b72884dc22e898562f335002d70306069d496376e5ff3b6153/cymem-2.0.13-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:9d441d0e45798ec1fd330373bf7ffa6b795f229275f64016b6a193e6e2a51522", size = 290353, upload-time = "2025-11-14T14:58:00.562Z" },
+    { url = "https://files.pythonhosted.org/packages/50/23/dbf2ad6ecd19b99b3aab6203b1a06608bbd04a09c522d836b854f2f30f73/cymem-2.0.13-cp313-cp313t-win_amd64.whl", hash = "sha256:d1c950eebb9f0f15e3ef3591313482a5a611d16fc12d545e2018cd607f40f472", size = 44764, upload-time = "2025-11-14T14:58:01.793Z" },
+    { url = "https://files.pythonhosted.org/packages/54/3f/35701c13e1fc7b0895198c8b20068c569a841e0daf8e0b14d1dc0816b28f/cymem-2.0.13-cp313-cp313t-win_arm64.whl", hash = "sha256:042e8611ef862c34a97b13241f5d0da86d58aca3cecc45c533496678e75c5a1f", size = 38964, upload-time = "2025-11-14T14:58:02.87Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/2e/f0e1596010a9a57fa9ebd124a678c07c5b2092283781ae51e79edcf5cb98/cymem-2.0.13-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d2a4bf67db76c7b6afc33de44fb1c318207c3224a30da02c70901936b5aafdf1", size = 43812, upload-time = "2025-11-14T14:58:04.227Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/45/8ccc21df08fcbfa6aa3efeb7efc11a1c81c90e7476e255768bb9c29ba02a/cymem-2.0.13-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:92a2ce50afa5625fb5ce7c9302cee61e23a57ccac52cd0410b4858e572f8614b", size = 42951, upload-time = "2025-11-14T14:58:05.424Z" },
+    { url = "https://files.pythonhosted.org/packages/01/8c/fe16531631f051d3d1226fa42e2d76fd2c8d5cfa893ec93baee90c7a9d90/cymem-2.0.13-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bc116a70cc3a5dc3d1684db5268eff9399a0be8603980005e5b889564f1ea42f", size = 249878, upload-time = "2025-11-14T14:58:06.95Z" },
+    { url = "https://files.pythonhosted.org/packages/47/4b/39d67b80ffb260457c05fcc545de37d82e9e2dbafc93dd6b64f17e09b933/cymem-2.0.13-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:68489bf0035c4c280614067ab6a82815b01dc9fcd486742a5306fe9f68deb7ef", size = 252571, upload-time = "2025-11-14T14:58:08.232Z" },
+    { url = "https://files.pythonhosted.org/packages/53/0e/76f6531f74dfdfe7107899cce93ab063bb7ee086ccd3910522b31f623c08/cymem-2.0.13-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:03cb7bdb55718d5eb6ef0340b1d2430ba1386db30d33e9134d01ba9d6d34d705", size = 248555, upload-time = "2025-11-14T14:58:09.429Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7c/eee56757db81f0aefc2615267677ae145aff74228f529838425057003c0d/cymem-2.0.13-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1710390e7fb2510a8091a1991024d8ae838fd06b02cdfdcd35f006192e3c6b0e", size = 254177, upload-time = "2025-11-14T14:58:10.594Z" },
+    { url = "https://files.pythonhosted.org/packages/77/e0/a4b58ec9e53c836dce07ef39837a64a599f4a21a134fc7ca57a3a8f9a4b5/cymem-2.0.13-cp314-cp314-win_amd64.whl", hash = "sha256:ac699c8ec72a3a9de8109bd78821ab22f60b14cf2abccd970b5ff310e14158ed", size = 40853, upload-time = "2025-11-14T14:58:12.116Z" },
+    { url = "https://files.pythonhosted.org/packages/61/81/9931d1f83e5aeba175440af0b28f0c2e6f71274a5a7b688bc3e907669388/cymem-2.0.13-cp314-cp314-win_arm64.whl", hash = "sha256:90c2d0c04bcda12cd5cebe9be93ce3af6742ad8da96e1b1907e3f8e00291def1", size = 36970, upload-time = "2025-11-14T14:58:13.114Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/ef/af447c2184dec6dec973be14614df8ccb4d16d1c74e0784ab4f02538433c/cymem-2.0.13-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:ff036bbc1464993552fd1251b0a83fe102af334b301e3896d7aa05a4999ad042", size = 46804, upload-time = "2025-11-14T14:58:14.113Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/95/e10f33a8d4fc17f9b933d451038218437f9326c2abb15a3e7f58ce2a06ec/cymem-2.0.13-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:fb8291691ba7ff4e6e000224cc97a744a8d9588418535c9454fd8436911df612", size = 46254, upload-time = "2025-11-14T14:58:15.156Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/7a/5efeb2d2ea6ebad2745301ad33a4fa9a8f9a33b66623ee4d9185683007a6/cymem-2.0.13-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d8d06ea59006b1251ad5794bcc00121e148434826090ead0073c7b7fedebe431", size = 296061, upload-time = "2025-11-14T14:58:16.254Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/28/2a3f65842cc8443c2c0650cf23d525be06c8761ab212e0a095a88627be1b/cymem-2.0.13-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c0046a619ecc845ccb4528b37b63426a0cbcb4f14d7940add3391f59f13701e6", size = 285784, upload-time = "2025-11-14T14:58:17.412Z" },
+    { url = "https://files.pythonhosted.org/packages/98/73/dd5f9729398f0108c2e71d942253d0d484d299d08b02e474d7cfc43ed0b0/cymem-2.0.13-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:18ad5b116a82fa3674bc8838bd3792891b428971e2123ae8c0fd3ca472157c5e", size = 288062, upload-time = "2025-11-14T14:58:20.225Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/01/ffe51729a8f961a437920560659073e47f575d4627445216c1177ecd4a41/cymem-2.0.13-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:666ce6146bc61b9318aa70d91ce33f126b6344a25cf0b925621baed0c161e9cc", size = 290465, upload-time = "2025-11-14T14:58:21.815Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/ac/c9e7d68607f71ef978c81e334ab2898b426944c71950212b1467186f69f9/cymem-2.0.13-cp314-cp314t-win_amd64.whl", hash = "sha256:84c1168c563d9d1e04546cb65e3e54fde2bf814f7c7faf11fc06436598e386d1", size = 46665, upload-time = "2025-11-14T14:58:23.512Z" },
+    { url = "https://files.pythonhosted.org/packages/66/66/150e406a2db5535533aa3c946de58f0371f2e412e23f050c704588023e6e/cymem-2.0.13-cp314-cp314t-win_arm64.whl", hash = "sha256:e9027764dc5f1999fb4b4cabee1d0322c59e330c0a6485b436a68275f614277f", size = 39715, upload-time = "2025-11-14T14:58:24.773Z" },
 ]
 
 [[package]]
@@ -563,6 +690,21 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
 name = "httpx2"
 version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -594,6 +736,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
 ]
 
 [[package]]
@@ -711,6 +865,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -794,12 +960,222 @@ wheels = [
 ]
 
 [[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "murmurhash"
+version = "1.0.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/2e/88c147931ea9725d634840d538622e94122bceaf346233349b7b5c62964b/murmurhash-1.0.15.tar.gz", hash = "sha256:58e2b27b7847f9e2a6edf10b47a8c8dd70a4705f45dccb7bf76aeadacf56ba01", size = 13291, upload-time = "2025-11-14T09:51:15.272Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/ca/77d3e69924a8eb4508bb4f0ad34e46adbeedeb93616a71080e61e53dad71/murmurhash-1.0.15-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f32307fb9347680bb4fe1cbef6362fb39bd994f1b59abd8c09ca174e44199081", size = 27397, upload-time = "2025-11-14T09:50:03.077Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/53/a936f577d35b245d47b310f29e5e9f09fcac776c8c992f1ab51a9fb0cee2/murmurhash-1.0.15-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:539d8405885d1d19c005f3a2313b47e8e54b0ee89915eb8dfbb430b194328e6c", size = 27692, upload-time = "2025-11-14T09:50:04.144Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/64/5f8cfd1fd9cbeb43fcff96672f5bd9e7e1598d1c970f808ecd915490dc20/murmurhash-1.0.15-cp311-cp311-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c4cd739a00f5a4602201b74568ddabae46ec304719d9be752fd8f534a9464b5e", size = 128396, upload-time = "2025-11-14T09:50:05.268Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/10/d9ce29d559a75db0d8a3f13ea12c7f541ec9de2afca38dc70418b890eedb/murmurhash-1.0.15-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:44d211bcc3ec203c47dac06f48ee871093fcbdffa6652a6cc5ea7180306680a8", size = 128687, upload-time = "2025-11-14T09:50:06.527Z" },
+    { url = "https://files.pythonhosted.org/packages/48/cd/dc97ab7e68cdfa1537a56e36dbc846c5a66701cc39ecee2d4399fe61996c/murmurhash-1.0.15-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:f9bf47101354fb1dc4b2e313192566f04ba295c28a37e2f71c692759acc1ba3c", size = 128198, upload-time = "2025-11-14T09:50:08.062Z" },
+    { url = "https://files.pythonhosted.org/packages/53/73/32f2aaa22c1e4afae337106baf0c938abf36a6cc879cfee83a00461bbbf7/murmurhash-1.0.15-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3c69b4d3bcd6233782a78907fe10b9b7a796bdc5d28060cf097d067bec280a5d", size = 127214, upload-time = "2025-11-14T09:50:09.265Z" },
+    { url = "https://files.pythonhosted.org/packages/82/ed/812103a7f353eba2d83655b08205e13a38c93b4db0692f94756e1eb44516/murmurhash-1.0.15-cp311-cp311-win_amd64.whl", hash = "sha256:e43a69496342ce530bdd670264cb7c8f45490b296e4764c837ce577e3c7ebd53", size = 25241, upload-time = "2025-11-14T09:50:10.373Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/5f/2c511bdd28f7c24da37a00116ffd0432b65669d098f0d0260c66ac0ffdc2/murmurhash-1.0.15-cp311-cp311-win_arm64.whl", hash = "sha256:f3e99a6ee36ef5372df5f138e3d9c801420776d3641a34a49e5c2555f44edba7", size = 23216, upload-time = "2025-11-14T09:50:11.651Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/46/be8522d3456fdccf1b8b049c6d82e7a3c1114c4fc2cfe14b04cba4b3e701/murmurhash-1.0.15-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d37e3ae44746bca80b1a917c2ea625cf216913564ed43f69d2888e5df97db0cb", size = 27884, upload-time = "2025-11-14T09:50:13.133Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/cc/630449bf4f6178d7daf948ce46ad00b25d279065fc30abd8d706be3d87e0/murmurhash-1.0.15-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0861cb11039409eaf46878456b7d985ef17b6b484103a6fc367b2ecec846891d", size = 27855, upload-time = "2025-11-14T09:50:14.859Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/30/ea8f601a9bf44db99468696efd59eb9cff1157cd55cb586d67116697583f/murmurhash-1.0.15-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5a301decfaccfec70fe55cb01dde2a012c3014a874542eaa7cc73477bb749616", size = 134088, upload-time = "2025-11-14T09:50:15.958Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/de/c40ce8c0877d406691e735b8d6e9c815f36a82b499d358313db5dbe219d7/murmurhash-1.0.15-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:32c6fde7bd7e9407003370a07b5f4addacabe1556ad3dc2cac246b7a2bba3400", size = 133978, upload-time = "2025-11-14T09:50:17.572Z" },
+    { url = "https://files.pythonhosted.org/packages/47/84/bd49963ecd84ebab2fe66595e2d1ed41d5e8b5153af5dc930f0bd827007c/murmurhash-1.0.15-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5d8b43a7011540dc3c7ce66f2134df9732e2bc3bbb4a35f6458bc755e48bde26", size = 132956, upload-time = "2025-11-14T09:50:18.742Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/7c/2530769c545074417c862583f05f4245644599f1e9ff619b3dfe2969aafc/murmurhash-1.0.15-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:43bf4541892ecd95963fcd307bf1c575fc0fee1682f41c93007adee71ca2bb40", size = 134184, upload-time = "2025-11-14T09:50:19.941Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a4/b249b042f5afe34d14ada2dc4afc777e883c15863296756179652e081c44/murmurhash-1.0.15-cp312-cp312-win_amd64.whl", hash = "sha256:f4ac15a2089dc42e6eb0966622d42d2521590a12c92480aafecf34c085302cca", size = 25647, upload-time = "2025-11-14T09:50:21.049Z" },
+    { url = "https://files.pythonhosted.org/packages/13/bf/028179259aebc18fd4ba5cae2601d1d47517427a537ab44336446431a215/murmurhash-1.0.15-cp312-cp312-win_arm64.whl", hash = "sha256:4a70ca4ae19e600d9be3da64d00710e79dde388a4d162f22078d64844d0ebdda", size = 23338, upload-time = "2025-11-14T09:50:22.359Z" },
+    { url = "https://files.pythonhosted.org/packages/29/2f/ba300b5f04dae0409202d6285668b8a9d3ade43a846abee3ef611cb388d5/murmurhash-1.0.15-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fe50dc70e52786759358fd1471e309b94dddfffb9320d9dfea233c7684c894ba", size = 27861, upload-time = "2025-11-14T09:50:23.804Z" },
+    { url = "https://files.pythonhosted.org/packages/34/02/29c19d268e6f4ea1ed2a462c901eed1ed35b454e2cbc57da592fad663ac6/murmurhash-1.0.15-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1349a7c23f6092e7998ddc5bd28546cc31a595afc61e9fdb3afc423feec3d7ad", size = 27840, upload-time = "2025-11-14T09:50:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/63/58e2de2b5232cd294c64092688c422196e74f9fa8b3958bdf02d33df24b9/murmurhash-1.0.15-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b3ba6d05de2613535b5a9227d4ad8ef40a540465f64660d4a8800634ae10e04f", size = 133080, upload-time = "2025-11-14T09:50:26.566Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/9a/d13e2e9f8ba1ced06840921a50f7cece0a475453284158a3018b72679761/murmurhash-1.0.15-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fa1b70b3cc2801ab44179c65827bbd12009c68b34e9d9ce7125b6a0bd35af63c", size = 132648, upload-time = "2025-11-14T09:50:27.788Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e1/47994f1813fa205c84977b0ff51ae6709f8539af052c7491a5f863d82bdc/murmurhash-1.0.15-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:213d710fb6f4ef3bc11abbfad0fa94a75ffb675b7dc158c123471e5de869f9af", size = 131502, upload-time = "2025-11-14T09:50:29.339Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ea/90c1fd00b4aeb704fb5e84cd666b33ffd7f245155048071ffbb51d2bb57d/murmurhash-1.0.15-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b65a5c4e7f5d71f7ccac2d2b60bdf7092d7976270878cfec59d5a66a533db823", size = 132736, upload-time = "2025-11-14T09:50:30.545Z" },
+    { url = "https://files.pythonhosted.org/packages/00/db/da73462dbfa77f6433b128d2120ba7ba300f8c06dc4f4e022c38d240a5f5/murmurhash-1.0.15-cp313-cp313-win_amd64.whl", hash = "sha256:9aba94c5d841e1904cd110e94ceb7f49cfb60a874bbfb27e0373622998fb7c7c", size = 25682, upload-time = "2025-11-14T09:50:31.624Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/83/032729ef14971b938fbef41ee125fc8800020ee229bd35178b6ede8ee934/murmurhash-1.0.15-cp313-cp313-win_arm64.whl", hash = "sha256:263807eca40d08c7b702413e45cca75ecb5883aa337237dc5addb660f1483378", size = 23370, upload-time = "2025-11-14T09:50:33.264Z" },
+    { url = "https://files.pythonhosted.org/packages/10/83/7547d9205e9bd2f8e5dfd0b682cc9277594f98909f228eb359489baec1df/murmurhash-1.0.15-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:694fd42a74b7ce257169d14c24aa616aa6cd4ccf8abe50eca0557e08da99d055", size = 29955, upload-time = "2025-11-14T09:50:34.488Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/c7/3afd5de7a5b3ae07fe2d3a3271b327ee1489c58ba2b2f2159bd31a25edb9/murmurhash-1.0.15-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a2ea4546ba426390beff3cd10db8f0152fdc9072c4f2583ec7d8aa9f3e4ac070", size = 30108, upload-time = "2025-11-14T09:50:35.53Z" },
+    { url = "https://files.pythonhosted.org/packages/02/69/d6637ee67d78ebb2538c00411f28ea5c154886bbe1db16c49435a8a4ab16/murmurhash-1.0.15-cp313-cp313t-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:34e5a91139c40b10f98d0b297907f5d5267b4b1b2e5dd2eb74a021824f751b98", size = 164054, upload-time = "2025-11-14T09:50:36.591Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/4c/89e590165b4c7da6bf941441212a721a270195332d3aacfdfdf527d466ca/murmurhash-1.0.15-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:dc35606868a5961cf42e79314ca0bddf5a400ce377b14d83192057928d6252ec", size = 168153, upload-time = "2025-11-14T09:50:37.856Z" },
+    { url = "https://files.pythonhosted.org/packages/07/7a/95c42df0c21d2e413b9fcd17317a7587351daeb264dc29c6aec1fdbd26f8/murmurhash-1.0.15-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:43cc6ac3b91ca0f7a5ae9c063ba4d6c26972c97fd7c25280ecc666413e4c5535", size = 164345, upload-time = "2025-11-14T09:50:39.346Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/22/9d02c880a88b83bb3ce7d6a38fb727373ab78d82e5f3d8d9fc5612219f90/murmurhash-1.0.15-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:847d712136cb462f0e4bd6229ee2d9eb996d8854eb8312dff3d20c8f5181fda5", size = 161990, upload-time = "2025-11-14T09:50:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e3/750232524e0dc262e8dcede6536dafc766faadd9a52f1d23746b02948ad8/murmurhash-1.0.15-cp313-cp313t-win_amd64.whl", hash = "sha256:2680851af6901dbe66cc4aa7ef8e263de47e6e1b425ae324caa571bdf18f8d58", size = 28812, upload-time = "2025-11-14T09:50:41.971Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/89/4ad9d215ef6ade89f27a72dc4e86b98ef1a43534cc3e6a6900a362a0bf0a/murmurhash-1.0.15-cp313-cp313t-win_arm64.whl", hash = "sha256:189a8de4d657b5da9efd66601b0636330b08262b3a55431f2379097c986995d0", size = 25398, upload-time = "2025-11-14T09:50:43.023Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/69/726df275edf07688146966e15eaaa23168100b933a2e1a29b37eb56c6db8/murmurhash-1.0.15-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:7c4280136b738e85ff76b4bdc4341d0b867ee753e73fd8b6994288080c040d0b", size = 28029, upload-time = "2025-11-14T09:50:44.124Z" },
+    { url = "https://files.pythonhosted.org/packages/59/8f/24ecf9061bc2b20933df8aba47c73e904274ea8811c8300cab92f6f82372/murmurhash-1.0.15-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d4d681f474830489e2ec1d912095cfff027fbaf2baa5414c7e9d25b89f0fab68", size = 27912, upload-time = "2025-11-14T09:50:45.266Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/26/fff3caba25aa3c0622114e03c69fb66c839b22335b04d7cce91a3a126d44/murmurhash-1.0.15-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d7e47c5746785db6a43b65fac47b9e63dd71dfbd89a8c92693425b9715e68c6e", size = 131847, upload-time = "2025-11-14T09:50:46.819Z" },
+    { url = "https://files.pythonhosted.org/packages/df/e4/0f2b9fc533467a27afb4e906c33f32d5f637477de87dd94690e0c44335a6/murmurhash-1.0.15-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e8e674f02a99828c8a671ba99cd03299381b2f0744e6f25c29cadfc6151dc724", size = 132267, upload-time = "2025-11-14T09:50:48.298Z" },
+    { url = "https://files.pythonhosted.org/packages/da/bf/9d1c107989728ec46e25773d503aa54070b32822a18cfa7f9d5f41bc17a5/murmurhash-1.0.15-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:26fd7c7855ac4850ad8737991d7b0e3e501df93ebaf0cf45aa5954303085fdba", size = 131894, upload-time = "2025-11-14T09:50:49.485Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/81/dcf27c71445c0e993b10e33169a098ca60ee702c5c58fcbde205fa6332a6/murmurhash-1.0.15-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cb8ebafae60d5f892acff533cc599a359954d8c016a829514cb3f6e9ee10f322", size = 132054, upload-time = "2025-11-14T09:50:50.747Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/32/e874a14b2d2246bd2d16f80f49fad393a3865d4ee7d66d2cae939a67a29a/murmurhash-1.0.15-cp314-cp314-win_amd64.whl", hash = "sha256:898a629bf111f1aeba4437e533b5b836c0a9d2dd12d6880a9c75f6ca13e30e22", size = 26579, upload-time = "2025-11-14T09:50:52.278Z" },
+    { url = "https://files.pythonhosted.org/packages/af/8e/4fca051ed8ae4d23a15aaf0a82b18cb368e8cf84f1e3b474d5749ec46069/murmurhash-1.0.15-cp314-cp314-win_arm64.whl", hash = "sha256:88dc1dd53b7b37c0df1b8b6bce190c12763014492f0269ff7620dc6027f470f4", size = 24341, upload-time = "2025-11-14T09:50:53.295Z" },
+    { url = "https://files.pythonhosted.org/packages/38/9c/c72c2a4edd86aac829337ab9f83cf04cdb15e5d503e4c9a3a243f30a261c/murmurhash-1.0.15-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:6cb4e962ec4f928b30c271b2d84e6707eff6d942552765b663743cfa618b294b", size = 30146, upload-time = "2025-11-14T09:50:54.705Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d7/72b47ebc86436cd0aa1fd4c6e8779521ec389397ac11389990278d0f7a47/murmurhash-1.0.15-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5678a3ea4fbf0cbaaca2bed9b445f556f294d5f799c67185d05ffcb221a77faf", size = 30141, upload-time = "2025-11-14T09:50:55.829Z" },
+    { url = "https://files.pythonhosted.org/packages/64/bb/6d2f09135079c34dc2d26e961c52742d558b320c61503f273eab6ba743d9/murmurhash-1.0.15-cp314-cp314t-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ef19f38c6b858eef83caf710773db98c8f7eb2193b4c324650c74f3d8ba299e0", size = 163898, upload-time = "2025-11-14T09:50:56.946Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/e2/9c1b462e33f9cb2d632056f07c90b502fc20bd7da50a15d0557343bd2fed/murmurhash-1.0.15-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22aa3ceaedd2e57078b491ed08852d512b84ff4ff9bb2ff3f9bf0eec7f214c9e", size = 168040, upload-time = "2025-11-14T09:50:58.234Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/73/8694db1408fcdfa73589f7df6c445437ea146986fa1e393ec60d26d6e30c/murmurhash-1.0.15-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bba0e0262c0d08682b028cb963ac477bd9839029486fa1333fc5c01fb6072749", size = 164239, upload-time = "2025-11-14T09:50:59.95Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/f9/8e360bdfc3c44e267e7e046f0e0b9922766da92da26959a6963f597e6bb5/murmurhash-1.0.15-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4fd8189ee293a09f30f4931408f40c28ccd42d9de4f66595f8814879339378bc", size = 161811, upload-time = "2025-11-14T09:51:01.289Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/31/97649680595b1096803d877ababb9a67c07f4378f177ec885eea28b9db6d/murmurhash-1.0.15-cp314-cp314t-win_amd64.whl", hash = "sha256:66395b1388f7daa5103db92debe06842ae3be4c0749ef6db68b444518666cdcc", size = 29817, upload-time = "2025-11-14T09:51:02.493Z" },
+    { url = "https://files.pythonhosted.org/packages/76/66/4fce8755f25d77324401886c00017c556be7ca3039575b94037aff905385/murmurhash-1.0.15-cp314-cp314t-win_arm64.whl", hash = "sha256:c22e56c6a0b70598a66e456de5272f76088bc623688da84ef403148a6d41851d", size = 26219, upload-time = "2025-11-14T09:51:03.563Z" },
+]
+
+[[package]]
+name = "mutagen"
+version = "1.48.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/70/1675da133ea92227da41bf5b24e1c66be597ff736a1533ade41da986852f/mutagen-1.48.1.tar.gz", hash = "sha256:8f95637ab9f6f305cec6bd1294e197debe207998e3e068596563c74f86b0a173", size = 1276978, upload-time = "2026-06-25T09:47:32.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/d8/a29e4e3991765e7ce4ed1f7e4074fe1ba9da03e0048639734de60f9cadb9/mutagen-1.48.1-py3-none-any.whl", hash = "sha256:4f077fe87d3fc7fba259aa63d8c026b18382ca6a42ef37c61e16f1b1b5b82fe7", size = 195706, upload-time = "2026-06-25T09:47:30.296Z" },
+]
+
+[[package]]
 name = "mypy-extensions"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.4.6"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/49/ec46835a70be8fa6446c495126ac84fdb28cb2558e1620ffb87a10c8b64c/numpy-2.4.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0280e0356c0829a18d9de1cb7eee50ec22ca639878d7240307ca0943d73cd2c4", size = 16969194, upload-time = "2026-05-18T23:33:13.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0d/f5957185c0ee2f3e12f78715aa9e3b353fd83633316c8532b38faa37e3f6/numpy-2.4.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:110f8b71aacb688ec69062bb7f6938a0f8acb01b7c1c4beb453c65b6d234584d", size = 14964111, upload-time = "2026-05-18T23:33:17.795Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/40/40a40ee0ddf7ceb782c49af278894b686e586d65d8c1889c8b5da01a3d7d/numpy-2.4.6-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:4cfe66903cc32a9921a6733d96b19bb6abf310397581bbad89c228f5abaf0ee8", size = 5469159, upload-time = "2026-05-18T23:33:20.654Z" },
+    { url = "https://files.pythonhosted.org/packages/63/13/f9a8046535cb21deae82f8d03de9617e08882d274fad2539630761888228/numpy-2.4.6-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:8155154c7c691289fe18f510b5d4657c68c67989f293f0535a91360392ff6538", size = 6798936, upload-time = "2026-05-18T23:33:22.987Z" },
+    { url = "https://files.pythonhosted.org/packages/33/a8/6fa8c1a345a8c85dbb21932c447bee07c30a2c2a3f31e369c0a84b300147/numpy-2.4.6-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ab0a9c4ffb1a6d95ef519fe4247dba8eb6b18ad93999f76b7f657039acabd47", size = 15966692, upload-time = "2026-05-18T23:33:26.62Z" },
+    { url = "https://files.pythonhosted.org/packages/02/03/74fe2a4cb3817d94d86402f2506554130a2f01414e299b5a843e5a8a957f/numpy-2.4.6-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:89cd468399cfd2504718f0ba50e410dca55a170b61a02ad92bb18c8a65186e93", size = 16918164, upload-time = "2026-05-18T23:33:29.955Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/80/3615be3313f7e7696609bc194b9f0101da809df79e859bdb84e0cd043f46/numpy-2.4.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c2d37ab77531417474168eb79d6d80b14f821a966818505d03013d0833edb7a8", size = 17322877, upload-time = "2026-05-18T23:33:34.724Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ac/a691e0fe2675e370d0e08ff905adc49a1c8830e8cae03efe4477e92cd55d/numpy-2.4.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f407cb6b8e9d6d8c626bc73c945db1706035af8fd632295547bf1c9e46d092d6", size = 18651487, upload-time = "2026-05-18T23:33:38.217Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a7/9bc1cd626d7bf6869bfedf27b91b6ab5dd607758bf8e959d6fa80c6a59cb/numpy-2.4.6-cp311-cp311-win32.whl", hash = "sha256:ddea102b48f9e339f3948bf22040944184627a30fdf7f858667673b9c5f033c8", size = 6233945, upload-time = "2026-05-18T23:33:41.331Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/31/7fc6239c12bce7e931463251cca4426c465e1876ba3cc785402ef4dd8f4e/numpy-2.4.6-cp311-cp311-win_amd64.whl", hash = "sha256:1e254a00cdf42b1e4d5b3d68d33af63268d41340d8885df2ab6470f2e1500147", size = 12608406, upload-time = "2026-05-18T23:33:44.131Z" },
+    { url = "https://files.pythonhosted.org/packages/27/83/140f85a466595a16382996a1bf06b2b54bcd597488921b0c9daaeeda72af/numpy-2.4.6-cp311-cp311-win_arm64.whl", hash = "sha256:ed9749eef4cbd126da3dc1d6bcb3a57f5eb7ac6a6484146bdbf743f552dfc577", size = 10479528, upload-time = "2026-05-18T23:33:50.725Z" },
+    { url = "https://files.pythonhosted.org/packages/95/2a/3d7b5ac8aac24feaf9ad7ed58f45b0bbc06d37e4338ae84c9f2298b570f9/numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1", size = 16689119, upload-time = "2026-05-18T23:33:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/12/92c4c131527599e8288d6918e888d88726f84d805d784b771f32408aeaef/numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb", size = 14699246, upload-time = "2026-05-18T23:33:57.621Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fe/c0a6b7b2ca128a8fb228575147073b660656734b8ebe4d76c8fd748dcc79/numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41", size = 5204410, upload-time = "2026-05-18T23:34:00.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d4/9770d14ba719432bb90a421bfd443872ed0f70f7264b64bec12ea363d5fd/numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698", size = 6551240, upload-time = "2026-05-18T23:34:02.852Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c6/50a46a6205feba2343f1d6d17438107c5dc491ed1c736e6ea68689fd906b/numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f", size = 15671012, upload-time = "2026-05-18T23:34:05.485Z" },
+    { url = "https://files.pythonhosted.org/packages/99/60/14115e6364fa676c5397c2ad3004e527e9aa487abf5d0706ec81bbd08529/numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853", size = 16645538, upload-time = "2026-05-18T23:34:09.265Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/c5/693cbe59e57db94d2231fa519ca3978dc9e19da5a8f088588f5c6e947ff2/numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a", size = 17020706, upload-time = "2026-05-18T23:34:13.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/fc/85b7c4eff9b4966ade25c2273cf7e7012e92366c032058653934b37de044/numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2", size = 18368541, upload-time = "2026-05-18T23:34:17.024Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/e1b27545deedce7f4a0b348618c6b62d74e36a4dc9ccd42f3eb2f85eee32/numpy-2.4.6-cp312-cp312-win32.whl", hash = "sha256:e3eeb0aabd6bd5ce64faae67e9935203a6991b4bc2a485a767fbafb2c5125f45", size = 5962825, upload-time = "2026-05-18T23:34:20.3Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ca/feab00bd44aa5fe1ad2c18f08b4d3bb92e26484b0b1d1443897809ed528c/numpy-2.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751", size = 12321687, upload-time = "2026-05-18T23:34:23.095Z" },
+    { url = "https://files.pythonhosted.org/packages/63/cf/5a6d34850a39d1093558564f77ee8e8e0bee5061151b8f05a55711001ec7/numpy-2.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8", size = 10221482, upload-time = "2026-05-18T23:34:25.876Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/82/bdab26d7438c6791ca31b7c024ca37c1eab8b726ba236129005cd4a06e45/numpy-2.4.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:511dbaf848decaaaf4b4ca48032619fb3138710c4bf7da7617765edad1ef96b0", size = 16684648, upload-time = "2026-05-18T23:34:29.41Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/30/a80189bcc7f5e4258b3fbc3968d909d1756f54d023299ecc39ad6fdb9ef8/numpy-2.4.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bf162abab1c1a736333192707cef898e735a5ca00f38f27eeedf44b39d9e85eb", size = 14693902, upload-time = "2026-05-18T23:34:33.013Z" },
+    { url = "https://files.pythonhosted.org/packages/97/12/70b5d0d7c15e1ebb8a6a84a8caa1d19e181d84fb58bb6d70aca29099dec1/numpy-2.4.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:043191bfa8eab18c776647b62723ac9dddece59743b13f49b2016094129c2b3f", size = 5198992, upload-time = "2026-05-18T23:34:36.132Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/ebd2a8f8a83541f8d38cc5667e8c2b69cecfd30da6e45693e8158857d44b/numpy-2.4.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:6180d8b35af935aed8ece3a85e0a43f87393ae0ac87c8d2c8bd2c993f7270ef3", size = 6546944, upload-time = "2026-05-18T23:34:38.484Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/c5/7b863a97a91671a0338f4253bd3b5a3d3852f0692dae91711c9f4a10e787/numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b", size = 15669392, upload-time = "2026-05-18T23:34:41.257Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9d/3584b9984ca4c047aea75214ce1a4c4c73d849bd71b604264b7f5653f8a8/numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089", size = 16633220, upload-time = "2026-05-18T23:34:45.075Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ae/7c67fba23bd98caec7c99261f3a16072ade14813486b0282cb29846de832/numpy-2.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ef4aea96ce4d3b074422cb4f2f64e216bf9e213004bb58ecfdf50ea02ea8eb9a", size = 17020800, upload-time = "2026-05-18T23:34:49.065Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/5d/3b6725cb31d983c5e66916f5d36f6d7e5521129e4c4404d64f918292a5b6/numpy-2.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfa20cc6ca228e6b155b11da03825975ce66aea520985dbbddf0f2a5a495c605", size = 18357600, upload-time = "2026-05-18T23:34:52.709Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/da/2ccc6c2fe8898dee01d90c75c5f5f914a23daf99e3e0f59516a08760c8b5/numpy-2.4.6-cp313-cp313-win32.whl", hash = "sha256:56b39e5e0622a09a25bf5baf62f4bcf0cb8a41ae6e2819cf49bbc5a74c083f91", size = 5961134, upload-time = "2026-05-18T23:34:55.618Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/cd/9cc4dc876fb065d5c220aae4d5e14826b2715331bb7618ce1fb07a679d99/numpy-2.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:c4fc99836233ea196540b17ab0983aff60ed07941751930f5f4d05bc3b3b7359", size = 12318598, upload-time = "2026-05-18T23:34:58.928Z" },
+    { url = "https://files.pythonhosted.org/packages/39/1e/c0bcba1f8694116485fe28fd1be698c278fcda4141c5b0e53a2aed8b12a8/numpy-2.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a7c711e21628b52034bb5ab8d1bce291f752fcc5e92accc615778acee1ff4778", size = 10222272, upload-time = "2026-05-18T23:35:02.167Z" },
+    { url = "https://files.pythonhosted.org/packages/63/6d/cc5619247c8f4204e507f5883528372e4ac4bb189e579fb859a12e480b1f/numpy-2.4.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:112b06a867b235ef466ed3508ddf0238050df9c727cafb5301ac385b899189a1", size = 14821197, upload-time = "2026-05-18T23:35:05.468Z" },
+    { url = "https://files.pythonhosted.org/packages/00/58/f1c39161c87d9e9bed660f1ed4bafc0e403d5ec9650b6dd77aead07d489b/numpy-2.4.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:eaf7fa2de5c0be8ae6ff8e9bea2ccd725e980541244521d8d4b5f3354a27babe", size = 5326287, upload-time = "2026-05-18T23:35:08.693Z" },
+    { url = "https://files.pythonhosted.org/packages/af/57/3917ab0fd97f271a8694513581b8a36c655f111c446852c302f04ccdb6fc/numpy-2.4.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:7265a2f3d436e54ef9f2b52b5c937e6be778781bd97a590319d7348f1c1ca997", size = 6646763, upload-time = "2026-05-18T23:35:11.459Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0f/037e64c494b67581ae18193d770adef354c41f3f2c8ebf865602d949bf8f/numpy-2.4.6-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f74a575920ab21fe304421a3fc28793d82e299cae9eccb37084e9fc7f3617c20", size = 15728070, upload-time = "2026-05-18T23:35:14.79Z" },
+    { url = "https://files.pythonhosted.org/packages/21/a6/5d2bae9c9542eb4df16dc9c46dc79c186e9bad53805dfa5399a6023c6db0/numpy-2.4.6-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ede83e07a75dd06bc501566c1eca2afc0d61677c1472ac9ad93fdee6e638a48d", size = 16681752, upload-time = "2026-05-18T23:35:18.836Z" },
+    { url = "https://files.pythonhosted.org/packages/92/14/23d1dfb410ae362cd59ce53e936b1513d545eb40db3949ced632e19a459e/numpy-2.4.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:68bb27509ac1b9a3443094260f6326150663b06abe40b73a2f81160623da5b67", size = 17086024, upload-time = "2026-05-18T23:35:22.52Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/23595a2c642cdf3bc567877064bdd7f91c8b0038a4453cf2daf7248eafe9/numpy-2.4.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a0df0043bdb289bde1f62da130d20df23d58b45429f752bc7a8fc5325a225ecd", size = 18403398, upload-time = "2026-05-18T23:35:26.398Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/90/0ac3bc947217e66dec77e7cbc6a1979d1af70b6461b82f620d3bccd5e4c8/numpy-2.4.6-cp313-cp313t-win32.whl", hash = "sha256:29a287e0cf63ff528da061de6b9f64a4618da591ca1046aafc54062e40ca7eab", size = 6084971, upload-time = "2026-05-18T23:35:29.387Z" },
+    { url = "https://files.pythonhosted.org/packages/77/71/5673e351671a1d2bd6063b91b44f70c0affea7d1516fa7a6572941ba4aa1/numpy-2.4.6-cp313-cp313t-win_amd64.whl", hash = "sha256:25c692919ac5a01f170a3bfcd62d745b24fd095c353d50812637d6fcab442e75", size = 12458532, upload-time = "2026-05-18T23:35:32.175Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/88/19d3503c5046e688f049274b27a3ef3d771152fa80d3ba3d01a3dff61abe/numpy-2.4.6-cp313-cp313t-win_arm64.whl", hash = "sha256:1e978ec1e8bd0e0e4de6bb75de9d30cbb74db6b6a2bb727618613703ca0167dd", size = 10291881, upload-time = "2026-05-18T23:35:35.465Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/3ab2044d05fd16d343c5ac2e69b127f1b2854040dd20b193257c78028bd3/numpy-2.4.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06ca2f61ec4385a07a6977c55ba998a4466c123642b4a32694d3128fce18c079", size = 16683458, upload-time = "2026-05-18T23:35:38.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/62/764ce66fa4147ae6d73071a3abf804ffe606f174618697c571acdf26a7c9/numpy-2.4.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:38efbc8de75c7a0fc1ac190162d892787f3f47b57cc291231aafee36b80982b7", size = 14704559, upload-time = "2026-05-18T23:35:42.14Z" },
+    { url = "https://files.pythonhosted.org/packages/60/61/23f27c172f022e04025b7dc2367f4d63c1a398120607ec896228649a6f48/numpy-2.4.6-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d581b735e177fdcdce6fed8e7e8880a3fb6ee4e3653a3ac6af01c6f4c03effc5", size = 5209716, upload-time = "2026-05-18T23:35:45.377Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/21cf70dc6ea3e3acb95fc53a265b2fc248b981f0194ceb5b475271b8809d/numpy-2.4.6-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:0a041d3d761dc3c35cc56ce0351506a02bcbc25f7b169f652435141a17db9096", size = 6543947, upload-time = "2026-05-18T23:35:47.926Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/91/64288395ee1799bd2e0b04a305dce9666da90c961e1f3fe982a05ee1c036/numpy-2.4.6-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40fdc1ae7125e518ea98e53e69a4ebc27e1fd50510c47b7ea130cf21e5e1d42b", size = 15685197, upload-time = "2026-05-18T23:35:50.863Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/eb/ebffaa97dc55502df69584a8f0dcf07f69a3e0b3e2323670a2722db9aa39/numpy-2.4.6-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2c306dea656c12c68f51f4cea133cbe78ca7435eb28c735eac1d3ebe73be6e8", size = 16638245, upload-time = "2026-05-18T23:35:54.752Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0b/54f9da33128d7e350fab89c7455902eeae70349ee52bddb448dc4a576f45/numpy-2.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:33111801a01c12a8a1e3721f0a9232f8cfc8ae2c6b7098167e6f623c6073f402", size = 17036587, upload-time = "2026-05-18T23:35:58.355Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f0/fdebc1052db1cc37c64beb22072d67cd6d1c71adca1299f53dec2b5e20d3/numpy-2.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ae506e6902902557576a26ff33eda8695e7ecb3cb36c3b573a0765dee114ebdb", size = 18363226, upload-time = "2026-05-18T23:36:02.845Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b4/298628d98c72b57e57f7165ae6a481a1deaf6f3c28262a6e4c739c275930/numpy-2.4.6-cp314-cp314-win32.whl", hash = "sha256:aaf159caa35993cb1f56fb9b8e4610d35758e7ca005412eb1daa856a78c9c4b1", size = 6010196, upload-time = "2026-05-18T23:36:05.92Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ac/46de6dda46478f7942f839e094970be2d4a861e005c4b3bf07c92e291a09/numpy-2.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:b507f5c4c1d508876d1819b6bf9a49d365b96320b5d4993426b33a23ca4b8261", size = 12450334, upload-time = "2026-05-18T23:36:09.107Z" },
+    { url = "https://files.pythonhosted.org/packages/78/92/b8b798ac784102c0da830d2257d59358e3d3d90d1e2b3f2575dad976c5cf/numpy-2.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:6f41ae150c4e32db4f3310cdaf64b1593a03dbabe29eec77fc9b50fe64061df6", size = 10495678, upload-time = "2026-05-18T23:36:12.766Z" },
+    { url = "https://files.pythonhosted.org/packages/30/34/ec28d1aa8115971537c01469ab2011ee96827930f0a124de1000cc2a7ed7/numpy-2.4.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ece3d2cfe132e7d51f44a832b303895e6f2d499c5e74dfbdb06ee246147a304a", size = 14823672, upload-time = "2026-05-18T23:36:16.473Z" },
+    { url = "https://files.pythonhosted.org/packages/16/bd/f6d1fede4e54e8042a7ff97bb495510f3c220f94bcd9e8b228e87c92cc0d/numpy-2.4.6-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:e3e5193ef5a3dc73bceee50f7fdc2c90dbb76c42df8d8fae3d1067a583df579e", size = 5328731, upload-time = "2026-05-18T23:36:19.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f0/e105b9e2fd728a9910103884decd6951d9dd73896b914a98d9a231de02ee/numpy-2.4.6-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:17f9ade344e7d9b464a084d69bcf18fc691cb1db67c62ed80820bf4926d78f0e", size = 6649805, upload-time = "2026-05-18T23:36:22.266Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/1206a7ca6ab15e3f02069707ca96222e202af681bb73756da7527f3cb837/numpy-2.4.6-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cd5ffd25db4e7ba6a375693b3fc0fc1791ec636c17db3720da19bde7180ec43", size = 15730496, upload-time = "2026-05-18T23:36:25.713Z" },
+    { url = "https://files.pythonhosted.org/packages/51/e7/38d3ea825dcab85a591734decb2f6c67caa7c8367d374df1a1c3842f9b07/numpy-2.4.6-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d92c3819208a60205a12a245c91ad70cb0a85336659b19b834205573ac8456e", size = 16679616, upload-time = "2026-05-18T23:36:29.652Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b7/caabfdf53edf663e0b4eb74d7d405d83baef09eb5e83bcd32d601d72b93e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e85b752a1e912b70eaad4fafbd4d1238007ab221de2009b9a2f5ae7461239895", size = 17085145, upload-time = "2026-05-18T23:36:33.449Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/45/68d7c33a6bcf3e5aa3bdbd57a367e6f615286dfd6482f97e8ffeb734306e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:29cb7f67d10b479ff07c17d33e39f78c07f71c40ef30d63c153d340e96cd3fb4", size = 18403813, upload-time = "2026-05-18T23:36:37.369Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/50/0753655aa844c99cd9e018aacf76f130f1bd81d881bb74bc0aef5d73a8ba/numpy-2.4.6-cp314-cp314t-win32.whl", hash = "sha256:260a5d70215b61ab4fadf5c7baacd64821842975eea312125ed3c39a6391b063", size = 6156982, upload-time = "2026-05-18T23:36:40.817Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/d4/7c67becf668f973cb490cec3e98dfd799d866f9c989a54d355672cfa0db6/numpy-2.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:81a1cca95ed5bb92aa8b10dd2cdc9a0d3853a50fad926c28b5d7e8ea54389627", size = 12638908, upload-time = "2026-05-18T23:36:43.996Z" },
+    { url = "https://files.pythonhosted.org/packages/43/bb/e1c71a4295b1b1d1393d50dbb4f2a36283c6859d9d3892e84f00ec5a91d5/numpy-2.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:0c9136e14ed34a9e343a31c533d78a9813a69a3148332bce5e9821cb2f996e66", size = 10565867, upload-time = "2026-05-18T23:36:47.114Z" },
+    { url = "https://files.pythonhosted.org/packages/de/12/b422cc84439adc0d00de605bf4a308890ae5c26f2c71fbd73e5d08fbb0dd/numpy-2.4.6-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:55cced7c52e981362f708ad635198e97a752dfba412cc03c23bbf3bd8d5cd662", size = 16847511, upload-time = "2026-05-18T23:36:50.673Z" },
+    { url = "https://files.pythonhosted.org/packages/44/53/f481bef68011740f8849418d82db07230e825013f31f4eef5ba5b805316a/numpy-2.4.6-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d6da64deb6b8ed903e7560180a92f2d804ee1ba5eeb849ac2748b8c1aba1f6d7", size = 14889064, upload-time = "2026-05-18T23:36:53.879Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/57/42ed575c10ced8af951d426bc4e1f8aff16fd851db33f067036215a7f860/numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_arm64.whl", hash = "sha256:68a5124b13fa6cc2086764a20005d30bc0548146f7f5322f02fce212ca14317f", size = 5394157, upload-time = "2026-05-18T23:36:57.194Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/ef/f66cc724fcc36c1e364c67f51ae9146090b8b584f27d58b97fdae3edd737/numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_x86_64.whl", hash = "sha256:948424b06129ce883307e8cff868c31396d8dc7630a59c61d70d98dbe70f222c", size = 6708728, upload-time = "2026-05-18T23:36:59.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/9c/c531f2293b91265d8b48e9b329f54fdd7ffae73cb4134ea10cca4237e9cc/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5dbbdb29840ca3d91ee0fece42fc29278886d908280bfec0a5846c6f901a3eb0", size = 15798374, upload-time = "2026-05-18T23:37:02.674Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b0/413077f6b1153ed3cba361401c6783bbad6114804a000cc22eb71c13e190/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ad03c0965fb3c692200e74d458ca28c1dbb4ce96f9a479a8aa041ad5fabca02", size = 16747286, upload-time = "2026-05-18T23:37:06.327Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ce/e5ec180bc41812edcd8daeb8639d205622c0e8c02259d8ab25a0201b3c2a/numpy-2.4.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:2803abfebfc990042cd494d8ce2d5f82e9d847af6d35ec486923aa19dbad5e73", size = 12504263, upload-time = "2026-05-18T23:37:09.715Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/7b/14687aa674250e5e546f616f486b0d56d3631cd5b2415739141ce40bdcea/numpy-2.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c889b56fe48b1018f764b0eec8df59ab654e9148aa91faa12596043500de277", size = 16801574, upload-time = "2026-07-04T17:06:12.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/19/cc5bb2a3f2913d27d6dbb2c78d25921fabaedc6741d4a5a615a11f3c5bf3/numpy-2.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab451b59c5643c570974c43aef780703ef1d3b4965d2be07afd530615a9358d1", size = 11772250, upload-time = "2026-07-04T17:06:15.726Z" },
+    { url = "https://files.pythonhosted.org/packages/42/77/fdf34a71dd30f54979b18603bee915e0aaf825b07afe79acd60b04b691e2/numpy-2.5.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:78798bd5b9ad744056af8efa90e3b9ddaa53272a0848a483084a1cc0a13b2dc0", size = 5331516, upload-time = "2026-07-04T17:06:17.913Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e2/eb7efa015b4cce41e2517bf182a7fce0d7d5b9d9ed76a29bfa0f4fe4505c/numpy-2.5.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:2ae0ca40bcb22d6ba59c1dfd5446f49940b0f2d821fde133f10dda11f816b84e", size = 6664863, upload-time = "2026-07-04T17:06:20.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/4b/a2b32dd94ee9ffbeecb28152240042a3949db33b1c834d44090b80e1b3b8/numpy-2.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61ac47e772e6b8ea489e1d2f441a34c5c3ac17327e7ce294cbdf535795ad4e75", size = 15167977, upload-time = "2026-07-04T17:06:21.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/6e73d68500f80773f65f0654ea932019d6694329a0eb0ed0533de38df376/numpy-2.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59fda5e192b570217ec2580c96f00e9a7e12ef6866a900eb089b62c1a32545ca", size = 16672469, upload-time = "2026-07-04T17:06:24.064Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7d/ad3e59015135f5261c95fd4cafeff159c955febd83a99a1d9250c4233815/numpy-2.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f7119ebff1a9829e9f431a4f9d28e703023bb6b9fe7c8f724467dbfc27c94ab3", size = 16527531, upload-time = "2026-07-04T17:06:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d0/a39b2fbcde9cb17a1dac678f254b33a6336298af9df338824c685425d5e8/numpy-2.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e824c2acf8862052246be5a44c15da1777940c60d010dd2aab897824d9c430f9", size = 18431940, upload-time = "2026-07-04T17:06:29.521Z" },
+    { url = "https://files.pythonhosted.org/packages/04/12/cff070947791c1ed425ff76413189adbdc2fbe215eba7ce7fa454a03c7f8/numpy-2.5.1-cp312-cp312-win32.whl", hash = "sha256:08d60c810432eb83360958dea0999ac4cfb94531ea8efcbf0b7f277c2068aeb2", size = 6066764, upload-time = "2026-07-04T17:06:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/65/66/53f31807a48a750f9d748da273bc3fcedd12b27ff1f3e373bfec55ef2dc0/numpy-2.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:f7d60026c0bdb1380e83bfa7a0419c4577ee4b9a08880afcb6dadeb74c649fa2", size = 12430966, upload-time = "2026-07-04T17:06:34.926Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/2a/d1a88066b1c14186f5d3c0d18c94f17b064511982bab0578d49ee9d43c29/numpy-2.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:17a25e09640602e10bc8de0e6fa2b3fd68eedd84ba6d7842dc8f32f9ab87bd0b", size = 10350488, upload-time = "2026-07-04T17:06:37.785Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/07/ec2a3f0c91761581d4b7104a740791800025983f9a4dc4e73f91a99aeac4/numpy-2.5.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0bfebd8695f9863592fe744be833a258120b14a9f39da255e8aa8fade2c0ddd1", size = 16796419, upload-time = "2026-07-04T17:06:40.37Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ab/ddb499fc4f8780354395face5b65c7fd107bcd6e1d667a5f07d046956f6f/numpy-2.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:30b44a6b53a7ae63c54c089a8726e5563ed302716c5b7ccc85afade40b0e7ff6", size = 11765832, upload-time = "2026-07-04T17:06:42.768Z" },
+    { url = "https://files.pythonhosted.org/packages/88/b3/3c28c558a09fc72100c646dac6d2fce8e834c471b0edca01a29996706117/numpy-2.5.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:6165343f81b56ef8f514f396989e529b61d9dc709b99421b07e9f3e698e2287d", size = 5325143, upload-time = "2026-07-04T17:06:45.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/0e/ce19b985bb15c596f4f05954e76cccc77c845083b3b8f938a6c68e523128/numpy-2.5.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4939237038ada79308dda3204ac6462df056b5672b2e25db1149cf873668b3e1", size = 6659749, upload-time = "2026-07-04T17:06:47.288Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/20/1ee6614d64332a1bba6411f38e68cb79eec1b2459e20a623777c5c5492a2/numpy-2.5.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c6759f538fb912fc46de0a6b1758ccf7b57bc7c7ebebc23974fdac3de8db0cd", size = 15164716, upload-time = "2026-07-04T17:06:49.494Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a7/2bcd3fdbb87804755c35b729bf8709d62025c5f4cfd7d5b2415997097515/numpy-2.5.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9726558e8db4a5bf7929a70ae50f63abda4daf0efe810e3bfbab95976f75fc1a", size = 16661440, upload-time = "2026-07-04T17:06:52.061Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d7/a41e3310c886fe457d36e670bbf24fae411aca8a7b6ad92a32afd924077c/numpy-2.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3935f3b419b244a02732676fa5317a9193cc596a4c0646db07e5b421229ac9f7", size = 16526305, upload-time = "2026-07-04T17:06:54.605Z" },
+    { url = "https://files.pythonhosted.org/packages/53/75/4333a9a707c1edd3a4e1a0c58eca52c0f31e55089fa80db02b5565b24df7/numpy-2.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dc932a65ded7ce9013d120845a2514dcccb1a67bfc8deb8d37633762951904a6", size = 18423008, upload-time = "2026-07-04T17:06:57.54Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/e314a32b1c11a2ffe818ddad3a57b50b4b6e1b6c487192eb50cdef0415d0/numpy-2.5.1-cp313-cp313-win32.whl", hash = "sha256:4b4ff1608417eb7a59da7b967bbb798cacfe071d2caf526a24281cd562072ed9", size = 6063885, upload-time = "2026-07-04T17:07:00.14Z" },
+    { url = "https://files.pythonhosted.org/packages/10/70/800b3fca480af32df9e8ea9f3d4a0c8feb4b32d7f195d174eabbda4829ad/numpy-2.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:6c3fe51bc6a16453d452997053454f309e8e0ed7b42d6b361ce4ac8c32913d74", size = 12425674, upload-time = "2026-07-04T17:07:02.387Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/0b/196350c122f50f6ca56846f2d71efd5e0d24b7b2e07355e019b2e2c7a11e/numpy-2.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:f7feb014281029e628ba2d5a007407443b06e418b6fe451d1e2adcbc8eba0107", size = 10350256, upload-time = "2026-07-04T17:07:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/db/f4/731b6085a83faf6ca843394cbd5e217280c214399f7e8b21b9f552af0ae2/numpy-2.5.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:7c786fe9a5bbe360022e584c5a34cf6b54265c71bd7ec8ac3d8fec38968071f8", size = 16795063, upload-time = "2026-07-04T17:07:07.374Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/64/0e215f2048dd11a55bb989ed41b3585ef57452404e638d703a211a3e4157/numpy-2.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:32985c896d897419ef8da6917872d80b78ad0ea26d85b23245c7366ffde76d75", size = 11776652, upload-time = "2026-07-04T17:07:09.907Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/59/2b844c7a6e9deff69b404a66221e1542937734f65d5e6e39411876053862/numpy-2.5.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:efd736408cc97c79b9e6917338dfc8f06013b2274f992e96b1d9a81a71e2a2c2", size = 5335944, upload-time = "2026-07-04T17:07:12.227Z" },
+    { url = "https://files.pythonhosted.org/packages/86/51/9bf7cb2cabcebc9e017e4ec7e6322b378317a542c08b4cb68479c1efc716/numpy-2.5.1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:ab84dc6b074fa881cae55bea94cc4f68e285181ba7f32497bf7dee6b1496165b", size = 6656266, upload-time = "2026-07-04T17:07:14.368Z" },
+    { url = "https://files.pythonhosted.org/packages/83/3e/fb7615b211b82a32f44d5180a6d421b61f84d4fadd578b48ba4ac34e189f/numpy-2.5.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caf3e317d33d60c37986b452613f4ab51246d0691350c03d0cb4a898627f4a95", size = 15179720, upload-time = "2026-07-04T17:07:16.272Z" },
+    { url = "https://files.pythonhosted.org/packages/41/5f/0f992cb24560673496c5d68de61913b57166ce530ffda07c1f280e0cc464/numpy-2.5.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:54ad769f17bc2d833b620851989f62054fb9ab93c969d9e1dc3c8e3d56beea21", size = 16664835, upload-time = "2026-07-04T17:07:19.021Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/2f/97d6475ee91afe2587797d09446f9d3e475ad4cb681662d824809327b75a/numpy-2.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c12afb53450fa976d4c681c50a7423729a4c51c0465ed9f32b8a9cabbc472373", size = 16539135, upload-time = "2026-07-04T17:07:22.015Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/5b/4db81e4ba0be7e2776b1de68c82aa862c7f8ec27e1b4927d4ae075e20678/numpy-2.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e8c11c405efc5ff6816d5983c96cdfa215bab3428961243af3ff59b228490438", size = 18426684, upload-time = "2026-07-04T17:07:24.941Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/64/c0ba2d90724d450279a7df8f32057241070250a26a7e2b5337d77347f481/numpy-2.5.1-cp314-cp314-win32.whl", hash = "sha256:f2479a47f8d5932d1718168a681ad6e536a9df484c83cfcf9de365e164537ace", size = 6116103, upload-time = "2026-07-04T17:07:27.622Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/1a/837f9ed7405adcd7a40538792eb169eddd8fa5630c16a1ef49dae71a30f4/numpy-2.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:24d0eb82c0541d3415a33425db64ae439dffccd7b4dbcb30e7c35120205c506a", size = 12562177, upload-time = "2026-07-04T17:07:29.887Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/49707938b6dd0a78a9178dd93227dc89e4c11af47f5c798d70366e8d0483/numpy-2.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:5a4c988b38d261deeeaad9954e3deb091ad905c94e8bb6708654ef1d97f286b0", size = 10627739, upload-time = "2026-07-04T17:07:32.568Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c7/bb4b882cfe7f299cbc8b66e42e7dd78cf9d14e40f9469fc5e3db7e15b3bd/numpy-2.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a33276be12fa045805f477f22482088b66bb758ffbe89a9d21457de863a32e22", size = 11894709, upload-time = "2026-07-04T17:07:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/40/3f/5af7f4a7f6224aef48017aa82bb6174c7a659d724be0c75017b7e64a55b4/numpy-2.5.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:f089d7b00756190aacf1f5d34bdf38c3c430ac82b4f868f8cede73380460fce7", size = 5453810, upload-time = "2026-07-04T17:07:37.495Z" },
+    { url = "https://files.pythonhosted.org/packages/20/c9/3474309bc94d634d3f9c3eddf03250ecb8c22cd948ef16fef69a77cc5d7b/numpy-2.5.1-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:09e9bfd8d2cf479c7d174804fb3811c53a8e9f20a37444008606b57d6b7a826d", size = 6761189, upload-time = "2026-07-04T17:07:39.563Z" },
+    { url = "https://files.pythonhosted.org/packages/90/8a/558ae39fdd55d7e7f7fef9a84a6e964ac6b23edbd2a07e52bb084500507d/numpy-2.5.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e68d8dd1e7eba712948f2053a29ec86917bc70ba1358df869d9f06649ef9cf09", size = 15225039, upload-time = "2026-07-04T17:07:41.682Z" },
+    { url = "https://files.pythonhosted.org/packages/63/27/ca7392b2d030277bdf0273e7d23255b3ee57d57a7c170a6f4fb3981e1e5d/numpy-2.5.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:99d5095fa265a0c4152e7bb12759e14381ef5496152f1ce58f44bdf55c44beb4", size = 16701306, upload-time = "2026-07-04T17:07:44.611Z" },
+    { url = "https://files.pythonhosted.org/packages/02/42/03d53ae7996c44d4374a8262e9dc41671fd56cbb98f7d47ef85cf5da4c6b/numpy-2.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ab87a91b3cc3382b8956095bd8f95e00cf679bb81554339be1a2ba404a1473c1", size = 16589955, upload-time = "2026-07-04T17:07:47.694Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/15/6c1784ae469640e65db111e9a34b3d0f14d91e8a38b9ce34810ced370dbb/numpy-2.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:224ca51130ef7da85bea2191625181cb4f337f9cb64b471f10c1a12aa8b60077", size = 18464252, upload-time = "2026-07-04T17:07:50.684Z" },
+    { url = "https://files.pythonhosted.org/packages/94/a8/f98e50356cf167df656c526c2dfeec2d7dde182f2a3da4b458a5938e2776/numpy-2.5.1-cp314-cp314t-win32.whl", hash = "sha256:6eab239876581b2b3c5a242281b6007bbdbcd1c7085d7709bb57c5929b11e6bf", size = 6263298, upload-time = "2026-07-04T17:07:53.445Z" },
+    { url = "https://files.pythonhosted.org/packages/72/ac/96ae880cdecad0b3275d9359fcec72667b49a4863c9f12942e43679dda02/numpy-2.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:83ce9c80d5b521b0d77ddcbe5447c218d247929b6cc056ca5351342accfff0af", size = 12748623, upload-time = "2026-07-04T17:07:55.384Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/5a/4d2b1601df3602dba7a14f3348ba9bfe94a18adb428e693df6154c293831/numpy-2.5.1-cp314-cp314t-win_arm64.whl", hash = "sha256:5a6db61f9aaa57e369905c67d852045d3c4f7126405b29d09b19dec118e9c9cb", size = 10697674, upload-time = "2026-07-04T17:07:58.506Z" },
 ]
 
 [[package]]
@@ -836,6 +1212,58 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "preshed"
+version = "3.0.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cymem" },
+    { name = "murmurhash" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/75/fe6b7bbd0dea530a001b0e24c331b21a0be2786e402abf3c57f5dce43d4b/preshed-3.0.13.tar.gz", hash = "sha256:d75f718bbfd97e992f7827e0fa7faf6a91bdd9c922d5baa4b50d62731396cb89", size = 18338, upload-time = "2026-03-23T08:57:31.378Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/d1/7bc39738388b38ff48cecbb326a9b2bb3f422bb32097be92e010f3162395/preshed-3.0.13-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5268c0e6fa96f50cdf87f516c2d4b32563c12706ee768e75c00e8d0098acd545", size = 136718, upload-time = "2026-03-23T08:56:23.889Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/65/de465b6801740140c2b5d2db6c312ca7937dcfd0442f1ae7d50dee529544/preshed-3.0.13-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:df642547a1a94079978a0ea8f4593ab4b8d3bd43f767bef0ef64d9a214f8c4c9", size = 137261, upload-time = "2026-03-23T08:56:25.303Z" },
+    { url = "https://files.pythonhosted.org/packages/89/83/478ee078746a4a413c841542caebd2ea74b659475b8bf5f2e3724b6fe655/preshed-3.0.13-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:09397592d333a77f88454e72b7f1f941b2afaf040b392b9e74898dbc4648cdf5", size = 821010, upload-time = "2026-03-23T08:56:26.455Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/2e/1ac761e973966893cd3a0ad3256360365276e2d1e779e351448981a1156a/preshed-3.0.13-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f8e6fe0620ed0f96a246d46447055c447e071cd8222731a045c235e8a758c918", size = 823096, upload-time = "2026-03-23T08:56:28.126Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/51/7824cfd85dd7fe547888de20228ebd87d9acd3708206d30b82211e382d23/preshed-3.0.13-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:502f93f49a22788203f02d3067d4ea077a0cca3864de6a792eae12e7ce589e14", size = 1812148, upload-time = "2026-03-23T08:56:29.755Z" },
+    { url = "https://files.pythonhosted.org/packages/34/48/32160a24705d56179de6af838c10a0c735c955dae5f9e4bb344750b79bc2/preshed-3.0.13-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:acd4d89abeca3678c5d8c89b3cd351314465bc67c7fa053d2644f8513e543386", size = 1881154, upload-time = "2026-03-23T08:56:31.49Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/22/0344b50f8b1ad9e3aac08099c47e1aba91c81602fd117d2673f6606ecae6/preshed-3.0.13-cp311-cp311-win_amd64.whl", hash = "sha256:de87fbabb0f37c3c92d4dd9b94fc82ab73cdab4247cdfbd57ab3926caa983919", size = 122219, upload-time = "2026-03-23T08:56:32.74Z" },
+    { url = "https://files.pythonhosted.org/packages/33/c4/812eeaa568510f396e27edab01100ca71418f032fd7098b107f12e572361/preshed-3.0.13-cp311-cp311-win_arm64.whl", hash = "sha256:5e2753779832e411e93eb727f3d409c0a6b7408e5ce4dd868076d8ece48c7693", size = 109308, upload-time = "2026-03-23T08:56:33.839Z" },
+    { url = "https://files.pythonhosted.org/packages/39/fb/ccff23c44c04088c248539005fcda78b9014512a34d170c5360f02ad908b/preshed-3.0.13-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5d14eea14bd01291388928991d7df7d60b9fd19ae970e55006eb4d29b0c1e8eb", size = 138497, upload-time = "2026-03-23T08:56:35.321Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ce/cad5a8145881a771e6c0d002f2e585fc19b962f120860b54d32af5baa342/preshed-3.0.13-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f05b08ce92399c0655b5e0eb5a1cc1f9e295703ed3aabdfaf6538dfa8ae23d57", size = 138010, upload-time = "2026-03-23T08:56:36.399Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/a2/c5fed4fb3e946699259d11e4036a3cfdd8c89b3e542e3077d46781642425/preshed-3.0.13-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:62cf7f3113132891d6bba70ff547ad81c6fe50a31930bbbb8499f1d47cd122b7", size = 861498, upload-time = "2026-03-23T08:56:37.67Z" },
+    { url = "https://files.pythonhosted.org/packages/51/94/8c9bc48a6ea4903f53a1a0031ce8e35687526949f25821762ef21493c007/preshed-3.0.13-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8b8de3f58043070a354477995acdd98626ce43e4193c708ebd0f694e467f5155", size = 868988, upload-time = "2026-03-23T08:56:39.324Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/df/ecd2f40055ff52527ca117ffbfafb888c1a3079b59fbabe03c5b8f9b7240/preshed-3.0.13-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:183b339956a9e1d7a4a00038a3b9587a734db9e8bd915939a49791bd1b372156", size = 1847382, upload-time = "2026-03-23T08:56:40.89Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/88/bdb244e40284ded3632a9f88c23bc80230bd7b2ae4a8b7f2cc91adead7a8/preshed-3.0.13-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2e77bed56aded7cbe5d28d6bd2178bc5b13eda0e0e464dab205fb578fa915000", size = 1919236, upload-time = "2026-03-23T08:56:42.616Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/c9/c91ea56342e6c364fc69b444a1ac5432327857199c44032c9cc9dc4c3a23/preshed-3.0.13-cp312-cp312-win_amd64.whl", hash = "sha256:04d8f13f2986e5d11af5ac51f55ce3106c70c41b483d20ea392e6180bdd0f870", size = 122938, upload-time = "2026-03-23T08:56:44.271Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/0b/6a99d99619fd83b14c696e2489caed7070647488d4d3ac0b723d35db2de0/preshed-3.0.13-cp312-cp312-win_arm64.whl", hash = "sha256:19318dc1cd8cac6663c6c830bf7e0002d2de853769fb03e056774e97c21bedfd", size = 109194, upload-time = "2026-03-23T08:56:45.346Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/2a/401158195d6dc7f6aef0b354d74d0e95c9da124499448c2b3dbb95b71204/preshed-3.0.13-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c0d0c14187dc0078d8a63bf190ec045a4d13e7748b6caeb557a7d575e411410b", size = 137289, upload-time = "2026-03-23T08:56:46.516Z" },
+    { url = "https://files.pythonhosted.org/packages/88/8f/e20e64573988528785447a6893b2e7ab287ecfd85b3888e978b28812fd20/preshed-3.0.13-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7770987c2e57497cd26124a9be5f652b5b3ccd0def89859ab0da8bca6144a3de", size = 136847, upload-time = "2026-03-23T08:56:47.572Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/72/18168f881359c4482d312f8dc196371bdd61c1583a52b34390da4c88bbea/preshed-3.0.13-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4a7bc48220de579be6bdb0a8715482cf36e2a625a6fd5ad26c9f43485a4a23b5", size = 831478, upload-time = "2026-03-23T08:56:48.769Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/3a/3543476091087102775568cea9885dde3453569e9aeee365809108de572f/preshed-3.0.13-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e5c8462472f790c16708306aef3a102a762bd19dfe3d2f8ee08bd5e12f51b835", size = 839913, upload-time = "2026-03-23T08:56:49.937Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/65/b13f01329decc44ef53cfb6b4601ba85382dcb2a4ec78d9250f03a418066/preshed-3.0.13-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c046736239cc8d72670749b79b526e4111839a2fc461a58545d212797649129c", size = 1816452, upload-time = "2026-03-23T08:56:51.233Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/c7/f1a996c6832234efd4d543041b582418d41ac480ee55c557ec9e65344637/preshed-3.0.13-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7c333f18e9a81c8a6de0603fd8781e17115324b117c445ca91abdf7bfb1abe49", size = 1888978, upload-time = "2026-03-23T08:56:52.591Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/b9/96fb71499049885ce19545903fdd38877bbc2be0da47e37c04d01f3e9f66/preshed-3.0.13-cp313-cp313-win_amd64.whl", hash = "sha256:461327f8dd36520dcf1fd55a671e0c3c2c97a2d95e22fc85faa31173f4785dda", size = 122134, upload-time = "2026-03-23T08:56:54.392Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/a7/32a4903019d936a2316fdd330bedddac287ac26326107d24fb76a1fbc60a/preshed-3.0.13-cp313-cp313-win_arm64.whl", hash = "sha256:35d6c5acb3ee3b12b87a551913063f0cec784055c2af16e028c19fe875f079d0", size = 108497, upload-time = "2026-03-23T08:56:55.816Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/b5/993886c98f5caaa6f07a648cac97a7c62a3093091cad65e1e43a1bd41cc4/preshed-3.0.13-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d2f1efae396cadab5f3890a2fd43d2ee65373ef9096ccbb805e51e8d8bcc563b", size = 137882, upload-time = "2026-03-23T08:56:56.878Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/86/b7fd137cbf140afd6c45e895946068a15f5b55642916de0075e6eb18581c/preshed-3.0.13-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8d6acc1f5031a535a55a6f7148e2f274554a8343a16309c700cebea0fe7aee8c", size = 138233, upload-time = "2026-03-23T08:56:58.318Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ca/21a7e79625614134273dfed32bca5bb4c2ec1313e33fbd12d41657536f1f/preshed-3.0.13-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7da9d931e7660dcdd757e5870269f0c159126d682ed73ed313971d199eb0f334", size = 834835, upload-time = "2026-03-23T08:56:59.48Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/3a/2dbd299516461831ae90e0d5b0637137bf28520c4e6dd0b01d6f1886659a/preshed-3.0.13-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d4ae5cfe075bb7a07982e382bca44f41ddf041f4d24cbd358e8cccfc049259b8", size = 834928, upload-time = "2026-03-23T08:57:01.075Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/d3/af654eba4f6587c4ee02c5043e62c194b0a1c4431ffef0c67b9518f6b61c/preshed-3.0.13-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7557963d0125a3a7bcdb2eb6948f3e45da31b5a7f066b55320de3dea22d7557f", size = 1820368, upload-time = "2026-03-23T08:57:02.351Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/9b/ebcb2b9e8cb881e40b55b0bf450f8a6b187e2ef3ae0c685cce81d2d85026/preshed-3.0.13-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c4bc60dc994864095d784b7e4d77dba3e64188d169ac88722b699d175561fddb", size = 1888251, upload-time = "2026-03-23T08:57:04.158Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f7/c6c012779edcaa6e2cd092c554e98dc53e77f41205b07208655ba77e2327/preshed-3.0.13-cp314-cp314-win_amd64.whl", hash = "sha256:208dcebbe294bf1881ce33fb015d56ab2a7587aece85a09147727174207892e4", size = 125211, upload-time = "2026-03-23T08:57:05.83Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/82/390ef87d732ef64e673ef6bf9e5d898453986e979efa50fb3a400e2c0766/preshed-3.0.13-cp314-cp314-win_arm64.whl", hash = "sha256:cf8e1a7a1823b2a7765121446c630140ac6e8650c07a6efbf375e168d1fef4f7", size = 111942, upload-time = "2026-03-23T08:57:06.996Z" },
+    { url = "https://files.pythonhosted.org/packages/80/3a/a9dde3167bcecb27ae82ce4567b5ab1aa3989113ae6814c092ce223cc4ef/preshed-3.0.13-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:9ca43ecbc3783eda4d6ab3416ae2ecd9ef23dca5f53995843f69f7457bcd0677", size = 144997, upload-time = "2026-03-23T08:57:08.064Z" },
+    { url = "https://files.pythonhosted.org/packages/74/d4/22d9355b50b6a13b407dcad0a81df83fb1d5602092d1f05834674dde8fda/preshed-3.0.13-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c8596e41a258ff213553a441e0bb3eb388fd8158e84a7bf3aae6d8ede2c166d3", size = 147294, upload-time = "2026-03-23T08:57:09.411Z" },
+    { url = "https://files.pythonhosted.org/packages/70/42/a225ee83fdb306d2a503f21a627953b820f4e079c90c8a84338957cb8ff5/preshed-3.0.13-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4f8856ca3d88e9b250630d70abb4f260d8933151ddfb413024784b25b009868e", size = 952110, upload-time = "2026-03-23T08:57:10.592Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ba/09a9dfe3d22d7e745483fd5d7f2a82cd4d39c161f7d2daa0faa4bd6402be/preshed-3.0.13-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e5b2865aecbd2e1e10e5d19bb8bfad765863c1307c6c3e51f2a08bd64122409", size = 932217, upload-time = "2026-03-23T08:57:12.124Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/5c/e10e2e05133e7fcbd7c40536af1148c82dd24357b8f5726e2c7bc51cfd53/preshed-3.0.13-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:09f96b477c987755b3c945df214ea1c1c80bfb350e9f34e78da89585535b77e8", size = 1896542, upload-time = "2026-03-23T08:57:13.525Z" },
+    { url = "https://files.pythonhosted.org/packages/37/aa/51e5b4109a4cdfae28c3613eeeb10764a3794ebef8de93ffbb109465bea3/preshed-3.0.13-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:670db59a52e1823b5f088c764df474e65b686592d4093adbeef14581c95ee2cb", size = 1959473, upload-time = "2026-03-23T08:57:15.706Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/6a/1d966f367a14c703dde629d150d996c1b727d442f620300b21c9ec1a24d1/preshed-3.0.13-cp314-cp314t-win_amd64.whl", hash = "sha256:b03e21b0bf95eb56e23973f32cabb930e94f352228652f81c0955dbd6967d904", size = 146229, upload-time = "2026-03-23T08:57:17.457Z" },
+    { url = "https://files.pythonhosted.org/packages/22/80/368139067603e590a000122355f9c8576c8ebed4fb0b8849feaa2698489d/preshed-3.0.13-cp314-cp314t-win_arm64.whl", hash = "sha256:b980f3ea9bb74b7f94464bc3d6eb3c9162b6b79b531febd14c6465c24344d2cc", size = 119339, upload-time = "2026-03-23T08:57:18.882Z" },
 ]
 
 [[package]]
@@ -1267,12 +1695,55 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "83.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "smart-open"
+version = "8.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/3e/79fd5fd2375a8a500b9ec2f6a0762fc1ac33e35582d4a87483a78d19408f/smart_open-8.0.0.tar.gz", hash = "sha256:5a2008d60688bd3b33c52e2ef666d3c60cf956e73e215de8c7b242cf56fdd1b2", size = 61520, upload-time = "2026-06-27T16:28:11.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/bd/1c92e69a1daff70118f21e18ef3a100c114f00f08b64a1074484f12d9020/smart_open-8.0.0-py3-none-any.whl", hash = "sha256:ff4f395c9e86f23e27771dc4ba756ad4bd145f181859a782c50d64168485761b", size = 73029, upload-time = "2026-06-27T16:28:10.589Z" },
 ]
 
 [[package]]
@@ -1291,6 +1762,76 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
+]
+
+[[package]]
+name = "spacy"
+version = "3.8.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "catalogue" },
+    { name = "confection" },
+    { name = "cymem" },
+    { name = "jinja2" },
+    { name = "murmurhash" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "packaging" },
+    { name = "preshed" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "setuptools" },
+    { name = "spacy-legacy" },
+    { name = "spacy-loggers" },
+    { name = "srsly" },
+    { name = "thinc" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "wasabi" },
+    { name = "weasel" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/8c/0ccf32d9a6b4fd8737bba33d599ddb98934399c1d523f825a4beb4bd1495/spacy-3.8.14-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8c55cb123c3edfba8c252ce6ae27ffb3d7f60a53ba5e108c3534421586c5fdda", size = 6617470, upload-time = "2026-03-29T10:40:25.572Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/61/7f7d38e71daac7f91ffd362fb15645b6f9a68ad231e0ed6ff5c1dc6f6930/spacy-3.8.14-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ab6c1ace316338dac334fc93c849994bbd717f9ebf59d2bc4158e978b2f542ee", size = 6441524, upload-time = "2026-03-29T10:40:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ef/18385aa5aeb9bcb299e8074da162b24e5c8bea5aa4d1dfa3dbafb35e9d1f/spacy-3.8.14-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7bece0450cd8ab841cfa8527fcc0ce18c4454f28e3b9fca42a450803a067355b", size = 32050591, upload-time = "2026-03-29T10:40:29.704Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/67/5c4a65ed2cedc598ad000a2b9f45afc76bb8d17a592cc01082dffa8bbc50/spacy-3.8.14-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc5e5f2ed121d57d819d247bb59253dc320a58acbd237b85f86c2aa38cab6bd1", size = 32296467, upload-time = "2026-03-29T10:40:32.557Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a7/28c118879791b3a7ffa81796d22203daac428e6f75572f1b8da1539e1ac6/spacy-3.8.14-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3c4e5bc5cdefe39ea139985776a2e8eae05e7ff2bf51ca1bd65247dc45feeb8e", size = 32288404, upload-time = "2026-03-29T10:40:35.583Z" },
+    { url = "https://files.pythonhosted.org/packages/72/1c/32aefcea2468782fcdb994f2f96cac93dc74f6589ce01047db42d9a299a2/spacy-3.8.14-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:2c228f4c9ae618173334c17adb748d66b574b6594bc3575233e15cd5ad1cb26b", size = 33113476, upload-time = "2026-03-29T10:40:38.577Z" },
+    { url = "https://files.pythonhosted.org/packages/86/32/fc00532eabeace451175dd9b152ddd636e8f6a42248b5d90141f98be2af5/spacy-3.8.14-cp311-cp311-win_amd64.whl", hash = "sha256:6f51d1ce8b1ba30123f6bef6e795c4bc5466608e6e8a015dc828bd21d399aa9c", size = 15359704, upload-time = "2026-03-29T10:40:41.25Z" },
+    { url = "https://files.pythonhosted.org/packages/de/31/89ff6722ec91f328dc717932849c6f57249c8a9d429d8670a6c8f70e576b/spacy-3.8.14-cp311-cp311-win_arm64.whl", hash = "sha256:c0c6c9d8771cc3708e309b07310d330fc8443a6bca34f4ff20b0f22751d8faf9", size = 14717168, upload-time = "2026-03-29T10:40:43.916Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/78/e4f2ae19a791cae756cd0e801204953eaec4e9ab75a60ad39f671dbb8d5a/spacy-3.8.14-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:726f02c60a2c6b0029167370d22d51731172a053d29c7e2ea6190db6de3ab483", size = 6218335, upload-time = "2026-03-29T10:40:46.298Z" },
+    { url = "https://files.pythonhosted.org/packages/06/df/178bbab47fa209c8baf2f1e609cbddc6b18a985200be1ceee22bd5b89beb/spacy-3.8.14-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e3ebe50b93f2d40e8ec3451255528bb622ccb12be39fd140bb87668ce8d1075b", size = 6033860, upload-time = "2026-03-29T10:40:47.861Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/e8/048d83b73b28686307bd9a60878a58de7b7b21b562ca4de8b5bd558031e9/spacy-3.8.14-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:daeb64b048f12c059997281aed53eb8776d26416dd313cf17ad6f63124b2b564", size = 32725099, upload-time = "2026-03-29T10:40:50.194Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3f/1799af5f4ccc8eb7500e4a20ca301488134429dba08cda5be68ce6ab2992/spacy-3.8.14-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6d45715a24446f23b98ec3f09409a1d4111983d1d64613250ee38c3270e21853", size = 33205838, upload-time = "2026-03-29T10:40:53.029Z" },
+    { url = "https://files.pythonhosted.org/packages/78/07/81ab9acd0ec64bfdd7339acfc4cf35f5fb74bbbb0b2be7e64d717c416bac/spacy-3.8.14-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1069a8be34940809f8462eb69f09a3f0ce59bf8b9cb82475f2a8e3580f50ece0", size = 32090380, upload-time = "2026-03-29T10:40:56.115Z" },
+    { url = "https://files.pythonhosted.org/packages/74/a5/b081b5bd3cedb2634c23eb470b5e24c65c894c57646567f47627291c2b3f/spacy-3.8.14-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2dfa77aec7fdebac0455d8afd4ce1d92d6f868b03d507ed1976179a63db7b374", size = 32991946, upload-time = "2026-03-29T10:40:58.852Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/55/4371413a6dfc1fa837282a365498165f828c2f3fe018dfb35336acc869e0/spacy-3.8.14-cp312-cp312-win_amd64.whl", hash = "sha256:9def18c76a4472b326cb91a195623c9ca38a2b86999ad2df9e00b49ba8c63734", size = 14226946, upload-time = "2026-03-29T10:41:01.63Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/5e/12ac876017da6c1e6b72afcc3c8b309996227fd3aa15382cd3311aee21b8/spacy-3.8.14-cp312-cp312-win_arm64.whl", hash = "sha256:d6257133357e4801c9c5d011925af5439b0a015aacf3c16528aa0009982431c7", size = 13628765, upload-time = "2026-03-29T10:41:03.806Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/e5/822bbdfa459fee863ef2e9879a34b0ae5db7cd1e3eb76d32c766f19222e9/spacy-3.8.14-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2b4f60fa8b9641a5e93e7a96db0cdd106d05d61756bf1d0ddcd1705ad347909a", size = 6202114, upload-time = "2026-03-29T10:41:06.119Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/de/0e512154113e1f341567f2b9341835775e4180c180221e60faedaebb2f65/spacy-3.8.14-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0860c57220c633ccb20468bcd64bfb0d28908990c371a8857951d093a148dc8e", size = 6015458, upload-time = "2026-03-29T10:41:07.79Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/4f/29c7e56afc7db07348a9e0efe0243b5eef465d5dc3d56433f164378c3fa6/spacy-3.8.14-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c24620b7dba879c69cebc51ef3b1107d4d4e44a1e0d4baa439372887d00c3fd9", size = 32510659, upload-time = "2026-03-29T10:41:09.88Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/ce/cae678f664d5467016819253f5d6e52f8e68a12d8e799b651d73ec2a9a4b/spacy-3.8.14-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9699c1248d115d5825987c287a6f6acd66386ef3ebee7994ee67ba093e932c59", size = 32841057, upload-time = "2026-03-29T10:41:12.585Z" },
+    { url = "https://files.pythonhosted.org/packages/04/d4/419868afd449bdd367df005932537eea66c71e97c899ba278f3124933f3c/spacy-3.8.14-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:042d799e342fdb6bb5b02a4213a95acc9116c40ed3c849bb0a8296fbe648ec22", size = 31763252, upload-time = "2026-03-29T10:41:15.569Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/53/df5c1fee45f200b749ba72eeb536fbb2c545fc56230324954263b2f3be00/spacy-3.8.14-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:69b2264294097336e86832e8663f1ab3a7215621184863c96c082ab17ee11937", size = 32717872, upload-time = "2026-03-29T10:41:18.193Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c2/f1882ec2f5cc9c4e73cf2132997a03c397d7ceeb5ee7f7bb878b51a16365/spacy-3.8.14-cp313-cp313-win_amd64.whl", hash = "sha256:4b6d4f20e291a7c70e37de2f246622b44a0ce82efaa710c9801c6bd599e75177", size = 14220335, upload-time = "2026-03-29T10:41:20.89Z" },
+]
+
+[[package]]
+name = "spacy-legacy"
+version = "3.0.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/79/91f9d7cc8db5642acad830dcc4b49ba65a7790152832c4eceb305e46d681/spacy-legacy-3.0.12.tar.gz", hash = "sha256:b37d6e0c9b6e1d7ca1cf5bc7152ab64a4c4671f59c85adaf7a3fcb870357a774", size = 23806, upload-time = "2023-01-23T09:04:15.104Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/55/12e842c70ff8828e34e543a2c7176dac4da006ca6901c9e8b43efab8bc6b/spacy_legacy-3.0.12-py2.py3-none-any.whl", hash = "sha256:476e3bd0d05f8c339ed60f40986c07387c0a71479245d6d0f4298dbd52cda55f", size = 29971, upload-time = "2023-01-23T09:04:13.45Z" },
+]
+
+[[package]]
+name = "spacy-loggers"
+version = "1.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/67/3d/926db774c9c98acf66cb4ed7faf6c377746f3e00b84b700d0868b95d0712/spacy-loggers-1.0.5.tar.gz", hash = "sha256:d60b0bdbf915a60e516cc2e653baeff946f0cfc461b452d11a4d5458c6fe5f24", size = 20811, upload-time = "2023-09-11T12:26:52.323Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/78/d1a1a026ef3af911159398c939b1509d5c36fe524c7b644f34a5146c4e16/spacy_loggers-1.0.5-py3-none-any.whl", hash = "sha256:196284c9c446cc0cdb944005384270d775fdeaf4f494d8e269466cfa497ef645", size = 22343, upload-time = "2023-09-11T12:26:50.586Z" },
 ]
 
 [[package]]
@@ -1347,6 +1888,57 @@ wheels = [
 ]
 
 [[package]]
+name = "srsly"
+version = "2.5.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "catalogue" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2b/db/f794f219a6c788b881252d2536a8c4a97d2bdaadc690391e1cb53d123d71/srsly-2.5.3.tar.gz", hash = "sha256:08f98dbecbff3a31466c4ae7c833131f59d3655a0ad8ac749e6e2c149e2b0680", size = 490881, upload-time = "2026-03-23T11:56:59.865Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/36/5d7bb412d52e9cca787f9bfe838b596367189b254e50bf90f234a97184bf/srsly-2.5.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:785a09216ac31570fb301ddb9f61ee73d1f18f8b9561f712dce0b8ac8628bc88", size = 656760, upload-time = "2026-03-23T11:55:47.155Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/dc/124f008cd2be3e887e972cbdeb17c5aee0f42093eca02c7cfd63bb5daf19/srsly-2.5.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0017c7d2a0cd9a4f1bdc00d946b45edcf90bb0e271e8f084c1ce542bf6708c32", size = 657503, upload-time = "2026-03-23T11:55:48.681Z" },
+    { url = "https://files.pythonhosted.org/packages/35/8a/2c97244ebab125d55f1bfb7bb94e9572b3e819410dffd6a040eca1112350/srsly-2.5.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:66ebae2c70305987341519ec1a720072a3cb3e4b1d52ac0e9e841f4d02658d3d", size = 1139161, upload-time = "2026-03-23T11:55:50.179Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/ea/ecd396188f7591d80b89665f7af9e3ae02e42683daef57033ad7993ad3f9/srsly-2.5.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4ca4a068f6e14d84113a02fcb875c6b50a6285a12938c0e7a157eb3a63c50a86", size = 1142438, upload-time = "2026-03-23T11:55:52.607Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/65/143e2e143c53d498ad0956f69d0e09189aa7a6e0ee6017758c285ba1ab2d/srsly-2.5.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e283fa2a8f7350fb9fb70ecdee28d59d39c92f4c7f1cc90a44d6b86db3b3a8b3", size = 1101783, upload-time = "2026-03-23T11:55:53.906Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/86/1392a5593de0cd3d08c2d6c071b877c84358a37f63172c4e9cb71706842d/srsly-2.5.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9ffc97e22730ea97b00f7c303ccc60b1305e786afadb2a4a46578dafa4d29da0", size = 1115876, upload-time = "2026-03-23T11:55:55.624Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/a5/6193aa4c08e488821538fcbce2282449e228fd2183ed67d118bb5ccd8b54/srsly-2.5.3-cp311-cp311-win_amd64.whl", hash = "sha256:f09b551f6c3e334652831ac68c770ee4284741ce0a3895bf1ccf2a1178d66cdd", size = 651733, upload-time = "2026-03-23T11:55:56.964Z" },
+    { url = "https://files.pythonhosted.org/packages/66/a8/a73181743b6d237026615ca75c3fb3e4780736f1390550a7350d0c7f1149/srsly-2.5.3-cp311-cp311-win_arm64.whl", hash = "sha256:21cf09e417d3e4f3fbf7dd337fd6d948c97abd01896b9b4cb80e81cd9778a73a", size = 639124, upload-time = "2026-03-23T11:55:58.532Z" },
+    { url = "https://files.pythonhosted.org/packages/02/cc/e9f7fcec4cc92ad8bad6316c4241638b8cf7380382d4489d94ec6c436452/srsly-2.5.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:71e51c046ccbeefb86524c6b1e17574f579c6ac4dc8ea4a09437d3e8f88342d3", size = 658379, upload-time = "2026-03-23T11:55:59.85Z" },
+    { url = "https://files.pythonhosted.org/packages/21/e4/fea4512e9785f58509b2cf67d993323848e583161b5fcfdc7dd9d7c1f3df/srsly-2.5.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2f73c0db911552e94fe2016e1759d261d2f47926f68826664cada3723c87006a", size = 658513, upload-time = "2026-03-23T11:56:01.239Z" },
+    { url = "https://files.pythonhosted.org/packages/20/b1/53591681b6ff2699a4f97b2d5552ba196eaa6a979b0873605f4c04b5f7ee/srsly-2.5.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c1ac27ae5f4bb9163c7d2c45fc8ec173aac3d92e32086d9472b326c5c6e570e", size = 1172265, upload-time = "2026-03-23T11:56:02.589Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/c9/741e29f534919a944a16da4184924b1d3404c4bf60716ab2b91be771d1e3/srsly-2.5.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:99026bcd9cbd3211cc36517400b04ca0fc5d3e412b14daf84ee6e65f67d9a2d8", size = 1180873, upload-time = "2026-03-23T11:56:03.944Z" },
+    { url = "https://files.pythonhosted.org/packages/89/57/5554f786eccf78b2750d6ac63be126e1b67badec2cb409dd611cf6f8c52b/srsly-2.5.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:07d682679e639eb46ff7e6da4a92714f4d5ffe351d088ee66f221e9b1f8865bb", size = 1120437, upload-time = "2026-03-23T11:56:05.283Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/95/9b4f73b1be3692f86d72ccc131c8e50f26f824d5c8830a59390bcc5b60ef/srsly-2.5.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8e0542d85d6b55cf2934050d6ffcb1cd76c768dcf9572e7467002cf087bb366d", size = 1137376, upload-time = "2026-03-23T11:56:06.613Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/de/89ca640ca1953c4612279ce515d0af35658df3c06cdb324329bc91b4a7e1/srsly-2.5.3-cp312-cp312-win_amd64.whl", hash = "sha256:598f1e494c18cacb978299d77125415a586417081959f8ec3f068b32d97f8933", size = 652459, upload-time = "2026-03-23T11:56:07.994Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/4f/7ab6d49e36d9cc72ee15746cabd116eb6f338be8a06c1882968ee9d6c7d7/srsly-2.5.3-cp312-cp312-win_arm64.whl", hash = "sha256:4b1b721cd3ad1a9b2343519aadc786a4d09d5c0666962d49852eb12d6ec3fe26", size = 638411, upload-time = "2026-03-23T11:56:09.31Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/5c/12901e3794f4158abc6da750725aad6c2afddb1e4227b300fe7c71f66957/srsly-2.5.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e67b6bbacbfadea5e100266d2797f2d4cec9883ea4dc84a5537673850036a8d8", size = 656750, upload-time = "2026-03-23T11:56:10.708Z" },
+    { url = "https://files.pythonhosted.org/packages/04/61/181c26370995f96f56f1b64b801e3ca1e0d703fc36506ae28606d62369fb/srsly-2.5.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:348c231b4477d8fe86603131d0f166d2feac9c372704dfc4398be71cc5b6fb07", size = 656746, upload-time = "2026-03-23T11:56:12.28Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c6/35876c78889f8ffe11ed3521644e666c3aef20ea31527b70f47456cf35c2/srsly-2.5.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b0938c2978c91ae1ef9c1f2ba35abb86330e198fb23469e356eba311e02233ee", size = 1155762, upload-time = "2026-03-23T11:56:14.075Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/da/40b71ca9906c8eb8f8feb6ac11d33dad458c85a56e1de764b96d402168a0/srsly-2.5.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5f6a837954429ecbe6dcdd27390d2fb4c7d01a3f99c9ffcf9ce66b2a6dd1b738", size = 1161092, upload-time = "2026-03-23T11:56:15.778Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/14/c0dd30cc8b93ce8137ff4766f743c882440ce49195fffc5d50eaeef311a6/srsly-2.5.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3576c125c486ce2958c2047e8858fe3cfc9ea877adfa05203b0986f9badee355", size = 1109984, upload-time = "2026-03-23T11:56:17.056Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f3/34354f183d8faafc631585571224b54d1b4b67e796972c36519c074ca355/srsly-2.5.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5fb59c42922e095d1ea36085c55bc16e2adb06a7bfe57b24d381e0194ae699f2", size = 1128409, upload-time = "2026-03-23T11:56:18.761Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/d9/5531f8a19492060b4e76e4ab06aca6f096fb5128fe18cc813d1772daf653/srsly-2.5.3-cp313-cp313-win_amd64.whl", hash = "sha256:111805927f05f5db440aeeacb85ce43da0b19ce7b2a09567a9ef8d30f3cc4d83", size = 650820, upload-time = "2026-03-23T11:56:20.096Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/8a/62fb7a971eca29e12f03fb9ddacb058548c14d33e5b5675ff0f85839cc7b/srsly-2.5.3-cp313-cp313-win_arm64.whl", hash = "sha256:0f106b0a700ab56e4a7c431b0f1444009ab6cb332edc7bbf6811c2a43f4722cb", size = 637278, upload-time = "2026-03-23T11:56:21.439Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5b/e4ef43c2a381711230af98d4c94a5323df48d6a7899ee652e05bf889290e/srsly-2.5.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:39c13d552a9f9674a12cdcdc66b0c2f02f3430d0cd04c5f9cf598824c2bd3d65", size = 661294, upload-time = "2026-03-23T11:56:23.29Z" },
+    { url = "https://files.pythonhosted.org/packages/92/2d/ebce7f3717e52cd0a01f4ec570f388f3b7098526794fcf1ad734e0b8f852/srsly-2.5.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:14c930767cc169611a2dc14e23bc7638cfb616d6f79029700ade033607343540", size = 660952, upload-time = "2026-03-23T11:56:24.908Z" },
+    { url = "https://files.pythonhosted.org/packages/22/47/a8f3e9b214be2624c8e8a78d38ca7b1d4e26b92d57018412e4bfc4abe89a/srsly-2.5.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2f2d464f0d0237e32fb53f0ec6f05418652c550e772b50e9918e83a1577cba4d", size = 1154554, upload-time = "2026-03-23T11:56:26.608Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/71/2a89dc3180a51e633a87a079ca064225f4aaf46c7b2a5fc720e28f261d98/srsly-2.5.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d18933248a5bb0ad56a1bae6003a9a7f37daac2ecb0c5bcbfaaf081b317e1c84", size = 1155746, upload-time = "2026-03-23T11:56:28.102Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/36/72e5ce3153927ca404b6f5bf5280e6ff3399c11557df472b153945468e0a/srsly-2.5.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7ea5412ea229e571ac9738cbe14f845cc06c8e4e956afb5f42061ccd087ef31f", size = 1112374, upload-time = "2026-03-23T11:56:29.591Z" },
+    { url = "https://files.pythonhosted.org/packages/04/b2/0895de109c28eca0d41a811ab7c076d4e4a505e8466f06bae22f5180a1dd/srsly-2.5.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8d3988970b4cf7d03bdd5b5169302ff84562dd2e1e0f84aeb34df3e5b5dc19bf", size = 1127732, upload-time = "2026-03-23T11:56:31.458Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/79/a37fa7759797fbdfe0a2e029ab13e78b1e81e191220d2bb8ff57d869aefb/srsly-2.5.3-cp314-cp314-win_amd64.whl", hash = "sha256:6a02d7dcc16126c8fae1c1c09b2072798a1dc482ab5f9c52b12c7114dac47325", size = 656467, upload-time = "2026-03-23T11:56:33.14Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/25/0dae019b3b90ad9037f91de4c390555cdaac9460a93ad62b02b03babdff5/srsly-2.5.3-cp314-cp314-win_arm64.whl", hash = "sha256:1c9129c4abe31903ff7996904a51afdd5428060de6c3d12af49a4da5e8df2821", size = 643040, upload-time = "2026-03-23T11:56:34.448Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/44/72dd5285b2e05435d98b0797f101d91d9b345d491ddc1fdb9bd09e27ccb8/srsly-2.5.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:29d5d01ba4c2e9c01f936e5e6d5babc4a47b38c9cbd6e1ec23f6d5a49df32605", size = 666200, upload-time = "2026-03-23T11:56:35.753Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ad/002c71b87fc3f648c9bf0ec47de0c3822bf2c95c8896a589dd03e7fd3977/srsly-2.5.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5c8df4039426d99f0148b5743542842ab96b82daded0b342555e15a639927757", size = 667409, upload-time = "2026-03-23T11:56:37.172Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/35/2cea3d5e80aeecfc4ece9e7e1783e7792cc3bad7ab85ab585882e1db4e38/srsly-2.5.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:06a43d63bde2e8cccadb953d7fff70b18196ca286b65dd2ad16006d65f3f8166", size = 1265941, upload-time = "2026-03-23T11:56:38.825Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/38/8a4d7e86dd0370a2e5af251b646000197bb5b7e0f9aa360c71bbfb253d0d/srsly-2.5.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:808cfafc047f0dec507a34c8fa8e4cda5722737fd33577df73452f52f7aca644", size = 1250693, upload-time = "2026-03-23T11:56:40.449Z" },
+    { url = "https://files.pythonhosted.org/packages/99/05/340129de5ea7b237271b12f8a6962cfa7eb0c5a3056794626d348c5ae7c7/srsly-2.5.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:71d4cbe2b2a1335c76ed0acae2dc862163787d8b01a705e1949796907ed94ccd", size = 1242408, upload-time = "2026-03-23T11:56:41.8Z" },
+    { url = "https://files.pythonhosted.org/packages/01/cb/d7fee7ab27c6aa2e3f865fb7b50ba18c81a4c763bba12bdf53df246441bc/srsly-2.5.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:565f69083d33cb329cfc74317da937fb3270c0f40fabc1b4488702d8074b4a3e", size = 1242749, upload-time = "2026-03-23T11:56:43.246Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/d1/9bad3a0f2fa7b72f4e0cf1d267b00513092d20ef538c47f72823ae4f7656/srsly-2.5.3-cp314-cp314t-win_amd64.whl", hash = "sha256:8ac016ffaeac35bc010992b71bf8afdd39d458f201c8138d84cf78778a936e6c", size = 673783, upload-time = "2026-03-23T11:56:44.875Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/ae/57d1d7af907e20c077e113e0e4976f87b82c0a415403d99284a262229dd0/srsly-2.5.3-cp314-cp314t-win_arm64.whl", hash = "sha256:d822083fe26ec6728bd8c273ac121fc4ab3864a0fdf0cf0ff3efb188fcd209ed", size = 650229, upload-time = "2026-03-23T11:56:46.148Z" },
+]
+
+[[package]]
 name = "starlette"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1384,8 +1976,10 @@ dependencies = [
     { name = "html5lib" },
     { name = "httpcore" },
     { name = "httptools" },
+    { name = "httpx2" },
     { name = "idna" },
     { name = "lxml" },
+    { name = "mutagen" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
     { name = "pydantic-core" },
@@ -1398,6 +1992,7 @@ dependencies = [
     { name = "six" },
     { name = "sniffio" },
     { name = "soupsieve" },
+    { name = "spacy" },
     { name = "sqlalchemy" },
     { name = "starlette" },
     { name = "typing-extensions" },
@@ -1416,7 +2011,6 @@ dev = [
     { name = "autoflake" },
     { name = "black" },
     { name = "flake8" },
-    { name = "httpx2" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
@@ -1453,10 +2047,11 @@ requires-dist = [
     { name = "html5lib", specifier = "==1.1" },
     { name = "httpcore", specifier = "==1.0.9" },
     { name = "httptools", specifier = "==0.7.1" },
-    { name = "httpx2", marker = "extra == 'dev'", specifier = "==2.5.0" },
+    { name = "httpx2", specifier = "==2.5.0" },
     { name = "idna", specifier = "==3.18" },
     { name = "iniconfig", marker = "extra == 'dev'", specifier = "==2.3.0" },
     { name = "lxml", specifier = "==6.1.1" },
+    { name = "mutagen", specifier = ">=1.47,<2" },
     { name = "packaging", marker = "extra == 'dev'", specifier = "==26.1" },
     { name = "pluggy", marker = "extra == 'dev'", specifier = "==1.6.0" },
     { name = "psycopg", extras = ["binary"], specifier = "==3.3.3" },
@@ -1476,6 +2071,7 @@ requires-dist = [
     { name = "six", specifier = "==1.17.0" },
     { name = "sniffio", specifier = "==1.3.1" },
     { name = "soupsieve", specifier = "==2.8.4" },
+    { name = "spacy", specifier = ">=3.7,<4" },
     { name = "sqlalchemy", specifier = "==2.0.49" },
     { name = "starlette", specifier = "==1.3.1" },
     { name = "typing-extensions", specifier = "==4.15.0" },
@@ -1490,12 +2086,94 @@ requires-dist = [
 provides-extras = ["dev"]
 
 [[package]]
+name = "thinc"
+version = "8.3.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "blis" },
+    { name = "catalogue" },
+    { name = "confection" },
+    { name = "cymem" },
+    { name = "murmurhash" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "packaging" },
+    { name = "preshed" },
+    { name = "pydantic" },
+    { name = "setuptools" },
+    { name = "srsly" },
+    { name = "wasabi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/46/76df95f2c327f9a9cef30c1523bf285627897097163584dcf5f77b2ebce2/thinc-8.3.13.tar.gz", hash = "sha256:68e658549fc1eb3ff92aed5147fcbb9c15d6e9cc0e623b4d0998d16522ffb4f9", size = 194640, upload-time = "2026-03-23T07:22:36.41Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/72/ca06842a007e8c794e8c59462f242cdfd6167d7cc9d0155ad004b194b015/thinc-8.3.13-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4565102638038a01a2193c7f5d41ccbd6233fbdcb1f1b184322a06add4f51f18", size = 844359, upload-time = "2026-03-23T07:21:43.017Z" },
+    { url = "https://files.pythonhosted.org/packages/48/44/e6aef092f478d263f72eb3933b55a6f37ba97c6a0ea0a61d13fbf9bf0c19/thinc-8.3.13-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:859fbd9d9b16af5278da23589b4afbe2ab6b0dd615df4d3229b7c4e67cd3107e", size = 812089, upload-time = "2026-03-23T07:21:44.618Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8a/9ce0424d456cd3580cc3a855b23a7ff86b81d5299fceb496a2f56f06c1c0/thinc-8.3.13-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a518d5c761a0f2341e530e867de133dc3ed814558365b2a68ec53b89c482a43f", size = 4101388, upload-time = "2026-03-23T07:21:46.135Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/51/ec91c0434bd9a1096ab874bbd6dc110c5089d7fc513137e6af59bd051eec/thinc-8.3.13-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:81337dfbee37f58f36c0c70f9a819dce1b32cdc13d959181e10de079621f6ac6", size = 4131972, upload-time = "2026-03-23T07:21:48.403Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/67/e30dea753c90cff5cb9e5feb34948fdb89a6774b84d849585b49e16a730e/thinc-8.3.13-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:fbc0ee16edd260c6a4a9e365ff36d0a682c9e7ca6d7b985682659ef2e3e73826", size = 5101283, upload-time = "2026-03-23T07:21:49.991Z" },
+    { url = "https://files.pythonhosted.org/packages/00/e9/b7544eddababa16e548b26a96fff29eeb307ce938df5fa4af9371fe8ed5d/thinc-8.3.13-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0355c37e40d1a9fc2a1b8e9c2e294d8586f6baa97bcac6b9002f2dddb4b82ae9", size = 5264488, upload-time = "2026-03-23T07:21:51.747Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/a9/49391a40d703efc0f7a451310373261835f71fd3e6e2e8cfc08ee02f78ad/thinc-8.3.13-cp311-cp311-win_amd64.whl", hash = "sha256:0a0fa13dcfe4b319c3a396432c1dbff30d3de37dbbdee559e76600ee2b9486df", size = 1795058, upload-time = "2026-03-23T07:21:53.424Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/31/fd5348d44beda12a3ee415cbba9ed4fd0b17ce65db1d473c38a29a8d6153/thinc-8.3.13-cp311-cp311-win_arm64.whl", hash = "sha256:cd8a2b714c061969eee65802965167a6ada1fe708d82fe176d98dcb95ebe182a", size = 1721215, upload-time = "2026-03-23T07:21:55.027Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/af/f7c1ebfe92eb5d27d7f2f3da67a11e2eb57bc30ab1553279af6dc65b65a8/thinc-8.3.13-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:77a41f66285321d20aaedaea1e87d7cd48dca6d2427bed1867ec7cba7109fc8d", size = 821097, upload-time = "2026-03-23T07:21:56.698Z" },
+    { url = "https://files.pythonhosted.org/packages/45/8f/69d7338575d98df85d0b54c0f5fc277dba72587fe9ab846ecdd12a998bcb/thinc-8.3.13-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3710d318b4e5460cf366a6f7b5ddbefb5d39dbd4cfa408222750fdc6c27c4411", size = 791932, upload-time = "2026-03-23T07:21:58.38Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/a5/21d010c81e81e1589e5ccb4950e521804d13726e541e87f644c51815673b/thinc-8.3.13-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5a08c87143a6d20177652dca1ec0dc815d88216d8fc62594a57e8bc45bf5ed49", size = 3854219, upload-time = "2026-03-23T07:21:59.819Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ff/6914bf370bd1d604d89e6dfb46b97d10cd9b00d42ff8c036283e92314a8c/thinc-8.3.13-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4b5ec9ff313819e7d8667794a3559463fa89ff45aaa73e3fd8d6273b1e0d7a7f", size = 3903307, upload-time = "2026-03-23T07:22:01.652Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/3d/5572b47fa155fb3388c071515b74024fa17a6efd1df9406da378f0aa84ef/thinc-8.3.13-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5c9a48f2bc1e04f138240ed5f9b815a9141a5de26accd0f08fa0137fcefed258", size = 4836882, upload-time = "2026-03-23T07:22:03.565Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/f0/a8d77c7bac089697c6df302cc3c936a1ab36a4720deae889e6f1dbcbd0eb/thinc-8.3.13-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:79a29a44d76bd02f5ac0624268c6e42b3576ae472c791a8ae9c2d813ae789b59", size = 5033398, upload-time = "2026-03-23T07:22:05.045Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/5651bb1f904d04220fc7670035ada921bf0638e2cff6444d67c12887a968/thinc-8.3.13-cp312-cp312-win_amd64.whl", hash = "sha256:ed1dc709ac4f2f03b710457889e4e02f05de51bc8456980c241d0b28798bc7cb", size = 1721248, upload-time = "2026-03-23T07:22:06.749Z" },
+    { url = "https://files.pythonhosted.org/packages/94/8d/683703de021ffbe46833d722b70f49ffbbca8e5bd6876256977555d92d7d/thinc-8.3.13-cp312-cp312-win_arm64.whl", hash = "sha256:c6a049703a6011c8fe26ee41af7e70272145594140d82f79bb23de619c6a6525", size = 1645777, upload-time = "2026-03-23T07:22:08.104Z" },
+    { url = "https://files.pythonhosted.org/packages/af/b9/7b46942176df459d1804a9e77b0976f7c56f3abf3ec7485d0e5f836a0382/thinc-8.3.13-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c2811dfd8d46d8b5d3b39051b23e64006b2994a5143b1978b436938018792af8", size = 817337, upload-time = "2026-03-23T07:22:09.538Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/79/53085a72cd8f4fc4e6e313d05ea5aa98e870684f4a0fb318a9875fc0a964/thinc-8.3.13-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5593e6300cb1ebe0c0e546e9c9fb49e7c2627a0aa688795cd4f995a8b820d2ec", size = 788120, upload-time = "2026-03-23T07:22:11.215Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/3e/d61b462b16da95ac6885f95bb395e672040ee594833e571a6edcffd234f5/thinc-8.3.13-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f697174d3fb474966ce50b430bbafa101a6d2f7ffb559dac4b5c59389ef72d22", size = 3844666, upload-time = "2026-03-23T07:22:12.67Z" },
+    { url = "https://files.pythonhosted.org/packages/78/4c/898cc654bb123734c71ec5a425c02ca34439517d01ce1c95a6563295580e/thinc-8.3.13-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e9c7c5c104737b414c8c4ec578e67d78b6c859afe25cbc0684402e721415bd7f", size = 3890658, upload-time = "2026-03-23T07:22:14.668Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/56/1abdbf0a4ad628e8a05d6516fe0745969649d805367a3dccad8ee872981b/thinc-8.3.13-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7a99d0e242d1ccd23f9ae6bea7cd502f8626efa65c156b91d84581d0356696c3", size = 4819933, upload-time = "2026-03-23T07:22:16.85Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/22/b84dbdc6be5055bbdb2a7352e2c393f67e8593c137f1b83c82bf1e062b6e/thinc-8.3.13-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e676edd21a747afbe3e6b9f3fca8b962e36d146ded03b070cb0c28e2dfbe9499", size = 5018099, upload-time = "2026-03-23T07:22:18.356Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/a8/763cd7ba949334c9d2cddc92dadb68b344cb9546dc01b8d4a733dcaa16c1/thinc-8.3.13-cp313-cp313-win_amd64.whl", hash = "sha256:8ad40307f20e83f77af28ff5c6be0b86af7a8b251d1231c545508d2763157d8f", size = 1720309, upload-time = "2026-03-23T07:22:19.81Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/15/a11f7bb3cbc97dfecf32a90552f5a8f8a5c99316a99c6c17bdabf5baf256/thinc-8.3.13-cp313-cp313-win_arm64.whl", hash = "sha256:723949cab11d1925c15447928513a718276316cec6e0de28337cca0a62be0521", size = 1644606, upload-time = "2026-03-23T07:22:21.339Z" },
+    { url = "https://files.pythonhosted.org/packages/80/40/f4937d113912c6d669ffe982356ab29dcb6c7fe3be926a15981dbbb6a91c/thinc-8.3.13-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:7badb0be4825535e6362c19e8a41872b65409e9da46d3453a391b843a0720865", size = 817024, upload-time = "2026-03-23T07:22:23.005Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/00/4d4ed1a11ba2920b85a03a0683b16d97dc5beb2e78078dbf0e13e43bcea7/thinc-8.3.13-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:565300b7e13de799e5abff00d445f537e9256cf7da4dcb0d0f005fc16748a29e", size = 792096, upload-time = "2026-03-23T07:22:24.349Z" },
+    { url = "https://files.pythonhosted.org/packages/44/5d/dc33d6932be8721af2ef76b4a3a6e8020648630eabae61fb916d2a861d1d/thinc-8.3.13-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c17cef1900a1aba7e1487493d16b8aa0a8633116f1b2a51c6649a4000697f17b", size = 3842215, upload-time = "2026-03-23T07:22:25.836Z" },
+    { url = "https://files.pythonhosted.org/packages/af/bc/a6d37d8dadc2c5b524f51192413481160c42c9dd6105e8d5551531623225/thinc-8.3.13-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f4f26d1eec9b2a6a8f2e0298a5515d13eb06d70730d0d9e1040bb329e12bf3fb", size = 3849253, upload-time = "2026-03-23T07:22:27.845Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/59/ce9c7067f1dfe5985875927de9cf7a79f9dae3e69487fd650dfba558029d/thinc-8.3.13-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a61a31fd0ce3c2771cf4901ba6df70e774ffe32febf1024c5b43d63575cd58fe", size = 4831163, upload-time = "2026-03-23T07:22:29.395Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/a8/f57819347fc4d8bef2204d15fcbb9d7dff2d6cdd5f83d5ed91456ddacc55/thinc-8.3.13-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ba8119daf84a12259ae4d251d36426417bafa0b34108890b4b7e2b50966bd990", size = 4986051, upload-time = "2026-03-23T07:22:30.933Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ef/a82214bb7c7c1e2d92b69e1a7654be90cfab180082c6108e45a98af2422c/thinc-8.3.13-cp314-cp314-win_amd64.whl", hash = "sha256:433e3826e018da489f1a8068e6de677f6eff3cc93991a599d90f12cd1bc26cdc", size = 1740382, upload-time = "2026-03-23T07:22:32.869Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ef/1648fda54e9689058335ff54f650a7a314db2a42e21af1b83949b2dc748e/thinc-8.3.13-cp314-cp314-win_arm64.whl", hash = "sha256:11754fada9ad5ba2e02d5f3f234f940e24015b82333db58372f4a6aedad9b43f", size = 1667687, upload-time = "2026-03-23T07:22:34.967Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.68.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/5f/57ff8b434839e70dab45601284ea413e947a63799891b7553e5960a793a8/tqdm-4.68.4.tar.gz", hash = "sha256:19829c9673638f2a0b8617da4cdcb927e831cd88bcfcb6e78d42a4d1af131520", size = 792418, upload-time = "2026-07-07T09:58:18.369Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/2a/5e5e750890ada51017d18d0d4c30da696e5b5bd3180947729927628fc3cb/tqdm-4.68.4-py3-none-any.whl", hash = "sha256:5168118b2368f48c561afda8020fd79195b1bdb0bdf8086b88442c267a315dc2", size = 676612, upload-time = "2026-07-07T09:58:16.256Z" },
+]
+
+[[package]]
 name = "truststore"
 version = "0.10.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.26.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/f7/68adc395201b20b872d68e975386832e8005ffeacedd43a1d837a32815be/typer-0.26.8.tar.gz", hash = "sha256:c244a6bd558886fe3f8780efb6bdd28bb9aff005a94eedebaa5cb32926fe2f7e", size = 202097, upload-time = "2026-06-26T09:22:45.705Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/87/b9fd69c92c6102a066e1b86a35243f53e70bd4c709f2a26d9f4fee4f4dc0/typer-0.26.8-py3-none-any.whl", hash = "sha256:3512ca79ac5c11113414b36e80281b872884477722440691c89d1112e321a49c", size = 122564, upload-time = "2026-06-26T09:22:44.72Z" },
 ]
 
 [[package]]
@@ -1601,6 +2279,18 @@ wheels = [
 ]
 
 [[package]]
+name = "wasabi"
+version = "1.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/f9/054e6e2f1071e963b5e746b48d1e3727470b2a490834d18ad92364929db3/wasabi-1.1.3.tar.gz", hash = "sha256:4bb3008f003809db0c3e28b4daf20906ea871a2bb43f9914197d540f4f2e0878", size = 30391, upload-time = "2024-05-31T16:56:18.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/7c/34330a89da55610daa5f245ddce5aab81244321101614751e7537f125133/wasabi-1.1.3-py3-none-any.whl", hash = "sha256:f76e16e8f7e79f8c4c8be49b4024ac725713ab10cd7f19350ad18a8e3f71728c", size = 27880, upload-time = "2024-05-31T16:56:16.699Z" },
+]
+
+[[package]]
 name = "watchfiles"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1688,6 +2378,26 @@ wheels = [
 ]
 
 [[package]]
+name = "weasel"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpathlib" },
+    { name = "confection" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "smart-open" },
+    { name = "srsly" },
+    { name = "typer" },
+    { name = "wasabi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/e5/e272bb9a045105a1fdf4b798d8086f5932a178f4d738f17a74f5c9e0ae9a/weasel-1.0.0.tar.gz", hash = "sha256:7b129b44c90cc543b760532974ca1e4eb30dad2aa2026f57bdce66354ae610fc", size = 38682, upload-time = "2026-03-20T08:10:25.266Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/07/57ebf7a6798b016c064bd0ca81b4c6a99daa4dc377b898bc7b41eb6b5af0/weasel-1.0.0-py3-none-any.whl", hash = "sha256:89518acee027f49d743126c3502d35e6dd14f5768be5c37c9af47c171b6005cc", size = 50713, upload-time = "2026-03-20T08:10:23.637Z" },
+]
+
+[[package]]
 name = "webencodings"
 version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1753,4 +2463,79 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
     { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/a4/282c8e64300a59fc834518a54bf0afabb4ff9218b5fa76958b450459a844/wrapt-2.2.2.tar.gz", hash = "sha256:0788e321027c999bf221b667bd4a54aaefd1a36283749a860ac3eb77daed0302", size = 129068, upload-time = "2026-06-20T23:49:44.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/15/0c2d55168707465abfc41f33c0b23d792a5fa9b65c26983606940900a120/wrapt-2.2.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f1a2ff355ece6a111ca7a20dc86df6659c9205d3fcee674ca34f2a2854fd4e73", size = 80782, upload-time = "2026-06-20T23:47:44.367Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/b5/5c0b093eb48f8a062ef6267d3cb36e9bb1b88440181f6545a383c60efdf8/wrapt-2.2.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:55b9a899e6fff5444f229d30aa6e9ac92d2216d9d60f33c771b5d76a760d5f8e", size = 81678, upload-time = "2026-06-20T23:47:45.857Z" },
+    { url = "https://files.pythonhosted.org/packages/34/f3/de70937472dd3e8a4e6811192f9c6075efdffd4a2cd9b4596bf160f89668/wrapt-2.2.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a2d78c363f97d8bd718ee40432c66395685e9e98528ccaa423c3355d1715a26d", size = 159671, upload-time = "2026-06-20T23:47:47.345Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ec/40aed2330e7f02ecf74386ffcfef9ccb7108c6a430f15b6a252b663b1bed/wrapt-2.2.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d619e1eed9bd4f6ed9f24cd61971aa086fa86505289628d464bcf8a2c2e3f328", size = 160785, upload-time = "2026-06-20T23:47:48.759Z" },
+    { url = "https://files.pythonhosted.org/packages/45/04/aa5309beed5344b00220ae6b3b24055852192656194c27947bee1736306a/wrapt-2.2.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:518b0c5e323511ec56a38894802ddd5e1222626484e68efe63f201854ad788e5", size = 153699, upload-time = "2026-06-20T23:47:50.177Z" },
+    { url = "https://files.pythonhosted.org/packages/01/df/2def7e99d1fe87eea413f95f671924cdddcb08823b1ffd212748dfa6d062/wrapt-2.2.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4bccea5cdecffa9dd70e343741f0e41e0a16619313d04b72f78bb525162ebcd0", size = 159695, upload-time = "2026-06-20T23:47:51.602Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f6/a906d01a2ce12157bad2404957b3e2140da354b8a70b2fa48bbf282871c0/wrapt-2.2.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:209112cafd963710a05d199aae431d79a28bc76eb8e6d1bbbb8ad24340722cae", size = 152813, upload-time = "2026-06-20T23:47:53.03Z" },
+    { url = "https://files.pythonhosted.org/packages/02/49/bc0086292d239575b4c08f4cf8a4079fa58abbad58ec23abf84833a283ed/wrapt-2.2.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e5a5290e4bf2f332fc29ce72ffb9a2fff678aaac047e2e9f5f7165cd7792e099", size = 158809, upload-time = "2026-06-20T23:47:54.391Z" },
+    { url = "https://files.pythonhosted.org/packages/55/83/8fbd034de1f3e907edaa18786d5dd8f6932874edee0826c7cecb5cab03a1/wrapt-2.2.2-cp311-cp311-win32.whl", hash = "sha256:5499236ad1dc116012e2a5dd943f3f31af12fce452128e2bbcbd55a7d3d4d14c", size = 77414, upload-time = "2026-06-20T23:47:55.882Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/9c/23695baa331c6de4e874c3d78b8e0bed92e1d2a274e665b29858f6841672/wrapt-2.2.2-cp311-cp311-win_amd64.whl", hash = "sha256:8636809939152be6ae20a6cef0fed9fe60f411b47847d0426a826884b469e971", size = 80368, upload-time = "2026-06-20T23:47:57.237Z" },
+    { url = "https://files.pythonhosted.org/packages/08/49/40cefc342bf89b234a4490d741290fce781774b831aefb39c25471da96c9/wrapt-2.2.2-cp311-cp311-win_arm64.whl", hash = "sha256:5d0a142f7af07caeb5e5da87493162a7b8efa19ba919e550a746f7446e13fb30", size = 79489, upload-time = "2026-06-20T23:47:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/85/180b40628b23772692a0c76e8030114e1c0ae068470ed531919f0a5f2a4a/wrapt-2.2.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8417fd3c674d3c8023d080292d29301531a12daf8bd938dd419710dd2f464f2b", size = 81484, upload-time = "2026-06-20T23:47:59.924Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f2/21c90f2a16689702e2aaff45795b11018dff2c9b1242bac10d225483f676/wrapt-2.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e7070c7472582e31af3dfc2622b2381a0df7435110a9388ed8db5ffbce67efb", size = 82151, upload-time = "2026-06-20T23:48:01.303Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/b3/7e6e9fcf4fe7e1b69a49fe6cc5a44e8224bab6283c5233c97e132f14908e/wrapt-2.2.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2e096c9d39a59b35b63c9aacfbbbec2088ff51ff1fc31051acc60a07f42f273a", size = 169828, upload-time = "2026-06-20T23:48:02.719Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/43/894f132d857ed5a9904d937baf368badcbe5ea9e436e2f1930fe21c9f1f0/wrapt-2.2.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d1a6050405bf334be33bf66296f113563622972a34900ae6fa60fd283a1a900", size = 171544, upload-time = "2026-06-20T23:48:04.266Z" },
+    { url = "https://files.pythonhosted.org/packages/29/de/3c833e03725b477e9ea34028224dd21a48781830101e4e036f77e8b6b102/wrapt-2.2.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10adb01371408c6de504a6658b9886480f1a4919a83752748a387a504a21df79", size = 160663, upload-time = "2026-06-20T23:48:05.708Z" },
+    { url = "https://files.pythonhosted.org/packages/33/be/27edce350b24e3054d9d047f65f16d4c4d4c1f3f31c4278a1f8a95c723c8/wrapt-2.2.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3442eee2a5798f9b451f1b2cd7518ce8b7e28a2a364696c414460a0e295c012a", size = 169387, upload-time = "2026-06-20T23:48:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c4/9fd9679af8bf38e146652c7f47b6b352c3e5795b4ad1c0b7f94e15ac2aa7/wrapt-2.2.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6c99012a22f735a85eed7c4b86a3e99c30fdd57d9e115b2b45f796264b58d0bf", size = 158849, upload-time = "2026-06-20T23:48:08.91Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/c2/aa6c0c2206803068c6859dabe01f8c84c43744da93d4c67b8946d21655ee/wrapt-2.2.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3b686cfc008776a3952d6213cb296ed7f45d782a8453936406faa89eac0835ab", size = 168147, upload-time = "2026-06-20T23:48:10.374Z" },
+    { url = "https://files.pythonhosted.org/packages/42/63/3eb25da41049d20ae18fcab2dd8b056e02387c4bfa626cbdfb7c3b872e4f/wrapt-2.2.2-cp312-cp312-win32.whl", hash = "sha256:ef2cce266b5b0b07e19fa82e59673b81142b7a3607c8ed1254113d048ed668da", size = 77734, upload-time = "2026-06-20T23:48:11.769Z" },
+    { url = "https://files.pythonhosted.org/packages/da/09/0390e008a305360948fa9ce69507d041ac12cb2ee5d28e34467e2ee79391/wrapt-2.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:abf8c20a2d72ee69e16328b3c91342c446e723bfe48bfcc4dded3b9722ac027f", size = 80585, upload-time = "2026-06-20T23:48:13.117Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b3/84c445c66969f2d3457276b183a48c91097d59bbef9af6c075366b0f8c36/wrapt-2.2.2-cp312-cp312-win_arm64.whl", hash = "sha256:c6c64c5d02578bc4c4bca4f0aef1504de933c1d5b4ac2710b9131111459506c8", size = 79553, upload-time = "2026-06-20T23:48:14.5Z" },
+    { url = "https://files.pythonhosted.org/packages/43/fc/f32f4b22c6511173c11d9e541ab4e7d8467a0f1b3455acaf784115d31ff8/wrapt-2.2.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9e8b648270c613720a202d9a45ebabc33261b22c3a839b115ac5bce8c0bb0d69", size = 81296, upload-time = "2026-06-20T23:48:15.881Z" },
+    { url = "https://files.pythonhosted.org/packages/72/06/4d117d5d77a9344776c0248b24dae3d3dd2f58e5f765fa08cf887072e719/wrapt-2.2.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6fb7e94e8fe3e4c3067bb1653a91cce7c5e83acc119fdd41501b1bf74654617", size = 81841, upload-time = "2026-06-20T23:48:17.262Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ff/63ad96f98eb58a742b1a20d80f21da88924405910149950b912368150468/wrapt-2.2.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fb18fc51e813df0d9c98049e3bf2298a5495a648602040e21fa3c7329371159e", size = 167882, upload-time = "2026-06-20T23:48:18.764Z" },
+    { url = "https://files.pythonhosted.org/packages/20/1f/8bb62d8933df7acf3247194e6e9fc68edf9d2fa203252c89c94b319dd472/wrapt-2.2.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94b00b00f806eb3ef2abe9049ed45994a81ee9284884d96e6b8314927c6cea3d", size = 167411, upload-time = "2026-06-20T23:48:20.315Z" },
+    { url = "https://files.pythonhosted.org/packages/17/09/8789dcb09ee1de715727db7521aabbb68ffa68dfade3a49468440cfced49/wrapt-2.2.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:62415fd095bc590b842b6d092f2b5d9ccbaeb7e0b28535c03dcea2718b48636b", size = 158607, upload-time = "2026-06-20T23:48:21.728Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/66e02562d53ee67d841f175e38e3c993c2d78a3e104c576cad61c028b43c/wrapt-2.2.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a41e758d80dc0ab8c210f641ac892009d356cf1f955d97db544c8dd317b4d14c", size = 166367, upload-time = "2026-06-20T23:48:23.177Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a3/832ac4e41222fb263b3042d42c2f08d305db7d0f0c9b1d3a271a9eede8f6/wrapt-2.2.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b84cd4058001c9727b0e9980b7a9e66325b5ca748b1b578e822cade1bc6b304f", size = 157176, upload-time = "2026-06-20T23:48:24.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/01/1bd5e4d2df9c0178989ac8da9186543465388588ee2ef153e2591accebef/wrapt-2.2.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:26fc73a1b15e0946d2942b9a4426d162b51676338327dc067ccd8d2d76385f94", size = 167025, upload-time = "2026-06-20T23:48:26.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/69/583ed25291ab53e1ec117135fb1c33425e2f46d2bc8f29c17f7a94cf4274/wrapt-2.2.2-cp313-cp313-win32.whl", hash = "sha256:3c4095803491f6ef72128914c28ec05bbad9758433bb35f6715a3e9c8e46fb2d", size = 77605, upload-time = "2026-06-20T23:48:27.643Z" },
+    { url = "https://files.pythonhosted.org/packages/29/68/e69fc6d06e1523c68e0d00f95c9aed1158ce9908ee41603f7f2eae3d5db6/wrapt-2.2.2-cp313-cp313-win_amd64.whl", hash = "sha256:2cb07f414fab25dbe6b5c7398e1491423a5c81a6209533639969a6c928d474a4", size = 80508, upload-time = "2026-06-20T23:48:29.013Z" },
+    { url = "https://files.pythonhosted.org/packages/55/21/fe7a393d9e5dc0923bed8f5d857e9dcff210f1fa0888c02cc8f3ffaa55aa/wrapt-2.2.2-cp313-cp313-win_arm64.whl", hash = "sha256:1fc7691f070220215cccb2a20836b9adbaecb8ff22ad47abe63de5f110994fac", size = 79565, upload-time = "2026-06-20T23:48:30.429Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e5/c120d13bf5091164f68c3c1657e84f16f57e71d978421b626393ac5bd7eb/wrapt-2.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ec8f83949028366531383603139403cac7a826e4011955813cdd640017845ce5", size = 83264, upload-time = "2026-06-20T23:48:31.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b0/d4a1eb97e0e286625bdf21bc7f702637f9607787ffbbdb5ec14d50c79dbf/wrapt-2.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4b481fb0c40d9fd90a5809911208da700987d373a20a4709dc9e3944af7a6bec", size = 83791, upload-time = "2026-06-20T23:48:33.482Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1e/f060df47755e87b57684cee7bfc1362b204df55fac96ffebc0631b697b79/wrapt-2.2.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0065a3b657cec06813b4241d2462ccec287f6863103d7445b725fb3a889736f9", size = 203399, upload-time = "2026-06-20T23:48:34.97Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/de/2316a757a1abb6453700b79d83e532146dcef2611348282d4d8889792161/wrapt-2.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30f7424af5c5c345b7f26490e097f74a2ef45b3d08b664dc33571aee3bd3b56c", size = 210461, upload-time = "2026-06-20T23:48:36.569Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/29/d1160785ae18ca2495a6d82a21154103d74f656c9fd457fb35f6b11b965a/wrapt-2.2.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:07fdcb012821859168641acf68afad61ef9783cf37100af85f152550e9677194", size = 195313, upload-time = "2026-06-20T23:48:38.175Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/2d/7caa9598ae61a9cf0989cc501739cbeeb7d650ab3193cca1407b9af0c6ab/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f90038ab58fafb584801ca62d72384d7d5225d93c76f7b773c22fae545bd8066", size = 206116, upload-time = "2026-06-20T23:48:39.804Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/02/281ea1088b8650d865f311b35cf86fd21df89128e2909714f1161e01c9d0/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:c5d7825491bfa2d08b97e9557768987952c7b9ae687d06c3320b40a37ccb7f20", size = 192668, upload-time = "2026-06-20T23:48:41.346Z" },
+    { url = "https://files.pythonhosted.org/packages/be/7d/976e2d5b4b5c5babda40974edd54d0a5585cb60132ed86b46f4b80239b16/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ad520e6daa9bbf136f14de735474dbec7dcc0891f718e1d274ce8dc92e645af", size = 198891, upload-time = "2026-06-20T23:48:43.056Z" },
+    { url = "https://files.pythonhosted.org/packages/59/b7/e47651797c097f75a37e2ce86dcf04048ff576f3a674f7c558df7b5e9622/wrapt-2.2.2-cp313-cp313t-win32.whl", hash = "sha256:25904acb9475f46c24fe0423dbc8fda8cc5fbc282ab3dc6e72e919748c53f4e9", size = 78537, upload-time = "2026-06-20T23:48:44.509Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/6f/9fa5d59fb06d890defb5a8f727ce6a14d2932c8760153f96956628559fee/wrapt-2.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:305d4c247d61c4115794a169141823c62f719525ddb90b23aa332741c77d2c28", size = 82005, upload-time = "2026-06-20T23:48:46.391Z" },
+    { url = "https://files.pythonhosted.org/packages/15/80/4c7bd9873d1f9f7d138d93556b500469dbe24f42710b877519c2b9eb380d/wrapt-2.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c20279cd1a29800815d7b2d6338b60a6c6e78263f9d6e62e0eda251ba9cae2d0", size = 80762, upload-time = "2026-06-20T23:48:47.964Z" },
+    { url = "https://files.pythonhosted.org/packages/24/05/7fd9c3f83b2c74cbfc572a0b88aa37431e04bd8aed70d2c0efd3464206de/wrapt-2.2.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0e64826f920c42d9d9f87e8cc09ffae66c51ede12d59061a5a426deb9aa71745", size = 81341, upload-time = "2026-06-20T23:48:49.39Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/68/1bfa43100dd90d4ef74a05897b86275cf57e1313ca14aae2545bc9f872c9/wrapt-2.2.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:dcaa5e1451bd8751d7bd1568dfa3321c78092a52a7ecb5d1a0f18a5791e1fd00", size = 81921, upload-time = "2026-06-20T23:48:50.986Z" },
+    { url = "https://files.pythonhosted.org/packages/74/eb/df7b7f0b631dbbc750f39be27d8b55f65777d8ac86da80e12be41a644c4b/wrapt-2.2.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0abfd648dac9ac9c5b3aa9b523d27f1789046640b58dcd5652a720ddb325e1fc", size = 167713, upload-time = "2026-06-20T23:48:52.598Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/9a/d1bd36f6d088c8e652a9383cabbd49af30b8c576302a7eccddbab6963e3f/wrapt-2.2.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f4bfd8d1eb438153eff8b8cfe87f032ba65731e1ce06138b5090f745a33f6f95", size = 166779, upload-time = "2026-06-20T23:48:54.33Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ae/24ffacd4187fac2740a1972093929e836dea092d42c87d728cd98fee11a6/wrapt-2.2.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c427c9d06d859848a69f0d928fe28b5c33a941b2265d10a0e1f15cd244f1ee33", size = 158407, upload-time = "2026-06-20T23:48:55.944Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ed/974427668249a356051e8d67d47fa54ef6c777f0fcf3bae9d292c047d4b6/wrapt-2.2.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4250b43d1a129d947e083c4dc6baf333c9bb34edd26f912d5b0457841fc858ab", size = 166594, upload-time = "2026-06-20T23:48:57.617Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/5f/e1d7c6e4523f78db2fbd7826babd0348da1d5e0834c4f918b9ab5757dfae/wrapt-2.2.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:173e5bb5ca350a6e0abab60b7ec7cdd7992a814cb14b4de670a28f067f105663", size = 157068, upload-time = "2026-06-20T23:48:59.171Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c1/7ebd1027f00700c0b0233b20aceef2b4784294ed64971424c4a78e069e34/wrapt-2.2.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:aa14b01804bce36c6d63d7b6a4f55df390f29f8648cc13a1f40b166f4d54680d", size = 166470, upload-time = "2026-06-20T23:49:00.737Z" },
+    { url = "https://files.pythonhosted.org/packages/99/eb/974e471a6a978b8180186b8a9dc5ae3361ce269a967190b709b8ce17abfb/wrapt-2.2.2-cp314-cp314-win32.whl", hash = "sha256:58f9f8d637c9a6e245c6ef5b109b67ec187d2faed23d1405656b51d96e0a5b56", size = 78062, upload-time = "2026-06-20T23:49:02.327Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ec/e1281156cdc7a66693838ad7a0865ad641c74abd337a957d668b575aaffb/wrapt-2.2.2-cp314-cp314-win_amd64.whl", hash = "sha256:385cb1866f20479e83299af585375bfa0a4b0c6c9907a981483ea782ea8ae406", size = 80832, upload-time = "2026-06-20T23:49:03.837Z" },
+    { url = "https://files.pythonhosted.org/packages/45/7d/1b6b5ddd94005a2dac97a4490c9838f3154977850d633abcb65b30089437/wrapt-2.2.2-cp314-cp314-win_arm64.whl", hash = "sha256:8ffbeaea6771a6eba6e6eeb09767864995726bc8240bb54baf88a9bb1db34d5c", size = 80029, upload-time = "2026-06-20T23:49:05.237Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/33/9ebcf8aafe91c601127cbd93708c16aa8f688f34a10bf004046803ecdc4f/wrapt-2.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:09f811d43f6f33ec7515f0be76b159569f4057ab54d3e079c3204dddb90afa2a", size = 83357, upload-time = "2026-06-20T23:49:06.632Z" },
+    { url = "https://files.pythonhosted.org/packages/39/38/ec45b635153327b52e52732a0ea980e5f00b7efba65f9e018828f1e69daa/wrapt-2.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a795d3c06e5fbf9ea2f13196180b77aeab1b4685917256ee0d014cc163d90063", size = 83794, upload-time = "2026-06-20T23:49:08.098Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ea/1a89e6d3b7a83c3affe5c09cde77792c947e63e4bc85ad84cd5bb9abb0d8/wrapt-2.2.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:45c2f2768e790c9f8db90f239ef23a2af8e7570f25a35619ef902df4a738447f", size = 203362, upload-time = "2026-06-20T23:49:09.811Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d8/3b58763d9863b5a73771c0d97110f9595d248db454009e07e1535ee905a4/wrapt-2.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbf00ee0cb55ec24e2b0995a71942b85b21a066db8f3f46e1dbfdb9433ffba81", size = 210449, upload-time = "2026-06-20T23:49:11.521Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/6f/17fd9e053103d8be148d20d5d7505facc72d5fe1f9127973904ceaed79cf/wrapt-2.2.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2252f77663651b89255895f58cc6ac08fcb206d4371813e5af61bb62d4f7689c", size = 195349, upload-time = "2026-06-20T23:49:13.346Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/04/d0d1ccaaa12cb7dccf28a23f0279a608ba498f71e81d949d5ed54bcfd5c1/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2cd7181ab1c31192ff5219269830744b5a62020b3a6d433588c4f1c95b8f8bff", size = 206099, upload-time = "2026-06-20T23:49:15.051Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/e8aa07b619890a2aa6cde1931b1887abb08820721b564a5f80b7ca3f3aa0/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:6fe35fd51b74867d8b80174c277bd6bbf6a73e443f908129dc531c4b688a20d5", size = 192728, upload-time = "2026-06-20T23:49:16.854Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f0/1819fb50f0d3c9bd758d8a83b56f1b470dee8b5b8eac8702b7c137cea9d4/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:11d95fc2fbad3163596c39d440e6f21ca9fccece74b56e30a37ac2fca786a07c", size = 198842, upload-time = "2026-06-20T23:49:18.504Z" },
+    { url = "https://files.pythonhosted.org/packages/67/7c/e88313f16a99930b899ef970d91c281544a470749a359decad994483bbda/wrapt-2.2.2-cp314-cp314t-win32.whl", hash = "sha256:d8a15813215f33fa83667bfc978b300e35669ea8bb424e970a1426bcb7bc6cca", size = 79059, upload-time = "2026-06-20T23:49:20.107Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/4f/ac12fda57a55068a094ec42851fb0a40e8489d8941863d517452de62e507/wrapt-2.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d09db0f7e8357060d3c38fc22a018aba683a796bf184360fd1a58f6fc180dc77", size = 82462, upload-time = "2026-06-20T23:49:21.631Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/df732dac86d9b2027c56bd163dbc883e037b16c3469614752e148d219c61/wrapt-2.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:f32fe639c39561ccc187bcae17e9271be0eb45f1c2952510d2f29b33ab577347", size = 81182, upload-time = "2026-06-20T23:49:23.199Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d2/6317eb6d4554855bbf12d61857774af34747bf88a42c19bf306de67e2fa3/wrapt-2.2.2-py3-none-any.whl", hash = "sha256:5bad217350f19ce99ca5b5e71d406765ea86fe541628426772b657375ee1c048", size = 61460, upload-time = "2026-06-20T23:49:42.966Z" },
 ]


### PR DESCRIPTION
## Stack

Part 1 of 6. Base: `main`.

## What changed

- Adds the opt-in EPUB audiobook data model and migration.
- Adds ingestion with stable sentence anchors, deterministic offline analysis/TTS, chapter assembly, SMIL generation, and EPUB packaging.
- Adds the initial API and frontend pipeline controls.
- Adds an offline end-to-end harness and focused backend/frontend coverage.

## Safety fixes included

- Protects generated audiobook files when admin authentication is enabled.
- Treats the packaged EPUB as part of durable completion state and rebuilds it atomically after interruption.
- Rejects cross-book character assignments.
- Prevents destructive rebuilds while a book is queued or running, including the worker-exit window after pausing.

## Why

This extracts the foundational offline pipeline from #144 so it can be reviewed and merged independently before adding runtime controls, real neural speech, and richer analysis.

## Validation

- Backend focused tests: 32 passed.
- Frontend tests: 32 passed.
- Black and ESLint passed.
- Full-stack validation on the completed series: 276 backend tests and 38 frontend tests passed; Flake8 and ESLint passed.
- PostgreSQL migration validation is left to GitHub Actions because Docker was unavailable locally.