### PR TITLE
Add resumable audiobook stage controls

### DIFF
--- a/backend/alembic/versions/0019_audiobook_pipeline_controls.py
+++ b/backend/alembic/versions/0019_audiobook_pipeline_controls.py
@@ -1,0 +1,29 @@
+"""add resumable audiobook pipeline controls
+
+Revision ID: 0019
+Revises: 0018
+Create Date: 2026-07-13 00:00:00
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0019"
+down_revision = "0018"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("books", sa.Column("audiobook_stop_after_phase", sa.String(), nullable=True))
+    op.add_column(
+        "books",
+        sa.Column("audiobook_pause_requested", sa.Boolean(), nullable=False, server_default="false"),
+    )
+    op.add_column("books", sa.Column("audiobook_last_error", sa.Text(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("books", "audiobook_last_error")
+    op.drop_column("books", "audiobook_pause_requested")
+    op.drop_column("books", "audiobook_stop_after_phase")

--- a/backend/app/crud/audiobook.py
+++ b/backend/app/crud/audiobook.py
@@ -96,9 +96,7 @@ async def pause_book_pipeline_after_phase(db: AsyncSession, book_id: int, phase:
     if row is None or row.audiobook_stop_after_phase != phase or row.audiobook_pipeline_status == "complete":
         return False
     await db.execute(
-        update(Book)
-        .where(Book.id == book_id)
-        .values(audiobook_pipeline_status="paused", audiobook_stop_after_phase=None)
+        update(Book).where(Book.id == book_id).values(audiobook_pipeline_status="paused", audiobook_stop_after_phase=None)
     )
     await db.commit()
     return True

--- a/backend/app/crud/audiobook.py
+++ b/backend/app/crud/audiobook.py
@@ -43,6 +43,81 @@ async def set_book_pipeline_status(db: AsyncSession, book_id: int, status: Optio
     await db.commit()
 
 
+async def configure_book_pipeline_run(
+    db: AsyncSession,
+    book_id: int,
+    *,
+    status: str,
+    stop_after_phase: Optional[str],
+) -> None:
+    """Start or resume a run and clear stale pause/error state atomically."""
+    await db.execute(
+        update(Book)
+        .where(Book.id == book_id)
+        .values(
+            audiobook_pipeline_status=status,
+            audiobook_stop_after_phase=stop_after_phase,
+            audiobook_pause_requested=False,
+            audiobook_last_error=None,
+        )
+    )
+    await db.commit()
+
+
+async def request_book_pipeline_pause(db: AsyncSession, book_id: int) -> None:
+    await db.execute(update(Book).where(Book.id == book_id).values(audiobook_pause_requested=True))
+    await db.commit()
+
+
+async def pause_book_pipeline_if_requested(db: AsyncSession, book_id: int) -> bool:
+    """Acknowledge a cooperative pause request at a durable work boundary."""
+    result = await db.execute(select(Book.audiobook_pause_requested).where(Book.id == book_id))
+    if not result.scalar_one_or_none():
+        return False
+    await db.execute(
+        update(Book)
+        .where(Book.id == book_id)
+        .values(
+            audiobook_pipeline_status="paused",
+            audiobook_pause_requested=False,
+            audiobook_stop_after_phase=None,
+        )
+    )
+    await db.commit()
+    return True
+
+
+async def pause_book_pipeline_after_phase(db: AsyncSession, book_id: int, phase: str) -> bool:
+    """Stop a single-stage run once its requested phase has committed."""
+    result = await db.execute(
+        select(Book.audiobook_stop_after_phase, Book.audiobook_pipeline_status).where(Book.id == book_id)
+    )
+    row = result.one_or_none()
+    if row is None or row.audiobook_stop_after_phase != phase or row.audiobook_pipeline_status == "complete":
+        return False
+    await db.execute(
+        update(Book)
+        .where(Book.id == book_id)
+        .values(audiobook_pipeline_status="paused", audiobook_stop_after_phase=None)
+    )
+    await db.commit()
+    return True
+
+
+async def set_book_pipeline_error(db: AsyncSession, book_id: int, message: str) -> None:
+    await db.execute(
+        update(Book)
+        .where(Book.id == book_id)
+        .values(
+            audiobook_pipeline_status="error",
+            audiobook_pause_requested=False,
+            audiobook_stop_after_phase=None,
+            audiobook_last_error=message,
+        )
+    )
+    await db.commit()
+
+
 async def get_in_progress_audiobook_books(db: AsyncSession) -> list[Book]:
     active_statuses = ["ingesting", "roster_gen", "diarizing", "audio_gen", "assembling"]
     result = await db.execute(

--- a/backend/app/epub_editor.py
+++ b/backend/app/epub_editor.py
@@ -259,8 +259,9 @@ async def apply_book_cleaning(book, db, force: bool = False, cleaning_configs: l
     selectors with the book's own settings, then rewrites current_path from
     immutable_path and updates current_word_count in the DB.
 
-    Books with no applicable rules are always skipped. If force=True, rewrites
-    even when the output would match the current file.
+    Books with no applicable rules are skipped unless force=True. A forced
+    rebuild must still restore current_path from immutable_path after the last
+    cleaning rule is removed.
     """
     from . import crud
 
@@ -276,8 +277,9 @@ async def apply_book_cleaning(book, db, force: bool = False, cleaning_configs: l
     normalize_prose_blocks = book.source_type == models.SourceType.web
     has_rules = bool(chapter_selectors or content_selectors or removed_chapters or normalize_prose_blocks)
 
-    # Nothing to do — skip the (potentially expensive) epub rewrite
-    if not has_rules:
+    # Nothing to do — skip the (potentially expensive) epub rewrite unless a
+    # forced rebuild needs to restore a stale current copy.
+    if not has_rules and not force:
         return False
 
     if not book.immutable_path or not book.current_path:
@@ -293,6 +295,9 @@ async def apply_book_cleaning(book, db, force: bool = False, cleaning_configs: l
     library_path = (Path(__file__).parent.resolve() / ".." / ".." / "library").resolve()
     immutable_path = library_path.parent / book.immutable_path
     current_path = library_path.parent / book.current_path
+
+    if not has_rules and _files_match(immutable_path, current_path):
+        return False
 
     try:
         word_count = process_epub(

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -44,6 +44,11 @@ class Book(Base):
     # Audiobook pipeline state. Values: None (idle), "ingesting", "roster_gen",
     # "diarizing", "audio_gen", "assembling", "complete", "error", "paused".
     audiobook_pipeline_status = Column(String, nullable=True)
+    # Cooperative control state is persisted so a restart cannot turn a
+    # single-stage/debug run into an unattended full-book run.
+    audiobook_stop_after_phase = Column(String, nullable=True)
+    audiobook_pause_requested = Column(Boolean, nullable=False, default=False, server_default="false")
+    audiobook_last_error = Column(Text, nullable=True)
 
     # Timestamps
     created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/backend/app/routers/audiobook.py
+++ b/backend/app/routers/audiobook.py
@@ -29,6 +29,10 @@ router = APIRouter()
 
 class AudiobookStatusResponse(BaseModel):
     pipeline_status: Optional[str]
+    next_phase: str
+    pause_requested: bool
+    stop_after_phase: Optional[str]
+    last_error: Optional[str]
     sentence_counts: dict[str, int]
 
 
@@ -155,10 +159,14 @@ async def start_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> di
 
     resume_status = await crud.audiobook.infer_audiobook_resume_status(db, book_id)
     if resume_status == "complete":
-        await crud.audiobook.set_book_pipeline_status(db, book_id, "complete")
+        await crud.audiobook.configure_book_pipeline_run(
+            db, book_id, status="complete", stop_after_phase=None
+        )
         return {"status": "complete", "queued": False}
 
-    await crud.audiobook.set_book_pipeline_status(db, book_id, resume_status)
+    await crud.audiobook.configure_book_pipeline_run(
+        db, book_id, status=resume_status, stop_after_phase=None
+    )
 
     queue = get_audiobook_queue()
     queued = await queue.enqueue(book_id)
@@ -166,11 +174,39 @@ async def start_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> di
     return {"status": current_status, "queued": queued}
 
 
+@router.post("/api/books/{book_id}/audiobook/step")
+async def step_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> dict[str, Any]:
+    """Run exactly the next recoverable phase, then stop for review."""
+    book = await _get_audiobook_book_or_404(book_id, db)
+    if book.audiobook_pipeline_status in ("ingesting", "roster_gen", "diarizing", "audio_gen", "assembling"):
+        return {"status": book.audiobook_pipeline_status, "queued": False}
+
+    if book.audiobook_pipeline_status == "error" and await crud.audiobook.has_sentence_status(db, book_id, "error"):
+        await crud.audiobook.reset_error_sentences_for_book(db, book_id)
+
+    next_phase = await crud.audiobook.infer_audiobook_resume_status(db, book_id)
+    if next_phase == "complete":
+        await crud.audiobook.configure_book_pipeline_run(
+            db, book_id, status="complete", stop_after_phase=None
+        )
+        return {"status": "complete", "queued": False}
+
+    await crud.audiobook.configure_book_pipeline_run(
+        db, book_id, status=next_phase, stop_after_phase=next_phase
+    )
+    queued = await get_audiobook_queue().enqueue(book_id)
+    return {"status": next_phase, "queued": queued, "stop_after_phase": next_phase}
+
+
 @router.post("/api/books/{book_id}/audiobook/pause")
 async def pause_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> dict[str, Any]:
-    await _get_audiobook_book_or_404(book_id, db)
-    await crud.audiobook.set_book_pipeline_status(db, book_id, "paused")
-    return {"status": "paused"}
+    book = await _get_audiobook_book_or_404(book_id, db)
+    active = book.audiobook_pipeline_status in ("ingesting", "roster_gen", "diarizing", "audio_gen", "assembling")
+    await crud.audiobook.request_book_pipeline_pause(db, book_id)
+    if active:
+        return {"status": book.audiobook_pipeline_status, "pause_requested": True}
+    await crud.audiobook.pause_book_pipeline_if_requested(db, book_id)
+    return {"status": "paused", "pause_requested": False}
 
 
 @router.post("/api/books/{book_id}/audiobook/rebuild")
@@ -188,7 +224,9 @@ async def rebuild_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> 
     # Delete existing pipeline data so ingestion runs fresh
     await crud.audiobook.delete_chapters_for_book(db, book_id)
     await crud.audiobook.delete_characters_for_book(db, book_id)
-    await crud.audiobook.set_book_pipeline_status(db, book_id, "ingesting")
+    await crud.audiobook.configure_book_pipeline_run(
+        db, book_id, status="ingesting", stop_after_phase=None
+    )
     await queue.enqueue(book_id)
     return {"status": "ingesting", "queued": True}
 
@@ -197,8 +235,14 @@ async def rebuild_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> 
 async def get_pipeline_status(book_id: int, db: AsyncSession = Depends(get_db)) -> AudiobookStatusResponse:
     book = await _get_audiobook_book_or_404(book_id, db)
     counts = await crud.audiobook.count_sentences_by_status(db, book_id)
+    next_phase = await crud.audiobook.infer_audiobook_resume_status(db, book_id)
+    await db.refresh(book)
     return AudiobookStatusResponse(
         pipeline_status=book.audiobook_pipeline_status,
+        next_phase=next_phase,
+        pause_requested=book.audiobook_pause_requested,
+        stop_after_phase=book.audiobook_stop_after_phase,
+        last_error=book.audiobook_last_error,
         sentence_counts=counts,
     )
 

--- a/backend/app/routers/audiobook.py
+++ b/backend/app/routers/audiobook.py
@@ -159,14 +159,10 @@ async def start_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> di
 
     resume_status = await crud.audiobook.infer_audiobook_resume_status(db, book_id)
     if resume_status == "complete":
-        await crud.audiobook.configure_book_pipeline_run(
-            db, book_id, status="complete", stop_after_phase=None
-        )
+        await crud.audiobook.configure_book_pipeline_run(db, book_id, status="complete", stop_after_phase=None)
         return {"status": "complete", "queued": False}
 
-    await crud.audiobook.configure_book_pipeline_run(
-        db, book_id, status=resume_status, stop_after_phase=None
-    )
+    await crud.audiobook.configure_book_pipeline_run(db, book_id, status=resume_status, stop_after_phase=None)
 
     queue = get_audiobook_queue()
     queued = await queue.enqueue(book_id)
@@ -186,14 +182,10 @@ async def step_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> dic
 
     next_phase = await crud.audiobook.infer_audiobook_resume_status(db, book_id)
     if next_phase == "complete":
-        await crud.audiobook.configure_book_pipeline_run(
-            db, book_id, status="complete", stop_after_phase=None
-        )
+        await crud.audiobook.configure_book_pipeline_run(db, book_id, status="complete", stop_after_phase=None)
         return {"status": "complete", "queued": False}
 
-    await crud.audiobook.configure_book_pipeline_run(
-        db, book_id, status=next_phase, stop_after_phase=next_phase
-    )
+    await crud.audiobook.configure_book_pipeline_run(db, book_id, status=next_phase, stop_after_phase=next_phase)
     queued = await get_audiobook_queue().enqueue(book_id)
     return {"status": next_phase, "queued": queued, "stop_after_phase": next_phase}
 
@@ -224,9 +216,7 @@ async def rebuild_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> 
     # Delete existing pipeline data so ingestion runs fresh
     await crud.audiobook.delete_chapters_for_book(db, book_id)
     await crud.audiobook.delete_characters_for_book(db, book_id)
-    await crud.audiobook.configure_book_pipeline_run(
-        db, book_id, status="ingesting", stop_after_phase=None
-    )
+    await crud.audiobook.configure_book_pipeline_run(db, book_id, status="ingesting", stop_after_phase=None)
     await queue.enqueue(book_id)
     return {"status": "ingesting", "queued": True}
 

--- a/backend/app/services/audiobook_assembly.py
+++ b/backend/app/services/audiobook_assembly.py
@@ -149,7 +149,7 @@ async def assemble_book(book_id: int, db: AsyncSession) -> None:
     output_dir = LIBRARY_PATH.parent / "library" / "audiobooks" / str(book_id)
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    if await crud.audiobook.get_book_pipeline_status(db, book_id) == "paused":
+    if await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):
         logger.info("Book %s paused before assembly.", book_id)
         return
 
@@ -172,6 +172,9 @@ async def assemble_book(book_id: int, db: AsyncSession) -> None:
         logger.info("No chapters need reassembly for book %s; rebuilding the EPUB package.", book_id)
 
     for chapter in chapters:
+        if await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):
+            logger.info("Book %s paused between chapter assemblies.", book_id)
+            return
         sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
         await _assemble_chapter(book_id, chapter, sentences, output_dir, db)
 
@@ -222,7 +225,7 @@ async def assemble_book(book_id: int, db: AsyncSession) -> None:
     temporary_epub_path.replace(audiobook_epub_path)
     logger.info("Repackaged audiobook EPUB: %s", audiobook_epub_path)
 
-    if await crud.audiobook.get_book_pipeline_status(db, book_id) != "paused":
+    if not await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):
         await crud.audiobook.set_book_pipeline_status(db, book_id, "complete")
     logger.info("Assembly complete for book %s.", book_id)
 

--- a/backend/app/services/audiobook_ingestion.py
+++ b/backend/app/services/audiobook_ingestion.py
@@ -193,6 +193,6 @@ async def ingest_epub(book_id: int, db: AsyncSession) -> None:
     await db.commit()
     if persisted_chapters == 0:
         raise RuntimeError(f"EPUB for book {book_id} contains no narratable text.")
-    if await crud.audiobook.get_book_pipeline_status(db, book_id) != "paused":
+    if not await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):
         await crud.audiobook.set_book_pipeline_status(db, book_id, "roster_gen")
     logger.info("Ingestion complete for book %s: %d chapters processed", book_id, persisted_chapters)

--- a/backend/app/services/audiobook_llm.py
+++ b/backend/app/services/audiobook_llm.py
@@ -176,7 +176,7 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
 
     await crud.audiobook.create_characters_bulk(db, book_id=book_id, characters_data=normalised)
     logger.info("Created %d characters for book %s.", len(normalised), book_id)
-    if await crud.audiobook.get_book_pipeline_status(db, book_id) != "paused":
+    if not await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):
         await crud.audiobook.set_book_pipeline_status(db, book_id, "diarizing")
 
 
@@ -197,7 +197,7 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
     batch_size = 50
 
     while True:
-        if await crud.audiobook.get_book_pipeline_status(db, book_id) == "paused":
+        if await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):
             logger.info("Book %s paused during diarization.", book_id)
             return
 
@@ -244,5 +244,5 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
             context_window.append(sentence.original_text)
 
     logger.info("Diarization complete for book %s.", book_id)
-    if await crud.audiobook.get_book_pipeline_status(db, book_id) != "paused":
+    if not await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):
         await crud.audiobook.set_book_pipeline_status(db, book_id, "audio_gen")

--- a/backend/app/services/audiobook_queue.py
+++ b/backend/app/services/audiobook_queue.py
@@ -81,10 +81,10 @@ class AudiobookQueue:
                 book_id = item
                 try:
                     await self._process(book_id)
-                except Exception:
+                except Exception as exc:
                     logger.exception("Unhandled exception in audiobook pipeline for book %s.", book_id)
                     async with SessionLocal() as db:
-                        await crud.audiobook.set_book_pipeline_status(db, book_id, "error")
+                        await crud.audiobook.set_book_pipeline_error(db, book_id, str(exc))
                 finally:
                     self._queued_book_ids.discard(book_id)
                     if book_id in self._rerun_book_ids:
@@ -130,13 +130,20 @@ class AudiobookQueue:
                 elif phase == "assembling":
                     await assemble_book(book_id, db)
 
-            # Check if the book was paused mid-pipeline
+            # Stop only at durable boundaries. Mid-phase services also check
+            # cooperative pause requests between batches/items.
             async with SessionLocal() as db:
                 from ..models import Book
 
                 book = await db.get(Book, book_id)
                 if book and book.audiobook_pipeline_status == "paused":
                     logger.info("Book %s paused after phase '%s'.", book_id, phase)
+                    return
+                if await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):
+                    logger.info("Book %s acknowledged pause after phase '%s'.", book_id, phase)
+                    return
+                if await crud.audiobook.pause_book_pipeline_after_phase(db, book_id, phase):
+                    logger.info("Book %s stopped for review after phase '%s'.", book_id, phase)
                     return
 
         logger.info("Audiobook pipeline complete for book %s.", book_id)

--- a/backend/app/services/audiobook_tts.py
+++ b/backend/app/services/audiobook_tts.py
@@ -93,7 +93,7 @@ async def generate_audio_for_book(book_id: int, db: AsyncSession) -> None:
     processed = 0
     failed = 0
     while True:
-        if await crud.audiobook.get_book_pipeline_status(db, book_id) == "paused":
+        if await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):
             logger.info("Book %s paused during TTS generation.", book_id)
             return
 
@@ -102,7 +102,7 @@ async def generate_audio_for_book(book_id: int, db: AsyncSession) -> None:
             break
 
         for sentence in batch:
-            if await crud.audiobook.get_book_pipeline_status(db, book_id) == "paused":
+            if await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):
                 logger.info("Book %s paused during TTS generation.", book_id)
                 return
 
@@ -158,7 +158,7 @@ async def generate_audio_for_book(book_id: int, db: AsyncSession) -> None:
         await crud.audiobook.set_book_pipeline_status(db, book_id, "error")
         raise RuntimeError(f"TTS finished before all sentences had audio for book {book_id}.")
 
-    if await crud.audiobook.get_book_pipeline_status(db, book_id) == "paused":
+    if await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):
         logger.info("Book %s paused after TTS generation.", book_id)
         return
 

--- a/backend/tests/test_audiobook_pipeline.py
+++ b/backend/tests/test_audiobook_pipeline.py
@@ -11,6 +11,7 @@ from ebooklib import epub
 from backend.app import crud, models
 from backend.app.routers import audiobook as audiobook_router
 from backend.app.services import audiobook_assembly, audiobook_ingestion, audiobook_llm, audiobook_tts
+from backend.app.services import audiobook_queue
 from backend.app.services.audiobook_queue import AudiobookQueue
 
 
@@ -109,6 +110,32 @@ async def test_queue_schedules_one_rerun_for_changes_during_processing(monkeypat
         assert processed == [42, 42]
     finally:
         await queue.stop()
+
+
+@pytest.mark.asyncio
+async def test_queue_persists_actionable_pipeline_error(db, sqlite_sessionmaker, monkeypatch):
+    book = await _make_book(
+        db,
+        audiobook_enabled=True,
+        audiobook_pipeline_status="ingesting",
+    )
+    queue = AudiobookQueue()
+
+    async def fail(_book_id):
+        raise RuntimeError("EPUB contains no narratable text")
+
+    monkeypatch.setattr(audiobook_queue, "SessionLocal", sqlite_sessionmaker)
+    monkeypatch.setattr(queue, "_process", fail)
+    await queue.start()
+    try:
+        await queue.enqueue(book.id)
+        await queue._queue.join()
+    finally:
+        await queue.stop()
+
+    await db.refresh(book)
+    assert book.audiobook_pipeline_status == "error"
+    assert book.audiobook_last_error == "EPUB contains no narratable text"
 
 
 @pytest.mark.asyncio
@@ -228,6 +255,80 @@ async def test_sentence_speaker_must_belong_to_the_same_book(db, monkeypatch):
     assert exc_info.value.status_code == 404
     assert sentence.character_id != other_character.id
     assert queue.enqueued == []
+
+
+@pytest.mark.asyncio
+async def test_step_pipeline_runs_only_next_recoverable_phase(db, monkeypatch):
+    book = await _make_book(db, audiobook_enabled=True)
+    queue = _FakeQueue()
+    monkeypatch.setattr(audiobook_router, "get_audiobook_queue", lambda: queue)
+
+    response = await audiobook_router.step_pipeline(book.id, db)
+
+    await db.refresh(book)
+    assert response == {
+        "status": "ingesting",
+        "queued": True,
+        "stop_after_phase": "ingesting",
+    }
+    assert book.audiobook_pipeline_status == "ingesting"
+    assert book.audiobook_stop_after_phase == "ingesting"
+    assert book.audiobook_last_error is None
+    assert queue.enqueued == [book.id]
+
+
+@pytest.mark.asyncio
+async def test_queue_stops_for_review_after_requested_phase(db, sqlite_sessionmaker, monkeypatch):
+    book = await _make_book(
+        db,
+        audiobook_enabled=True,
+        audiobook_pipeline_status="ingesting",
+        audiobook_stop_after_phase="ingesting",
+    )
+    phases: list[str] = []
+
+    async def ingest(book_id, phase_db):
+        phases.append("ingesting")
+        await crud.audiobook.set_book_pipeline_status(phase_db, book_id, "roster_gen")
+
+    async def unexpected(*_args):
+        phases.append("unexpected")
+
+    monkeypatch.setattr(audiobook_queue, "SessionLocal", sqlite_sessionmaker)
+    monkeypatch.setattr(audiobook_queue, "ingest_epub", ingest)
+    monkeypatch.setattr(audiobook_queue, "generate_character_roster", unexpected)
+
+    await AudiobookQueue()._process(book.id)
+
+    await db.refresh(book)
+    assert phases == ["ingesting"]
+    assert book.audiobook_pipeline_status == "paused"
+    assert book.audiobook_stop_after_phase is None
+
+
+@pytest.mark.asyncio
+async def test_pause_is_cooperative_and_status_exposes_error_context(db):
+    book = await _make_book(
+        db,
+        audiobook_enabled=True,
+        audiobook_pipeline_status="audio_gen",
+        audiobook_last_error="Previous failure",
+    )
+
+    response = await audiobook_router.pause_pipeline(book.id, db)
+    await db.refresh(book)
+
+    assert response == {"status": "audio_gen", "pause_requested": True}
+    assert book.audiobook_pipeline_status == "audio_gen"
+    assert book.audiobook_pause_requested is True
+
+    await crud.audiobook.pause_book_pipeline_if_requested(db, book.id)
+    status = await audiobook_router.get_pipeline_status(book.id, db)
+
+    assert status.pipeline_status == "paused"
+    assert status.pause_requested is False
+    assert status.next_phase == "ingesting"
+    assert status.last_error == "Previous failure"
 
 
 @pytest.mark.asyncio
@@ -391,8 +492,6 @@ async def test_offline_harness_builds_downloadable_media_overlay_epub(db, tmp_pa
     assert Path(response.path) == output_path
     assert response.media_type == "application/epub+zip"
 
-    # A crash or cleanup after chapter assembly must resume packaging rather
-    # than leaving a false complete state with a missing download.
     output_path.unlink()
     monkeypatch.setattr(crud.audiobook, "LIBRARY_PATH", library_path)
     assert await crud.audiobook.infer_audiobook_resume_status(db, book.id) == "assembling"

--- a/backend/tests/test_epub_editor.py
+++ b/backend/tests/test_epub_editor.py
@@ -1,10 +1,11 @@
 import zipfile
 from pathlib import Path
 
+import pytest
 from bs4 import BeautifulSoup
 from ebooklib import epub
 
-from backend.app import epub_editor
+from backend.app import epub_editor, models
 from backend.app.services.epub_utils import PROSE_BLOCK_MAX_CHARS
 
 
@@ -51,3 +52,34 @@ def test_process_epub_normalizes_oversized_prose_blocks(tmp_path):
     assert word_count is not None
     assert len(paragraphs) == 3
     assert all(len(p.get_text(" ", strip=True)) <= PROSE_BLOCK_MAX_CHARS for p in paragraphs)
+
+
+@pytest.mark.asyncio
+async def test_forced_cleaning_rebuild_restores_epub_after_last_rule_is_removed(db, monkeypatch):
+    book = models.Book(
+        title="Restored",
+        author="Reader",
+        source_type=models.SourceType.epub,
+        immutable_path="library/restored-immutable.epub",
+        current_path="library/restored.epub",
+        removed_chapters=[],
+        content_selectors=[],
+        current_word_count=0,
+    )
+    db.add(book)
+    await db.commit()
+    await db.refresh(book)
+    calls = []
+
+    def process(*args, **kwargs):
+        calls.append((args, kwargs))
+        return 3
+
+    monkeypatch.setattr(epub_editor, "process_epub", process)
+
+    changed = await epub_editor.apply_book_cleaning(book, db, force=True)
+
+    assert changed is True
+    assert len(calls) == 1
+    assert calls[0][0][2:4] == ([], [])
+    assert book.current_word_count == 3

--- a/docs/AUDIOBOOK_PIPELINE.md
+++ b/docs/AUDIOBOOK_PIPELINE.md
@@ -154,6 +154,9 @@ PUT /api/audiobook/sentences/{id}
 - `audiobook_enabled` (Boolean, default `false`) — per-book opt-in gate for this pipeline
 - `audiobook_pipeline_status` (String, nullable)
 Values: `None` (idle), `ingesting`, `roster_gen`, `diarizing`, `audio_gen`, `assembling`, `complete`, `error`, `paused`
+- `audiobook_stop_after_phase` (String, nullable) — persisted checkpoint for a single-stage run
+- `audiobook_pause_requested` (Boolean, default `false`) — cooperative pause request acknowledged at a durable boundary
+- `audiobook_last_error` (Text, nullable) — actionable worker error shown in the book UI
 
 ---
 
@@ -205,6 +208,18 @@ Choose **Deterministic local harness** in Audio Settings to make this mode expli
 choose an LLM provider and configure an OmniVoice-compatible endpoint. The harness is intentionally deterministic;
 it is a validation and UI-development path, not synthetic speech.
 
+## Review and Recovery Controls
+
+The book UI offers **Run Next Stage** for debugging or reviewing intermediate artifacts and **Run to Completion**
+for unattended processing. A single-stage run persists its target phase and moves to `paused` only after that phase
+has committed. **Pause Safely** is cooperative: diarization pauses between batches, TTS between sentences, and
+assembly between chapters. Roster LLM requests and individual external TTS calls finish before the pause is
+acknowledged. Starting or stepping again infers the next safe phase from durable chapter/sentence state, so an app
+restart does not require restarting the entire book.
+
+Worker exceptions are stored in `audiobook_last_error` and returned by the status endpoint. Retrying clears the
+stale message; failed sentence audio is reset to `ready_for_audio` before TTS resumes.
+
 ---
 
 ## File Storage Layout
@@ -232,9 +247,10 @@ All paths stored in the database as relative to `LIBRARY_PATH.parent`, matching 
 | Method | Path | Description |
 |---|---|---|
 | POST | `/api/books/{id}/audiobook/start` | Start or resume pipeline |
-| POST | `/api/books/{id}/audiobook/pause` | Pause workers (set status=paused) |
+| POST | `/api/books/{id}/audiobook/step` | Run only the next recoverable phase, then pause for review |
+| POST | `/api/books/{id}/audiobook/pause` | Request a cooperative pause at the next durable boundary |
 | POST | `/api/books/{id}/audiobook/rebuild` | Force full rebuild |
-| GET | `/api/books/{id}/audiobook/status` | Pipeline status + sentence counts by status |
+| GET | `/api/books/{id}/audiobook/status` | Status, next phase, controls, last error, and sentence counts |
 | GET | `/api/books/{id}/audiobook/characters` | List characters |
 | PUT | `/api/audiobook/characters/{char_id}` | Update voice profile (triggers cascade) |
 | GET | `/api/books/{id}/audiobook/sentences` | Paginated sentence list (`?page=&limit=&chapter_id=`) |
@@ -252,8 +268,9 @@ All paths stored in the database as relative to `LIBRARY_PATH.parent`, matching 
 
 | File | Purpose |
 |---|---|
-| `backend/app/models.py` | +4 new models, +1 Book column |
-| `backend/alembic/versions/0018_audiobook_pipeline.py` | Schema migration |
+| `backend/app/models.py` | Audiobook models and per-book pipeline/control state |
+| `backend/alembic/versions/0018_audiobook_pipeline.py` | Core audiobook schema migration |
+| `backend/alembic/versions/0019_audiobook_pipeline_controls.py` | Review, pause, and error-state migration |
 | `backend/app/crud/audiobook.py` | DB queries for all new tables |
 | `backend/app/services/audiobook_ingestion.py` | Phase 1: EPUB parse + span injection |
 | `backend/app/services/audiobook_llm.py` | Phases 2 & 3: character roster + diarization |

--- a/frontend/src/api/audiobook.js
+++ b/frontend/src/api/audiobook.js
@@ -2,13 +2,23 @@ import { getJson, sendJson, sendWithoutBody } from "./client";
 
 // Pipeline control
 export function getAudiobookStatus(bookId) {
-  return getJson(`/api/books/${bookId}/audiobook/status`, "Failed to fetch audiobook status");
+  return getJson(
+    `/api/books/${bookId}/audiobook/status`,
+    "Failed to fetch audiobook status",
+  );
 }
 
 export function startPipeline(bookId) {
   return sendWithoutBody(`/api/books/${bookId}/audiobook/start`, {
     method: "POST",
     fallbackMessage: "Failed to start pipeline",
+  });
+}
+
+export function stepPipeline(bookId) {
+  return sendWithoutBody(`/api/books/${bookId}/audiobook/step`, {
+    method: "POST",
+    fallbackMessage: "Failed to run the next pipeline stage",
   });
 }
 
@@ -28,7 +38,10 @@ export function rebuildPipeline(bookId) {
 
 // Characters
 export function getCharacters(bookId) {
-  return getJson(`/api/books/${bookId}/audiobook/characters`, "Failed to fetch characters");
+  return getJson(
+    `/api/books/${bookId}/audiobook/characters`,
+    "Failed to fetch characters",
+  );
 }
 
 export function updateCharacter(charId, data) {
@@ -43,7 +56,10 @@ export function updateCharacter(charId, data) {
 export function getSentences(bookId, { page = 1, limit = 50, chapterId } = {}) {
   const params = new URLSearchParams({ page, limit });
   if (chapterId != null) params.set("chapter_id", chapterId);
-  return getJson(`/api/books/${bookId}/audiobook/sentences?${params}`, "Failed to fetch sentences");
+  return getJson(
+    `/api/books/${bookId}/audiobook/sentences?${params}`,
+    "Failed to fetch sentences",
+  );
 }
 
 export function updateSentence(sentenceId, data) {
@@ -60,7 +76,10 @@ export function getSentenceAudioUrl(sentenceId) {
 
 // Chapters
 export function getAudiobookChapters(bookId) {
-  return getJson(`/api/books/${bookId}/audiobook/chapters`, "Failed to fetch chapters");
+  return getJson(
+    `/api/books/${bookId}/audiobook/chapters`,
+    "Failed to fetch chapters",
+  );
 }
 
 export function getChapterAudioUrl(bookId, chapterId) {
@@ -73,7 +92,10 @@ export function getAudiobookDownloadUrl(bookId) {
 
 // Settings
 export function getAudiobookSettings() {
-  return getJson("/api/audiobook/settings", "Failed to fetch audiobook settings");
+  return getJson(
+    "/api/audiobook/settings",
+    "Failed to fetch audiobook settings",
+  );
 }
 
 export function updateAudiobookSettings(data) {

--- a/frontend/src/components/AudiobookPipeline.jsx
+++ b/frontend/src/components/AudiobookPipeline.jsx
@@ -1,10 +1,11 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   getAudiobookStatus,
   getCharacters,
   getAudiobookChapters,
   startPipeline,
+  stepPipeline,
   pausePipeline,
   rebuildPipeline,
   getAudiobookDownloadUrl,
@@ -22,7 +23,13 @@ const PIPELINE_STEPS = [
   { status: "complete", label: "Complete" },
 ];
 
-const ACTIVE_STATUSES = new Set(["ingesting", "roster_gen", "diarizing", "audio_gen", "assembling"]);
+const ACTIVE_STATUSES = new Set([
+  "ingesting",
+  "roster_gen",
+  "diarizing",
+  "audio_gen",
+  "assembling",
+]);
 
 function PipelineProgress({ status }) {
   const currentIdx = PIPELINE_STEPS.findIndex((s) => s.status === status);
@@ -78,12 +85,19 @@ function AudiobookPipeline({ book }) {
 
   const invalidateAll = () => {
     queryClient.invalidateQueries({ queryKey: ["audiobook-status", bookId] });
-    queryClient.invalidateQueries({ queryKey: ["audiobook-characters", bookId] });
+    queryClient.invalidateQueries({
+      queryKey: ["audiobook-characters", bookId],
+    });
     queryClient.invalidateQueries({ queryKey: ["audiobook-chapters", bookId] });
   };
 
   const startMutation = useMutation({
     mutationFn: () => startPipeline(bookId),
+    onSuccess: invalidateAll,
+  });
+
+  const stepMutation = useMutation({
+    mutationFn: () => stepPipeline(bookId),
     onSuccess: invalidateAll,
   });
 
@@ -101,14 +115,40 @@ function AudiobookPipeline({ book }) {
   });
 
   const pipelineStatus = statusData?.pipeline_status ?? null;
+  const nextPhase = statusData?.next_phase ?? "ingesting";
+  const pauseRequested = statusData?.pause_requested ?? false;
+  const progressStatus =
+    isActive(pipelineStatus) || pipelineStatus === "complete"
+      ? pipelineStatus
+      : nextPhase;
+  const nextPhaseLabel =
+    PIPELINE_STEPS.find((step) => step.status === nextPhase)?.label ??
+    nextPhase;
   const sentenceCounts = statusData?.sentence_counts ?? {};
-  const totalSentences = Object.values(sentenceCounts).reduce((a, b) => a + b, 0);
+  const totalSentences = Object.values(sentenceCounts).reduce(
+    (a, b) => a + b,
+    0,
+  );
   const doneCount = sentenceCounts["audio_generated"] ?? 0;
+
+  // A fast local/stub phase can finish before the slower data queries poll.
+  // Refresh editor data whenever the durable pipeline state advances so the
+  // review screen always reflects the checkpoint that was just reached.
+  useEffect(() => {
+    if (pipelineStatus !== undefined) {
+      queryClient.invalidateQueries({
+        queryKey: ["audiobook-characters", bookId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["audiobook-chapters", bookId],
+      });
+    }
+  }, [bookId, pipelineStatus, queryClient]);
 
   return (
     <div className="audiobook-pipeline">
       <div className="pipeline-header">
-        <PipelineProgress status={pipelineStatus} />
+        <PipelineProgress status={progressStatus} />
 
         <div className="pipeline-meta">
           {totalSentences > 0 && (
@@ -117,39 +157,62 @@ function AudiobookPipeline({ book }) {
             </span>
           )}
           {pipelineStatus === "error" && (
-            <span className="badge badge--error">Pipeline error — check logs</span>
+            <span className="badge badge--error">Pipeline error</span>
           )}
           {pipelineStatus === "paused" && (
-            <span className="badge badge--warning">Paused</span>
+            <span className="badge badge--warning">
+              Paused — next: {nextPhaseLabel}
+            </span>
+          )}
+          {pauseRequested && (
+            <span className="badge badge--warning">Pause requested…</span>
+          )}
+          {statusData?.last_error && (
+            <p className="error">{statusData.last_error}</p>
           )}
         </div>
 
         <div className="pipeline-controls">
           {pipelineStatus === "complete" && (
-            <a className="btn btn-primary" href={getAudiobookDownloadUrl(bookId)} download>
+            <a
+              className="btn btn-primary"
+              href={getAudiobookDownloadUrl(bookId)}
+              download
+            >
               Download Audiobook EPUB
             </a>
           )}
           {pipelineStatus !== "complete" && !isActive(pipelineStatus) && (
-            <button
-              onClick={() => startMutation.mutate()}
-              disabled={startMutation.isPending}
-              className="btn-primary"
-            >
-              {pipelineStatus ? "Resume Pipeline" : "Start Pipeline"}
-            </button>
+            <>
+              <button
+                onClick={() => stepMutation.mutate()}
+                disabled={stepMutation.isPending || startMutation.isPending}
+              >
+                Run Next Stage: {nextPhaseLabel}
+              </button>
+              <button
+                onClick={() => startMutation.mutate()}
+                disabled={startMutation.isPending || stepMutation.isPending}
+                className="btn-primary"
+              >
+                Run to Completion
+              </button>
+            </>
           )}
           {isActive(pipelineStatus) && (
             <button
               onClick={() => pauseMutation.mutate()}
-              disabled={pauseMutation.isPending}
+              disabled={pauseMutation.isPending || pauseRequested}
             >
-              Pause Workers
+              {pauseRequested ? "Pause Requested…" : "Pause Safely"}
             </button>
           )}
           {!isActive(pipelineStatus) &&
             (!confirmRebuild ? (
-              <button className="btn-danger" onClick={() => setConfirmRebuild(true)}>
+              <button
+                className="btn-danger"
+                onClick={() => setConfirmRebuild(true)}
+              >
                 Force Full Rebuild
               </button>
             ) : (
@@ -162,17 +225,27 @@ function AudiobookPipeline({ book }) {
                 >
                   {rebuildMutation.isPending ? "Rebuilding…" : "Yes, rebuild"}
                 </button>{" "}
-                <button className="btn-text" onClick={() => setConfirmRebuild(false)}>
+                <button
+                  className="btn-text"
+                  onClick={() => setConfirmRebuild(false)}
+                >
                   Cancel
                 </button>
               </span>
             ))}
         </div>
 
-        {(startMutation.isError || pauseMutation.isError || rebuildMutation.isError) && (
+        {(startMutation.isError ||
+          stepMutation.isError ||
+          pauseMutation.isError ||
+          rebuildMutation.isError) && (
           <p className="error">
-            {(startMutation.error || pauseMutation.error || rebuildMutation.error)?.message ||
-              "Action failed"}
+            {(
+              startMutation.error ||
+              stepMutation.error ||
+              pauseMutation.error ||
+              rebuildMutation.error
+            )?.message || "Action failed"}
           </p>
         )}
       </div>

--- a/frontend/src/components/AudiobookPipeline.test.jsx
+++ b/frontend/src/components/AudiobookPipeline.test.jsx
@@ -1,0 +1,67 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import AudiobookPipeline from "./AudiobookPipeline";
+import { renderWithClient } from "../test-utils";
+
+describe("AudiobookPipeline", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shows the actionable error and can run only the next stage", async () => {
+    const fetchMock = vi.fn((url, options) => {
+      if (url === "/api/books/11/audiobook/status") {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              pipeline_status: "error",
+              next_phase: "ingesting",
+              pause_requested: false,
+              stop_after_phase: null,
+              last_error: "EPUB contains no narratable text.",
+              sentence_counts: {},
+            }),
+        });
+      }
+      if (
+        url === "/api/books/11/audiobook/characters" ||
+        url === "/api/books/11/audiobook/chapters"
+      ) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+      }
+      if (
+        url === "/api/books/11/audiobook/step" &&
+        options?.method === "POST"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              status: "ingesting",
+              queued: true,
+              stop_after_phase: "ingesting",
+            }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+    globalThis.fetch = fetchMock;
+
+    renderWithClient(<AudiobookPipeline book={{ id: 11 }} />);
+
+    expect(
+      await screen.findByText("EPUB contains no narratable text."),
+    ).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Run Next Stage: Ingesting" }),
+    );
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/books/11/audiobook/step", {
+        method: "POST",
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Stack

Part 2 of 6. Depends on #148. Base: `agent/audiobook-core`.

## What changed

- Adds cooperative pause requests and durable error context.
- Adds resume inference and one-stage execution for review checkpoints.
- Persists stop-after-phase controls through migration 0019.
- Preserves EPUB editor state while audiobook work is paused or resumed.
- Adds UI controls and regression coverage for pause, retry, and phase stepping.

## Why

Keeping orchestration separate from the core pipeline makes the state machine and migration reviewable without the neural TTS or advanced analysis layers.

## Validation

- Backend focused tests: 38 passed.
- Frontend tests: 33 passed.
- Black and ESLint passed.
- PostgreSQL migration validation is delegated to GitHub Actions because Docker was unavailable locally.