### PR TITLE
Add observable resumable audiobook analysis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup setup-omnivoice run-omnivoice run-ui run-api run-db ensure-db migrate fmt lint test test-migrations e2e e2e-debug
+.PHONY: help setup setup-omnivoice run-omnivoice pull-ollama-model run-ui run-api run-db ensure-db migrate fmt lint test test-migrations e2e e2e-debug
 
 E2E_DB_CONTAINER ?= story-manager-e2e-db
 E2E_DB_PORT ?= 5434
@@ -13,6 +13,7 @@ help:
 	@echo "  make run-ui           Run the Vite frontend"
 	@echo "  make setup-omnivoice  Install official OmniVoice in an isolated environment"
 	@echo "  make run-omnivoice    Run the local MPS/CUDA/CPU OmniVoice adapter"
+	@echo "  make pull-ollama-model Pull the recommended local audiobook LLM"
 	@echo "  make test             Run backend and frontend unit tests"
 	@echo "  make test-migrations  Run migrations against throwaway PostgreSQL"
 	@echo "  make e2e              Run Playwright E2E tests"
@@ -30,6 +31,9 @@ setup-omnivoice:
 run-omnivoice: setup-omnivoice
 	PYTORCH_ENABLE_MPS_FALLBACK=1 services/omnivoice/.venv/bin/uvicorn \
 		services.omnivoice.server:app --host 127.0.0.1 --port $(OMNIVOICE_PORT)
+
+pull-ollama-model:
+	ollama pull qwen3.5:9b
 
 run-ui:
 	cd frontend && npm run dev

--- a/backend/alembic/versions/0020_audiobook_observability.py
+++ b/backend/alembic/versions/0020_audiobook_observability.py
@@ -1,0 +1,61 @@
+"""add audiobook LLM observability and batch controls
+
+Revision ID: 0020
+Revises: 0019
+Create Date: 2026-07-14 00:00:00
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0020"
+down_revision = "0019"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("books", sa.Column("audiobook_summary", sa.Text(), nullable=True))
+    op.add_column(
+        "books",
+        sa.Column("audiobook_progress_current", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.add_column(
+        "books",
+        sa.Column("audiobook_progress_total", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.add_column("books", sa.Column("audiobook_progress_detail", sa.String(), nullable=True))
+    op.add_column("books", sa.Column("audiobook_pipeline_started_at", sa.DateTime(timezone=True), nullable=True))
+    op.add_column("books", sa.Column("audiobook_pipeline_updated_at", sa.DateTime(timezone=True), nullable=True))
+    op.add_column("books", sa.Column("audiobook_batch_limit", sa.Integer(), nullable=True))
+    op.add_column(
+        "books",
+        sa.Column("audiobook_llm_requests", sa.Integer(), nullable=False, server_default="0"),
+    )
+
+    op.add_column("audiobook_chapters", sa.Column("summary", sa.Text(), nullable=True))
+    op.add_column(
+        "audiobook_chapters",
+        sa.Column("summary_updated_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column("audiobook_characters", sa.Column("aliases", sa.JSON(), nullable=True))
+    op.add_column("audiobook_characters", sa.Column("evidence", sa.JSON(), nullable=True))
+    op.add_column("audiobook_sentences", sa.Column("speaker_confidence", sa.Float(), nullable=True))
+    op.add_column("audiobook_sentences", sa.Column("speaker_reason", sa.Text(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("audiobook_sentences", "speaker_reason")
+    op.drop_column("audiobook_sentences", "speaker_confidence")
+    op.drop_column("audiobook_characters", "evidence")
+    op.drop_column("audiobook_characters", "aliases")
+    op.drop_column("audiobook_chapters", "summary_updated_at")
+    op.drop_column("audiobook_chapters", "summary")
+    op.drop_column("books", "audiobook_llm_requests")
+    op.drop_column("books", "audiobook_batch_limit")
+    op.drop_column("books", "audiobook_pipeline_updated_at")
+    op.drop_column("books", "audiobook_pipeline_started_at")
+    op.drop_column("books", "audiobook_progress_detail")
+    op.drop_column("books", "audiobook_progress_total")
+    op.drop_column("books", "audiobook_progress_current")
+    op.drop_column("books", "audiobook_summary")

--- a/backend/app/crud/audiobook.py
+++ b/backend/app/crud/audiobook.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Optional
 
-from sqlalchemy import func, or_, select, update
+from sqlalchemy import and_, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..config import LIBRARY_PATH
@@ -39,7 +40,11 @@ async def upsert_audiobook_settings(db: AsyncSession, data: dict) -> AudiobookSe
 
 
 async def set_book_pipeline_status(db: AsyncSession, book_id: int, status: Optional[str]) -> None:
-    await db.execute(update(Book).where(Book.id == book_id).values(audiobook_pipeline_status=status))
+    await db.execute(
+        update(Book)
+        .where(Book.id == book_id)
+        .values(audiobook_pipeline_status=status, audiobook_pipeline_updated_at=datetime.now(timezone.utc))
+    )
     await db.commit()
 
 
@@ -49,6 +54,7 @@ async def configure_book_pipeline_run(
     *,
     status: str,
     stop_after_phase: Optional[str],
+    batch_limit: Optional[int] = None,
 ) -> None:
     """Start or resume a run and clear stale pause/error state atomically."""
     await db.execute(
@@ -59,6 +65,13 @@ async def configure_book_pipeline_run(
             audiobook_stop_after_phase=stop_after_phase,
             audiobook_pause_requested=False,
             audiobook_last_error=None,
+            audiobook_batch_limit=batch_limit,
+            audiobook_progress_current=0,
+            audiobook_progress_total=0,
+            audiobook_progress_detail=None,
+            audiobook_pipeline_started_at=datetime.now(timezone.utc),
+            audiobook_pipeline_updated_at=datetime.now(timezone.utc),
+            audiobook_llm_requests=0,
         )
     )
     await db.commit()
@@ -67,6 +80,62 @@ async def configure_book_pipeline_run(
 async def request_book_pipeline_pause(db: AsyncSession, book_id: int) -> None:
     await db.execute(update(Book).where(Book.id == book_id).values(audiobook_pause_requested=True))
     await db.commit()
+
+
+async def update_book_pipeline_progress(
+    db: AsyncSession,
+    book_id: int,
+    *,
+    current: int,
+    total: int,
+    detail: Optional[str],
+    llm_request_increment: int = 0,
+) -> None:
+    values = {
+        "audiobook_progress_current": max(0, current),
+        "audiobook_progress_total": max(0, total),
+        "audiobook_progress_detail": detail,
+        "audiobook_pipeline_updated_at": datetime.now(timezone.utc),
+    }
+    if llm_request_increment:
+        values["audiobook_llm_requests"] = Book.audiobook_llm_requests + llm_request_increment
+    await db.execute(update(Book).where(Book.id == book_id).values(**values))
+    await db.commit()
+
+
+async def set_book_audiobook_summary(db: AsyncSession, book_id: int, summary: Optional[str]) -> None:
+    await db.execute(
+        update(Book)
+        .where(Book.id == book_id)
+        .values(audiobook_summary=summary, audiobook_pipeline_updated_at=datetime.now(timezone.utc))
+    )
+    await db.commit()
+
+
+async def consume_book_batch_limit(db: AsyncSession, book_id: int) -> bool:
+    """Consume one durable work unit and pause when a one-batch run is exhausted."""
+    result = await db.execute(select(Book.audiobook_batch_limit).where(Book.id == book_id))
+    remaining = result.scalar_one_or_none()
+    if remaining is None:
+        return False
+    remaining -= 1
+    if remaining > 0:
+        await db.execute(update(Book).where(Book.id == book_id).values(audiobook_batch_limit=remaining))
+        await db.commit()
+        return False
+    await db.execute(
+        update(Book)
+        .where(Book.id == book_id)
+        .values(
+            audiobook_pipeline_status="paused",
+            audiobook_batch_limit=None,
+            audiobook_stop_after_phase=None,
+            audiobook_pause_requested=False,
+            audiobook_pipeline_updated_at=datetime.now(timezone.utc),
+        )
+    )
+    await db.commit()
+    return True
 
 
 async def pause_book_pipeline_if_requested(db: AsyncSession, book_id: int) -> bool:
@@ -81,6 +150,8 @@ async def pause_book_pipeline_if_requested(db: AsyncSession, book_id: int) -> bo
             audiobook_pipeline_status="paused",
             audiobook_pause_requested=False,
             audiobook_stop_after_phase=None,
+            audiobook_batch_limit=None,
+            audiobook_pipeline_updated_at=datetime.now(timezone.utc),
         )
     )
     await db.commit()
@@ -96,7 +167,14 @@ async def pause_book_pipeline_after_phase(db: AsyncSession, book_id: int, phase:
     if row is None or row.audiobook_stop_after_phase != phase or row.audiobook_pipeline_status == "complete":
         return False
     await db.execute(
-        update(Book).where(Book.id == book_id).values(audiobook_pipeline_status="paused", audiobook_stop_after_phase=None)
+        update(Book)
+        .where(Book.id == book_id)
+        .values(
+            audiobook_pipeline_status="paused",
+            audiobook_stop_after_phase=None,
+            audiobook_batch_limit=None,
+            audiobook_pipeline_updated_at=datetime.now(timezone.utc),
+        )
     )
     await db.commit()
     return True
@@ -110,6 +188,8 @@ async def set_book_pipeline_error(db: AsyncSession, book_id: int, message: str) 
             audiobook_pipeline_status="error",
             audiobook_pause_requested=False,
             audiobook_stop_after_phase=None,
+            audiobook_batch_limit=None,
+            audiobook_pipeline_updated_at=datetime.now(timezone.utc),
             audiobook_last_error=message,
         )
     )
@@ -190,6 +270,15 @@ async def update_chapter_assembly(
     await db.commit()
 
 
+async def update_chapter_summary(db: AsyncSession, chapter_id: int, summary: Optional[str]) -> None:
+    await db.execute(
+        update(AudiobookChapter)
+        .where(AudiobookChapter.id == chapter_id)
+        .values(summary=summary, summary_updated_at=datetime.now(timezone.utc))
+    )
+    await db.commit()
+
+
 async def flag_chapter_for_reassembly(db: AsyncSession, chapter_id: int) -> None:
     await db.execute(update(AudiobookChapter).where(AudiobookChapter.id == chapter_id).values(needs_reassembly=True))
     await db.commit()
@@ -261,6 +350,35 @@ async def delete_characters_for_book(db: AsyncSession, book_id: int) -> None:
     await db.commit()
 
 
+async def reset_roster_and_diarization_for_book(db: AsyncSession, book_id: int) -> None:
+    """Clear derived speaker analysis while preserving the expensive EPUB ingestion."""
+    chapter_ids = select(AudiobookChapter.id).where(AudiobookChapter.book_id == book_id)
+    await db.execute(
+        update(AudiobookSentence)
+        .where(AudiobookSentence.chapter_id.in_(chapter_ids))
+        .values(
+            character_id=None,
+            tagged_text=AudiobookSentence.original_text,
+            audio_file_path=None,
+            audio_duration_ms=None,
+            speaker_confidence=None,
+            speaker_reason=None,
+            status="pending_diarization",
+        )
+    )
+    await db.execute(
+        update(AudiobookChapter)
+        .where(AudiobookChapter.book_id == book_id)
+        .values(
+            summary=None,
+            summary_updated_at=None,
+            needs_reassembly=True,
+        )
+    )
+    await db.commit()
+    await delete_characters_for_book(db, book_id)
+
+
 # ---------------------------------------------------------------------------
 # Sentences
 # ---------------------------------------------------------------------------
@@ -286,6 +404,7 @@ async def get_sentences_paginated(
     page: int = 1,
     limit: int = 50,
     chapter_id: Optional[int] = None,
+    review_only: bool = False,
 ) -> tuple[list[AudiobookSentence], int]:
     base_query = (
         select(AudiobookSentence)
@@ -301,6 +420,17 @@ async def get_sentences_paginated(
     if chapter_id is not None:
         base_query = base_query.where(AudiobookSentence.chapter_id == chapter_id)
         count_query = count_query.where(AudiobookSentence.chapter_id == chapter_id)
+    if review_only:
+        review_filter = and_(
+            AudiobookSentence.status != "pending_diarization",
+            or_(
+                AudiobookSentence.character_id.is_(None),
+                AudiobookSentence.speaker_confidence.is_(None),
+                AudiobookSentence.speaker_confidence < 0.65,
+            ),
+        )
+        base_query = base_query.where(review_filter)
+        count_query = count_query.where(review_filter)
 
     total_result = await db.execute(count_query)
     total = total_result.scalar_one()
@@ -313,8 +443,13 @@ async def get_sentences_paginated(
     return list(result.scalars().all()), total
 
 
-async def get_sentences_pending_diarization(db: AsyncSession, book_id: int, limit: int = 50) -> list[AudiobookSentence]:
-    result = await db.execute(
+async def get_sentences_pending_diarization(
+    db: AsyncSession,
+    book_id: int,
+    limit: int = 50,
+    chapter_id: Optional[int] = None,
+) -> list[AudiobookSentence]:
+    query = (
         select(AudiobookSentence)
         .join(AudiobookChapter, AudiobookSentence.chapter_id == AudiobookChapter.id)
         .where(
@@ -324,6 +459,9 @@ async def get_sentences_pending_diarization(db: AsyncSession, book_id: int, limi
         .order_by(AudiobookChapter.chapter_number, AudiobookSentence.sequence_order)
         .limit(limit)
     )
+    if chapter_id is not None:
+        query = query.where(AudiobookSentence.chapter_id == chapter_id)
+    result = await db.execute(query)
     return list(result.scalars().all())
 
 
@@ -342,12 +480,23 @@ async def get_sentences_ready_for_audio(db: AsyncSession, book_id: int, limit: i
 
 
 async def update_sentence_diarization(
-    db: AsyncSession, sentence_id: int, character_id: Optional[int], tagged_text: str
+    db: AsyncSession,
+    sentence_id: int,
+    character_id: Optional[int],
+    tagged_text: str,
+    speaker_confidence: Optional[float] = None,
+    speaker_reason: Optional[str] = None,
 ) -> None:
     await db.execute(
         update(AudiobookSentence)
         .where(AudiobookSentence.id == sentence_id)
-        .values(character_id=character_id, tagged_text=tagged_text, status="ready_for_audio")
+        .values(
+            character_id=character_id,
+            tagged_text=tagged_text,
+            speaker_confidence=speaker_confidence,
+            speaker_reason=speaker_reason,
+            status="ready_for_audio",
+        )
     )
     await db.commit()
 
@@ -390,6 +539,8 @@ async def update_sentence_speaker(
         return None
     sentence.character_id = character_id
     sentence.tagged_text = tagged_text
+    sentence.speaker_confidence = 1.0
+    sentence.speaker_reason = "Manually assigned"
     sentence.status = "ready_for_audio"
     sentence.audio_file_path = None
     sentence.audio_duration_ms = None
@@ -407,6 +558,48 @@ async def count_sentences_by_status(db: AsyncSession, book_id: int) -> dict[str,
         .group_by(AudiobookSentence.status)
     )
     return {row[0]: row[1] for row in result.all()}
+
+
+async def count_sentence_review_flags(db: AsyncSession, book_id: int) -> dict[str, int]:
+    base = (
+        select(AudiobookSentence)
+        .join(AudiobookChapter, AudiobookSentence.chapter_id == AudiobookChapter.id)
+        .where(AudiobookChapter.book_id == book_id)
+        .subquery()
+    )
+    result = await db.execute(
+        select(
+            func.count().filter(base.c.character_id.is_(None)),
+            func.count().filter(base.c.speaker_confidence < 0.65),
+            func.count().filter(base.c.speaker_confidence.is_not(None)),
+        ).select_from(base)
+    )
+    unassigned, low_confidence, reviewed = result.one()
+    return {
+        "unassigned": unassigned or 0,
+        "low_confidence": low_confidence or 0,
+        "with_confidence": reviewed or 0,
+    }
+
+
+async def get_character_sentence_stats(db: AsyncSession, book_id: int) -> dict[int, dict[str, float | int | None]]:
+    result = await db.execute(
+        select(
+            AudiobookSentence.character_id,
+            func.count(),
+            func.avg(AudiobookSentence.speaker_confidence),
+        )
+        .join(AudiobookChapter, AudiobookSentence.chapter_id == AudiobookChapter.id)
+        .where(AudiobookChapter.book_id == book_id, AudiobookSentence.character_id.is_not(None))
+        .group_by(AudiobookSentence.character_id)
+    )
+    return {
+        character_id: {
+            "sentence_count": sentence_count,
+            "average_confidence": float(average_confidence) if average_confidence is not None else None,
+        }
+        for character_id, sentence_count, average_confidence in result.all()
+    }
 
 
 async def has_sentence_status(db: AsyncSession, book_id: int, statuses: str | list[str]) -> bool:

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Boolean, Column, Integer, String, DateTime, ForeignKey, Enum, JSON, Numeric, Text
+from sqlalchemy import Boolean, Column, Integer, String, DateTime, Float, ForeignKey, Enum, JSON, Numeric, Text
 from sqlalchemy.sql import func
 from .database import Base
 import enum
@@ -49,6 +49,14 @@ class Book(Base):
     audiobook_stop_after_phase = Column(String, nullable=True)
     audiobook_pause_requested = Column(Boolean, nullable=False, default=False, server_default="false")
     audiobook_last_error = Column(Text, nullable=True)
+    audiobook_summary = Column(Text, nullable=True)
+    audiobook_progress_current = Column(Integer, nullable=False, default=0, server_default="0")
+    audiobook_progress_total = Column(Integer, nullable=False, default=0, server_default="0")
+    audiobook_progress_detail = Column(String, nullable=True)
+    audiobook_pipeline_started_at = Column(DateTime(timezone=True), nullable=True)
+    audiobook_pipeline_updated_at = Column(DateTime(timezone=True), nullable=True)
+    audiobook_batch_limit = Column(Integer, nullable=True)
+    audiobook_llm_requests = Column(Integer, nullable=False, default=0, server_default="0")
 
     # Timestamps
     created_at = Column(DateTime(timezone=True), server_default=func.now())
@@ -196,6 +204,8 @@ class AudiobookChapter(Base):
     smil_file_path = Column(String, nullable=True)
     audio_file_path = Column(String, nullable=True)
     needs_reassembly = Column(Boolean, nullable=False, server_default="false")
+    summary = Column(Text, nullable=True)
+    summary_updated_at = Column(DateTime(timezone=True), nullable=True)
 
 
 class AudiobookCharacter(Base):
@@ -207,6 +217,8 @@ class AudiobookCharacter(Base):
     description = Column(Text, nullable=True)
     voice_design_prompt = Column(String, nullable=True)
     is_narrator = Column(Boolean, nullable=False, server_default="false")
+    aliases = Column(JSON, nullable=True)
+    evidence = Column(JSON, nullable=True)
 
 
 class AudiobookSentence(Base):
@@ -221,5 +233,7 @@ class AudiobookSentence(Base):
     tagged_text = Column(Text, nullable=True)
     audio_file_path = Column(String, nullable=True)
     audio_duration_ms = Column(Integer, nullable=True)
+    speaker_confidence = Column(Float, nullable=True)
+    speaker_reason = Column(Text, nullable=True)
     # Status values: pending_diarization, ready_for_audio, audio_generated, error
     status = Column(String, nullable=False, server_default="pending_diarization")

--- a/backend/app/routers/audiobook.py
+++ b/backend/app/routers/audiobook.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional
 
@@ -16,6 +17,7 @@ from ..config import LIBRARY_PATH
 from ..database import get_db
 from ..models import AudiobookChapter, AudiobookCharacter, AudiobookSentence, Book
 from ..services.audiobook_queue import get_audiobook_queue
+from ..services import audiobook_llm
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +36,18 @@ class AudiobookStatusResponse(BaseModel):
     stop_after_phase: Optional[str]
     last_error: Optional[str]
     sentence_counts: dict[str, int]
+    review_counts: dict[str, int]
+    summary: Optional[str]
+    progress_current: int
+    progress_total: int
+    progress_percent: Optional[float]
+    progress_detail: Optional[str]
+    pipeline_started_at: Optional[datetime]
+    pipeline_updated_at: Optional[datetime]
+    batch_limit: Optional[int]
+    llm_requests: int
+    llm_provider: str
+    llm_model: Optional[str]
 
 
 class CharacterResponse(BaseModel):
@@ -43,6 +57,10 @@ class CharacterResponse(BaseModel):
     description: Optional[str]
     voice_design_prompt: Optional[str]
     is_narrator: bool
+    aliases: Optional[list[str]] = None
+    evidence: Optional[list[str]] = None
+    sentence_count: int = 0
+    average_confidence: Optional[float] = None
 
     model_config = {"from_attributes": True}
 
@@ -64,6 +82,8 @@ class SentenceResponse(BaseModel):
     tagged_text: Optional[str]
     audio_file_path: Optional[str]
     audio_duration_ms: Optional[int]
+    speaker_confidence: Optional[float]
+    speaker_reason: Optional[str]
     status: str
 
     model_config = {"from_attributes": True}
@@ -82,6 +102,11 @@ class ChapterResponse(BaseModel):
     smil_file_path: Optional[str]
     audio_file_path: Optional[str]
     needs_reassembly: bool
+    summary: Optional[str]
+    summary_updated_at: Optional[datetime]
+    sentence_count: int = 0
+    processed_sentence_count: int = 0
+    low_confidence_count: int = 0
 
     model_config = {"from_attributes": True}
 
@@ -190,6 +215,26 @@ async def step_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> dic
     return {"status": next_phase, "queued": queued, "stop_after_phase": next_phase}
 
 
+@router.post("/api/books/{book_id}/audiobook/run-batch")
+async def run_pipeline_batch(book_id: int, db: AsyncSession = Depends(get_db)) -> dict[str, Any]:
+    """Run one durable LLM/TTS/assembly work unit, then pause for review."""
+    book = await _get_audiobook_book_or_404(book_id, db)
+    if book.audiobook_pipeline_status in ("ingesting", "roster_gen", "diarizing", "audio_gen", "assembling"):
+        return {"status": book.audiobook_pipeline_status, "queued": False}
+    next_phase = await crud.audiobook.infer_audiobook_resume_status(db, book_id)
+    if next_phase not in ("diarizing", "audio_gen", "assembling"):
+        raise HTTPException(status_code=409, detail=f"{next_phase} is atomic; use Run Next Stage instead")
+    await crud.audiobook.configure_book_pipeline_run(
+        db,
+        book_id,
+        status=next_phase,
+        stop_after_phase=None,
+        batch_limit=1,
+    )
+    queued = await get_audiobook_queue().enqueue(book_id)
+    return {"status": next_phase, "queued": queued, "batch_limit": 1}
+
+
 @router.post("/api/books/{book_id}/audiobook/pause")
 async def pause_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> dict[str, Any]:
     book = await _get_audiobook_book_or_404(book_id, db)
@@ -216,17 +261,43 @@ async def rebuild_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> 
     # Delete existing pipeline data so ingestion runs fresh
     await crud.audiobook.delete_chapters_for_book(db, book_id)
     await crud.audiobook.delete_characters_for_book(db, book_id)
+    await crud.audiobook.set_book_audiobook_summary(db, book_id, None)
     await crud.audiobook.configure_book_pipeline_run(db, book_id, status="ingesting", stop_after_phase=None)
     await queue.enqueue(book_id)
     return {"status": "ingesting", "queued": True}
+
+
+@router.post("/api/books/{book_id}/audiobook/roster/rebuild")
+async def rebuild_character_roster(book_id: int, db: AsyncSession = Depends(get_db)) -> dict[str, Any]:
+    """Re-run roster and diarization analysis without parsing the EPUB again."""
+    book = await _get_audiobook_book_or_404(book_id, db)
+    if book.audiobook_pipeline_status in ("ingesting", "roster_gen", "diarizing", "audio_gen", "assembling"):
+        raise HTTPException(status_code=409, detail="Pause the active pipeline before regenerating the roster")
+    chapters = await crud.audiobook.get_chapters_for_book(db, book_id)
+    if not chapters:
+        raise HTTPException(status_code=409, detail="Run ingestion before regenerating the roster")
+    await crud.audiobook.reset_roster_and_diarization_for_book(db, book_id)
+    await crud.audiobook.set_book_audiobook_summary(db, book_id, None)
+    await crud.audiobook.configure_book_pipeline_run(
+        db,
+        book_id,
+        status="roster_gen",
+        stop_after_phase="roster_gen",
+    )
+    queued = await get_audiobook_queue().enqueue(book_id)
+    return {"status": "roster_gen", "queued": queued, "stop_after_phase": "roster_gen"}
 
 
 @router.get("/api/books/{book_id}/audiobook/status", response_model=AudiobookStatusResponse)
 async def get_pipeline_status(book_id: int, db: AsyncSession = Depends(get_db)) -> AudiobookStatusResponse:
     book = await _get_audiobook_book_or_404(book_id, db)
     counts = await crud.audiobook.count_sentences_by_status(db, book_id)
+    review_counts = await crud.audiobook.count_sentence_review_flags(db, book_id)
     next_phase = await crud.audiobook.infer_audiobook_resume_status(db, book_id)
+    settings = await crud.audiobook.get_audiobook_settings(db)
     await db.refresh(book)
+    total = book.audiobook_progress_total or 0
+    percent = round((book.audiobook_progress_current or 0) * 100 / total, 1) if total else None
     return AudiobookStatusResponse(
         pipeline_status=book.audiobook_pipeline_status,
         next_phase=next_phase,
@@ -234,6 +305,18 @@ async def get_pipeline_status(book_id: int, db: AsyncSession = Depends(get_db)) 
         stop_after_phase=book.audiobook_stop_after_phase,
         last_error=book.audiobook_last_error,
         sentence_counts=counts,
+        review_counts=review_counts,
+        summary=book.audiobook_summary,
+        progress_current=book.audiobook_progress_current or 0,
+        progress_total=total,
+        progress_percent=percent,
+        progress_detail=book.audiobook_progress_detail,
+        pipeline_started_at=book.audiobook_pipeline_started_at,
+        pipeline_updated_at=book.audiobook_pipeline_updated_at,
+        batch_limit=book.audiobook_batch_limit,
+        llm_requests=book.audiobook_llm_requests or 0,
+        llm_provider=(settings.llm_provider or "stub") if settings else "stub",
+        llm_model=settings.llm_model if settings else None,
     )
 
 
@@ -246,7 +329,22 @@ async def get_pipeline_status(book_id: int, db: AsyncSession = Depends(get_db)) 
 async def list_characters(book_id: int, db: AsyncSession = Depends(get_db)) -> list[CharacterResponse]:
     await _get_audiobook_book_or_404(book_id, db)
     chars = await crud.audiobook.get_characters_for_book(db, book_id)
-    return [CharacterResponse.model_validate(c) for c in chars]
+    stats = await crud.audiobook.get_character_sentence_stats(db, book_id)
+    return [
+        CharacterResponse(
+            id=character.id,
+            book_id=character.book_id,
+            name=character.name,
+            description=character.description,
+            voice_design_prompt=character.voice_design_prompt,
+            is_narrator=character.is_narrator,
+            aliases=character.aliases or [],
+            evidence=character.evidence or [],
+            sentence_count=stats.get(character.id, {}).get("sentence_count", 0),
+            average_confidence=stats.get(character.id, {}).get("average_confidence"),
+        )
+        for character in chars
+    ]
 
 
 @router.put("/api/audiobook/characters/{char_id}", response_model=CharacterResponse)
@@ -282,10 +380,18 @@ async def list_sentences(
     page: int = Query(1, ge=1),
     limit: int = Query(50, ge=1, le=200),
     chapter_id: Optional[int] = Query(None),
+    review_only: bool = Query(False),
     db: AsyncSession = Depends(get_db),
 ) -> SentenceListResponse:
     await _get_audiobook_book_or_404(book_id, db)
-    sentences, total = await crud.audiobook.get_sentences_paginated(db, book_id, page=page, limit=limit, chapter_id=chapter_id)
+    sentences, total = await crud.audiobook.get_sentences_paginated(
+        db,
+        book_id,
+        page=page,
+        limit=limit,
+        chapter_id=chapter_id,
+        review_only=review_only,
+    )
     return SentenceListResponse(
         items=[SentenceResponse.model_validate(s) for s in sentences],
         total=total,
@@ -346,7 +452,31 @@ async def get_sentence_audio(sentence_id: int, db: AsyncSession = Depends(get_db
 async def list_chapters(book_id: int, db: AsyncSession = Depends(get_db)) -> list[ChapterResponse]:
     await _get_audiobook_book_or_404(book_id, db)
     chapters = await crud.audiobook.get_chapters_for_book(db, book_id)
-    return [ChapterResponse.model_validate(c) for c in chapters]
+    response = []
+    for chapter in chapters:
+        sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
+        processed = [sentence for sentence in sentences if sentence.status != "pending_diarization"]
+        response.append(
+            ChapterResponse(
+                id=chapter.id,
+                book_id=chapter.book_id,
+                chapter_number=chapter.chapter_number,
+                content_file_name=chapter.content_file_name,
+                smil_file_path=chapter.smil_file_path,
+                audio_file_path=chapter.audio_file_path,
+                needs_reassembly=chapter.needs_reassembly,
+                summary=chapter.summary,
+                summary_updated_at=chapter.summary_updated_at,
+                sentence_count=len(sentences),
+                processed_sentence_count=len(processed),
+                low_confidence_count=sum(
+                    1
+                    for sentence in sentences
+                    if sentence.speaker_confidence is not None and sentence.speaker_confidence < 0.65
+                ),
+            )
+        )
+    return response
 
 
 @router.get("/api/books/{book_id}/audiobook/chapters/{chapter_id}/audio")
@@ -418,3 +548,27 @@ async def update_settings(body: SettingsUpdate, db: AsyncSession = Depends(get_d
         roster_prompt_template=settings.roster_prompt_template,
         diarization_prompt_template=settings.diarization_prompt_template,
     )
+
+
+@router.post("/api/audiobook/settings/test-llm")
+async def test_llm_settings(db: AsyncSession = Depends(get_db)) -> dict[str, Any]:
+    settings = await crud.audiobook.get_audiobook_settings(db)
+    if settings is None or (settings.llm_provider or "stub").lower() == "stub":
+        return {"status": "ready", "provider": "stub", "model": None, "response": "local harness"}
+    schema = {
+        "type": "object",
+        "properties": {"status": {"type": "string"}},
+        "required": ["status"],
+    }
+    raw = await audiobook_llm._call_llm(
+        settings,
+        [{"role": "user", "content": "Return JSON with status set to ready."}],
+        response_schema=schema,
+    )
+    parsed = audiobook_llm._extract_json(raw)
+    return {
+        "status": parsed.get("status", "unknown") if isinstance(parsed, dict) else "unknown",
+        "provider": settings.llm_provider,
+        "model": settings.llm_model,
+        "response": parsed,
+    }

--- a/backend/app/services/audiobook_assembly.py
+++ b/backend/app/services/audiobook_assembly.py
@@ -171,12 +171,25 @@ async def assemble_book(book_id: int, db: AsyncSession) -> None:
     else:
         logger.info("No chapters need reassembly for book %s; rebuilding the EPUB package.", book_id)
 
-    for chapter in chapters:
+    await crud.audiobook.update_book_pipeline_progress(
+        db, book_id, current=0, total=len(chapters), detail=f"Preparing {len(chapters)} chapter assemblies"
+    )
+    for chapter_index, chapter in enumerate(chapters, start=1):
         if await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):
             logger.info("Book %s paused between chapter assemblies.", book_id)
             return
         sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
         await _assemble_chapter(book_id, chapter, sentences, output_dir, db)
+        await crud.audiobook.update_book_pipeline_progress(
+            db,
+            book_id,
+            current=chapter_index,
+            total=len(chapters),
+            detail=f"Assembled chapter {chapter_index} of {len(chapters)}",
+        )
+        if await crud.audiobook.consume_book_batch_limit(db, book_id):
+            logger.info("Book %s paused after one chapter assembly.", book_id)
+            return
 
     # Repackage the EPUB with updated media-overlay references
     working_epub_path = output_dir / "working.epub"

--- a/backend/app/services/audiobook_ingestion.py
+++ b/backend/app/services/audiobook_ingestion.py
@@ -178,6 +178,14 @@ async def ingest_epub(book_id: int, db: AsyncSession) -> None:
 
     # Persist to database
     persisted_chapters = 0
+    total_chapters = sum(1 for _chapter_num, _item, sentences in all_chapter_records if sentences)
+    await crud.audiobook.update_book_pipeline_progress(
+        db,
+        book_id,
+        current=0,
+        total=total_chapters,
+        detail=f"Tokenized EPUB; saving {total_chapters} narratable sections",
+    )
     for chapter_num, item, chapter_sentences in all_chapter_records:
         if not chapter_sentences:
             continue
@@ -189,6 +197,13 @@ async def ingest_epub(book_id: int, db: AsyncSession) -> None:
         )
         await crud.audiobook.create_sentences_bulk(db, chapter_id=chapter.id, sentences_data=chapter_sentences)
         persisted_chapters += 1
+        await crud.audiobook.update_book_pipeline_progress(
+            db,
+            book_id,
+            current=persisted_chapters,
+            total=total_chapters,
+            detail=f"Saved section {persisted_chapters} of {total_chapters}",
+        )
 
     await db.commit()
     if persisted_chapters == 0:

--- a/backend/app/services/audiobook_llm.py
+++ b/backend/app/services/audiobook_llm.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import logging
+import re
+from collections import Counter
 from typing import Any
 
 import httpx
@@ -17,21 +19,35 @@ logger = logging.getLogger(__name__)
 STUB_PROVIDER = "stub"
 
 DEFAULT_ROSTER_PROMPT = """\
-You are a literary analyst. Analyze the following text excerpt from a book and extract a list of all named \
-characters (including the narrator if the text uses first person).
+You are a literary analyst preparing a cast list for an audiobook. Analyze the sampled excerpts from across the \
+book and identify the primary narrator plus the major or recurring speaking characters. Merge aliases, titles, and \
+surname-only references into one character. Do not include authors, publishers, places, organizations, unnamed \
+crowds, or one-line background figures. Prefer people with repeated mentions across the book and omit one-scene \
+figures even if they appear in an excerpt. Return no more than 15 characters.
 
 For each character produce:
-- name: their name (use "Narrator" for first-person narrators)
-- description: a 1-2 sentence description of their personality and role
+- name: canonical full name; use "Narrator" for the narrative prose voice
+- aliases: other names, surnames, nicknames, ranks, or titles used for this person
+- description: a concise description of their personality, relationships, and role
+- evidence: 1-3 short quotations or explicit textual facts supporting the identification
 - voice_design_prompt: an OmniVoice voice parameter string using ONLY these tokens:
-  [gender-{male|female|neutral}] [pitch-{low|medium|high}] [speed-{slow|normal|fast}]
-  Optional: [accent-{british|american|australian}] [age-{young|middle|old}]
+  [gender-{{male|female|neutral}}] [pitch-{{low|medium|high}}] [speed-{{slow|normal|fast}}]
+  Optional: [accent-{{british|american|australian}}] [age-{{young|middle|old}}]
   Example: [gender-male][pitch-low][speed-normal][age-middle]
-- is_narrator: true only for the primary narrator
+- is_narrator: true only for an entry named exactly "Narrator". In first-person books, the protagonist must be a \
+  separate character with is_narrator false so their spoken dialogue has a distinct voice.
 
-Return ONLY a valid JSON array of objects. No markdown, no explanation.
+Also produce a spoiler-light 2-4 sentence book_summary grounded only in these excerpts.
+Return JSON with keys book_summary and characters. No markdown or explanation.
 
-Text:
+Candidate name frequency hints from the complete book (not ground truth; ignore non-people):
+{candidate_hints}
+
+Names with explicit dialogue-tag hits (for example, "Harry said") are confirmed speaking candidates. Include the
+highest-hit confirmed speakers unless the evidence clearly shows they are not a person. Do not substitute low-count
+cameos for them. If the story is first-person, also include the named protagonist separately from Narrator.
+
+Sampled excerpts:
 {text}
 """
 
@@ -39,10 +55,17 @@ DEFAULT_DIARIZATION_PROMPT = """\
 You are a script editor. Assign each sentence to a speaker from the character roster and add non-verbal \
 expression tags where appropriate.
 
+Assign quoted dialogue to the person speaking it, even when the attribution (for example, "she asked") is in an
+adjacent sentence. Keep attribution and action prose on Narrator. If an unnamed or one-scene speaker is absent from
+the recurring roster, use "Minor Female Voice" or "Minor Male Voice" when present instead of Narrator.
+
 Character roster (JSON):
 {roster_json}
 
-Previous context (last 5 sentences):
+Chapter summary so far:
+{chapter_summary}
+
+Previous context (last 8 sentences):
 {context}
 
 Sentences to process (JSON array with id and text):
@@ -51,21 +74,124 @@ Sentences to process (JSON array with id and text):
 For each sentence return:
 - id: the sentence id (integer)
 - character_id: the character id from the roster (use the narrator's id for narration; null if uncertain)
-- tagged_text: the sentence text with optional non-verbal tags like [laughter], [sigh], [whisper], [shout]
+- tagged_text: the sentence text with optional non-verbal tags like [laughter], [sigh], [whisper], [shout], or null
+  when no tag is needed (do not repeat unchanged text)
+- confidence: a number from 0 to 1 for the speaker assignment
+- reason: a brief evidence-based reason, such as an adjacent dialogue tag or turn-taking context
 
-Return ONLY a valid JSON array. No markdown, no explanation.
+Also return chapter_summary: an updated spoiler-light summary incorporating this batch and the prior summary.
+The roster descriptions are identity hints only and may be inaccurate. Ground the chapter summary exclusively in the
+sentence text and prior chapter summary; never import plot events, body changes, relationships, or backstory from a
+character description.
+Return JSON with keys assignments and chapter_summary. No markdown or explanation.
 """
 
+_ALLOWED_EXPRESSION_TAGS = {"laughter", "sigh", "whisper", "shout"}
+_BRACKET_TAG_RE = re.compile(r"\[([^\[\]]+)\]")
+_GENDERED_ATTRIBUTION_RE = re.compile(
+    r"\b(she|he)\s+(?:said|asked|replied|yelled|shouted|whispered|muttered|added|continued|answered|snapped)\b",
+    re.IGNORECASE,
+)
+_NARRATION_REASON_RE = re.compile(
+    r"\b(?:narrat(?:or|ion|ive)|internal|reflection|action description|monologue|observation|recounting)\b",
+    re.IGNORECASE,
+)
 
-async def _call_llm(settings: AudiobookSettings, messages: list[dict[str, Any]]) -> str:
+ROSTER_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "book_summary": {"type": "string"},
+        "characters": {
+            "type": "array",
+            "maxItems": 15,
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "aliases": {
+                        "type": "array",
+                        "maxItems": 10,
+                        "items": {"type": "string"},
+                    },
+                    "description": {"type": "string"},
+                    "evidence": {
+                        "type": "array",
+                        "maxItems": 3,
+                        "items": {"type": "string"},
+                    },
+                    "voice_design_prompt": {"type": "string"},
+                    "is_narrator": {"type": "boolean"},
+                },
+                "required": [
+                    "name",
+                    "aliases",
+                    "description",
+                    "evidence",
+                    "voice_design_prompt",
+                    "is_narrator",
+                ],
+            },
+        },
+    },
+    "required": ["book_summary", "characters"],
+}
+
+DIARIZATION_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "assignments": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "integer"},
+                    "character_id": {"type": ["integer", "null"]},
+                    "tagged_text": {"type": ["string", "null"]},
+                    "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+                    "reason": {"type": "string"},
+                },
+                "required": ["id", "character_id", "tagged_text", "confidence", "reason"],
+            },
+        },
+        "chapter_summary": {"type": "string"},
+    },
+    "required": ["assignments", "chapter_summary"],
+}
+
+
+async def _call_llm(
+    settings: AudiobookSettings,
+    messages: list[dict[str, Any]],
+    *,
+    response_schema: dict[str, Any] | None = None,
+) -> str:
     """Route to the configured LLM provider and return the text response."""
-    if not settings.llm_api_key and not settings.llm_base_url:
+    provider = (settings.llm_provider or "openai").lower()
+    if provider != "ollama" and not settings.llm_api_key and not settings.llm_base_url:
         raise RuntimeError("LLM not configured: set llm_api_key or llm_base_url in Audio Settings.")
 
-    provider = (settings.llm_provider or "openai").lower()
-    model = settings.llm_model or "gpt-4o"
+    model = settings.llm_model or ("qwen3.5:9b" if provider == "ollama" else "gpt-4o")
 
     headers = {"Content-Type": "application/json"}
+
+    if provider == "ollama":
+        url = (settings.llm_base_url or "http://127.0.0.1:11434").rstrip("/") + "/api/chat"
+        payload: dict[str, Any] = {
+            "model": model,
+            "messages": messages,
+            "stream": False,
+            "think": False,
+            "format": response_schema or "json",
+            "options": {"temperature": 0, "num_ctx": 32768, "num_predict": 4096},
+            "keep_alive": "30m",
+        }
+        timeout = httpx.Timeout(600.0, connect=10.0)
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.post(url, json=payload, headers=headers)
+            if resp.is_error:
+                raise RuntimeError(f"Ollama returned HTTP {resp.status_code}: {resp.text[:1000]}")
+            data = resp.json()
+        return data["message"]["content"]
 
     if provider == "anthropic":
         url = (settings.llm_base_url or "https://api.anthropic.com").rstrip("/") + "/v1/messages"
@@ -88,11 +214,16 @@ async def _call_llm(settings: AudiobookSettings, messages: list[dict[str, Any]])
         url = base.rstrip("/") + "/v1/chat/completions"
         if settings.llm_api_key:
             headers["Authorization"] = f"Bearer {settings.llm_api_key}"
-        payload = {
+        payload: dict[str, Any] = {
             "model": model,
             "messages": messages,
-            "temperature": 0.2,
+            "temperature": 0,
         }
+        if response_schema:
+            payload["response_format"] = {
+                "type": "json_schema",
+                "json_schema": {"name": "audiobook_analysis", "strict": True, "schema": response_schema},
+            }
         async with httpx.AsyncClient(timeout=120.0) as client:
             resp = await client.post(url, json=payload, headers=headers)
             resp.raise_for_status()
@@ -110,6 +241,216 @@ def _extract_json(raw: str) -> Any:
     return json.loads(text)
 
 
+def _sanitize_tagged_text(original: str, tagged: Any) -> str:
+    """Accept expression-tag insertion, but reject unsupported tags or prose rewrites."""
+    if not isinstance(tagged, str) or not tagged.strip():
+        return original
+
+    def remove_unknown(match: re.Match[str]) -> str:
+        token = match.group(1).strip().casefold()
+        if token in _ALLOWED_EXPRESSION_TAGS or match.group(0) in original:
+            return match.group(0)
+        return ""
+
+    cleaned = _BRACKET_TAG_RE.sub(remove_unknown, tagged).strip()
+    without_allowed = _BRACKET_TAG_RE.sub(
+        lambda match: "" if match.group(1).strip().casefold() in _ALLOWED_EXPRESSION_TAGS else match.group(0),
+        cleaned,
+    )
+    if " ".join(without_allowed.split()) != " ".join(original.split()):
+        return original
+    return cleaned
+
+
+def _apply_speaker_guardrails(
+    *,
+    text: str,
+    next_text: str,
+    character_id: int | None,
+    narrator_id: int | None,
+    minor_female_id: int | None,
+    minor_male_id: int | None,
+    reason: str,
+) -> tuple[int | None, str, float | None]:
+    """Correct two common local-model ID errors without inventing named speakers."""
+    has_closing_quote = "”" in text or ('"' in text and not text.rstrip().endswith('"'))
+    starts_with_quote = text.lstrip().startswith(("“", '"'))
+    has_dialogue = has_closing_quote or starts_with_quote
+
+    if character_id == narrator_id and has_dialogue:
+        attribution = _GENDERED_ATTRIBUTION_RE.search(f"{text} {next_text}")
+        if attribution:
+            gender = attribution.group(1).casefold()
+            fallback_id = minor_female_id if gender == "she" else minor_male_id
+            if fallback_id is not None:
+                return fallback_id, f"Deterministic {gender} dialogue attribution to minor voice", 0.98
+
+    if character_id != narrator_id and not has_dialogue and _NARRATION_REASON_RE.search(reason):
+        return narrator_id, "Deterministic prose/narration guardrail", 0.98
+
+    return character_id, reason, None
+
+
+async def _build_roster_excerpt(chapters, db: AsyncSession) -> str:
+    """Sample real story chapters across the book instead of front matter."""
+    candidates: list[tuple[Any, list[Any]]] = []
+    for chapter in chapters:
+        sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
+        if len(sentences) >= 40:
+            candidates.append((chapter, sentences))
+
+    if not candidates:
+        for chapter in chapters:
+            sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
+            if sentences:
+                candidates.append((chapter, sentences))
+
+    if len(candidates) > 8:
+        indexes = sorted({round(index * (len(candidates) - 1) / 7) for index in range(8)})
+        selected = [candidates[index] for index in indexes]
+    else:
+        selected = candidates
+
+    excerpts: list[str] = []
+    for chapter, sentences in selected:
+        chapter_text = " ".join(sentence.original_text for sentence in sentences)
+        excerpts.append(f"### Chapter {chapter.chapter_number}\n{chapter_text[:4000]}")
+    return "\n\n".join(excerpts)[:32000]
+
+
+_CANDIDATE_TOKEN_RE = re.compile(r"\b[A-Z][a-z]{2,}\b")
+_DIALOGUE_TAG_RE = re.compile(
+    r"\b([A-Z][a-z]{2,})\s+(?:said|asked|replied|yelled|shouted|whispered|added|continued|noted|answered|"
+    r"snapped|muttered|called|agreed|insisted)\b|\b(?:said|asked|replied|yelled|shouted|whispered|added|"
+    r"continued|noted|answered|snapped|muttered|called|agreed|insisted)\s+([A-Z][a-z]{2,})\b"
+)
+_CANDIDATE_STOP_WORDS = {
+    "About",
+    "After",
+    "Again",
+    "And",
+    "Are",
+    "Before",
+    "But",
+    "Chapter",
+    "Copyright",
+    "Could",
+    "Did",
+    "Does",
+    "Earth",
+    "For",
+    "From",
+    "Had",
+    "Has",
+    "Have",
+    "Here",
+    "How",
+    "However",
+    "Into",
+    "Just",
+    "Like",
+    "Maybe",
+    "More",
+    "Much",
+    "Neither",
+    "Never",
+    "Next",
+    "None",
+    "Nothing",
+    "Now",
+    "One",
+    "Only",
+    "Other",
+    "Our",
+    "Part",
+    "Right",
+    "She",
+    "Since",
+    "Some",
+    "Something",
+    "Still",
+    "That",
+    "The",
+    "Then",
+    "There",
+    "These",
+    "They",
+    "This",
+    "Those",
+    "Through",
+    "Very",
+    "Was",
+    "We",
+    "Well",
+    "What",
+    "When",
+    "Where",
+    "Which",
+    "While",
+    "Who",
+    "Why",
+    "With",
+    "Would",
+    "Yes",
+    "You",
+    "Your",
+}
+
+
+async def _build_character_candidate_analysis(chapters, db: AsyncSession) -> tuple[str, list[dict[str, Any]]]:
+    """Provide whole-book evidence so sampled cameos do not crowd out recurring cast."""
+    counts: Counter[str] = Counter()
+    contextual_counts: Counter[str] = Counter()
+    dialogue_counts: Counter[str] = Counter()
+    dialogue_examples: dict[str, str] = {}
+    for chapter in chapters:
+        for sentence in await crud.audiobook.get_sentences_for_chapter(db, chapter.id):
+            for match in _CANDIDATE_TOKEN_RE.finditer(sentence.original_text):
+                token = match.group(0)
+                if token in _CANDIDATE_STOP_WORDS:
+                    continue
+                counts[token] += 1
+                if match.start() > 0:
+                    contextual_counts[token] += 1
+            for match in _DIALOGUE_TAG_RE.finditer(sentence.original_text):
+                name = match.group(1) or match.group(2)
+                if name in _CANDIDATE_STOP_WORDS:
+                    continue
+                dialogue_counts[name] += 1
+                dialogue_examples.setdefault(name, sentence.original_text[:220])
+
+    candidates = [
+        (name, count, contextual_counts[name], dialogue_counts[name])
+        for name, count in counts.items()
+        if contextual_counts[name] >= 2 or count >= 8
+    ]
+    candidates.sort(key=lambda item: (item[3], item[2], item[1], item[0]), reverse=True)
+    lines = []
+    for name, count, _, dialogue_count in candidates[:50]:
+        line = f"- {name}: {count} mentions; {dialogue_count} explicit dialogue tags"
+        if dialogue_count and name in dialogue_examples:
+            line += f'; example: "{dialogue_examples[name]}"'
+        lines.append(line)
+    confirmed = [
+        {
+            "name": name,
+            "mention_count": count,
+            "dialogue_count": dialogue_count,
+            "evidence": dialogue_examples.get(name),
+        }
+        for name, count, _, dialogue_count in candidates
+        if dialogue_count >= 5
+    ]
+    required_names = ", ".join(candidate["name"] for candidate in confirmed[:12])
+    heading = f"REQUIRED confirmed speakers (include all): {required_names}\n" if required_names else ""
+    return heading + ("\n".join(lines) or "(none)"), confirmed
+
+
+async def _build_character_candidate_hints(chapters, db: AsyncSession) -> str:
+    hints, _ = await _build_character_candidate_analysis(chapters, db)
+    return hints
+
+
 async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
     """Phase 2: extract characters from book text and persist to audiobook_characters."""
     settings = await crud.audiobook.get_audiobook_settings(db)
@@ -119,32 +460,53 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
     if not chapters:
         raise RuntimeError(f"No narratable chapters found for book {book_id} during roster generation.")
 
-    # Collect text from up to 5 chapters (keeps prompt size manageable)
-    text_chunks: list[str] = []
-    for chapter in chapters[:5]:
-        sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
-        text_chunks.append(" ".join(s.original_text for s in sentences))
-    combined_text = "\n\n".join(text_chunks)[:12000]  # ~10k tokens safety cap
+    combined_text = await _build_roster_excerpt(chapters, db)
+    candidate_hints, confirmed_speakers = await _build_character_candidate_analysis(chapters, db)
+    await crud.audiobook.update_book_pipeline_progress(
+        db, book_id, current=0, total=1, detail="Analyzing story excerpts for recurring characters"
+    )
 
     if provider == STUB_PROVIDER:
-        characters_data = [
-            {
-                "name": "Narrator",
-                "description": "Deterministic local harness narrator.",
-                "voice_design_prompt": "[gender-neutral][pitch-medium][speed-normal]",
-                "is_narrator": True,
-            }
-        ]
+        roster_result = {
+            "book_summary": "Deterministic local harness analysis.",
+            "characters": [
+                {
+                    "name": "Narrator",
+                    "aliases": [],
+                    "description": "Deterministic local harness narrator.",
+                    "evidence": [],
+                    "voice_design_prompt": "[gender-neutral][pitch-medium][speed-normal]",
+                    "is_narrator": True,
+                }
+            ],
+        }
     else:
         prompt_template = settings.roster_prompt_template or DEFAULT_ROSTER_PROMPT
-        prompt = prompt_template.format(text=combined_text)
+        prompt = prompt_template.format(text=combined_text, candidate_hints=candidate_hints)
         logger.info("Calling LLM for character roster (book %s).", book_id)
-        raw = await _call_llm(settings, [{"role": "user", "content": prompt}])
+        await crud.audiobook.update_book_pipeline_progress(
+            db,
+            book_id,
+            current=0,
+            total=1,
+            detail=f"Waiting for {settings.llm_model or provider} roster analysis",
+            llm_request_increment=1,
+        )
+        raw = await _call_llm(
+            settings,
+            [{"role": "user", "content": prompt}],
+            response_schema=ROSTER_SCHEMA,
+        )
         try:
-            characters_data = _extract_json(raw)
+            roster_result = _extract_json(raw)
         except json.JSONDecodeError as exc:
             raise RuntimeError(f"LLM returned invalid JSON for roster: {exc}\nRaw: {raw[:500]}") from exc
 
+    if isinstance(roster_result, list):
+        roster_result = {"book_summary": None, "characters": roster_result}
+    if not isinstance(roster_result, dict):
+        raise RuntimeError(f"Expected a JSON object from LLM, got: {type(roster_result)}")
+    characters_data = roster_result.get("characters")
     if not isinstance(characters_data, list):
         raise RuntimeError(f"Expected a JSON array from LLM, got: {type(characters_data)}")
 
@@ -156,25 +518,136 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
         normalised.append(
             {
                 "name": str(c.get("name", "Unknown")),
+                "aliases": [str(alias) for alias in c.get("aliases", []) if alias],
                 "description": c.get("description"),
+                "evidence": [str(item) for item in c.get("evidence", []) if item][:3],
                 "voice_design_prompt": c.get("voice_design_prompt"),
-                "is_narrator": bool(c.get("is_narrator", False)),
+                "is_narrator": str(c.get("name", "")).strip().casefold() == "narrator",
             }
         )
     if not normalised:
         raise RuntimeError("LLM returned an empty character roster.")
+    existing_names = {character["name"].strip().casefold() for character in normalised}
+    promoted_protagonists: list[dict] = []
+    for character in normalised:
+        if not character["is_narrator"]:
+            continue
+        retained_aliases = []
+        for alias in character["aliases"]:
+            canonical = alias.strip().casefold()
+            if canonical in {"narrator", "narrative voice", "storyteller"}:
+                continue
+            if " " in alias.strip() and canonical not in existing_names:
+                promoted_protagonists.append(
+                    {
+                        "name": alias.strip(),
+                        "aliases": [],
+                        "description": "First-person protagonist, kept separate from the narrative prose voice.",
+                        "evidence": character["evidence"],
+                        "voice_design_prompt": "[gender-male][pitch-medium][speed-normal]",
+                        "is_narrator": False,
+                    }
+                )
+                existing_names.add(canonical)
+            else:
+                retained_aliases.append(alias)
+        character["aliases"] = retained_aliases
+    for character in normalised:
+        if not character["is_narrator"]:
+            character["aliases"] = [alias for alias in character["aliases"] if alias.strip().casefold() != "narrator"]
     if not any(character["is_narrator"] for character in normalised):
         normalised.insert(
             0,
             {
                 "name": "Narrator",
+                "aliases": [],
                 "description": "Primary narrative voice.",
+                "evidence": [],
                 "voice_design_prompt": "[gender-neutral][pitch-medium][speed-normal]",
                 "is_narrator": True,
             },
         )
+    if promoted_protagonists:
+        narrator_index = next(index for index, character in enumerate(normalised) if character["is_narrator"])
+        for offset, protagonist in enumerate(promoted_protagonists, start=1):
+            normalised.insert(narrator_index + offset, protagonist)
 
-    await crud.audiobook.create_characters_bulk(db, book_id=book_id, characters_data=normalised)
+    def character_tokens(character: dict) -> set[str]:
+        values = [character["name"], *character["aliases"]]
+        return {token.casefold() for value in values for token in _CANDIDATE_TOKEN_RE.findall(value)}
+
+    represented_tokens = set().union(*(character_tokens(character) for character in normalised))
+    for candidate in confirmed_speakers[:12]:
+        canonical = candidate["name"].casefold()
+        if canonical in represented_tokens:
+            continue
+        normalised.append(
+            {
+                "name": candidate["name"],
+                "aliases": [],
+                "description": (
+                    f"Recurring speaking character identified from {candidate['dialogue_count']} explicit "
+                    "dialogue attributions across the book."
+                ),
+                "evidence": [candidate["evidence"]] if candidate["evidence"] else [],
+                "voice_design_prompt": "[gender-neutral][pitch-medium][speed-normal]",
+                "is_narrator": False,
+            }
+        )
+        represented_tokens.add(canonical)
+
+    protagonist_names = {character["name"].strip().casefold() for character in promoted_protagonists}
+    if protagonist_names:
+        for character in normalised:
+            if character["name"].strip().casefold() in protagonist_names:
+                continue
+            character["aliases"] = [
+                alias for alias in character["aliases"] if alias.strip().casefold() not in protagonist_names
+            ]
+
+    dialogue_scores = {candidate["name"].casefold(): candidate["dialogue_count"] for candidate in confirmed_speakers}
+
+    def roster_priority(character: dict) -> tuple[int, int, str]:
+        if character["is_narrator"]:
+            return (3, 0, character["name"])
+        if "protagonist" in str(character.get("description") or "").casefold():
+            return (2, 0, character["name"])
+        score = max((dialogue_scores.get(token, 0) for token in character_tokens(character)), default=0)
+        return (1, score, character["name"])
+
+    normalised.sort(key=roster_priority, reverse=True)
+
+    if provider != STUB_PROVIDER:
+        # Reserve stable voices for one-scene and unnamed dialogue without
+        # allowing hundreds of cameos to crowd recurring characters out.
+        normalised = normalised[:13]
+        normalised.extend(
+            [
+                {
+                    "name": "Minor Female Voice",
+                    "aliases": ["Unnamed female speaker"],
+                    "description": "Fallback voice for unnamed or one-scene female dialogue.",
+                    "evidence": [],
+                    "voice_design_prompt": "[gender-female][pitch-medium][speed-normal]",
+                    "is_narrator": False,
+                },
+                {
+                    "name": "Minor Male Voice",
+                    "aliases": ["Unnamed male speaker"],
+                    "description": "Fallback voice for unnamed or one-scene male dialogue.",
+                    "evidence": [],
+                    "voice_design_prompt": "[gender-male][pitch-medium][speed-normal]",
+                    "is_narrator": False,
+                },
+            ]
+        )
+
+    await crud.audiobook.delete_characters_for_book(db, book_id)
+    await crud.audiobook.create_characters_bulk(db, book_id=book_id, characters_data=normalised[:15])
+    await crud.audiobook.set_book_audiobook_summary(db, book_id, roster_result.get("book_summary"))
+    await crud.audiobook.update_book_pipeline_progress(
+        db, book_id, current=1, total=1, detail=f"Created {len(normalised[:15])} character profiles"
+    )
     logger.info("Created %d characters for book %s.", len(normalised), book_id)
     if not await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):
         await crud.audiobook.set_book_pipeline_status(db, book_id, "diarizing")
@@ -188,60 +661,182 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
     characters = await crud.audiobook.get_characters_for_book(db, book_id)
     character_ids = {character.id for character in characters}
     narrator_id = next((character.id for character in characters if character.is_narrator), None)
+    minor_female_id = next((character.id for character in characters if character.name == "Minor Female Voice"), None)
+    minor_male_id = next((character.id for character in characters if character.name == "Minor Male Voice"), None)
     roster_json = json.dumps(
         [{"id": c.id, "name": c.name, "description": c.description, "is_narrator": c.is_narrator} for c in characters],
         ensure_ascii=False,
     )
 
-    context_window: list[str] = []
-    batch_size = 50
+    chapters = await crud.audiobook.get_chapters_for_book(db, book_id)
+    counts = await crud.audiobook.count_sentences_by_status(db, book_id)
+    total = sum(counts.values())
+    processed = total - counts.get("pending_diarization", 0)
+    batch_size = 40
+    await crud.audiobook.update_book_pipeline_progress(
+        db, book_id, current=processed, total=total, detail="Preparing dialogue attribution"
+    )
 
-    while True:
+    story_started = False
+    for chapter_index, chapter in enumerate(chapters, start=1):
         if await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):
             logger.info("Book %s paused during diarization.", book_id)
             return
 
-        batch = await crud.audiobook.get_sentences_pending_diarization(db, book_id, limit=batch_size)
-        if not batch:
-            break
+        chapter_sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
+        pending = [sentence for sentence in chapter_sentences if sentence.status == "pending_diarization"]
+        if not pending:
+            continue
 
-        sentences_json = json.dumps(
-            [{"id": s.id, "text": s.original_text} for s in batch],
-            ensure_ascii=False,
-        )
-        context_str = "\n".join(context_window[-5:]) if context_window else "(none)"
-
-        if provider == STUB_PROVIDER:
-            results = [
-                {"id": sentence.id, "character_id": narrator_id, "tagged_text": sentence.original_text} for sentence in batch
-            ]
-        else:
-            prompt_template = settings.diarization_prompt_template or DEFAULT_DIARIZATION_PROMPT
-            prompt = prompt_template.format(
-                roster_json=roster_json,
-                context=context_str,
-                sentences_json=sentences_json,
+        # Treat short files before the first substantial chapter as front matter.
+        # Once the story begins, retain short chapters and only skip tiny dividers.
+        if len(chapter_sentences) >= batch_size:
+            story_started = True
+        is_front_matter = (not story_started and len(chapter_sentences) < batch_size) or len(chapter_sentences) < 20
+        if is_front_matter:
+            for sentence in pending:
+                await crud.audiobook.update_sentence_diarization(
+                    db,
+                    sentence.id,
+                    narrator_id,
+                    sentence.original_text,
+                    speaker_confidence=0.99,
+                    speaker_reason="Front matter narration",
+                )
+            processed += len(pending)
+            await crud.audiobook.update_chapter_summary(db, chapter.id, "Front matter or section divider.")
+            await crud.audiobook.update_book_pipeline_progress(
+                db,
+                book_id,
+                current=processed,
+                total=total,
+                detail=f"Skipped front matter; next is chapter {chapter.chapter_number}",
             )
-            logger.debug("Diarizing %d sentences for book %s.", len(batch), book_id)
-            raw = await _call_llm(settings, [{"role": "user", "content": prompt}])
-            try:
-                results = _extract_json(raw)
-            except json.JSONDecodeError as exc:
-                raise RuntimeError(f"LLM returned invalid JSON for diarization: {exc}\nRaw: {raw[:500]}") from exc
+            continue
 
-        if not isinstance(results, list):
-            raise RuntimeError(f"Expected a JSON array from diarization, got: {type(results)}")
+        context_window = [
+            sentence.original_text for sentence in chapter_sentences if sentence.status != "pending_diarization"
+        ][-8:]
+        while True:
+            batch = await crud.audiobook.get_sentences_pending_diarization(
+                db, book_id, limit=batch_size, chapter_id=chapter.id
+            )
+            if not batch:
+                break
 
-        result_map = {r["id"]: r for r in results if isinstance(r, dict) and isinstance(r.get("id"), int)}
+            sentences_json = json.dumps(
+                [{"id": s.id, "text": s.original_text} for s in batch],
+                ensure_ascii=False,
+            )
+            context_str = "\n".join(context_window[-8:]) if context_window else "(none)"
 
-        for sentence in batch:
-            result = result_map.get(sentence.id, {})
-            char_id = result.get("character_id")
-            if char_id not in character_ids:
-                char_id = narrator_id
-            tagged = result.get("tagged_text") or sentence.original_text
-            await crud.audiobook.update_sentence_diarization(db, sentence.id, char_id, tagged)
-            context_window.append(sentence.original_text)
+            await crud.audiobook.update_book_pipeline_progress(
+                db,
+                book_id,
+                current=processed,
+                total=total,
+                detail=(
+                    f"Chapter {chapter.chapter_number} ({chapter_index}/{len(chapters)}): "
+                    f"attributing {len(batch)} sentences"
+                ),
+            )
+            if provider == STUB_PROVIDER:
+                batch_result = {
+                    "assignments": [
+                        {
+                            "id": sentence.id,
+                            "character_id": narrator_id,
+                            "tagged_text": sentence.original_text,
+                            "confidence": 1.0,
+                            "reason": "Deterministic local harness",
+                        }
+                        for sentence in batch
+                    ],
+                    "chapter_summary": "Deterministic local harness chapter summary.",
+                }
+            else:
+                prompt_template = settings.diarization_prompt_template or DEFAULT_DIARIZATION_PROMPT
+                prompt = prompt_template.format(
+                    roster_json=roster_json,
+                    chapter_summary=chapter.summary or "(none yet)",
+                    context=context_str,
+                    sentences_json=sentences_json,
+                )
+                logger.debug("Diarizing %d sentences for book %s.", len(batch), book_id)
+                await crud.audiobook.update_book_pipeline_progress(
+                    db,
+                    book_id,
+                    current=processed,
+                    total=total,
+                    detail=f"Waiting for {settings.llm_model or provider}: chapter {chapter.chapter_number}",
+                    llm_request_increment=1,
+                )
+                raw = await _call_llm(
+                    settings,
+                    [{"role": "user", "content": prompt}],
+                    response_schema=DIARIZATION_SCHEMA,
+                )
+                try:
+                    batch_result = _extract_json(raw)
+                except json.JSONDecodeError as exc:
+                    raise RuntimeError(f"LLM returned invalid JSON for diarization: {exc}\nRaw: {raw[:500]}") from exc
+
+            if isinstance(batch_result, list):
+                batch_result = {"assignments": batch_result, "chapter_summary": chapter.summary}
+            if not isinstance(batch_result, dict) or not isinstance(batch_result.get("assignments"), list):
+                raise RuntimeError(f"Expected a JSON object from diarization, got: {type(batch_result)}")
+            results = batch_result["assignments"]
+
+            result_map = {r["id"]: r for r in results if isinstance(r, dict) and isinstance(r.get("id"), int)}
+
+            for sentence_index, sentence in enumerate(batch):
+                result = result_map.get(sentence.id, {})
+                char_id = result.get("character_id")
+                if char_id not in character_ids:
+                    char_id = narrator_id
+                tagged = _sanitize_tagged_text(sentence.original_text, result.get("tagged_text"))
+                confidence = result.get("confidence")
+                try:
+                    confidence = max(0.0, min(1.0, float(confidence)))
+                except (TypeError, ValueError):
+                    confidence = 0.0
+                reason = str(result.get("reason") or "No model rationale returned")[:500]
+                next_text = batch[sentence_index + 1].original_text if sentence_index + 1 < len(batch) else ""
+                char_id, reason, guardrail_confidence = _apply_speaker_guardrails(
+                    text=sentence.original_text,
+                    next_text=next_text,
+                    character_id=char_id,
+                    narrator_id=narrator_id,
+                    minor_female_id=minor_female_id,
+                    minor_male_id=minor_male_id,
+                    reason=reason,
+                )
+                if guardrail_confidence is not None:
+                    confidence = guardrail_confidence
+                await crud.audiobook.update_sentence_diarization(
+                    db,
+                    sentence.id,
+                    char_id,
+                    tagged,
+                    speaker_confidence=confidence,
+                    speaker_reason=reason,
+                )
+                context_window.append(sentence.original_text)
+
+            chapter_summary = str(batch_result.get("chapter_summary") or chapter.summary or "")[:4000]
+            await crud.audiobook.update_chapter_summary(db, chapter.id, chapter_summary or None)
+            chapter.summary = chapter_summary or None
+            processed += len(batch)
+            await crud.audiobook.update_book_pipeline_progress(
+                db,
+                book_id,
+                current=processed,
+                total=total,
+                detail=f"Chapter {chapter.chapter_number}: attributed {processed} of {total} sentences",
+            )
+            if await crud.audiobook.consume_book_batch_limit(db, book_id):
+                logger.info("Book %s paused after one diarization batch.", book_id)
+                return
 
     logger.info("Diarization complete for book %s.", book_id)
     if not await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):

--- a/backend/app/services/audiobook_tts.py
+++ b/backend/app/services/audiobook_tts.py
@@ -95,6 +95,11 @@ async def generate_audio_for_book(book_id: int, db: AsyncSession) -> None:
 
     processed = 0
     failed = 0
+    counts = await crud.audiobook.count_sentences_by_status(db, book_id)
+    total = counts.get("ready_for_audio", 0)
+    await crud.audiobook.update_book_pipeline_progress(
+        db, book_id, current=0, total=total, detail=f"Preparing speech for {total} sentences"
+    )
     while True:
         if await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):
             logger.info("Book %s paused during TTS generation.", book_id)
@@ -148,10 +153,20 @@ async def generate_audio_for_book(book_id: int, db: AsyncSession) -> None:
 
             await crud.audiobook.update_sentence_audio(db, sentence.id, _relative_path(out_path), duration_ms)
             processed += 1
+            await crud.audiobook.update_book_pipeline_progress(
+                db,
+                book_id,
+                current=processed,
+                total=total,
+                detail=f"Generated speech for {processed} of {total} sentences",
+            )
 
             # Flag chapter for reassembly if all its sentences are done
             if await crud.audiobook.chapter_all_audio_generated(db, sentence.chapter_id):
                 await crud.audiobook.flag_chapter_for_reassembly(db, sentence.chapter_id)
+            if await crud.audiobook.consume_book_batch_limit(db, book_id):
+                logger.info("Book %s paused after one TTS sentence.", book_id)
+                return
 
     if failed or await crud.audiobook.has_sentence_status(db, book_id, "error"):
         await crud.audiobook.set_book_pipeline_status(db, book_id, "error")

--- a/backend/tests/test_audiobook_pipeline.py
+++ b/backend/tests/test_audiobook_pipeline.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import shutil
 import zipfile
 from pathlib import Path
@@ -81,6 +82,112 @@ class _FakeQueue:
 
     def has_book_job(self, book_id: int) -> bool:
         return book_id in self.active_book_ids
+
+
+def test_default_roster_prompt_formats_voice_token_examples():
+    prompt = audiobook_llm.DEFAULT_ROSTER_PROMPT.format(
+        text="A story excerpt.",
+        candidate_hints="- Harry: 12 mentions",
+    )
+
+    assert "[gender-{male|female|neutral}]" in prompt
+    assert "A story excerpt." in prompt
+
+
+def test_tagged_text_sanitizer_only_accepts_supported_insertions():
+    original = "Take your time, I said."
+
+    assert audiobook_llm._sanitize_tagged_text(original, "[whisper] Take your time, I said.") == (
+        "[whisper] Take your time, I said."
+    )
+    assert audiobook_llm._sanitize_tagged_text(original, "[fade in] Take your time, I said.") == original
+    assert audiobook_llm._sanitize_tagged_text(original, "I completely rewrote this sentence.") == original
+
+
+def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
+    prose = audiobook_llm._apply_speaker_guardrails(
+        text="I sat down and waited.",
+        next_text="",
+        character_id=20,
+        narrator_id=10,
+        minor_female_id=30,
+        minor_male_id=40,
+        reason="Action description by the protagonist.",
+    )
+    dialogue = audiobook_llm._apply_speaker_guardrails(
+        text="“You coming or going?”",
+        next_text="she asked without looking up.",
+        character_id=10,
+        narrator_id=10,
+        minor_female_id=30,
+        minor_male_id=40,
+        reason="Dialogue attributed to the unnamed recruiter.",
+    )
+    setup = audiobook_llm._apply_speaker_guardrails(
+        text="The recruiter looked up. “",
+        next_text="Hello,” she said.",
+        character_id=10,
+        narrator_id=10,
+        minor_female_id=30,
+        minor_male_id=40,
+        reason="Narration setting up dialogue.",
+    )
+
+    assert prose == (10, "Deterministic prose/narration guardrail", 0.98)
+    assert dialogue == (30, "Deterministic she dialogue attribution to minor voice", 0.98)
+    assert setup == (10, "Narration setting up dialogue.", None)
+
+
+@pytest.mark.asyncio
+async def test_ollama_call_requests_schema_constrained_non_thinking_json(monkeypatch):
+    captured = {}
+
+    class FakeResponse:
+        is_error = False
+
+        def json(self):
+            return {"message": {"content": json.dumps({"status": "ready"})}}
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            captured["client"] = kwargs
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def post(self, url, **kwargs):
+            captured["url"] = url
+            captured["request"] = kwargs
+            return FakeResponse()
+
+    monkeypatch.setattr(audiobook_llm.httpx, "AsyncClient", FakeClient)
+    settings = models.AudiobookSettings(
+        llm_provider="ollama",
+        llm_base_url="http://127.0.0.1:11434",
+        llm_model="qwen3.5:27b",
+    )
+    schema = {
+        "type": "object",
+        "properties": {"status": {"type": "string"}},
+        "required": ["status"],
+    }
+
+    raw = await audiobook_llm._call_llm(
+        settings,
+        [{"role": "user", "content": "ready?"}],
+        response_schema=schema,
+    )
+
+    assert json.loads(raw) == {"status": "ready"}
+    assert captured["url"] == "http://127.0.0.1:11434/api/chat"
+    payload = captured["request"]["json"]
+    assert payload["model"] == "qwen3.5:27b"
+    assert payload["think"] is False
+    assert payload["format"] == schema
+    assert payload["options"]["temperature"] == 0
 
 
 @pytest.mark.asyncio
@@ -278,6 +385,103 @@ async def test_step_pipeline_runs_only_next_recoverable_phase(db, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_run_batch_persists_one_unit_limit(db, monkeypatch):
+    book = await _make_book(db, audiobook_enabled=True, audiobook_pipeline_status="paused")
+    await _seed_audio_chapter(db, book.id, sentence_status="ready_for_audio")
+    queue = _FakeQueue()
+    monkeypatch.setattr(audiobook_router, "get_audiobook_queue", lambda: queue)
+
+    response = await audiobook_router.run_pipeline_batch(book.id, db)
+
+    await db.refresh(book)
+    assert response == {
+        "status": "audio_gen",
+        "queued": True,
+        "batch_limit": 1,
+    }
+    assert book.audiobook_pipeline_status == "audio_gen"
+    assert book.audiobook_batch_limit == 1
+    assert queue.enqueued == [book.id]
+
+
+@pytest.mark.asyncio
+async def test_review_filter_excludes_pending_and_keeps_uncertain_assignments(db):
+    book = await _make_book(db, audiobook_enabled=True)
+    chapter, character, sentence = await _seed_audio_chapter(
+        db,
+        book.id,
+        sentence_status="ready_for_audio",
+    )
+    sentence.speaker_confidence = 0.4
+    sentence.speaker_reason = "Ambiguous dialogue turn"
+    await crud.audiobook.create_sentences_bulk(
+        db,
+        chapter_id=chapter.id,
+        sentences_data=[
+            {
+                "html_element_id": "ch1_s1",
+                "sequence_order": 1,
+                "original_text": "Pending.",
+                "status": "pending_diarization",
+            },
+            {
+                "html_element_id": "ch1_s2",
+                "sequence_order": 2,
+                "original_text": "Certain.",
+                "tagged_text": "Certain.",
+                "character_id": character.id,
+                "speaker_confidence": 0.95,
+                "status": "ready_for_audio",
+            },
+        ],
+    )
+
+    review, total = await crud.audiobook.get_sentences_paginated(
+        db,
+        book.id,
+        review_only=True,
+    )
+
+    assert total == 1
+    assert [item.original_text for item in review] == ["One sentence."]
+
+
+@pytest.mark.asyncio
+async def test_roster_rebuild_preserves_ingestion_and_clears_derived_analysis(db, monkeypatch):
+    book = await _make_book(db, audiobook_enabled=True, audiobook_pipeline_status="paused")
+    chapter, _character, sentence = await _seed_audio_chapter(
+        db,
+        book.id,
+        sentence_status="audio_generated",
+    )
+    chapter.summary = "Old summary"
+    sentence.speaker_confidence = 0.9
+    sentence.audio_file_path = "library/audiobooks/1/snippets/1.mp3"
+    await db.commit()
+    queue = _FakeQueue()
+    monkeypatch.setattr(audiobook_router, "get_audiobook_queue", lambda: queue)
+
+    response = await audiobook_router.rebuild_character_roster(book.id, db)
+
+    await db.refresh(book)
+    await db.refresh(chapter)
+    await db.refresh(sentence)
+    assert response == {
+        "status": "roster_gen",
+        "queued": True,
+        "stop_after_phase": "roster_gen",
+    }
+    assert book.audiobook_pipeline_status == "roster_gen"
+    assert sentence.status == "pending_diarization"
+    assert sentence.character_id is None
+    assert sentence.speaker_confidence is None
+    assert sentence.audio_file_path is None
+    assert chapter.summary is None
+    assert await crud.audiobook.get_characters_for_book(db, book.id) == []
+    assert queue.enqueued == [book.id]
+
+
+@pytest.mark.asyncio
 async def test_queue_stops_for_review_after_requested_phase(db, sqlite_sessionmaker, monkeypatch):
     book = await _make_book(
         db,
@@ -445,6 +649,107 @@ async def test_ingestion_preserves_nested_markup_and_records_spine_file(db, tmp_
     assert soup.find("a", href="next.xhtml") is not None
     assert soup.find("span", id="ch1_s0") is not None
     assert soup.find("span", id="ch1_s1") is not None
+
+
+@pytest.mark.asyncio
+async def test_roster_excerpt_skips_short_front_matter(db):
+    book = await _make_book(db, audiobook_enabled=True)
+    front = await crud.audiobook.create_chapter(db, book.id, 1, "front.xhtml")
+    await crud.audiobook.create_sentences_bulk(
+        db,
+        front.id,
+        [
+            {
+                "html_element_id": "front_0",
+                "sequence_order": 0,
+                "original_text": "Copyright page only.",
+                "status": "pending_diarization",
+            }
+        ],
+    )
+    story = await crud.audiobook.create_chapter(db, book.id, 2, "story.xhtml")
+    await crud.audiobook.create_sentences_bulk(
+        db,
+        story.id,
+        [
+            {
+                "html_element_id": f"story_{index}",
+                "sequence_order": index,
+                "original_text": f"John and Kathy continue the story in sentence {index}.",
+                "status": "pending_diarization",
+            }
+            for index in range(40)
+        ],
+    )
+
+    excerpt = await audiobook_llm._build_roster_excerpt(
+        await crud.audiobook.get_chapters_for_book(db, book.id),
+        db,
+    )
+
+    assert "Copyright page only" not in excerpt
+    assert "John and Kathy continue the story" in excerpt
+    assert "### Chapter 2" in excerpt
+
+
+@pytest.mark.asyncio
+async def test_roster_keeps_first_person_protagonist_separate_from_narrator(db, monkeypatch):
+    book = await _make_book(db, audiobook_enabled=True)
+    settings = models.AudiobookSettings(
+        llm_provider="ollama",
+        llm_base_url="http://ollama.test",
+        llm_model="qwen-test",
+    )
+    db.add(settings)
+    chapter = await crud.audiobook.create_chapter(db, book.id, 1, "story.xhtml")
+    await crud.audiobook.create_sentences_bulk(
+        db,
+        chapter.id,
+        [
+            {
+                "html_element_id": f"story_{index}",
+                "sequence_order": index,
+                "original_text": f'Harry said, "John, sentence {index}."',
+                "status": "pending_diarization",
+            }
+            for index in range(40)
+        ],
+    )
+    captured = {}
+
+    async def fake_call(_settings, messages, **_kwargs):
+        captured["prompt"] = messages[0]["content"]
+        return json.dumps(
+            {
+                "book_summary": "John tells a story.",
+                "characters": [
+                    {
+                        "name": "John Perry",
+                        "aliases": ["Narrator"],
+                        "description": "First-person protagonist.",
+                        "evidence": ["John speaks."],
+                        "voice_design_prompt": "[gender-male][pitch-medium][speed-normal]",
+                        "is_narrator": True,
+                    }
+                ],
+            }
+        )
+
+    monkeypatch.setattr(audiobook_llm, "_call_llm", fake_call)
+
+    await audiobook_llm.generate_character_roster(book.id, db)
+
+    characters = await crud.audiobook.get_characters_for_book(db, book.id)
+    assert [(character.name, character.is_narrator) for character in characters] == [
+        ("Narrator", True),
+        ("Harry", False),
+        ("John Perry", False),
+        ("Minor Female Voice", False),
+        ("Minor Male Voice", False),
+    ]
+    assert characters[2].aliases == []
+    assert "40 explicit dialogue attributions" in characters[1].description
+    assert "Harry: 40 mentions" in captured["prompt"]
 
 
 @pytest.mark.asyncio

--- a/docs/AUDIOBOOK_PIPELINE.md
+++ b/docs/AUDIOBOOK_PIPELINE.md
@@ -39,15 +39,15 @@ AudiobookQueue.enqueue(book_id)
 │                                                          │
 │  Phase 2 – Roster Gen (status="roster_gen")              │
 │    audiobook_llm.generate_character_roster(book_id)      │
-│    • chunk chapter text → LLM (provider from settings)   │
+│    • sample story chapters across the book → LLM         │
 │    • parse characters + voice params                     │
 │    • INSERT audiobook_characters (incl. Narrator)        │
 │    • set status = "diarizing"                            │
 │                                                          │
 │  Phase 3 – Diarization (status="diarizing")              │
 │    audiobook_llm.diarize_sentences(book_id)              │
-│    • batch 50 sentences + 5-sentence context window      │
-│    • LLM assigns character_id + tagged_text              │
+│    • batch 40 sentences + 8-sentence context window      │
+│    • LLM assigns speaker, confidence, rationale + tags   │
 │    • UPDATE sentence status → "ready_for_audio"          │
 │    • set status = "audio_gen" when all done              │
 │                                                          │
@@ -107,7 +107,7 @@ PUT /api/audiobook/sentences/{id}
 | Column | Type | Notes |
 |---|---|---|
 | id | Integer PK | |
-| llm_provider | String | `"stub"`, `"openai"`, `"anthropic"`, `"custom"` |
+| llm_provider | String | `"stub"`, `"ollama"`, `"openai"`, `"anthropic"`, `"custom"` |
 | llm_api_key | String | Stored plaintext; masked on GET |
 | llm_base_url | String | Override for custom/local LLMs |
 | llm_model | String | e.g. `"gpt-4o"`, `"claude-opus-4-7"` |
@@ -149,6 +149,8 @@ PUT /api/audiobook/sentences/{id}
 | audio_file_path | String | Path to snippet MP3 |
 | audio_duration_ms | Integer | Used for SMIL timestamp calculation |
 | status | String | `pending_diarization` → `ready_for_audio` → `audio_generated` / `error` |
+| speaker_confidence | Float | Model confidence from `0` to `1`; manual assignments use `1` |
+| speaker_reason | Text | Short attribution rationale for review |
 
 **New columns on `books`**:
 - `audiobook_enabled` (Boolean, default `false`) — per-book opt-in gate for this pipeline
@@ -157,6 +159,15 @@ Values: `None` (idle), `ingesting`, `roster_gen`, `diarizing`, `audio_gen`, `ass
 - `audiobook_stop_after_phase` (String, nullable) — persisted checkpoint for a single-stage run
 - `audiobook_pause_requested` (Boolean, default `false`) — cooperative pause request acknowledged at a durable boundary
 - `audiobook_last_error` (Text, nullable) — actionable worker error shown in the book UI
+- `audiobook_summary` (Text, nullable) — roster-stage, spoiler-light story analysis
+- `audiobook_progress_current` / `audiobook_progress_total` — current phase work counters
+- `audiobook_progress_detail` — human-readable active operation
+- `audiobook_pipeline_started_at` / `audiobook_pipeline_updated_at` — run timing
+- `audiobook_batch_limit` — durable work-unit budget for **Run One Batch**
+- `audiobook_llm_requests` — model calls made during the current run
+
+Migration `0020_audiobook_observability.py` also adds chapter summaries, character aliases/evidence, and sentence
+confidence/rationales.
 
 ---
 
@@ -230,9 +241,30 @@ Choose **Deterministic local harness** in Audio Settings to make this mode expli
 choose an LLM provider and configure an OmniVoice-compatible endpoint. The harness is intentionally deterministic;
 it is a validation and UI-development path, not synthetic speech.
 
+## Recommended Local LLM (Ollama)
+
+The recommended local analysis model is `qwen3.5:9b`. The model is about 6.6 GB, has enough instruction-following
+capacity for schema-constrained roster and speaker assignment, and is substantially more practical for the many
+calls required by a full book than the 17 GB 27B quality tier. Install Ollama, start its service, and pull the model:
+
+```bash
+# macOS
+brew install ollama
+brew services start ollama
+make pull-ollama-model
+
+curl http://127.0.0.1:11434/api/tags
+```
+
+In **Audio Settings**, click **Use Recommended Local Ollama**, then **Save & Test LLM**. The preset uses provider
+`ollama`, base URL `http://127.0.0.1:11434`, and model `qwen3.5:9b`. Calls use Ollama's schema-constrained structured
+outputs, thinking disabled, temperature 0, and a 32K working context. This makes roster and speaker output directly
+machine-validated instead of relying on best-effort JSON prompting.
+
 ## Review and Recovery Controls
 
-The book UI offers **Run Next Stage** for debugging or reviewing intermediate artifacts and **Run to Completion**
+The book UI offers **Run Next Stage** for debugging or reviewing intermediate artifacts, **Run One Batch** for one
+40-sentence diarization batch, one TTS sentence, or one assembly chapter, and **Run to Completion**
 for unattended processing. A single-stage run persists its target phase and moves to `paused` only after that phase
 has committed. **Pause Safely** is cooperative: diarization pauses between batches, TTS between sentences, and
 assembly between chapters. Roster LLM requests and individual external TTS calls finish before the pause is
@@ -241,6 +273,11 @@ restart does not require restarting the entire book.
 
 Worker exceptions are stored in `audiobook_last_error` and returned by the status endpoint. Retrying clears the
 stale message; failed sentence audio is reset to `ready_for_audio` before TTS resumes.
+
+The Characters tab also offers **Regenerate Character Roster**. It preserves the parsed EPUB and sentence IDs while
+clearing roster, diarization, summaries, and derived audio state. Roster generation samples real story chapters
+across the book and supplements those excerpts with whole-book capitalized-name frequency hints, reducing the chance
+that front matter or a one-scene cameo displaces a recurring speaker.
 
 ---
 
@@ -270,12 +307,14 @@ All paths stored in the database as relative to `LIBRARY_PATH.parent`, matching 
 |---|---|---|
 | POST | `/api/books/{id}/audiobook/start` | Start or resume pipeline |
 | POST | `/api/books/{id}/audiobook/step` | Run only the next recoverable phase, then pause for review |
+| POST | `/api/books/{id}/audiobook/run-batch` | Run one diarization/TTS/assembly work unit, then pause |
 | POST | `/api/books/{id}/audiobook/pause` | Request a cooperative pause at the next durable boundary |
 | POST | `/api/books/{id}/audiobook/rebuild` | Force full rebuild |
-| GET | `/api/books/{id}/audiobook/status` | Status, next phase, controls, last error, and sentence counts |
+| POST | `/api/books/{id}/audiobook/roster/rebuild` | Preserve ingestion and regenerate roster/speaker analysis |
+| GET | `/api/books/{id}/audiobook/status` | Status, model, progress, summary, review flags, and sentence counts |
 | GET | `/api/books/{id}/audiobook/characters` | List characters |
 | PUT | `/api/audiobook/characters/{char_id}` | Update voice profile (triggers cascade) |
-| GET | `/api/books/{id}/audiobook/sentences` | Paginated sentence list (`?page=&limit=&chapter_id=`) |
+| GET | `/api/books/{id}/audiobook/sentences` | Paginated sentences (`?page=&limit=&chapter_id=&review_only=`) |
 | PUT | `/api/audiobook/sentences/{id}` | Update speaker/tags (triggers cascade) |
 | GET | `/api/audiobook/sentences/{id}/audio` | Stream sentence snippet MP3 |
 | GET | `/api/books/{id}/audiobook/chapters` | Chapter list with assembly status |
@@ -283,6 +322,7 @@ All paths stored in the database as relative to `LIBRARY_PATH.parent`, matching 
 | GET | `/api/books/{id}/audiobook/download` | Download the completed EPUB 3 Media Overlay audiobook |
 | GET | `/api/audiobook/settings` | Get LLM/TTS config (API key masked) |
 | PUT | `/api/audiobook/settings` | Upsert LLM/TTS config |
+| POST | `/api/audiobook/settings/test-llm` | Validate the saved model with a structured-output request |
 
 ---
 
@@ -293,6 +333,7 @@ All paths stored in the database as relative to `LIBRARY_PATH.parent`, matching 
 | `backend/app/models.py` | Audiobook models and per-book pipeline/control state |
 | `backend/alembic/versions/0018_audiobook_pipeline.py` | Core audiobook schema migration |
 | `backend/alembic/versions/0019_audiobook_pipeline_controls.py` | Review, pause, and error-state migration |
+| `backend/alembic/versions/0020_audiobook_observability.py` | Progress, summaries, evidence, confidence, and batch controls |
 | `backend/app/crud/audiobook.py` | DB queries for all new tables |
 | `backend/app/services/audiobook_ingestion.py` | Phase 1: EPUB parse + span injection |
 | `backend/app/services/audiobook_llm.py` | Phases 2 & 3: character roster + diarization |

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -6,7 +6,7 @@
 }
 
 .app-container.drag-over::after {
-  content: '';
+  content: "";
   position: fixed;
   inset: 0;
   border: 3px solid var(--accent);
@@ -92,7 +92,6 @@
     border-color: var(--accent);
     background: rgba(98, 114, 234, 0.1);
   }
-
 }
 
 /* ─── Collapsible Add Book ───────────────────────────────── */
@@ -1369,6 +1368,385 @@
 }
 .settings-actions h3 {
   display: none;
+}
+
+.settings-actions-inline {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+/* ─── Audiobook pipeline ────────────────────────────────── */
+.audiobook-pipeline {
+  display: grid;
+  gap: 1rem;
+}
+
+.pipeline-header,
+.pipeline-inspector,
+.analysis-book-summary,
+.chapter-analysis-card,
+.character-card,
+.script-editor,
+.chapter-assembly {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.pipeline-header {
+  display: grid;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.pipeline-progress {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 0.25rem;
+}
+
+.pipeline-step {
+  position: relative;
+  display: grid;
+  justify-items: center;
+  gap: 0.35rem;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  text-align: center;
+}
+
+.pipeline-step::before {
+  content: "";
+  position: absolute;
+  top: 0.38rem;
+  left: calc(-50% - 0.1rem);
+  width: 100%;
+  height: 2px;
+  background: var(--border);
+}
+
+.pipeline-step:first-child::before {
+  display: none;
+}
+
+.pipeline-step-dot {
+  z-index: 1;
+  width: 0.8rem;
+  height: 0.8rem;
+  border: 2px solid var(--border-strong);
+  border-radius: 999px;
+  background: var(--surface);
+}
+
+.pipeline-step--done,
+.pipeline-step--active {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.pipeline-step--done::before,
+.pipeline-step--active::before {
+  background: var(--accent);
+}
+
+.pipeline-step--done .pipeline-step-dot,
+.pipeline-step--active .pipeline-step-dot {
+  border-color: var(--accent);
+  background: var(--accent);
+}
+
+.pipeline-step--active .pipeline-step-dot {
+  box-shadow: 0 0 0 4px rgba(98, 114, 234, 0.16);
+}
+
+.pipeline-meta,
+.pipeline-controls,
+.script-editor-controls,
+.character-metrics,
+.chapter-analysis-counts {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.55rem;
+}
+
+.pipeline-controls {
+  padding-top: 0.25rem;
+}
+
+.pipeline-inspector {
+  display: grid;
+  gap: 0.9rem;
+  padding: 0.9rem;
+  background: var(--surface-2);
+}
+
+.pipeline-inspector-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.8rem;
+}
+
+.pipeline-inspector-grid > div {
+  display: grid;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.metric-label {
+  color: var(--text-muted);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.pipeline-work-progress,
+.chapter-analysis-card {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.pipeline-work-progress-label,
+.analysis-section-heading,
+.chapter-analysis-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.pipeline-work-progress-label {
+  font-size: 0.8rem;
+}
+
+.pipeline-work-progress progress,
+.chapter-analysis-card progress {
+  width: 100%;
+  accent-color: var(--accent);
+}
+
+.pipeline-summary summary,
+.character-evidence summary {
+  cursor: pointer;
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+.pipeline-summary p,
+.analysis-book-summary p,
+.chapter-analysis-card p {
+  margin: 0.55rem 0 0;
+  line-height: 1.55;
+}
+
+.sub-tabs {
+  display: flex;
+  gap: 0.25rem;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--border);
+}
+
+.sub-tab {
+  border: 0;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
+  background: none;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.sub-tab--active {
+  border-bottom-color: var(--accent);
+  color: var(--text);
+  font-weight: 600;
+}
+
+.analysis-overview,
+.character-roster {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.roster-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.7rem;
+  margin-bottom: 0.8rem;
+  padding: 0.75rem 0.9rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface-2);
+  color: var(--text-muted);
+  font-size: 0.8rem;
+}
+
+.analysis-book-summary,
+.chapter-analysis-card,
+.character-card {
+  padding: 1rem;
+}
+
+.analysis-section-heading h3 {
+  margin: 0.15rem 0 0;
+}
+
+.chapter-analysis-list,
+.character-roster {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.chapter-analysis-counts,
+.character-metrics,
+.character-aliases,
+.character-voice-hint {
+  color: var(--text-muted);
+  font-size: 0.78rem;
+}
+
+.character-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.character-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.character-description,
+.character-aliases,
+.character-voice-hint {
+  margin: 0;
+  line-height: 1.45;
+}
+
+.character-evidence ul {
+  margin-bottom: 0;
+  padding-left: 1.2rem;
+}
+
+.character-voice-label {
+  display: grid;
+  gap: 0.3rem;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+}
+
+.script-editor,
+.chapter-assembly {
+  overflow: hidden;
+}
+
+.script-editor-controls {
+  padding: 0.8rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.script-editor-controls label {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--text-muted);
+  font-size: 0.78rem;
+}
+
+.script-editor-controls .pagination {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-left: auto;
+}
+
+.script-table-wrap,
+.chapter-assembly {
+  overflow-x: auto;
+}
+
+.script-table,
+.chapter-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.78rem;
+}
+
+.script-table th,
+.script-table td,
+.chapter-table th,
+.chapter-table td {
+  padding: 0.55rem;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+  vertical-align: top;
+}
+
+.script-table th,
+.chapter-table th {
+  color: var(--text-muted);
+  font-size: 0.7rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.sentence-text {
+  min-width: 16rem;
+  max-width: 24rem;
+  line-height: 1.45;
+}
+
+.sentence-tags {
+  min-width: 12rem;
+}
+
+.sentence-tags-input,
+.sentence-speaker select {
+  width: 100%;
+}
+
+.confidence-badge {
+  display: inline-flex;
+  padding: 0.18rem 0.4rem;
+  border-radius: 999px;
+  background: rgba(48, 164, 108, 0.14);
+  color: var(--success);
+  font-weight: 700;
+}
+
+.confidence-badge--low {
+  background: rgba(214, 143, 44, 0.15);
+  color: var(--warning);
+}
+
+@media (max-width: 720px) {
+  .pipeline-inspector-grid,
+  .chapter-analysis-list,
+  .character-roster {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 480px) {
+  .pipeline-inspector-grid,
+  .chapter-analysis-list,
+  .character-roster {
+    grid-template-columns: 1fr;
+  }
+
+  .pipeline-step span {
+    font-size: 0.62rem;
+  }
+
+  .script-editor-controls .pagination {
+    width: 100%;
+    margin-left: 0;
+  }
 }
 
 /* ─── Actions bar ───────────────────────────────────────── */

--- a/frontend/src/api/audiobook.js
+++ b/frontend/src/api/audiobook.js
@@ -22,6 +22,13 @@ export function stepPipeline(bookId) {
   });
 }
 
+export function runPipelineBatch(bookId) {
+  return sendWithoutBody(`/api/books/${bookId}/audiobook/run-batch`, {
+    method: "POST",
+    fallbackMessage: "Failed to run one pipeline batch",
+  });
+}
+
 export function pausePipeline(bookId) {
   return sendWithoutBody(`/api/books/${bookId}/audiobook/pause`, {
     method: "POST",
@@ -33,6 +40,13 @@ export function rebuildPipeline(bookId) {
   return sendWithoutBody(`/api/books/${bookId}/audiobook/rebuild`, {
     method: "POST",
     fallbackMessage: "Failed to rebuild pipeline",
+  });
+}
+
+export function rebuildCharacterRoster(bookId) {
+  return sendWithoutBody(`/api/books/${bookId}/audiobook/roster/rebuild`, {
+    method: "POST",
+    fallbackMessage: "Failed to regenerate the character roster",
   });
 }
 
@@ -53,9 +67,13 @@ export function updateCharacter(charId, data) {
 }
 
 // Sentences
-export function getSentences(bookId, { page = 1, limit = 50, chapterId } = {}) {
+export function getSentences(
+  bookId,
+  { page = 1, limit = 50, chapterId, reviewOnly = false } = {},
+) {
   const params = new URLSearchParams({ page, limit });
   if (chapterId != null) params.set("chapter_id", chapterId);
+  if (reviewOnly) params.set("review_only", "true");
   return getJson(
     `/api/books/${bookId}/audiobook/sentences?${params}`,
     "Failed to fetch sentences",
@@ -103,5 +121,12 @@ export function updateAudiobookSettings(data) {
     method: "PUT",
     body: data,
     fallbackMessage: "Failed to save audiobook settings",
+  });
+}
+
+export function testAudiobookLlm() {
+  return sendWithoutBody("/api/audiobook/settings/test-llm", {
+    method: "POST",
+    fallbackMessage: "Failed to connect to the configured LLM",
   });
 }

--- a/frontend/src/components/AudiobookPipeline.jsx
+++ b/frontend/src/components/AudiobookPipeline.jsx
@@ -6,6 +6,7 @@ import {
   getAudiobookChapters,
   startPipeline,
   stepPipeline,
+  runPipelineBatch,
   pausePipeline,
   rebuildPipeline,
   getAudiobookDownloadUrl,
@@ -13,6 +14,7 @@ import {
 import CharacterRoster from "./audiobook/CharacterRoster";
 import ScriptEditor from "./audiobook/ScriptEditor";
 import ChapterAssembly from "./audiobook/ChapterAssembly";
+import AnalysisOverview from "./audiobook/AnalysisOverview";
 
 const PIPELINE_STEPS = [
   { status: "ingesting", label: "Ingesting" },
@@ -30,6 +32,7 @@ const ACTIVE_STATUSES = new Set([
   "audio_gen",
   "assembling",
 ]);
+const BATCHABLE_STATUSES = new Set(["diarizing", "audio_gen", "assembling"]);
 
 function PipelineProgress({ status }) {
   const currentIdx = PIPELINE_STEPS.findIndex((s) => s.status === status);
@@ -50,12 +53,73 @@ function PipelineProgress({ status }) {
   );
 }
 
-const SUB_TABS = ["Characters", "Script Editor", "Chapter Assembly"];
+function JobInspector({ statusData, totalSentences, doneCount }) {
+  const progressTotal = statusData?.progress_total ?? 0;
+  const progressCurrent = statusData?.progress_current ?? 0;
+  const percent = statusData?.progress_percent ?? 0;
+  const review = statusData?.review_counts ?? {};
+
+  return (
+    <section className="pipeline-inspector" aria-label="Audiobook job details">
+      <div className="pipeline-inspector-grid">
+        <div>
+          <span className="metric-label">Active model</span>
+          <strong>
+            {statusData?.llm_provider || "stub"}
+            {statusData?.llm_model ? ` / ${statusData.llm_model}` : ""}
+          </strong>
+        </div>
+        <div>
+          <span className="metric-label">Model requests</span>
+          <strong>{statusData?.llm_requests ?? 0}</strong>
+        </div>
+        <div>
+          <span className="metric-label">Sentence state</span>
+          <strong>
+            {doneCount} audio / {totalSentences} total
+          </strong>
+        </div>
+        <div>
+          <span className="metric-label">Needs review</span>
+          <strong>
+            {review.low_confidence ?? 0} low confidence ·{" "}
+            {review.unassigned ?? 0} unassigned
+          </strong>
+        </div>
+      </div>
+      {progressTotal > 0 && (
+        <div className="pipeline-work-progress">
+          <div className="pipeline-work-progress-label">
+            <span>{statusData?.progress_detail || "Working…"}</span>
+            <strong>
+              {progressCurrent.toLocaleString()} /{" "}
+              {progressTotal.toLocaleString()} ({percent}%)
+            </strong>
+          </div>
+          <progress value={progressCurrent} max={progressTotal} />
+        </div>
+      )}
+      {statusData?.summary && (
+        <details className="pipeline-summary" open>
+          <summary>Model analysis summary · review required</summary>
+          <p>{statusData.summary}</p>
+        </details>
+      )}
+    </section>
+  );
+}
+
+const SUB_TABS = [
+  "Analysis",
+  "Characters",
+  "Script Editor",
+  "Chapter Assembly",
+];
 
 function AudiobookPipeline({ book }) {
   const bookId = book.id;
   const queryClient = useQueryClient();
-  const [subTab, setSubTab] = useState("Characters");
+  const [subTab, setSubTab] = useState("Analysis");
   const [confirmRebuild, setConfirmRebuild] = useState(false);
 
   const isActive = (status) => ACTIVE_STATUSES.has(status);
@@ -98,6 +162,11 @@ function AudiobookPipeline({ book }) {
 
   const stepMutation = useMutation({
     mutationFn: () => stepPipeline(bookId),
+    onSuccess: invalidateAll,
+  });
+
+  const batchMutation = useMutation({
+    mutationFn: () => runPipelineBatch(bookId),
     onSuccess: invalidateAll,
   });
 
@@ -172,6 +241,12 @@ function AudiobookPipeline({ book }) {
           )}
         </div>
 
+        <JobInspector
+          statusData={statusData}
+          totalSentences={totalSentences}
+          doneCount={doneCount}
+        />
+
         <div className="pipeline-controls">
           {pipelineStatus === "complete" && (
             <a
@@ -184,15 +259,37 @@ function AudiobookPipeline({ book }) {
           )}
           {pipelineStatus !== "complete" && !isActive(pipelineStatus) && (
             <>
+              {BATCHABLE_STATUSES.has(nextPhase) && (
+                <button
+                  onClick={() => batchMutation.mutate()}
+                  disabled={
+                    batchMutation.isPending ||
+                    stepMutation.isPending ||
+                    startMutation.isPending
+                  }
+                >
+                  {batchMutation.isPending
+                    ? "Starting Batch…"
+                    : "Run One Batch"}
+                </button>
+              )}
               <button
                 onClick={() => stepMutation.mutate()}
-                disabled={stepMutation.isPending || startMutation.isPending}
+                disabled={
+                  stepMutation.isPending ||
+                  startMutation.isPending ||
+                  batchMutation.isPending
+                }
               >
                 Run Next Stage: {nextPhaseLabel}
               </button>
               <button
                 onClick={() => startMutation.mutate()}
-                disabled={startMutation.isPending || stepMutation.isPending}
+                disabled={
+                  startMutation.isPending ||
+                  stepMutation.isPending ||
+                  batchMutation.isPending
+                }
                 className="btn-primary"
               >
                 Run to Completion
@@ -237,12 +334,14 @@ function AudiobookPipeline({ book }) {
 
         {(startMutation.isError ||
           stepMutation.isError ||
+          batchMutation.isError ||
           pauseMutation.isError ||
           rebuildMutation.isError) && (
           <p className="error">
             {(
               startMutation.error ||
               stepMutation.error ||
+              batchMutation.error ||
               pauseMutation.error ||
               rebuildMutation.error
             )?.message || "Action failed"}
@@ -263,11 +362,22 @@ function AudiobookPipeline({ book }) {
       </nav>
 
       <div className="sub-tab-content">
+        {subTab === "Analysis" && (
+          <AnalysisOverview status={statusData} chapters={chapters} />
+        )}
         {subTab === "Characters" && (
-          <CharacterRoster characters={characters} bookId={bookId} />
+          <CharacterRoster
+            characters={characters}
+            bookId={bookId}
+            pipelineStatus={pipelineStatus}
+          />
         )}
         {subTab === "Script Editor" && (
-          <ScriptEditor bookId={bookId} characters={characters} />
+          <ScriptEditor
+            bookId={bookId}
+            characters={characters}
+            chapters={chapters}
+          />
         )}
         {subTab === "Chapter Assembly" && (
           <ChapterAssembly chapters={chapters} bookId={bookId} />

--- a/frontend/src/components/AudiobookPipeline.test.jsx
+++ b/frontend/src/components/AudiobookPipeline.test.jsx
@@ -64,4 +64,88 @@ describe("AudiobookPipeline", () => {
       });
     });
   });
+
+  it("shows model progress and can run exactly one diarization batch", async () => {
+    const fetchMock = vi.fn((url, options) => {
+      if (url === "/api/books/11/audiobook/status") {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              pipeline_status: "paused",
+              next_phase: "diarizing",
+              pause_requested: false,
+              stop_after_phase: null,
+              last_error: null,
+              sentence_counts: { pending_diarization: 100 },
+              review_counts: {
+                low_confidence: 2,
+                unassigned: 100,
+              },
+              progress_current: 40,
+              progress_total: 100,
+              progress_percent: 40,
+              progress_detail: "Chapter 2: attributed 40 of 100 sentences",
+              llm_requests: 1,
+              llm_provider: "ollama",
+              llm_model: "qwen3.5:27b",
+              summary: "A test story summary.",
+            }),
+        });
+      }
+      if (url === "/api/books/11/audiobook/characters") {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+      }
+      if (url === "/api/books/11/audiobook/chapters") {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve([
+              {
+                id: 9,
+                chapter_number: 2,
+                sentence_count: 100,
+                processed_sentence_count: 40,
+                low_confidence_count: 2,
+                summary: "The story begins.",
+              },
+            ]),
+        });
+      }
+      if (
+        url === "/api/books/11/audiobook/run-batch" &&
+        options?.method === "POST"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              status: "diarizing",
+              queued: true,
+              batch_limit: 1,
+            }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+    globalThis.fetch = fetchMock;
+
+    renderWithClient(<AudiobookPipeline book={{ id: 11 }} />);
+
+    expect(await screen.findByText("ollama / qwen3.5:27b")).toBeInTheDocument();
+    expect(screen.getAllByText("A test story summary.")).toHaveLength(2);
+    expect(screen.getByText("The story begins.")).toBeInTheDocument();
+    expect(
+      screen.getByText("2 low confidence · 100 unassigned"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Run One Batch" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/books/11/audiobook/run-batch",
+        { method: "POST" },
+      );
+    });
+  });
 });

--- a/frontend/src/components/AudiobookSettings.jsx
+++ b/frontend/src/components/AudiobookSettings.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   getAudiobookSettings,
+  testAudiobookLlm,
   updateAudiobookSettings,
 } from "../api/audiobook";
 
@@ -46,8 +47,7 @@ function AudiobookSettings() {
     },
   });
 
-  const handleSave = (e) => {
-    e.preventDefault();
+  const buildPayload = () => {
     const payload = {
       llm_provider: llmProvider || null,
       llm_base_url: llmBaseUrl || null,
@@ -59,7 +59,22 @@ function AudiobookSettings() {
     if (llmApiKey) {
       payload.llm_api_key = llmApiKey;
     }
-    saveMutation.mutate(payload);
+    return payload;
+  };
+
+  const testMutation = useMutation({
+    mutationFn: async () => {
+      await updateAudiobookSettings(buildPayload());
+      return testAudiobookLlm();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["audiobook-settings"] });
+    },
+  });
+
+  const handleSave = (e) => {
+    e.preventDefault();
+    saveMutation.mutate(buildPayload());
   };
 
   if (isLoading) return <p>Loading settings…</p>;
@@ -78,6 +93,7 @@ function AudiobookSettings() {
             >
               <option value="openai">OpenAI</option>
               <option value="anthropic">Anthropic</option>
+              <option value="ollama">Ollama (local)</option>
               <option value="custom">Custom / Local</option>
               <option value="stub">Deterministic local harness</option>
             </select>
@@ -113,6 +129,43 @@ function AudiobookSettings() {
               placeholder="e.g. gpt-4o or claude-opus-4-7"
             />
           </label>
+          <div className="settings-actions-inline">
+            <button
+              type="button"
+              className="btn-secondary"
+              onClick={() => {
+                setLlmProvider("ollama");
+                setLlmBaseUrl("http://127.0.0.1:11434");
+                setLlmModel("qwen3.5:9b");
+              }}
+            >
+              Use Recommended Local Ollama
+            </button>
+            <button
+              type="button"
+              onClick={() => testMutation.mutate()}
+              disabled={testMutation.isPending}
+            >
+              {testMutation.isPending ? "Testing…" : "Save & Test LLM"}
+            </button>
+          </div>
+          <p className="settings-hint">
+            Recommended local default: <code>qwen3.5:9b</code> (6.6 GB). Run{" "}
+            <code>ollama pull qwen3.5:9b</code> first. Story Manager uses
+            Ollama&apos;s schema-constrained JSON output and disables thinking
+            for predictable extraction latency.
+          </p>
+          {testMutation.isSuccess && (
+            <p className="success">
+              Connected to {testMutation.data.provider} /{" "}
+              {testMutation.data.model || "local harness"}.
+            </p>
+          )}
+          {testMutation.isError && (
+            <p className="error">
+              {testMutation.error?.message || "LLM test failed"}
+            </p>
+          )}
         </section>
 
         <section className="settings-section">

--- a/frontend/src/components/audiobook/AnalysisOverview.jsx
+++ b/frontend/src/components/audiobook/AnalysisOverview.jsx
@@ -1,0 +1,67 @@
+function AnalysisOverview({ status, chapters = [] }) {
+  const analyzed = chapters.filter((chapter) => chapter.summary);
+
+  return (
+    <div className="analysis-overview">
+      <section className="analysis-book-summary">
+        <div className="analysis-section-heading">
+          <div>
+            <span className="metric-label">Book-level analysis</span>
+            <h3>Story summary</h3>
+          </div>
+          <span className="badge badge--neutral">
+            {analyzed.length} / {chapters.length} chapters analyzed
+          </span>
+        </div>
+        <p>
+          {status?.summary ||
+            "The roster stage will add a spoiler-light book summary here."}
+        </p>
+        {status?.summary && (
+          <small className="analysis-review-note">
+            Model-generated working analysis — verify names and plot details before production.
+          </small>
+        )}
+      </section>
+
+      <div className="chapter-analysis-list">
+        {chapters.map((chapter) => {
+          const percent = chapter.sentence_count
+            ? Math.round(
+                (chapter.processed_sentence_count * 100) /
+                  chapter.sentence_count,
+              )
+            : 0;
+          return (
+            <article className="chapter-analysis-card" key={chapter.id}>
+              <div className="chapter-analysis-header">
+                <strong>Chapter {chapter.chapter_number}</strong>
+                <span>{percent}% attributed</span>
+              </div>
+              <div className="chapter-analysis-counts">
+                <span>{chapter.sentence_count} sentences</span>
+                <span>{chapter.low_confidence_count} need review</span>
+              </div>
+              <progress
+                value={chapter.processed_sentence_count}
+                max={Math.max(1, chapter.sentence_count)}
+              />
+              <p>
+                {chapter.summary ||
+                  "No chapter summary yet. Run a diarization batch to analyze it."}
+              </p>
+            </article>
+          );
+        })}
+      </div>
+
+      {chapters.length === 0 && (
+        <p className="empty-state">
+          No chapters yet. Run the ingestion stage to inspect book structure.
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default AnalysisOverview;

--- a/frontend/src/components/audiobook/CharacterRoster.jsx
+++ b/frontend/src/components/audiobook/CharacterRoster.jsx
@@ -1,10 +1,20 @@
 import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { updateCharacter } from "../../api/audiobook";
+import { rebuildCharacterRoster, updateCharacter } from "../../api/audiobook";
+
+const ACTIVE_STATUSES = new Set([
+  "ingesting",
+  "roster_gen",
+  "diarizing",
+  "audio_gen",
+  "assembling",
+]);
 
 function CharacterCard({ character, bookId }) {
   const queryClient = useQueryClient();
-  const [voicePrompt, setVoicePrompt] = useState(character.voice_design_prompt || "");
+  const [voicePrompt, setVoicePrompt] = useState(
+    character.voice_design_prompt || "",
+  );
   const [saved, setSaved] = useState(false);
 
   const mutation = useMutation({
@@ -12,7 +22,9 @@ function CharacterCard({ character, bookId }) {
     onSuccess: () => {
       setSaved(true);
       setTimeout(() => setSaved(false), 3000);
-      queryClient.invalidateQueries({ queryKey: ["audiobook-characters", bookId] });
+      queryClient.invalidateQueries({
+        queryKey: ["audiobook-characters", bookId],
+      });
       queryClient.invalidateQueries({ queryKey: ["audiobook-status", bookId] });
     },
   });
@@ -29,6 +41,31 @@ function CharacterCard({ character, bookId }) {
       </div>
       {character.description && (
         <p className="character-description">{character.description}</p>
+      )}
+      <div className="character-metrics">
+        <span>{character.sentence_count ?? 0} assigned sentences</span>
+        {character.average_confidence != null && (
+          <span>
+            {Math.round(character.average_confidence * 100)}% average confidence
+          </span>
+        )}
+      </div>
+      {character.aliases?.length > 0 && (
+        <p className="character-aliases">
+          <strong>Also known as:</strong> {character.aliases.join(", ")}
+        </p>
+      )}
+      {character.evidence?.length > 0 && (
+        <details className="character-evidence">
+          <summary>
+            Identification evidence ({character.evidence.length})
+          </summary>
+          <ul>
+            {character.evidence.map((item, index) => (
+              <li key={`${character.id}-evidence-${index}`}>{item}</li>
+            ))}
+          </ul>
+        </details>
       )}
       <label className="character-voice-label">
         Voice Design Prompt
@@ -50,7 +87,9 @@ function CharacterCard({ character, bookId }) {
         <p className="error">{mutation.error?.message || "Save failed"}</p>
       )}
       {saved && (
-        <p className="success">Saved — audio for this character will be regenerated.</p>
+        <p className="success">
+          Saved — audio for this character will be regenerated.
+        </p>
       )}
       <button onClick={handleSave} disabled={mutation.isPending}>
         {mutation.isPending ? "Saving…" : "Save Profile"}
@@ -59,7 +98,23 @@ function CharacterCard({ character, bookId }) {
   );
 }
 
-function CharacterRoster({ characters, bookId }) {
+function CharacterRoster({ characters, bookId, pipelineStatus }) {
+  const queryClient = useQueryClient();
+  const [confirmRegenerate, setConfirmRegenerate] = useState(false);
+  const regenerateMutation = useMutation({
+    mutationFn: () => rebuildCharacterRoster(bookId),
+    onSuccess: () => {
+      setConfirmRegenerate(false);
+      queryClient.invalidateQueries({ queryKey: ["audiobook-status", bookId] });
+      queryClient.invalidateQueries({
+        queryKey: ["audiobook-characters", bookId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["audiobook-chapters", bookId],
+      });
+    },
+  });
+
   if (!characters || characters.length === 0) {
     return (
       <p className="empty-state">
@@ -69,11 +124,50 @@ function CharacterRoster({ characters, bookId }) {
   }
 
   return (
-    <div className="character-roster">
-      {characters.map((char) => (
-        <CharacterCard key={char.id} character={char} bookId={bookId} />
-      ))}
-    </div>
+    <>
+      <div className="roster-controls">
+        <span>
+          {characters.length} voice profiles. Regenerating preserves EPUB
+          ingestion but clears speaker assignments and invalidates generated
+          snippets.
+        </span>
+        {!confirmRegenerate ? (
+          <button
+            onClick={() => setConfirmRegenerate(true)}
+            disabled={ACTIVE_STATUSES.has(pipelineStatus)}
+          >
+            Regenerate Character Roster
+          </button>
+        ) : (
+          <span className="confirm-inline">
+            Clear existing speaker analysis?{" "}
+            <button
+              className="btn-danger"
+              onClick={() => regenerateMutation.mutate()}
+              disabled={regenerateMutation.isPending}
+            >
+              {regenerateMutation.isPending
+                ? "Regenerating…"
+                : "Yes, regenerate"}
+            </button>{" "}
+            <button
+              className="btn-text"
+              onClick={() => setConfirmRegenerate(false)}
+            >
+              Cancel
+            </button>
+          </span>
+        )}
+        {regenerateMutation.isError && (
+          <span className="error">{regenerateMutation.error?.message}</span>
+        )}
+      </div>
+      <div className="character-roster">
+        {characters.map((char) => (
+          <CharacterCard key={char.id} character={char} bookId={bookId} />
+        ))}
+      </div>
+    </>
   );
 }
 

--- a/frontend/src/components/audiobook/ScriptEditor.jsx
+++ b/frontend/src/components/audiobook/ScriptEditor.jsx
@@ -1,6 +1,10 @@
 import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { getSentences, updateSentence, getSentenceAudioUrl } from "../../api/audiobook";
+import {
+  getSentences,
+  updateSentence,
+  getSentenceAudioUrl,
+} from "../../api/audiobook";
 
 const STATUS_ICONS = {
   pending_diarization: { icon: "⏳", label: "Pending diarization" },
@@ -11,7 +15,9 @@ const STATUS_ICONS = {
 
 function SentenceRow({ sentence, characters, bookId }) {
   const queryClient = useQueryClient();
-  const [tags, setTags] = useState(sentence.tagged_text || sentence.original_text);
+  const [tags, setTags] = useState(
+    sentence.tagged_text || sentence.original_text,
+  );
   const [characterId, setCharacterId] = useState(sentence.character_id ?? "");
   const [editing, setEditing] = useState(false);
 
@@ -19,7 +25,9 @@ function SentenceRow({ sentence, characters, bookId }) {
     mutationFn: (data) => updateSentence(sentence.id, data),
     onSuccess: () => {
       setEditing(false);
-      queryClient.invalidateQueries({ queryKey: ["audiobook-sentences", bookId] });
+      queryClient.invalidateQueries({
+        queryKey: ["audiobook-sentences", bookId],
+      });
       queryClient.invalidateQueries({ queryKey: ["audiobook-status", bookId] });
     },
   });
@@ -31,8 +39,14 @@ function SentenceRow({ sentence, characters, bookId }) {
     });
   };
 
-  const statusInfo = STATUS_ICONS[sentence.status] || { icon: "?", label: sentence.status };
-  const audioUrl = sentence.status === "audio_generated" ? getSentenceAudioUrl(sentence.id) : null;
+  const statusInfo = STATUS_ICONS[sentence.status] || {
+    icon: "?",
+    label: sentence.status,
+  };
+  const audioUrl =
+    sentence.status === "audio_generated"
+      ? getSentenceAudioUrl(sentence.id)
+      : null;
 
   return (
     <tr className={`sentence-row sentence-row--${sentence.status}`}>
@@ -68,18 +82,43 @@ function SentenceRow({ sentence, characters, bookId }) {
           ))}
         </select>
       </td>
+      <td
+        className="sentence-confidence"
+        title={sentence.speaker_reason || "No model rationale"}
+      >
+        {sentence.speaker_confidence == null ? (
+          "—"
+        ) : (
+          <span
+            className={`confidence-badge${
+              sentence.speaker_confidence < 0.65 ? " confidence-badge--low" : ""
+            }`}
+          >
+            {Math.round(sentence.speaker_confidence * 100)}%
+          </span>
+        )}
+      </td>
       <td className="sentence-status" title={statusInfo.label}>
         {statusInfo.icon}
       </td>
       <td className="sentence-audio">
         {audioUrl && (
-          <audio controls src={audioUrl} preload="none" style={{ height: "24px" }} />
+          <audio
+            controls
+            src={audioUrl}
+            preload="none"
+            style={{ height: "24px" }}
+          />
         )}
       </td>
       <td className="sentence-actions">
         {editing && (
           <>
-            <button onClick={handleSave} disabled={mutation.isPending} className="btn-small">
+            <button
+              onClick={handleSave}
+              disabled={mutation.isPending}
+              className="btn-small"
+            >
               {mutation.isPending ? "…" : "Save"}
             </button>
             <button
@@ -94,30 +133,37 @@ function SentenceRow({ sentence, characters, bookId }) {
             </button>
           </>
         )}
-        {mutation.isError && <span className="error">{mutation.error?.message}</span>}
+        {mutation.isError && (
+          <span className="error">{mutation.error?.message}</span>
+        )}
       </td>
     </tr>
   );
 }
 
-function ScriptEditor({ bookId, characters }) {
+function ScriptEditor({ bookId, characters, chapters = [] }) {
   const [page, setPage] = useState(1);
-  const [chapterFilter, _setChapterFilter] = useState("");
+  const [chapterFilter, setChapterFilter] = useState("");
+  const [reviewOnly, setReviewOnly] = useState(false);
   const limit = 50;
 
   const { data, isLoading, isError, error } = useQuery({
-    queryKey: ["audiobook-sentences", bookId, page, chapterFilter],
+    queryKey: ["audiobook-sentences", bookId, page, chapterFilter, reviewOnly],
     queryFn: () =>
       getSentences(bookId, {
         page,
         limit,
         chapterId: chapterFilter ? Number(chapterFilter) : undefined,
+        reviewOnly,
       }),
     keepPreviousData: true,
   });
 
   if (isLoading) return <p>Loading sentences…</p>;
-  if (isError) return <p className="error">{error?.message || "Failed to load sentences"}</p>;
+  if (isError)
+    return (
+      <p className="error">{error?.message || "Failed to load sentences"}</p>
+    );
 
   const { items = [], total = 0 } = data || {};
   const totalPages = Math.max(1, Math.ceil(total / limit));
@@ -126,21 +172,58 @@ function ScriptEditor({ bookId, characters }) {
     <div className="script-editor">
       <div className="script-editor-controls">
         <span>{total} sentences</span>
+        <label>
+          Chapter
+          <select
+            value={chapterFilter}
+            onChange={(event) => {
+              setChapterFilter(event.target.value);
+              setPage(1);
+            }}
+          >
+            <option value="">All</option>
+            {chapters.map((chapter) => (
+              <option key={chapter.id} value={chapter.id}>
+                {chapter.chapter_number} · {chapter.processed_sentence_count}/
+                {chapter.sentence_count}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="review-filter">
+          <input
+            type="checkbox"
+            checked={reviewOnly}
+            onChange={(event) => {
+              setReviewOnly(event.target.checked);
+              setPage(1);
+            }}
+          />
+          Needs review only
+        </label>
         <div className="pagination">
-          <button onClick={() => setPage((p) => Math.max(1, p - 1))} disabled={page === 1}>
+          <button
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={page === 1}
+          >
             ‹ Prev
           </button>
           <span>
             Page {page} / {totalPages}
           </span>
-          <button onClick={() => setPage((p) => Math.min(totalPages, p + 1))} disabled={page === totalPages}>
+          <button
+            onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+            disabled={page === totalPages}
+          >
             Next ›
           </button>
         </div>
       </div>
 
       {items.length === 0 ? (
-        <p className="empty-state">No sentences found. Start the pipeline first.</p>
+        <p className="empty-state">
+          No sentences found. Start the pipeline first.
+        </p>
       ) : (
         <div className="script-table-wrap">
           <table className="script-table">
@@ -150,6 +233,7 @@ function ScriptEditor({ bookId, characters }) {
                 <th>Original Text</th>
                 <th>Tags</th>
                 <th>Speaker</th>
+                <th>Confidence</th>
                 <th>Status</th>
                 <th>Audio</th>
                 <th></th>


### PR DESCRIPTION
## Stack

Part 4 of 6. Depends on the local-OmniVoice PR. Base: `agent/audiobook-local-omnivoice`.

## What changed

- Adds migration 0020 for summaries, progress, evidence, confidence, and request counters.
- Adds structured Ollama, OpenAI-compatible, and Anthropic analysis paths.
- Adds durable batched diarization and retry behavior.
- Adds roster evidence, review flags, summaries, and a job inspector.
- Expands the frontend analysis and script-review experience.

## Why

This isolates the expensive/model-driven analysis behavior and its observability schema from the mechanical ingestion and speech layers.

## Validation

- Backend focused tests: 50 passed.
- Frontend tests: 34 passed.
- Black and ESLint passed.
- PostgreSQL migration validation is delegated to GitHub Actions because Docker was unavailable locally.