### PR TITLE
Add shared series voices and audiobook previews

### DIFF
--- a/backend/alembic/versions/0021_series_roster_and_chapter_previews.py
+++ b/backend/alembic/versions/0021_series_roster_and_chapter_previews.py
@@ -1,0 +1,70 @@
+"""add shared series rosters and manual chapter preview state
+
+Revision ID: 0021
+Revises: 0020
+Create Date: 2026-07-15 00:00:00
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0021"
+down_revision = "0020"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "audiobook_series_characters",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("series_name", sa.String(), nullable=False),
+        sa.Column("canonical_name", sa.String(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("voice_design_prompt", sa.String(), nullable=True),
+        sa.Column("is_narrator", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column("aliases", sa.JSON(), nullable=True),
+        sa.Column("evidence", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.UniqueConstraint("series_name", "canonical_name", name="uq_audiobook_series_character"),
+    )
+    op.create_index(
+        "ix_audiobook_series_characters_series_name",
+        "audiobook_series_characters",
+        ["series_name"],
+    )
+    op.add_column("audiobook_characters", sa.Column("series_character_id", sa.Integer(), nullable=True))
+    op.create_index(
+        "ix_audiobook_characters_series_character_id",
+        "audiobook_characters",
+        ["series_character_id"],
+    )
+    op.create_foreign_key(
+        "fk_audiobook_characters_series_character_id",
+        "audiobook_characters",
+        "audiobook_series_characters",
+        ["series_character_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.add_column("audiobook_chapters", sa.Column("preview_status", sa.String(), nullable=True))
+    op.add_column("audiobook_chapters", sa.Column("preview_error", sa.Text(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("audiobook_chapters", "preview_error")
+    op.drop_column("audiobook_chapters", "preview_status")
+    op.drop_constraint(
+        "fk_audiobook_characters_series_character_id",
+        "audiobook_characters",
+        type_="foreignkey",
+    )
+    op.drop_index("ix_audiobook_characters_series_character_id", table_name="audiobook_characters")
+    op.drop_column("audiobook_characters", "series_character_id")
+    op.drop_index(
+        "ix_audiobook_series_characters_series_name",
+        table_name="audiobook_series_characters",
+    )
+    op.drop_table("audiobook_series_characters")

--- a/backend/app/crud/audiobook.py
+++ b/backend/app/crud/audiobook.py
@@ -822,10 +822,7 @@ async def infer_audiobook_resume_status(db: AsyncSession, book_id: int) -> str:
     counts = await count_sentences_by_status(db, book_id)
     if counts.get("pending_diarization", 0) > 0:
         return "diarizing"
-    if any(
-        counts.get(status, 0) > 0
-        for status in ("ready_for_audio", "audio_queued", "audio_generating", "error")
-    ):
+    if any(counts.get(status, 0) > 0 for status in ("ready_for_audio", "audio_queued", "audio_generating", "error")):
         return "audio_gen"
 
     total = sum(counts.values())

--- a/backend/app/crud/audiobook.py
+++ b/backend/app/crud/audiobook.py
@@ -287,7 +287,11 @@ async def update_chapter_summary(db: AsyncSession, chapter_id: int, summary: Opt
 
 
 async def flag_chapter_for_reassembly(db: AsyncSession, chapter_id: int) -> None:
-    await db.execute(update(AudiobookChapter).where(AudiobookChapter.id == chapter_id).values(needs_reassembly=True))
+    await db.execute(
+        update(AudiobookChapter)
+        .where(AudiobookChapter.id == chapter_id)
+        .values(needs_reassembly=True, preview_status=None, preview_error=None)
+    )
     await db.commit()
 
 
@@ -643,6 +647,22 @@ async def get_sentences_ready_for_audio(db: AsyncSession, book_id: int, limit: i
     return list(result.scalars().all())
 
 
+async def get_pending_sentence_audio_jobs(db: AsyncSession) -> list[tuple[int, int]]:
+    """Return durable manual sentence jobs as (book_id, sentence_id)."""
+    result = await db.execute(
+        select(AudiobookChapter.book_id, AudiobookSentence.id)
+        .join(AudiobookChapter, AudiobookSentence.chapter_id == AudiobookChapter.id)
+        .where(AudiobookSentence.status.in_(["audio_queued", "audio_generating"]))
+        .order_by(AudiobookSentence.id)
+    )
+    return [(book_id, sentence_id) for book_id, sentence_id in result.all()]
+
+
+async def set_sentence_status(db: AsyncSession, sentence_id: int, status: str) -> None:
+    await db.execute(update(AudiobookSentence).where(AudiobookSentence.id == sentence_id).values(status=status))
+    await db.commit()
+
+
 async def update_sentence_diarization(
     db: AsyncSession,
     sentence_id: int,
@@ -802,7 +822,10 @@ async def infer_audiobook_resume_status(db: AsyncSession, book_id: int) -> str:
     counts = await count_sentences_by_status(db, book_id)
     if counts.get("pending_diarization", 0) > 0:
         return "diarizing"
-    if counts.get("ready_for_audio", 0) > 0 or counts.get("error", 0) > 0:
+    if any(
+        counts.get(status, 0) > 0
+        for status in ("ready_for_audio", "audio_queued", "audio_generating", "error")
+    ):
         return "audio_gen"
 
     total = sum(counts.values())

--- a/backend/app/crud/audiobook.py
+++ b/backend/app/crud/audiobook.py
@@ -9,7 +9,14 @@ from sqlalchemy import and_, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..config import LIBRARY_PATH
-from ..models import AudiobookSettings, AudiobookChapter, AudiobookCharacter, AudiobookSentence, Book
+from ..models import (
+    AudiobookSettings,
+    AudiobookChapter,
+    AudiobookCharacter,
+    AudiobookSeriesCharacter,
+    AudiobookSentence,
+    Book,
+)
 
 # ---------------------------------------------------------------------------
 # Settings
@@ -284,6 +291,23 @@ async def flag_chapter_for_reassembly(db: AsyncSession, chapter_id: int) -> None
     await db.commit()
 
 
+async def set_chapter_preview_status(
+    db: AsyncSession,
+    chapter_id: int,
+    status: Optional[str],
+    error: Optional[str] = None,
+) -> None:
+    await db.execute(
+        update(AudiobookChapter).where(AudiobookChapter.id == chapter_id).values(preview_status=status, preview_error=error)
+    )
+    await db.commit()
+
+
+async def get_chapters_with_pending_previews(db: AsyncSession) -> list[AudiobookChapter]:
+    result = await db.execute(select(AudiobookChapter).where(AudiobookChapter.preview_status.in_(["queued", "generating"])))
+    return list(result.scalars().all())
+
+
 async def delete_chapters_for_book(db: AsyncSession, book_id: int) -> None:
     chapters = await get_chapters_for_book(db, book_id)
     for ch in chapters:
@@ -329,6 +353,140 @@ async def update_character(db: AsyncSession, char_id: int, data: dict) -> Option
     return char
 
 
+def _canonical_character_name(name: str) -> str:
+    return " ".join(name.casefold().split())
+
+
+async def get_series_characters(db: AsyncSession, series_name: str) -> list[AudiobookSeriesCharacter]:
+    result = await db.execute(
+        select(AudiobookSeriesCharacter)
+        .where(func.lower(AudiobookSeriesCharacter.series_name) == series_name.lower())
+        .order_by(AudiobookSeriesCharacter.is_narrator.desc(), AudiobookSeriesCharacter.name)
+    )
+    return list(result.scalars().all())
+
+
+def _copy_series_profile_to_book_character(
+    profile: AudiobookSeriesCharacter,
+    character: AudiobookCharacter,
+) -> None:
+    character.series_character_id = profile.id
+    character.name = profile.name
+    character.description = profile.description
+    character.voice_design_prompt = profile.voice_design_prompt
+    character.is_narrator = profile.is_narrator
+    character.aliases = profile.aliases or []
+    character.evidence = profile.evidence or []
+
+
+async def sync_book_roster_with_series(
+    db: AsyncSession,
+    book: Book,
+    characters: list[AudiobookCharacter],
+    *,
+    prefer_series: bool = True,
+) -> int:
+    """Link a book roster to durable series profiles without changing sentence IDs."""
+    if not book.series:
+        return 0
+
+    profiles = await get_series_characters(db, book.series)
+    by_name = {profile.canonical_name: profile for profile in profiles}
+    linked = 0
+    for character in characters:
+        canonical = _canonical_character_name(character.name)
+        profile = by_name.get(canonical)
+        if profile is None:
+            profile = AudiobookSeriesCharacter(
+                series_name=book.series,
+                canonical_name=canonical,
+                name=character.name,
+                description=character.description,
+                voice_design_prompt=character.voice_design_prompt,
+                is_narrator=character.is_narrator,
+                aliases=character.aliases or [],
+                evidence=character.evidence or [],
+            )
+            db.add(profile)
+            await db.flush()
+            by_name[canonical] = profile
+        elif prefer_series:
+            _copy_series_profile_to_book_character(profile, character)
+        character.series_character_id = profile.id
+        linked += 1
+
+    await db.commit()
+    return linked
+
+
+async def unlink_book_roster_from_series(db: AsyncSession, book_id: int) -> None:
+    """Detach book-local characters when a book is removed from a series."""
+    await db.execute(update(AudiobookCharacter).where(AudiobookCharacter.book_id == book_id).values(series_character_id=None))
+    await db.commit()
+
+
+async def propagate_character_profile_across_series(
+    db: AsyncSession,
+    character: AudiobookCharacter,
+) -> list[AudiobookCharacter]:
+    """Promote an edited character and update matching profiles in sibling books."""
+    book = await db.get(Book, character.book_id)
+    if book is None or not book.series:
+        return [character]
+
+    linked_profile = (
+        await db.get(AudiobookSeriesCharacter, character.series_character_id) if character.series_character_id else None
+    )
+    canonical = _canonical_character_name(character.name)
+    result = await db.execute(
+        select(AudiobookSeriesCharacter).where(
+            func.lower(AudiobookSeriesCharacter.series_name) == book.series.lower(),
+            AudiobookSeriesCharacter.canonical_name == canonical,
+        )
+    )
+    matching_profile = result.scalar_one_or_none()
+    profile = matching_profile or linked_profile
+    if matching_profile is not None and linked_profile is not None and matching_profile.id != linked_profile.id:
+        await db.execute(
+            update(AudiobookCharacter)
+            .where(AudiobookCharacter.series_character_id == linked_profile.id)
+            .values(series_character_id=matching_profile.id)
+        )
+        await db.delete(linked_profile)
+        await db.flush()
+    if profile is None:
+        profile = AudiobookSeriesCharacter(series_name=book.series, canonical_name=canonical, name=character.name)
+        db.add(profile)
+        await db.flush()
+
+    profile.canonical_name = canonical
+    profile.name = character.name
+    profile.description = character.description
+    profile.voice_design_prompt = character.voice_design_prompt
+    profile.is_narrator = character.is_narrator
+    profile.aliases = character.aliases or []
+    profile.evidence = character.evidence or []
+
+    result = await db.execute(
+        select(AudiobookCharacter)
+        .join(Book, Book.id == AudiobookCharacter.book_id)
+        .where(
+            func.lower(Book.series) == book.series.lower(),
+            or_(
+                AudiobookCharacter.series_character_id == profile.id,
+                func.lower(AudiobookCharacter.name) == character.name.lower(),
+            ),
+        )
+    )
+    matching = list(result.scalars().all())
+    if character not in matching:
+        matching.append(character)
+    for sibling in matching:
+        _copy_series_profile_to_book_character(profile, sibling)
+    await db.commit()
+    return matching
+
+
 async def cascade_voice_change(db: AsyncSession, char_id: int) -> None:
     """Reset audio for all sentences by this character and flag affected chapters."""
     await db.execute(
@@ -339,7 +497,11 @@ async def cascade_voice_change(db: AsyncSession, char_id: int) -> None:
     result = await db.execute(select(AudiobookSentence.chapter_id).where(AudiobookSentence.character_id == char_id).distinct())
     chapter_ids = [row[0] for row in result.all()]
     if chapter_ids:
-        await db.execute(update(AudiobookChapter).where(AudiobookChapter.id.in_(chapter_ids)).values(needs_reassembly=True))
+        await db.execute(
+            update(AudiobookChapter)
+            .where(AudiobookChapter.id.in_(chapter_ids))
+            .values(needs_reassembly=True, preview_status=None, preview_error=None)
+        )
     await db.commit()
 
 
@@ -373,6 +535,8 @@ async def reset_roster_and_diarization_for_book(db: AsyncSession, book_id: int) 
             summary=None,
             summary_updated_at=None,
             needs_reassembly=True,
+            preview_status=None,
+            preview_error=None,
         )
     )
     await db.commit()
@@ -544,7 +708,11 @@ async def update_sentence_speaker(
     sentence.status = "ready_for_audio"
     sentence.audio_file_path = None
     sentence.audio_duration_ms = None
-    await db.execute(update(AudiobookChapter).where(AudiobookChapter.id == sentence.chapter_id).values(needs_reassembly=True))
+    await db.execute(
+        update(AudiobookChapter)
+        .where(AudiobookChapter.id == sentence.chapter_id)
+        .values(needs_reassembly=True, preview_status=None, preview_error=None)
+    )
     await db.commit()
     await db.refresh(sentence)
     return sentence

--- a/backend/app/crud/audiobook.py
+++ b/backend/app/crud/audiobook.py
@@ -18,6 +18,22 @@ from ..models import (
     Book,
 )
 
+
+async def invalidate_packaged_audiobook(db: AsyncSession, book_id: int) -> None:
+    """Remove a stale EPUB package and make a completed book resumable."""
+    packaged_epub = LIBRARY_PATH / "audiobooks" / str(book_id) / "audiobook.epub"
+    packaged_epub.unlink(missing_ok=True)
+    await db.execute(
+        update(Book)
+        .where(Book.id == book_id, Book.audiobook_pipeline_status == "complete")
+        .values(
+            audiobook_pipeline_status="paused",
+            audiobook_pipeline_updated_at=datetime.now(timezone.utc),
+        )
+    )
+    await db.commit()
+
+
 # ---------------------------------------------------------------------------
 # Settings
 # ---------------------------------------------------------------------------
@@ -287,12 +303,16 @@ async def update_chapter_summary(db: AsyncSession, chapter_id: int, summary: Opt
 
 
 async def flag_chapter_for_reassembly(db: AsyncSession, chapter_id: int) -> None:
+    result = await db.execute(select(AudiobookChapter.book_id).where(AudiobookChapter.id == chapter_id))
+    book_id = result.scalar_one_or_none()
     await db.execute(
         update(AudiobookChapter)
         .where(AudiobookChapter.id == chapter_id)
         .values(needs_reassembly=True, preview_status=None, preview_error=None)
     )
     await db.commit()
+    if book_id is not None:
+        await invalidate_packaged_audiobook(db, book_id)
 
 
 async def set_chapter_preview_status(
@@ -500,13 +520,18 @@ async def cascade_voice_change(db: AsyncSession, char_id: int) -> None:
     )
     result = await db.execute(select(AudiobookSentence.chapter_id).where(AudiobookSentence.character_id == char_id).distinct())
     chapter_ids = [row[0] for row in result.all()]
+    book_ids: list[int] = []
     if chapter_ids:
+        result = await db.execute(select(AudiobookChapter.book_id).where(AudiobookChapter.id.in_(chapter_ids)).distinct())
+        book_ids = [row[0] for row in result.all()]
         await db.execute(
             update(AudiobookChapter)
             .where(AudiobookChapter.id.in_(chapter_ids))
             .values(needs_reassembly=True, preview_status=None, preview_error=None)
         )
     await db.commit()
+    for book_id in book_ids:
+        await invalidate_packaged_audiobook(db, book_id)
 
 
 async def delete_characters_for_book(db: AsyncSession, book_id: int) -> None:
@@ -734,6 +759,9 @@ async def update_sentence_speaker(
         .values(needs_reassembly=True, preview_status=None, preview_error=None)
     )
     await db.commit()
+    chapter = await db.get(AudiobookChapter, sentence.chapter_id)
+    if chapter is not None:
+        await invalidate_packaged_audiobook(db, chapter.book_id)
     await db.refresh(sentence)
     return sentence
 

--- a/backend/app/crud/books.py
+++ b/backend/app/crud/books.py
@@ -16,6 +16,7 @@ def _build_books_query(sort_by: str = "title", sort_order: str = "asc"):
         "series": models.Book.series,
         "word_count": models.Book.current_word_count,
         "updated_at": models.Book.updated_at,
+        "audiobook_enabled": models.Book.audiobook_enabled,
     }
     column = sort_columns.get(sort_by, models.Book.title)
     order = asc(column) if sort_order == "asc" else desc(column)

--- a/backend/app/crud/series.py
+++ b/backend/app/crud/series.py
@@ -148,6 +148,8 @@ async def rename_series(db: AsyncSession, old_name: str, new_name: str) -> int:
         else:
             old_metadata.series_name = new_name
 
+    await _merge_audiobook_series_rosters(db, old_name, new_name)
+
     await db.commit()
     return len(books)
 
@@ -170,8 +172,44 @@ async def merge_series(db: AsyncSession, source: str, target: str) -> int:
             )
             await db.delete(source_metadata)
 
+    await _merge_audiobook_series_rosters(db, source, target)
+
     await db.commit()
     return len(books)
+
+
+async def _merge_audiobook_series_rosters(db: AsyncSession, source: str, target: str) -> None:
+    """Move or merge shared character profiles when a library series changes."""
+    source_result = await db.execute(
+        select(models.AudiobookSeriesCharacter).where(
+            func.lower(models.AudiobookSeriesCharacter.series_name) == source.lower()
+        )
+    )
+    target_result = await db.execute(
+        select(models.AudiobookSeriesCharacter).where(
+            func.lower(models.AudiobookSeriesCharacter.series_name) == target.lower()
+        )
+    )
+    source_profiles = list(source_result.scalars().all())
+    target_profiles = {profile.canonical_name: profile for profile in target_result.scalars().all()}
+    for profile in source_profiles:
+        existing = target_profiles.get(profile.canonical_name)
+        if existing is None:
+            profile.series_name = target
+            target_profiles[profile.canonical_name] = profile
+            continue
+        await db.execute(
+            models.AudiobookCharacter.__table__.update()
+            .where(models.AudiobookCharacter.series_character_id == profile.id)
+            .values(series_character_id=existing.id)
+        )
+        existing.aliases = _normalize_tags([*(existing.aliases or []), *(profile.aliases or [])])
+        existing.evidence = [*(existing.evidence or []), *(profile.evidence or [])][:6]
+        if not existing.description:
+            existing.description = profile.description
+        if not existing.voice_design_prompt:
+            existing.voice_design_prompt = profile.voice_design_prompt
+        await db.delete(profile)
 
 
 def validate_genre_tags(tags: list[str]) -> None:
@@ -227,11 +265,11 @@ def compute_effective_series_genre_tags(
 
 
 async def cleanup_orphaned_series_metadata(db: AsyncSession) -> int:
-    """Delete SeriesMetadata records whose series_name has no matching books."""
+    """Delete series metadata and audiobook rosters with no matching books."""
     result = await db.execute(select(models.SeriesMetadata))
     all_metadata = result.scalars().all()
-    if not all_metadata:
-        return 0
+    roster_result = await db.execute(select(models.AudiobookSeriesCharacter))
+    all_roster_profiles = roster_result.scalars().all()
 
     active_result = await db.execute(select(func.lower(models.Book.series)).filter(models.Book.series.isnot(None)).distinct())
     active_series = {row[0] for row in active_result.all()}
@@ -240,6 +278,10 @@ async def cleanup_orphaned_series_metadata(db: AsyncSession) -> int:
     for metadata in all_metadata:
         if metadata.series_name.lower() not in active_series:
             await db.delete(metadata)
+            deleted += 1
+    for profile in all_roster_profiles:
+        if profile.series_name.lower() not in active_series:
+            await db.delete(profile)
             deleted += 1
 
     if deleted:

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,4 +1,17 @@
-from sqlalchemy import Boolean, Column, Integer, String, DateTime, Float, ForeignKey, Enum, JSON, Numeric, Text
+from sqlalchemy import (
+    Boolean,
+    Column,
+    Integer,
+    String,
+    DateTime,
+    Float,
+    ForeignKey,
+    Enum,
+    JSON,
+    Numeric,
+    Text,
+    UniqueConstraint,
+)
 from sqlalchemy.sql import func
 from .database import Base
 import enum
@@ -206,6 +219,27 @@ class AudiobookChapter(Base):
     needs_reassembly = Column(Boolean, nullable=False, server_default="false")
     summary = Column(Text, nullable=True)
     summary_updated_at = Column(DateTime(timezone=True), nullable=True)
+    # Manual chapter previews are independent of the full-book pipeline.
+    # Values: None, queued, generating, ready, error.
+    preview_status = Column(String, nullable=True)
+    preview_error = Column(Text, nullable=True)
+
+
+class AudiobookSeriesCharacter(Base):
+    __tablename__ = "audiobook_series_characters"
+    __table_args__ = (UniqueConstraint("series_name", "canonical_name", name="uq_audiobook_series_character"),)
+
+    id = Column(Integer, primary_key=True, index=True)
+    series_name = Column(String, nullable=False, index=True)
+    canonical_name = Column(String, nullable=False)
+    name = Column(String, nullable=False)
+    description = Column(Text, nullable=True)
+    voice_design_prompt = Column(String, nullable=True)
+    is_narrator = Column(Boolean, nullable=False, server_default="false")
+    aliases = Column(JSON, nullable=True)
+    evidence = Column(JSON, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now(), nullable=True)
 
 
 class AudiobookCharacter(Base):
@@ -213,6 +247,12 @@ class AudiobookCharacter(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     book_id = Column(Integer, ForeignKey("books.id", ondelete="CASCADE"), nullable=False, index=True)
+    series_character_id = Column(
+        Integer,
+        ForeignKey("audiobook_series_characters.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
     name = Column(String, nullable=False)
     description = Column(Text, nullable=True)
     voice_design_prompt = Column(String, nullable=True)

--- a/backend/app/routers/audiobook.py
+++ b/backend/app/routers/audiobook.py
@@ -453,13 +453,34 @@ async def update_sentence(sentence_id: int, body: SentenceUpdate, db: AsyncSessi
         tagged_text=body.tagged_text or "",
     )
 
-    # Re-enqueue for TTS
-    if chapter:
-        queue = get_audiobook_queue()
-        await crud.audiobook.set_book_pipeline_status(db, chapter.book_id, "audio_gen")
-        await queue.enqueue(chapter.book_id)
-
     return SentenceResponse.model_validate(sentence)
+
+
+@router.post("/api/books/{book_id}/audiobook/sentences/{sentence_id}/generate-audio")
+async def generate_sentence_audio(
+    book_id: int,
+    sentence_id: int,
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    book = await _get_audiobook_book_or_404(book_id, db)
+    if book.audiobook_pipeline_status in ("ingesting", "roster_gen", "diarizing", "audio_gen", "assembling"):
+        raise HTTPException(status_code=409, detail="Pause the full-book pipeline before generating sentence audio")
+    sentence = await db.get(AudiobookSentence, sentence_id)
+    if sentence is None:
+        raise HTTPException(status_code=404, detail="Audiobook sentence not found")
+    chapter = await db.get(AudiobookChapter, sentence.chapter_id)
+    if chapter is None or chapter.book_id != book_id:
+        raise HTTPException(status_code=404, detail="Audiobook sentence not found")
+    if sentence.status in ("audio_queued", "audio_generating"):
+        return {"status": sentence.status, "queued": False, "sentence_id": sentence_id}
+    if sentence.status not in ("ready_for_audio", "error"):
+        raise HTTPException(status_code=409, detail=f"Sentence is {sentence.status}, not ready for audio")
+    if sentence.character_id is None:
+        raise HTTPException(status_code=409, detail="Assign a speaker before generating sentence audio")
+
+    await crud.audiobook.set_sentence_status(db, sentence_id, "audio_queued")
+    queued = await get_audiobook_queue().enqueue_sentence_audio(book_id, sentence_id)
+    return {"status": "audio_queued", "queued": queued, "sentence_id": sentence_id}
 
 
 @router.get("/api/audiobook/sentences/{sentence_id}/audio")

--- a/backend/app/routers/audiobook.py
+++ b/backend/app/routers/audiobook.py
@@ -53,6 +53,8 @@ class AudiobookStatusResponse(BaseModel):
 class CharacterResponse(BaseModel):
     id: int
     book_id: int
+    series_character_id: Optional[int] = None
+    shared_series_name: Optional[str] = None
     name: str
     description: Optional[str]
     voice_design_prompt: Optional[str]
@@ -104,8 +106,11 @@ class ChapterResponse(BaseModel):
     needs_reassembly: bool
     summary: Optional[str]
     summary_updated_at: Optional[datetime]
+    preview_status: Optional[str]
+    preview_error: Optional[str]
     sentence_count: int = 0
     processed_sentence_count: int = 0
+    audio_generated_count: int = 0
     low_confidence_count: int = 0
 
     model_config = {"from_attributes": True}
@@ -327,13 +332,15 @@ async def get_pipeline_status(book_id: int, db: AsyncSession = Depends(get_db)) 
 
 @router.get("/api/books/{book_id}/audiobook/characters", response_model=list[CharacterResponse])
 async def list_characters(book_id: int, db: AsyncSession = Depends(get_db)) -> list[CharacterResponse]:
-    await _get_audiobook_book_or_404(book_id, db)
+    book = await _get_audiobook_book_or_404(book_id, db)
     chars = await crud.audiobook.get_characters_for_book(db, book_id)
     stats = await crud.audiobook.get_character_sentence_stats(db, book_id)
     return [
         CharacterResponse(
             id=character.id,
             book_id=character.book_id,
+            series_character_id=character.series_character_id,
+            shared_series_name=book.series if character.series_character_id else None,
             name=character.name,
             description=character.description,
             voice_design_prompt=character.voice_design_prompt,
@@ -358,15 +365,41 @@ async def update_character(char_id: int, body: CharacterUpdate, db: AsyncSession
     await _get_audiobook_book_or_404(existing.book_id, db)
 
     char = await crud.audiobook.update_character(db, char_id, data)
+    linked_characters = await crud.audiobook.propagate_character_profile_across_series(db, char)
 
     if voice_changed:
-        await crud.audiobook.cascade_voice_change(db, char_id)
-        # Re-enqueue for TTS phase
-        queue = get_audiobook_queue()
-        await crud.audiobook.set_book_pipeline_status(db, char.book_id, "audio_gen")
-        await queue.enqueue(char.book_id)
+        for linked_character in linked_characters:
+            await crud.audiobook.cascade_voice_change(db, linked_character.id)
 
     return CharacterResponse.model_validate(char)
+
+
+@router.post("/api/books/{book_id}/audiobook/roster/share-series")
+async def share_character_roster_with_series(
+    book_id: int,
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    book = await _get_audiobook_book_or_404(book_id, db)
+    if not book.series:
+        raise HTTPException(status_code=409, detail="Assign this book to a series before sharing its roster")
+    characters = await crud.audiobook.get_characters_for_book(db, book_id)
+    if not characters:
+        raise HTTPException(status_code=409, detail="Generate a character roster before sharing it")
+    linked = await crud.audiobook.sync_book_roster_with_series(
+        db,
+        book,
+        characters,
+        prefer_series=True,
+    )
+    affected_book_ids: set[int] = {book_id}
+    for character in characters:
+        siblings = await crud.audiobook.propagate_character_profile_across_series(db, character)
+        affected_book_ids.update(sibling.book_id for sibling in siblings)
+    return {
+        "series": book.series,
+        "profiles": linked,
+        "books_updated": len(affected_book_ids),
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -378,7 +411,7 @@ async def update_character(char_id: int, body: CharacterUpdate, db: AsyncSession
 async def list_sentences(
     book_id: int,
     page: int = Query(1, ge=1),
-    limit: int = Query(50, ge=1, le=200),
+    limit: int = Query(50, ge=1, le=1000),
     chapter_id: Optional[int] = Query(None),
     review_only: bool = Query(False),
     db: AsyncSession = Depends(get_db),
@@ -467,8 +500,11 @@ async def list_chapters(book_id: int, db: AsyncSession = Depends(get_db)) -> lis
                 needs_reassembly=chapter.needs_reassembly,
                 summary=chapter.summary,
                 summary_updated_at=chapter.summary_updated_at,
+                preview_status=chapter.preview_status,
+                preview_error=chapter.preview_error,
                 sentence_count=len(sentences),
                 processed_sentence_count=len(processed),
+                audio_generated_count=sum(1 for sentence in sentences if sentence.status == "audio_generated"),
                 low_confidence_count=sum(
                     1
                     for sentence in sentences
@@ -477,6 +513,36 @@ async def list_chapters(book_id: int, db: AsyncSession = Depends(get_db)) -> lis
             )
         )
     return response
+
+
+@router.post("/api/books/{book_id}/audiobook/chapters/{chapter_id}/preview-audio")
+async def generate_chapter_preview(
+    book_id: int,
+    chapter_id: int,
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    book = await _get_audiobook_book_or_404(book_id, db)
+    if book.audiobook_pipeline_status in ("ingesting", "roster_gen", "diarizing", "audio_gen", "assembling"):
+        raise HTTPException(status_code=409, detail="Pause the full-book pipeline before generating a preview")
+    chapter = await db.get(AudiobookChapter, chapter_id)
+    if chapter is None or chapter.book_id != book_id:
+        raise HTTPException(status_code=404, detail="Audiobook chapter not found")
+    sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter_id)
+    pending = sum(1 for sentence in sentences if sentence.status == "pending_diarization")
+    if not sentences or pending:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Finish speaker analysis for this chapter first ({pending} sentences remain)"
+                if pending
+                else "Chapter has no narratable sentences"
+            ),
+        )
+    if chapter.preview_status in ("queued", "generating"):
+        return {"status": chapter.preview_status, "queued": False}
+    await crud.audiobook.set_chapter_preview_status(db, chapter_id, "queued")
+    queued = await get_audiobook_queue().enqueue_preview(book_id, chapter_id)
+    return {"status": "queued", "queued": queued, "chapter_id": chapter_id}
 
 
 @router.get("/api/books/{book_id}/audiobook/chapters/{chapter_id}/audio")

--- a/backend/app/routers/books.py
+++ b/backend/app/routers/books.py
@@ -240,6 +240,16 @@ async def update_book_details(
     ):
         await queue_metadata_sync_job(db, trigger="book_update", book_ids=[updated_book.id])
     if updated_book.series != previous_series:
+        characters = await crud.audiobook.get_characters_for_book(db, updated_book.id)
+        if updated_book.series and characters:
+            await crud.audiobook.sync_book_roster_with_series(
+                db,
+                updated_book,
+                characters,
+                prefer_series=True,
+            )
+        elif not updated_book.series:
+            await crud.audiobook.unlink_book_roster_from_series(db, updated_book.id)
         await crud.cleanup_orphaned_series_metadata(db)
     return updated_book
 

--- a/backend/app/services/audiobook_assembly.py
+++ b/backend/app/services/audiobook_assembly.py
@@ -155,6 +155,7 @@ async def assemble_chapter_preview(book_id: int, chapter_id: int, db: AsyncSessi
         raise RuntimeError("Every sentence in the chapter needs audio before preview assembly.")
     output_dir = LIBRARY_PATH.parent / "library" / "audiobooks" / str(book_id)
     output_dir.mkdir(parents=True, exist_ok=True)
+    await crud.audiobook.invalidate_packaged_audiobook(db, book_id)
     await _assemble_chapter(book_id, chapter, sentences, output_dir, db)
 
 

--- a/backend/app/services/audiobook_assembly.py
+++ b/backend/app/services/audiobook_assembly.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import crud
 from ..config import LIBRARY_PATH
+from ..models import AudiobookChapter
 
 logger = logging.getLogger(__name__)
 
@@ -142,6 +143,19 @@ async def _assemble_chapter(book_id: int, chapter, sentences: list, output_dir: 
         audio_file_path=_relative_path(audio_path),
         smil_file_path=_relative_path(smil_path),
     )
+
+
+async def assemble_chapter_preview(book_id: int, chapter_id: int, db: AsyncSession) -> None:
+    """Assemble one chapter without requiring the rest of the book to be ready."""
+    chapter = await db.get(AudiobookChapter, chapter_id)
+    if chapter is None or chapter.book_id != book_id:
+        raise RuntimeError("Audiobook chapter not found.")
+    sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter_id)
+    if not sentences or any(sentence.status != "audio_generated" for sentence in sentences):
+        raise RuntimeError("Every sentence in the chapter needs audio before preview assembly.")
+    output_dir = LIBRARY_PATH.parent / "library" / "audiobooks" / str(book_id)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    await _assemble_chapter(book_id, chapter, sentences, output_dir, db)
 
 
 async def assemble_book(book_id: int, db: AsyncSession) -> None:

--- a/backend/app/services/audiobook_llm.py
+++ b/backend/app/services/audiobook_llm.py
@@ -12,7 +12,7 @@ import httpx
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import crud
-from ..models import AudiobookSettings
+from ..models import AudiobookSettings, Book
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +42,9 @@ Return JSON with keys book_summary and characters. No markdown or explanation.
 
 Candidate name frequency hints from the complete book (not ground truth; ignore non-people):
 {candidate_hints}
+
+Existing shared roster for this series (reuse these canonical identities and voice profiles when they appear):
+{series_roster}
 
 Names with explicit dialogue-tag hits (for example, "Harry said") are confirmed speaking candidates. Include the
 highest-hit confirmed speakers unless the evidence clearly shows they are not a person. Do not substitute low-count
@@ -456,14 +459,54 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
     settings = await crud.audiobook.get_audiobook_settings(db)
     provider = (settings.llm_provider or STUB_PROVIDER).lower() if settings else STUB_PROVIDER
 
+    book = await db.get(Book, book_id)
+    if book is None:
+        raise RuntimeError(f"Book {book_id} was deleted during roster generation.")
+
     chapters = await crud.audiobook.get_chapters_for_book(db, book_id)
     if not chapters:
         raise RuntimeError(f"No narratable chapters found for book {book_id} during roster generation.")
 
-    combined_text = await _build_roster_excerpt(chapters, db)
-    candidate_hints, confirmed_speakers = await _build_character_candidate_analysis(chapters, db)
+    context_chapters = list(chapters)
+    series_profiles = []
+    series_book_count = 1
+    if book.series:
+        series_profiles = await crud.audiobook.get_series_characters(db, book.series)
+        sibling_books = await crud.get_books_by_series(db, book.series, skip=0, limit=1000)
+        series_book_count = len(sibling_books)
+        for sibling in sibling_books:
+            if sibling.id == book_id:
+                continue
+            context_chapters.extend(await crud.audiobook.get_chapters_for_book(db, sibling.id))
+
+    combined_text = await _build_roster_excerpt(context_chapters, db)
+    candidate_hints, confirmed_speakers = await _build_character_candidate_analysis(context_chapters, db)
+    series_roster = (
+        json.dumps(
+            [
+                {
+                    "name": profile.name,
+                    "aliases": profile.aliases or [],
+                    "description": profile.description,
+                    "voice_design_prompt": profile.voice_design_prompt,
+                }
+                for profile in series_profiles
+            ],
+            ensure_ascii=False,
+        )
+        if series_profiles
+        else "(none yet)"
+    )
     await crud.audiobook.update_book_pipeline_progress(
-        db, book_id, current=0, total=1, detail="Analyzing story excerpts for recurring characters"
+        db,
+        book_id,
+        current=0,
+        total=1,
+        detail=(
+            f"Analyzing recurring characters across {series_book_count} series books"
+            if book.series and series_book_count > 1
+            else "Analyzing story excerpts for recurring characters"
+        ),
     )
 
     if provider == STUB_PROVIDER:
@@ -482,7 +525,11 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
         }
     else:
         prompt_template = settings.roster_prompt_template or DEFAULT_ROSTER_PROMPT
-        prompt = prompt_template.format(text=combined_text, candidate_hints=candidate_hints)
+        prompt = prompt_template.format(
+            text=combined_text,
+            candidate_hints=candidate_hints,
+            series_roster=series_roster,
+        )
         logger.info("Calling LLM for character roster (book %s).", book_id)
         await crud.audiobook.update_book_pipeline_progress(
             db,
@@ -642,8 +689,36 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
             ]
         )
 
+    shared_by_name = {profile.canonical_name: profile for profile in series_profiles}
+    for character in normalised:
+        profile = shared_by_name.get(" ".join(character["name"].casefold().split()))
+        if profile is None:
+            continue
+        character.update(
+            {
+                "series_character_id": profile.id,
+                "name": profile.name,
+                "description": profile.description,
+                "voice_design_prompt": profile.voice_design_prompt,
+                "is_narrator": profile.is_narrator,
+                "aliases": profile.aliases or [],
+                "evidence": profile.evidence or [],
+            }
+        )
+
     await crud.audiobook.delete_characters_for_book(db, book_id)
-    await crud.audiobook.create_characters_bulk(db, book_id=book_id, characters_data=normalised[:15])
+    created_characters = await crud.audiobook.create_characters_bulk(
+        db,
+        book_id=book_id,
+        characters_data=normalised[:15],
+    )
+    if book.series:
+        await crud.audiobook.sync_book_roster_with_series(
+            db,
+            book,
+            created_characters,
+            prefer_series=True,
+        )
     await crud.audiobook.set_book_audiobook_summary(db, book_id, roster_result.get("book_summary"))
     await crud.audiobook.update_book_pipeline_progress(
         db, book_id, current=1, total=1, detail=f"Created {len(normalised[:15])} character profiles"

--- a/backend/app/services/audiobook_queue.py
+++ b/backend/app/services/audiobook_queue.py
@@ -11,7 +11,8 @@ from ..database import SessionLocal
 from .audiobook_ingestion import ingest_epub
 from .audiobook_llm import generate_character_roster, diarize_sentences
 from .audiobook_tts import generate_audio_for_book
-from .audiobook_assembly import assemble_book
+from .audiobook_tts import generate_audio_for_chapter_preview
+from .audiobook_assembly import assemble_book, assemble_chapter_preview
 
 logger = logging.getLogger(__name__)
 
@@ -29,12 +30,13 @@ class AudiobookQueue:
     """App-scoped queue that processes one audiobook pipeline job at a time."""
 
     def __init__(self) -> None:
-        self._queue: asyncio.Queue[Optional[int]] = asyncio.Queue()
+        self._queue: asyncio.Queue[Optional[int | tuple[int, int]]] = asyncio.Queue()
         self._queued_book_ids: set[int] = set()
         # A pipeline mutation may arrive while a book is already running. Keep
         # one follow-up job so the mutation is not lost when the current worker
         # finishes.
         self._rerun_book_ids: set[int] = set()
+        self._queued_preview_ids: set[int] = set()
         self._worker_task: Optional[asyncio.Task[None]] = None
 
     async def start(self) -> None:
@@ -50,6 +52,7 @@ class AudiobookQueue:
         self._worker_task = None
         self._queued_book_ids.clear()
         self._rerun_book_ids.clear()
+        self._queued_preview_ids.clear()
 
     async def enqueue(self, book_id: int) -> bool:
         if book_id in self._queued_book_ids:
@@ -63,12 +66,26 @@ class AudiobookQueue:
         """Return whether a book is queued or currently being processed."""
         return book_id in self._queued_book_ids
 
+    async def enqueue_preview(self, book_id: int, chapter_id: int) -> bool:
+        if chapter_id in self._queued_preview_ids:
+            return False
+        self._queued_preview_ids.add(chapter_id)
+        await self._queue.put((book_id, chapter_id))
+        return True
+
     async def requeue_in_progress(self) -> int:
         async with SessionLocal() as db:
             books = await crud.audiobook.get_in_progress_audiobook_books(db)
         queued = 0
         for book in books:
             if await self.enqueue(book.id):
+                queued += 1
+        async with SessionLocal() as db:
+            preview_chapters = await crud.audiobook.get_chapters_with_pending_previews(db)
+            for chapter in preview_chapters:
+                await crud.audiobook.set_chapter_preview_status(db, chapter.id, "queued")
+        for chapter in preview_chapters:
+            if await self.enqueue_preview(chapter.book_id, chapter.id):
                 queued += 1
         return queued
 
@@ -78,6 +95,17 @@ class AudiobookQueue:
             try:
                 if item is None:
                     return
+                if isinstance(item, tuple):
+                    book_id, chapter_id = item
+                    try:
+                        await self._process_preview(book_id, chapter_id)
+                    except Exception as exc:
+                        logger.exception("Chapter preview failed for chapter %s.", chapter_id)
+                        async with SessionLocal() as db:
+                            await crud.audiobook.set_chapter_preview_status(db, chapter_id, "error", str(exc))
+                    finally:
+                        self._queued_preview_ids.discard(chapter_id)
+                    continue
                 book_id = item
                 try:
                     await self._process(book_id)
@@ -92,6 +120,13 @@ class AudiobookQueue:
                         await self.enqueue(book_id)
             finally:
                 self._queue.task_done()
+
+    async def _process_preview(self, book_id: int, chapter_id: int) -> None:
+        async with SessionLocal() as db:
+            await crud.audiobook.set_chapter_preview_status(db, chapter_id, "generating")
+            await generate_audio_for_chapter_preview(book_id, chapter_id, db)
+            await assemble_chapter_preview(book_id, chapter_id, db)
+            await crud.audiobook.set_chapter_preview_status(db, chapter_id, "ready")
 
     async def _process(self, book_id: int) -> None:
         """Run the pipeline from the book's current status to completion."""

--- a/backend/app/services/audiobook_queue.py
+++ b/backend/app/services/audiobook_queue.py
@@ -10,7 +10,7 @@ from .. import crud
 from ..database import SessionLocal
 from .audiobook_ingestion import ingest_epub
 from .audiobook_llm import generate_character_roster, diarize_sentences
-from .audiobook_tts import generate_audio_for_book
+from .audiobook_tts import generate_audio_for_book, generate_audio_for_sentence
 from .audiobook_tts import generate_audio_for_chapter_preview
 from .audiobook_assembly import assemble_book, assemble_chapter_preview
 
@@ -30,13 +30,14 @@ class AudiobookQueue:
     """App-scoped queue that processes one audiobook pipeline job at a time."""
 
     def __init__(self) -> None:
-        self._queue: asyncio.Queue[Optional[int | tuple[int, int]]] = asyncio.Queue()
+        self._queue: asyncio.Queue[Optional[int | tuple[str, int, int]]] = asyncio.Queue()
         self._queued_book_ids: set[int] = set()
         # A pipeline mutation may arrive while a book is already running. Keep
         # one follow-up job so the mutation is not lost when the current worker
         # finishes.
         self._rerun_book_ids: set[int] = set()
         self._queued_preview_ids: set[int] = set()
+        self._queued_sentence_ids: set[int] = set()
         self._worker_task: Optional[asyncio.Task[None]] = None
 
     async def start(self) -> None:
@@ -53,6 +54,7 @@ class AudiobookQueue:
         self._queued_book_ids.clear()
         self._rerun_book_ids.clear()
         self._queued_preview_ids.clear()
+        self._queued_sentence_ids.clear()
 
     async def enqueue(self, book_id: int) -> bool:
         if book_id in self._queued_book_ids:
@@ -70,7 +72,14 @@ class AudiobookQueue:
         if chapter_id in self._queued_preview_ids:
             return False
         self._queued_preview_ids.add(chapter_id)
-        await self._queue.put((book_id, chapter_id))
+        await self._queue.put(("preview", book_id, chapter_id))
+        return True
+
+    async def enqueue_sentence_audio(self, book_id: int, sentence_id: int) -> bool:
+        if sentence_id in self._queued_sentence_ids:
+            return False
+        self._queued_sentence_ids.add(sentence_id)
+        await self._queue.put(("sentence", book_id, sentence_id))
         return True
 
     async def requeue_in_progress(self) -> int:
@@ -87,6 +96,13 @@ class AudiobookQueue:
         for chapter in preview_chapters:
             if await self.enqueue_preview(chapter.book_id, chapter.id):
                 queued += 1
+        async with SessionLocal() as db:
+            sentence_jobs = await crud.audiobook.get_pending_sentence_audio_jobs(db)
+            for _book_id, sentence_id in sentence_jobs:
+                await crud.audiobook.set_sentence_status(db, sentence_id, "audio_queued")
+        for book_id, sentence_id in sentence_jobs:
+            if await self.enqueue_sentence_audio(book_id, sentence_id):
+                queued += 1
         return queued
 
     async def _run(self) -> None:
@@ -96,15 +112,25 @@ class AudiobookQueue:
                 if item is None:
                     return
                 if isinstance(item, tuple):
-                    book_id, chapter_id = item
-                    try:
-                        await self._process_preview(book_id, chapter_id)
-                    except Exception as exc:
-                        logger.exception("Chapter preview failed for chapter %s.", chapter_id)
-                        async with SessionLocal() as db:
-                            await crud.audiobook.set_chapter_preview_status(db, chapter_id, "error", str(exc))
-                    finally:
-                        self._queued_preview_ids.discard(chapter_id)
+                    job_type, book_id, record_id = item
+                    if job_type == "preview":
+                        try:
+                            await self._process_preview(book_id, record_id)
+                        except Exception as exc:
+                            logger.exception("Chapter preview failed for chapter %s.", record_id)
+                            async with SessionLocal() as db:
+                                await crud.audiobook.set_chapter_preview_status(db, record_id, "error", str(exc))
+                        finally:
+                            self._queued_preview_ids.discard(record_id)
+                    elif job_type == "sentence":
+                        try:
+                            await self._process_sentence_audio(book_id, record_id)
+                        except Exception:
+                            logger.exception("Sentence audio failed for sentence %s.", record_id)
+                            async with SessionLocal() as db:
+                                await crud.audiobook.mark_sentence_error(db, record_id)
+                        finally:
+                            self._queued_sentence_ids.discard(record_id)
                     continue
                 book_id = item
                 try:
@@ -127,6 +153,11 @@ class AudiobookQueue:
             await generate_audio_for_chapter_preview(book_id, chapter_id, db)
             await assemble_chapter_preview(book_id, chapter_id, db)
             await crud.audiobook.set_chapter_preview_status(db, chapter_id, "ready")
+
+    async def _process_sentence_audio(self, book_id: int, sentence_id: int) -> None:
+        async with SessionLocal() as db:
+            await crud.audiobook.set_sentence_status(db, sentence_id, "audio_generating")
+            await generate_audio_for_sentence(book_id, sentence_id, db)
 
     async def _process(self, book_id: int) -> None:
         """Run the pipeline from the book's current status to completion."""

--- a/backend/app/services/audiobook_tts.py
+++ b/backend/app/services/audiobook_tts.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import crud
 from ..config import LIBRARY_PATH
-from ..models import AudiobookChapter, AudiobookCharacter
+from ..models import AudiobookChapter, AudiobookCharacter, AudiobookSentence
 
 logger = logging.getLogger(__name__)
 
@@ -80,14 +80,68 @@ async def _call_omnivoice(endpoint: str, voice_prompt: str, tagged_text: str) ->
     return resp.content
 
 
-async def generate_audio_for_book(book_id: int, db: AsyncSession) -> None:
-    """Phase 4: iterate ready_for_audio sentences and call OmniVoice for each."""
+async def _get_tts_endpoint(db: AsyncSession) -> str:
     settings = await crud.audiobook.get_audiobook_settings(db)
     endpoint = settings.omnivoice_endpoint if settings else None
     if not endpoint and (settings is None or (settings.llm_provider or "stub").lower() == "stub"):
         endpoint = "stub://local"
     if not endpoint:
         raise RuntimeError("OmniVoice endpoint not configured. Set it in Audio Settings.")
+    return endpoint
+
+
+async def _generate_sentence_clip(
+    endpoint: str,
+    book_id: int,
+    sentence: AudiobookSentence,
+    db: AsyncSession,
+) -> None:
+    voice_prompt = DEFAULT_VOICE_PROMPT
+    if sentence.character_id is not None:
+        char = await db.get(AudiobookCharacter, sentence.character_id)
+        if char and char.voice_design_prompt:
+            voice_prompt = char.voice_design_prompt
+
+    audio_bytes = await _call_omnivoice(
+        endpoint,
+        voice_prompt,
+        sentence.tagged_text or sentence.original_text,
+    )
+    out_path = _snippet_path(book_id, sentence.id)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_bytes(audio_bytes)
+    duration_ms = _get_mp3_duration_ms(out_path)
+    await crud.audiobook.update_sentence_audio(
+        db,
+        sentence.id,
+        _relative_path(out_path),
+        duration_ms,
+    )
+
+
+async def generate_audio_for_sentence(
+    book_id: int,
+    sentence_id: int,
+    db: AsyncSession,
+) -> None:
+    """Generate one manually requested sentence without advancing the book pipeline."""
+    sentence = await db.get(AudiobookSentence, sentence_id)
+    if sentence is None:
+        raise RuntimeError("Audiobook sentence not found.")
+    chapter = await db.get(AudiobookChapter, sentence.chapter_id)
+    if chapter is None or chapter.book_id != book_id:
+        raise RuntimeError("Audiobook sentence does not belong to this book.")
+    if sentence.character_id is None:
+        raise RuntimeError("Assign a speaker before generating sentence audio.")
+
+    endpoint = await _get_tts_endpoint(db)
+    await _generate_sentence_clip(endpoint, book_id, sentence, db)
+    await crud.audiobook.flag_chapter_for_reassembly(db, chapter.id)
+
+
+async def generate_audio_for_book(book_id: int, db: AsyncSession) -> None:
+    """Phase 4: iterate ready_for_audio sentences and call OmniVoice for each."""
+    endpoint = await _get_tts_endpoint(db)
 
     # Ensure snippets directory exists
     snippets_dir = LIBRARY_PATH.parent / "library" / "audiobooks" / str(book_id) / "snippets"
@@ -114,22 +168,9 @@ async def generate_audio_for_book(book_id: int, db: AsyncSession) -> None:
                 logger.info("Book %s paused during TTS generation.", book_id)
                 return
 
-            # Resolve voice prompt from the assigned character
-            voice_prompt = DEFAULT_VOICE_PROMPT
-            if sentence.character_id is not None:
-                char = await db.get(AudiobookCharacter, sentence.character_id)
-                if char and char.voice_design_prompt:
-                    voice_prompt = char.voice_design_prompt
-
-            text_to_speak = sentence.tagged_text or sentence.original_text
-
             logger.debug("Generating audio for sentence %s (book %s).", sentence.id, book_id)
             try:
-                audio_bytes = await _call_omnivoice(endpoint, voice_prompt, text_to_speak)
-                out_path = _snippet_path(book_id, sentence.id)
-                out_path.write_bytes(audio_bytes)
-
-                duration_ms = _get_mp3_duration_ms(out_path)
+                await _generate_sentence_clip(endpoint, book_id, sentence, db)
             except httpx.HTTPStatusError as exc:
                 response_text = exc.response.text[:200] if exc.response is not None else ""
                 logger.error(
@@ -151,7 +192,6 @@ async def generate_audio_for_book(book_id: int, db: AsyncSession) -> None:
                 failed += 1
                 continue
 
-            await crud.audiobook.update_sentence_audio(db, sentence.id, _relative_path(out_path), duration_ms)
             processed += 1
             await crud.audiobook.update_book_pipeline_progress(
                 db,
@@ -202,12 +242,7 @@ async def generate_audio_for_chapter_preview(
     if any(sentence.character_id is None for sentence in sentences):
         raise RuntimeError("Assign a speaker to every chapter sentence before generating a preview.")
 
-    settings = await crud.audiobook.get_audiobook_settings(db)
-    endpoint = settings.omnivoice_endpoint if settings else None
-    if not endpoint and (settings is None or (settings.llm_provider or "stub").lower() == "stub"):
-        endpoint = "stub://local"
-    if not endpoint:
-        raise RuntimeError("OmniVoice endpoint not configured. Set it in Audio Settings.")
+    endpoint = await _get_tts_endpoint(db)
 
     snippets_dir = LIBRARY_PATH.parent / "library" / "audiobooks" / str(book_id) / "snippets"
     snippets_dir.mkdir(parents=True, exist_ok=True)
@@ -225,25 +260,11 @@ async def generate_audio_for_chapter_preview(
             completed += 1
             continue
 
-        voice_prompt = DEFAULT_VOICE_PROMPT
-        char = await db.get(AudiobookCharacter, sentence.character_id)
-        if char and char.voice_design_prompt:
-            voice_prompt = char.voice_design_prompt
-        text_to_speak = sentence.tagged_text or sentence.original_text
         try:
-            audio_bytes = await _call_omnivoice(endpoint, voice_prompt, text_to_speak)
-            out_path = _snippet_path(book_id, sentence.id)
-            out_path.write_bytes(audio_bytes)
-            duration_ms = _get_mp3_duration_ms(out_path)
+            await _generate_sentence_clip(endpoint, book_id, sentence, db)
         except Exception:
             await crud.audiobook.mark_sentence_error(db, sentence.id)
             raise
-        await crud.audiobook.update_sentence_audio(
-            db,
-            sentence.id,
-            _relative_path(out_path),
-            duration_ms,
-        )
         completed += 1
         await crud.audiobook.update_book_pipeline_progress(
             db,

--- a/backend/app/services/audiobook_tts.py
+++ b/backend/app/services/audiobook_tts.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import crud
 from ..config import LIBRARY_PATH
-from ..models import AudiobookCharacter
+from ..models import AudiobookChapter, AudiobookCharacter
 
 logger = logging.getLogger(__name__)
 
@@ -182,3 +182,73 @@ async def generate_audio_for_book(book_id: int, db: AsyncSession) -> None:
 
     logger.info("TTS complete for book %s: %d sentences generated.", book_id, processed)
     await crud.audiobook.set_book_pipeline_status(db, book_id, "assembling")
+
+
+async def generate_audio_for_chapter_preview(
+    book_id: int,
+    chapter_id: int,
+    db: AsyncSession,
+) -> None:
+    """Generate/reuse sentence clips for one fully diarized chapter only."""
+    chapter = await db.get(AudiobookChapter, chapter_id)
+    if chapter is None or chapter.book_id != book_id:
+        raise RuntimeError("Audiobook chapter not found.")
+    sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter_id)
+    if not sentences:
+        raise RuntimeError("Chapter has no narratable sentences.")
+    pending = [sentence for sentence in sentences if sentence.status == "pending_diarization"]
+    if pending:
+        raise RuntimeError(f"Finish speaker analysis for this chapter first ({len(pending)} sentences remain).")
+    if any(sentence.character_id is None for sentence in sentences):
+        raise RuntimeError("Assign a speaker to every chapter sentence before generating a preview.")
+
+    settings = await crud.audiobook.get_audiobook_settings(db)
+    endpoint = settings.omnivoice_endpoint if settings else None
+    if not endpoint and (settings is None or (settings.llm_provider or "stub").lower() == "stub"):
+        endpoint = "stub://local"
+    if not endpoint:
+        raise RuntimeError("OmniVoice endpoint not configured. Set it in Audio Settings.")
+
+    snippets_dir = LIBRARY_PATH.parent / "library" / "audiobooks" / str(book_id) / "snippets"
+    snippets_dir.mkdir(parents=True, exist_ok=True)
+    completed = 0
+    await crud.audiobook.update_book_pipeline_progress(
+        db,
+        book_id,
+        current=0,
+        total=len(sentences),
+        detail=f"Generating manual preview for chapter {chapter.chapter_number}",
+    )
+    for sentence in sentences:
+        existing_path = LIBRARY_PATH.parent / sentence.audio_file_path if sentence.audio_file_path else None
+        if sentence.status == "audio_generated" and existing_path and existing_path.exists():
+            completed += 1
+            continue
+
+        voice_prompt = DEFAULT_VOICE_PROMPT
+        char = await db.get(AudiobookCharacter, sentence.character_id)
+        if char and char.voice_design_prompt:
+            voice_prompt = char.voice_design_prompt
+        text_to_speak = sentence.tagged_text or sentence.original_text
+        try:
+            audio_bytes = await _call_omnivoice(endpoint, voice_prompt, text_to_speak)
+            out_path = _snippet_path(book_id, sentence.id)
+            out_path.write_bytes(audio_bytes)
+            duration_ms = _get_mp3_duration_ms(out_path)
+        except Exception:
+            await crud.audiobook.mark_sentence_error(db, sentence.id)
+            raise
+        await crud.audiobook.update_sentence_audio(
+            db,
+            sentence.id,
+            _relative_path(out_path),
+            duration_ms,
+        )
+        completed += 1
+        await crud.audiobook.update_book_pipeline_progress(
+            db,
+            book_id,
+            current=completed,
+            total=len(sentences),
+            detail=(f"Chapter {chapter.chapter_number} preview: " f"generated {completed} of {len(sentences)} sentences"),
+        )

--- a/backend/tests/test_audiobook_pipeline.py
+++ b/backend/tests/test_audiobook_pipeline.py
@@ -76,6 +76,7 @@ class _FakeQueue:
         self.enqueued: list[int] = []
         self.active_book_ids = active_book_ids or set()
         self.preview_enqueued: list[tuple[int, int]] = []
+        self.sentence_enqueued: list[tuple[int, int]] = []
 
     async def enqueue(self, book_id: int) -> bool:
         self.enqueued.append(book_id)
@@ -86,6 +87,10 @@ class _FakeQueue:
 
     async def enqueue_preview(self, book_id: int, chapter_id: int) -> bool:
         self.preview_enqueued.append((book_id, chapter_id))
+        return True
+
+    async def enqueue_sentence_audio(self, book_id: int, sentence_id: int) -> bool:
+        self.sentence_enqueued.append((book_id, sentence_id))
         return True
 
 
@@ -853,6 +858,42 @@ async def test_manual_chapter_preview_requires_analysis_and_queues_work(db, monk
     with pytest.raises(audiobook_router.HTTPException) as exc_info:
         await audiobook_router.generate_chapter_preview(book.id, chapter.id, db)
     assert exc_info.value.status_code == 409
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg is required for MP3 generation")
+async def test_manual_sentence_audio_queues_and_generates_only_that_sentence(db, tmp_path, monkeypatch):
+    library_path = tmp_path / "library"
+    library_path.mkdir()
+    book = await _make_book(db, audiobook_enabled=True, audiobook_pipeline_status="paused")
+    chapter, _character, sentence = await _seed_audio_chapter(db, book.id)
+    chapter.preview_status = "ready"
+    chapter.audio_file_path = "library/audiobooks/old-preview.mp3"
+    await db.commit()
+    queue = _FakeQueue()
+    monkeypatch.setattr(audiobook_router, "get_audiobook_queue", lambda: queue)
+    monkeypatch.setattr(audiobook_tts, "LIBRARY_PATH", library_path)
+
+    response = await audiobook_router.generate_sentence_audio(book.id, sentence.id, db)
+    await db.refresh(sentence)
+
+    assert response == {
+        "status": "audio_queued",
+        "queued": True,
+        "sentence_id": sentence.id,
+    }
+    assert sentence.status == "audio_queued"
+    assert queue.sentence_enqueued == [(book.id, sentence.id)]
+
+    await audiobook_tts.generate_audio_for_sentence(book.id, sentence.id, db)
+    await db.refresh(sentence)
+    await db.refresh(chapter)
+
+    assert sentence.status == "audio_generated"
+    assert sentence.audio_file_path
+    assert (library_path.parent / sentence.audio_file_path).exists()
+    assert chapter.needs_reassembly is True
+    assert chapter.preview_status is None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_audiobook_pipeline.py
+++ b/backend/tests/test_audiobook_pipeline.py
@@ -901,18 +901,25 @@ async def test_manual_sentence_audio_queues_and_generates_only_that_sentence(db,
 async def test_manual_chapter_preview_generates_playable_audio(db, tmp_path, monkeypatch):
     library_path = tmp_path / "library"
     library_path.mkdir()
-    book = await _make_book(db, audiobook_enabled=True, audiobook_pipeline_status="paused")
+    book = await _make_book(db, audiobook_enabled=True, audiobook_pipeline_status="complete")
     chapter, _character, _sentence = await _seed_audio_chapter(db, book.id)
     monkeypatch.setattr(audiobook_tts, "LIBRARY_PATH", library_path)
     monkeypatch.setattr(audiobook_assembly, "LIBRARY_PATH", library_path)
+    monkeypatch.setattr(crud.audiobook, "LIBRARY_PATH", library_path)
+    packaged_epub = library_path / "audiobooks" / str(book.id) / "audiobook.epub"
+    packaged_epub.parent.mkdir(parents=True)
+    packaged_epub.write_bytes(b"stale package")
 
     await audiobook_tts.generate_audio_for_chapter_preview(book.id, chapter.id, db)
     await audiobook_assembly.assemble_chapter_preview(book.id, chapter.id, db)
     await db.refresh(chapter)
+    await db.refresh(book)
 
     assert chapter.audio_file_path
     assert (library_path.parent / chapter.audio_file_path).exists()
     assert chapter.smil_file_path
+    assert packaged_epub.exists() is False
+    assert book.audiobook_pipeline_status == "paused"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_audiobook_pipeline.py
+++ b/backend/tests/test_audiobook_pipeline.py
@@ -75,6 +75,7 @@ class _FakeQueue:
     def __init__(self, *, active_book_ids: set[int] | None = None):
         self.enqueued: list[int] = []
         self.active_book_ids = active_book_ids or set()
+        self.preview_enqueued: list[tuple[int, int]] = []
 
     async def enqueue(self, book_id: int) -> bool:
         self.enqueued.append(book_id)
@@ -83,11 +84,16 @@ class _FakeQueue:
     def has_book_job(self, book_id: int) -> bool:
         return book_id in self.active_book_ids
 
+    async def enqueue_preview(self, book_id: int, chapter_id: int) -> bool:
+        self.preview_enqueued.append((book_id, chapter_id))
+        return True
+
 
 def test_default_roster_prompt_formats_voice_token_examples():
     prompt = audiobook_llm.DEFAULT_ROSTER_PROMPT.format(
         text="A story excerpt.",
         candidate_hints="- Harry: 12 mentions",
+        series_roster="(none yet)",
     )
 
     assert "[gender-{male|female|neutral}]" in prompt
@@ -750,6 +756,122 @@ async def test_roster_keeps_first_person_protagonist_separate_from_narrator(db, 
     assert characters[2].aliases == []
     assert "40 explicit dialogue attributions" in characters[1].description
     assert "Harry: 40 mentions" in captured["prompt"]
+
+
+@pytest.mark.asyncio
+async def test_series_roster_reuses_and_propagates_voice_profiles(db):
+    first = await _make_book(db, title="Saga One", series="Shared Saga", audiobook_enabled=True)
+    second = await _make_book(db, title="Saga Two", series="Shared Saga", audiobook_enabled=True)
+    first_character = (
+        await crud.audiobook.create_characters_bulk(
+            db,
+            first.id,
+            [
+                {
+                    "name": "Captain Vale",
+                    "description": "Series captain.",
+                    "voice_design_prompt": "[gender-female][pitch-low][speed-normal]",
+                    "is_narrator": False,
+                    "aliases": ["Vale"],
+                    "evidence": [],
+                }
+            ],
+        )
+    )[0]
+    second_character = (
+        await crud.audiobook.create_characters_bulk(
+            db,
+            second.id,
+            [
+                {
+                    "name": "Captain Vale",
+                    "description": "Book-specific guess.",
+                    "voice_design_prompt": "[gender-neutral][pitch-high][speed-fast]",
+                    "is_narrator": False,
+                    "aliases": [],
+                    "evidence": [],
+                }
+            ],
+        )
+    )[0]
+
+    await crud.audiobook.sync_book_roster_with_series(db, first, [first_character])
+    await crud.audiobook.sync_book_roster_with_series(db, second, [second_character])
+    await db.refresh(second_character)
+
+    assert second_character.series_character_id == first_character.series_character_id
+    assert second_character.voice_design_prompt == "[gender-female][pitch-low][speed-normal]"
+
+    first_character.voice_design_prompt = "[gender-female][pitch-medium][speed-slow]"
+    await db.commit()
+    linked = await crud.audiobook.propagate_character_profile_across_series(db, first_character)
+    await db.refresh(second_character)
+
+    assert {character.book_id for character in linked} == {first.id, second.id}
+    assert second_character.voice_design_prompt == "[gender-female][pitch-medium][speed-slow]"
+
+    # Renaming onto an existing canonical identity merges the shared profiles
+    # instead of violating the series/name uniqueness constraint.
+    other_character = (
+        await crud.audiobook.create_characters_bulk(
+            db,
+            first.id,
+            [
+                {
+                    "name": "Commander Vale",
+                    "voice_design_prompt": "[gender-female][pitch-high][speed-normal]",
+                    "is_narrator": False,
+                }
+            ],
+        )
+    )[0]
+    await crud.audiobook.sync_book_roster_with_series(db, first, [other_character])
+    other_character.name = "Captain Vale"
+    await db.commit()
+    await crud.audiobook.propagate_character_profile_across_series(db, other_character)
+    await db.refresh(other_character)
+    assert other_character.series_character_id == first_character.series_character_id
+
+
+@pytest.mark.asyncio
+async def test_manual_chapter_preview_requires_analysis_and_queues_work(db, monkeypatch):
+    book = await _make_book(db, audiobook_enabled=True, audiobook_pipeline_status="paused")
+    chapter, _character, sentence = await _seed_audio_chapter(db, book.id)
+    queue = _FakeQueue()
+    monkeypatch.setattr(audiobook_router, "get_audiobook_queue", lambda: queue)
+
+    response = await audiobook_router.generate_chapter_preview(book.id, chapter.id, db)
+    await db.refresh(chapter)
+
+    assert response == {"status": "queued", "queued": True, "chapter_id": chapter.id}
+    assert queue.preview_enqueued == [(book.id, chapter.id)]
+    assert chapter.preview_status == "queued"
+
+    sentence.status = "pending_diarization"
+    chapter.preview_status = None
+    await db.commit()
+    with pytest.raises(audiobook_router.HTTPException) as exc_info:
+        await audiobook_router.generate_chapter_preview(book.id, chapter.id, db)
+    assert exc_info.value.status_code == 409
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg is required for MP3 assembly")
+async def test_manual_chapter_preview_generates_playable_audio(db, tmp_path, monkeypatch):
+    library_path = tmp_path / "library"
+    library_path.mkdir()
+    book = await _make_book(db, audiobook_enabled=True, audiobook_pipeline_status="paused")
+    chapter, _character, _sentence = await _seed_audio_chapter(db, book.id)
+    monkeypatch.setattr(audiobook_tts, "LIBRARY_PATH", library_path)
+    monkeypatch.setattr(audiobook_assembly, "LIBRARY_PATH", library_path)
+
+    await audiobook_tts.generate_audio_for_chapter_preview(book.id, chapter.id, db)
+    await audiobook_assembly.assemble_chapter_preview(book.id, chapter.id, db)
+    await db.refresh(chapter)
+
+    assert chapter.audio_file_path
+    assert (library_path.parent / chapter.audio_file_path).exists()
+    assert chapter.smil_file_path
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -97,6 +97,38 @@ async def test_get_book_catalog_returns_minimal_entries(db_session):
 
 
 @pytest.mark.asyncio
+async def test_book_catalog_sorts_audiobook_enabled_first(db_session):
+    async with AsyncTestingSessionLocal() as session:
+        enabled = await crud.create_book(
+            session,
+            schemas.BookCreate(
+                title="Audio Book",
+                author="Catalog Author",
+                immutable_path="audio-sort-enabled-source.epub",
+                current_path="audio-sort-enabled.epub",
+                source_type=models.SourceType.epub,
+            ),
+        )
+        enabled.audiobook_enabled = True
+        await crud.create_book(
+            session,
+            schemas.BookCreate(
+                title="Text Book",
+                author="Catalog Author",
+                immutable_path="audio-sort-disabled-source.epub",
+                current_path="audio-sort-disabled.epub",
+                source_type=models.SourceType.epub,
+            ),
+        )
+        await session.commit()
+
+    response = client.get("/api/books/catalog?sort_by=audiobook_enabled&sort_order=desc")
+
+    assert response.status_code == 200
+    assert [book["title"] for book in response.json()] == ["Audio Book", "Text Book"]
+
+
+@pytest.mark.asyncio
 async def test_get_book_catalog_includes_series_and_effective_genre_tags(db_session):
     async with AsyncTestingSessionLocal() as session:
         await crud.create_book(

--- a/docs/AUDIOBOOK_PIPELINE.md
+++ b/docs/AUDIOBOOK_PIPELINE.md
@@ -82,11 +82,12 @@ Changes propagate via cascades without requiring full rebuilds.
 **Character voice profile updated:**
 ```
 PUT /api/audiobook/characters/{id}
+  → promote the profile into the series roster and update matching sibling-book characters
   → UPDATE sentences SET status="ready_for_audio", audio_file_path=NULL
       WHERE character_id = {id}
   → UPDATE chapters SET needs_reassembly=TRUE
       WHERE id IN (SELECT chapter_id FROM audiobook_sentences WHERE character_id = {id})
-  → Re-enqueue book starting at "audio_gen" phase
+  → wait for an explicit chapter preview or full pipeline run
 ```
 
 **Sentence speaker or tags changed:**
@@ -94,7 +95,7 @@ PUT /api/audiobook/characters/{id}
 PUT /api/audiobook/sentences/{id}
   → UPDATE sentence: character_id, tagged_text, status="ready_for_audio", audio_file_path=NULL
   → UPDATE chapter SET needs_reassembly=TRUE WHERE id = sentence.chapter_id
-  → Re-enqueue book starting at "audio_gen" phase
+  → wait for an explicit chapter preview or full pipeline run
 ```
 
 ---
@@ -125,16 +126,25 @@ PUT /api/audiobook/sentences/{id}
 | smil_file_path | String | Relative path to generated `.smil` |
 | audio_file_path | String | Relative path to concatenated chapter MP3 |
 | needs_reassembly | Boolean | Worker polls for `True` |
+| preview_status | String | `queued`, `generating`, `ready`, or `error` for a manual preview |
+| preview_error | Text | Last preview-generation error |
 
 **`audiobook_characters`**
 | Column | Type | Notes |
 |---|---|---|
 | id | Integer PK | |
 | book_id | FK → books CASCADE | |
+| series_character_id | FK → audiobook_series_characters SET NULL | Shared series voice/profile link |
 | name | String | |
 | description | Text | LLM-generated summary |
 | voice_design_prompt | String | OmniVoice params e.g. `[gender-male][pitch-low]` |
 | is_narrator | Boolean | |
+
+**`audiobook_series_characters`** (migration 0021) — the canonical character and voice profile roster shared by
+all audiobook-enabled books in a named series. Book-specific character rows remain stable for sentence assignments,
+while edits to a linked voice profile propagate to matching sibling-book characters and invalidate only their derived
+audio. Roster generation includes previously identified series characters as context and reuses their profiles when
+the same character appears in a later book.
 
 **`audiobook_sentences`** — the state engine
 | Column | Type | Notes |
@@ -167,7 +177,8 @@ Values: `None` (idle), `ingesting`, `roster_gen`, `diarizing`, `audio_gen`, `ass
 - `audiobook_llm_requests` — model calls made during the current run
 
 Migration `0020_audiobook_observability.py` also adds chapter summaries, character aliases/evidence, and sentence
-confidence/rationales.
+confidence/rationales. Migration `0021_series_roster_and_chapter_previews.py` adds the shared series roster links and
+durable manual chapter-preview state.
 
 ---
 
@@ -276,8 +287,26 @@ stale message; failed sentence audio is reset to `ready_for_audio` before TTS re
 
 The Characters tab also offers **Regenerate Character Roster**. It preserves the parsed EPUB and sentence IDs while
 clearing roster, diarization, summaries, and derived audio state. Roster generation samples real story chapters
-across the book and supplements those excerpts with whole-book capitalized-name frequency hints, reducing the chance
-that front matter or a one-scene cameo displaces a recurring speaker.
+across the book and sibling books in the same series. It supplements those excerpts with capitalized-name frequency
+hints and any existing series roster, reducing the chance that front matter or a one-scene cameo displaces a recurring
+speaker. **Sync Series Roster** can promote an already-generated standalone book roster after its series metadata is
+assigned.
+
+## Manual Voice Evaluation
+
+Voice-profile edits deliberately do not start a potentially expensive full-book TTS run. In **Chapter Assembly**, a
+fully diarized chapter exposes **Generate Preview** (or **Rebuild Preview** after a voice change). The preview job runs
+through the same serial worker as the full pipeline, generates or reuses only that chapter's sentence clips, assembles
+its MP3 and SMIL, and leaves the full-book pipeline paused. A partially analyzed chapter shows its analyzed sentence
+count and keeps the action disabled, preventing audio from being generated against incomplete speaker assignments.
+
+Ready previews appear in **Listen & Read**, which provides chapter navigation, a seekable audio player, the chapter
+summary, and the chapter transcript with speaker names available as sentence tooltips. This supports early voice
+evaluation without pretending the final voice roster is complete; after refining a series profile, rebuild the chosen
+chapter explicitly to compare it.
+
+The library catalog shows a headphone badge on audiobook-enabled books and a count on series rows. The Audiobook
+filter can show only enabled or non-enabled books, and the main sort control can order enabled books first.
 
 ---
 
@@ -311,6 +340,8 @@ All paths stored in the database as relative to `LIBRARY_PATH.parent`, matching 
 | POST | `/api/books/{id}/audiobook/pause` | Request a cooperative pause at the next durable boundary |
 | POST | `/api/books/{id}/audiobook/rebuild` | Force full rebuild |
 | POST | `/api/books/{id}/audiobook/roster/rebuild` | Preserve ingestion and regenerate roster/speaker analysis |
+| POST | `/api/books/{id}/audiobook/roster/share-series` | Link/promote the book roster into its series roster |
+| POST | `/api/books/{id}/audiobook/chapters/{cid}/preview-audio` | Queue an explicit single-chapter audio preview |
 | GET | `/api/books/{id}/audiobook/status` | Status, model, progress, summary, review flags, and sentence counts |
 | GET | `/api/books/{id}/audiobook/characters` | List characters |
 | PUT | `/api/audiobook/characters/{char_id}` | Update voice profile (triggers cascade) |
@@ -334,6 +365,7 @@ All paths stored in the database as relative to `LIBRARY_PATH.parent`, matching 
 | `backend/alembic/versions/0018_audiobook_pipeline.py` | Core audiobook schema migration |
 | `backend/alembic/versions/0019_audiobook_pipeline_controls.py` | Review, pause, and error-state migration |
 | `backend/alembic/versions/0020_audiobook_observability.py` | Progress, summaries, evidence, confidence, and batch controls |
+| `backend/alembic/versions/0021_series_roster_and_chapter_previews.py` | Shared series profiles and chapter-preview state |
 | `backend/app/crud/audiobook.py` | DB queries for all new tables |
 | `backend/app/services/audiobook_ingestion.py` | Phase 1: EPUB parse + span injection |
 | `backend/app/services/audiobook_llm.py` | Phases 2 & 3: character roster + diarization |
@@ -353,8 +385,10 @@ All paths stored in the database as relative to `LIBRARY_PATH.parent`, matching 
 | `frontend/src/components/AudiobookPipeline.jsx` | Pipeline tab container (progress + sub-tabs) |
 | `frontend/src/components/audiobook/CharacterRoster.jsx` | Character card grid with voice editing |
 | `frontend/src/components/audiobook/ScriptEditor.jsx` | Paginated sentence table with inline editing |
-| `frontend/src/components/audiobook/ChapterAssembly.jsx` | Chapter assembly status list |
-| `frontend/src/App.jsx` | +Audio Settings tab routing |
+| `frontend/src/components/audiobook/ChapterAssembly.jsx` | Chapter assembly status and manual preview controls |
+| `frontend/src/components/audiobook/AudiobookReader.jsx` | Playable preview chapters with read-along text |
+| `frontend/src/components/BookList.jsx` | Library audiobook filter and enabled counts |
+| `frontend/src/App.jsx` | +Audio Settings tab routing and audiobook-enabled sorting |
 | `frontend/src/components/BookSettings.jsx` | +Audiobook Pipeline tab |
 
 ---

--- a/docs/AUDIOBOOK_PIPELINE.md
+++ b/docs/AUDIOBOOK_PIPELINE.md
@@ -95,8 +95,13 @@ PUT /api/audiobook/characters/{id}
 PUT /api/audiobook/sentences/{id}
   → UPDATE sentence: character_id, tagged_text, status="ready_for_audio", audio_file_path=NULL
   → UPDATE chapter SET needs_reassembly=TRUE WHERE id = sentence.chapter_id
-  → wait for an explicit chapter preview or full pipeline run
+  → wait for an explicit sentence/chapter preview or full pipeline run
 ```
+
+In the Script Editor, **Generate audio** queues only that ready sentence. Its durable status moves through
+`audio_queued` → `audio_generating` → `audio_generated` (or `error`), and the row polls while work is active so the
+button is replaced with visible progress and then an audio player. Manual sentence jobs share the same serial worker
+as chapter previews and the full pipeline, and are recovered after an app restart.
 
 ---
 
@@ -342,6 +347,7 @@ All paths stored in the database as relative to `LIBRARY_PATH.parent`, matching 
 | POST | `/api/books/{id}/audiobook/roster/rebuild` | Preserve ingestion and regenerate roster/speaker analysis |
 | POST | `/api/books/{id}/audiobook/roster/share-series` | Link/promote the book roster into its series roster |
 | POST | `/api/books/{id}/audiobook/chapters/{cid}/preview-audio` | Queue an explicit single-chapter audio preview |
+| POST | `/api/books/{id}/audiobook/sentences/{sid}/generate-audio` | Queue speech generation for one ready sentence |
 | GET | `/api/books/{id}/audiobook/status` | Status, model, progress, summary, review flags, and sentence counts |
 | GET | `/api/books/{id}/audiobook/characters` | List characters |
 | PUT | `/api/audiobook/characters/{char_id}` | Update voice profile (triggers cascade) |

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1311,9 +1311,15 @@
 
 /* ─── Book Settings page ─────────────────────────────────── */
 .book-settings {
+  box-sizing: border-box;
+  width: 100%;
   max-width: 720px;
   margin: 0 auto;
   padding: 0 1.25rem 3rem;
+}
+
+.book-settings--wide {
+  max-width: 1440px;
 }
 
 .settings-header {
@@ -1394,6 +1400,11 @@
 .audiobook-pipeline {
   display: grid;
   gap: 1rem;
+  min-width: 0;
+}
+
+.sub-tab-content {
+  min-width: 0;
 }
 
 .pipeline-header,
@@ -1680,6 +1691,7 @@
 
 .script-table-wrap,
 .chapter-assembly {
+  max-width: 100%;
   overflow-x: auto;
 }
 
@@ -1688,6 +1700,11 @@
   width: 100%;
   border-collapse: collapse;
   font-size: 0.78rem;
+}
+
+.script-table {
+  min-width: 1050px;
+  table-layout: fixed;
 }
 
 .script-table th,
@@ -1814,13 +1831,12 @@
 }
 
 .sentence-text {
-  min-width: 16rem;
-  max-width: 24rem;
   line-height: 1.45;
+  overflow-wrap: anywhere;
 }
 
 .sentence-tags {
-  min-width: 12rem;
+  overflow-wrap: anywhere;
 }
 
 .sentence-tags-input,
@@ -1840,6 +1856,51 @@
 .confidence-badge--low {
   background: rgba(214, 143, 44, 0.15);
   color: var(--warning);
+}
+
+.sentence-seq {
+  width: 3rem;
+}
+
+.sentence-text,
+.sentence-tags {
+  width: 24%;
+}
+
+.sentence-speaker {
+  width: 11rem;
+}
+
+.sentence-confidence {
+  width: 6rem;
+}
+
+.sentence-status {
+  width: 8.5rem;
+  white-space: nowrap;
+}
+
+.sentence-status span + span {
+  margin-left: 0.35rem;
+}
+
+.sentence-audio {
+  width: 16rem;
+}
+
+.sentence-audio audio {
+  width: 100%;
+  min-width: 10rem;
+}
+
+.sentence-actions {
+  width: 7rem;
+}
+
+.sentence-audio-progress,
+.sentence-audio-error {
+  display: block;
+  font-size: 0.75rem;
 }
 
 @media (max-width: 720px) {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -737,6 +737,19 @@
   color: var(--accent);
   border-radius: 3px;
 }
+.badge-audiobook {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3em;
+  padding: 0.15em 0.55em;
+  font-size: 0.68rem;
+  font-weight: 650;
+  background: rgba(34, 197, 94, 0.14);
+  color: #79d99a;
+  border: 1px solid rgba(34, 197, 94, 0.22);
+  border-radius: 999px;
+  white-space: nowrap;
+}
 .badge-config {
   display: inline-block;
   padding: 0.15em 0.55em;
@@ -1693,6 +1706,111 @@
   font-size: 0.7rem;
   letter-spacing: 0.03em;
   text-transform: uppercase;
+}
+
+.chapter-preview-hint,
+.chapter-preview-error {
+  display: block;
+  margin-top: 0.35rem;
+  max-width: 18rem;
+}
+
+.chapter-preview-note {
+  color: var(--text-muted);
+  font-size: 0.82rem;
+  margin: 1rem;
+}
+
+.audiobook-reader {
+  display: grid;
+  grid-template-columns: minmax(150px, 220px) minmax(0, 1fr);
+  gap: 1rem;
+}
+
+.audiobook-reader-chapters {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  max-height: 70vh;
+  overflow-y: auto;
+}
+
+.audiobook-reader-chapters button {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.2rem;
+  text-align: left;
+  background: var(--surface);
+  border: 1px solid var(--border);
+}
+
+.audiobook-reader-chapters button.active {
+  border-color: var(--accent);
+  background: rgba(98, 114, 234, 0.12);
+}
+
+.audiobook-reader-chapters small {
+  color: var(--text-muted);
+}
+
+.audiobook-reader-content {
+  min-width: 0;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1rem;
+}
+
+.audiobook-reader-heading {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.audiobook-reader-heading h3 {
+  margin: 0.15rem 0 0;
+}
+
+.audiobook-reader-nav {
+  display: flex;
+  gap: 0.4rem;
+}
+
+.audiobook-reader-player {
+  width: 100%;
+  margin: 1rem 0;
+}
+
+.audiobook-reader-summary {
+  color: var(--text-muted);
+  border-left: 3px solid var(--accent);
+  padding-left: 0.8rem;
+}
+
+.audiobook-reader-text {
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 1.05rem;
+  line-height: 1.75;
+  max-height: 56vh;
+  overflow-y: auto;
+  padding-right: 0.75rem;
+}
+
+@media (max-width: 760px) {
+  .audiobook-reader {
+    grid-template-columns: 1fr;
+  }
+
+  .audiobook-reader-chapters {
+    flex-direction: row;
+    overflow-x: auto;
+  }
+
+  .audiobook-reader-chapters button {
+    min-width: 9rem;
+  }
 }
 
 .sentence-text {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -139,7 +139,7 @@ function App() {
 
   const handleSortByChange = (newSortBy) => {
     setSortBy(newSortBy);
-    setSortOrder("asc");
+    setSortOrder(newSortBy === "audiobook_enabled" ? "desc" : "asc");
   };
 
   const handleToggleSortOrder = () => {
@@ -165,7 +165,10 @@ function App() {
     };
     const onDragLeave = (e) => {
       // Only clear when the drag exits the browser window entirely
-      if (e.relatedTarget === null || !document.documentElement.contains(e.relatedTarget)) {
+      if (
+        e.relatedTarget === null ||
+        !document.documentElement.contains(e.relatedTarget)
+      ) {
         setGlobalDragging(false);
       }
     };
@@ -179,7 +182,7 @@ function App() {
         (entry) =>
           entry.isDirectory ||
           entry.name.toLowerCase().endsWith(".epub") ||
-          entry.name.toLowerCase().endsWith(".zip")
+          entry.name.toLowerCase().endsWith(".zip"),
       );
       if (hasRelevant) {
         setActiveTab("library");
@@ -266,6 +269,7 @@ function App() {
               </div>
               <div className="sort-controls">
                 <select
+                  aria-label="Sort library by"
                   value={sortBy}
                   onChange={(e) => handleSortByChange(e.target.value)}
                 >
@@ -273,6 +277,7 @@ function App() {
                   <option value="author">Author</option>
                   <option value="word_count">Word Count</option>
                   <option value="updated_at">Last Updated</option>
+                  <option value="audiobook_enabled">Audiobook Enabled</option>
                 </select>
                 <button
                   className="sort-order-btn"

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -63,7 +63,13 @@ describe("App", () => {
 
   it("searches by unified query", async () => {
     const mockBooks = [
-      { id: 2, title: "Book B", author: "Author B", source_type: "epub", series: null },
+      {
+        id: 2,
+        title: "Book B",
+        author: "Author B",
+        source_type: "epub",
+        series: null,
+      },
     ];
 
     globalThis.fetch = vi.fn((url) => {
@@ -73,7 +79,9 @@ describe("App", () => {
           json: () => Promise.resolve([]),
         });
       }
-      if (url === "/api/books/catalog?q=Author%20B&sort_by=title&sort_order=asc") {
+      if (
+        url === "/api/books/catalog?q=Author%20B&sort_by=title&sort_order=asc"
+      ) {
         return Promise.resolve({
           ok: true,
           json: () => Promise.resolve(mockBooks),
@@ -171,8 +179,13 @@ describe("App", () => {
       expect(screen.getByText("Fantasy")).toBeInTheDocument();
     });
 
-    expect(globalThis.fetch).not.toHaveBeenCalledWith("/api/books/details?ids=1&ids=2");
-    expect(screen.getByAltText("Saga cover")).toHaveAttribute("src", "/api/covers/2");
+    expect(globalThis.fetch).not.toHaveBeenCalledWith(
+      "/api/books/details?ids=1&ids=2",
+    );
+    expect(screen.getByAltText("Saga cover")).toHaveAttribute(
+      "src",
+      "/api/covers/2",
+    );
 
     expect(screen.queryByText("Saga Book 1")).not.toBeInTheDocument();
 
@@ -239,12 +252,21 @@ describe("App", () => {
     fireEvent.click(screen.getByRole("button", { name: /genres/i }));
 
     await waitFor(() => {
-      expect(screen.getByPlaceholderText("Fantasy, Science Fiction, Progression Fantasy")).toBeInTheDocument();
+      expect(
+        screen.getByPlaceholderText(
+          "Fantasy, Science Fiction, Progression Fantasy",
+        ),
+      ).toBeInTheDocument();
     });
 
-    fireEvent.change(screen.getByPlaceholderText("Fantasy, Science Fiction, Progression Fantasy"), {
-      target: { value: "Fantasy, Epic Fantasy" },
-    });
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        "Fantasy, Science Fiction, Progression Fantasy",
+      ),
+      {
+        target: { value: "Fantasy, Epic Fantasy" },
+      },
+    );
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => {
@@ -264,7 +286,11 @@ describe("App", () => {
         author: "Author A",
         series: "Mixed Saga",
         effective_genre_tags: ["Fantasy"],
-        effective_series_genre_tags: ["Adventure", "Fantasy", "Progression Fantasy"],
+        effective_series_genre_tags: [
+          "Adventure",
+          "Fantasy",
+          "Progression Fantasy",
+        ],
         current_word_count: 1000,
         source_type: "epub",
       },
@@ -274,7 +300,11 @@ describe("App", () => {
         author: "Author A",
         series: "Mixed Saga",
         effective_genre_tags: ["Adventure"],
-        effective_series_genre_tags: ["Adventure", "Fantasy", "Progression Fantasy"],
+        effective_series_genre_tags: [
+          "Adventure",
+          "Fantasy",
+          "Progression Fantasy",
+        ],
         current_word_count: 1000,
         source_type: "epub",
       },
@@ -284,7 +314,11 @@ describe("App", () => {
         author: "Author A",
         series: "Mixed Saga",
         effective_genre_tags: ["Progression Fantasy"],
-        effective_series_genre_tags: ["Adventure", "Fantasy", "Progression Fantasy"],
+        effective_series_genre_tags: [
+          "Adventure",
+          "Fantasy",
+          "Progression Fantasy",
+        ],
         current_word_count: 1000,
         source_type: "epub",
       },
@@ -371,7 +405,9 @@ describe("App", () => {
     fireEvent.click(screen.getByRole("button", { name: /assign series/i }));
 
     await waitFor(() => {
-      expect(screen.getByPlaceholderText("Add to a series")).toBeInTheDocument();
+      expect(
+        screen.getByPlaceholderText("Add to a series"),
+      ).toBeInTheDocument();
     });
 
     fireEvent.change(screen.getByPlaceholderText("Add to a series"), {
@@ -385,6 +421,71 @@ describe("App", () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ series: "Saga" }),
       });
+    });
+  });
+
+  it("shows, filters, and sorts audiobook-enabled books", async () => {
+    const mockBooks = [
+      {
+        id: 31,
+        title: "Audio Ready",
+        author: "Narrator A",
+        current_word_count: 1200,
+        source_type: "epub",
+        series: null,
+        audiobook_enabled: true,
+        audiobook_pipeline_status: "paused",
+      },
+      {
+        id: 32,
+        title: "Text Only",
+        author: "Author B",
+        current_word_count: 900,
+        source_type: "epub",
+        series: null,
+        audiobook_enabled: false,
+      },
+    ];
+
+    globalThis.fetch = vi.fn((url) => {
+      if (
+        url === "/api/books/catalog?sort_by=title&sort_order=asc" ||
+        url === "/api/books/catalog?sort_by=audiobook_enabled&sort_order=desc"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockBooks),
+        });
+      }
+      if (url === "/api/series") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([]),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+    });
+
+    renderWithClient(<App />);
+    fireEvent.click(await screen.findByRole("tab", { name: /standalone/i }));
+
+    expect(await screen.findByTitle("Audiobook: paused")).toBeInTheDocument();
+    expect(screen.getByText("Showing 2 of 2 books")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Audiobook"), {
+      target: { value: "enabled" },
+    });
+    expect(screen.getByText("Showing 1 of 2 books")).toBeInTheDocument();
+    expect(screen.getByText("Audio Ready")).toBeInTheDocument();
+    expect(screen.queryByText("Text Only")).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Sort library by"), {
+      target: { value: "audiobook_enabled" },
+    });
+    await waitFor(() => {
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        "/api/books/catalog?sort_by=audiobook_enabled&sort_order=desc",
+      );
     });
   });
 });

--- a/frontend/src/api/audiobook.js
+++ b/frontend/src/api/audiobook.js
@@ -50,6 +50,23 @@ export function rebuildCharacterRoster(bookId) {
   });
 }
 
+export function shareCharacterRosterWithSeries(bookId) {
+  return sendWithoutBody(`/api/books/${bookId}/audiobook/roster/share-series`, {
+    method: "POST",
+    fallbackMessage: "Failed to sync the series character roster",
+  });
+}
+
+export function generateChapterPreview(bookId, chapterId) {
+  return sendWithoutBody(
+    `/api/books/${bookId}/audiobook/chapters/${chapterId}/preview-audio`,
+    {
+      method: "POST",
+      fallbackMessage: "Failed to queue the chapter preview",
+    },
+  );
+}
+
 // Characters
 export function getCharacters(bookId) {
   return getJson(

--- a/frontend/src/api/audiobook.js
+++ b/frontend/src/api/audiobook.js
@@ -105,6 +105,16 @@ export function updateSentence(sentenceId, data) {
   });
 }
 
+export function generateSentenceAudio(bookId, sentenceId) {
+  return sendWithoutBody(
+    `/api/books/${bookId}/audiobook/sentences/${sentenceId}/generate-audio`,
+    {
+      method: "POST",
+      fallbackMessage: "Failed to queue sentence audio",
+    },
+  );
+}
+
 export function getSentenceAudioUrl(sentenceId) {
   return `/api/audiobook/sentences/${sentenceId}/audio`;
 }

--- a/frontend/src/components/AudiobookPipeline.jsx
+++ b/frontend/src/components/AudiobookPipeline.jsx
@@ -383,6 +383,7 @@ function AudiobookPipeline({ book }) {
             bookId={bookId}
             characters={characters}
             chapters={chapters}
+            pipelineActive={isActive(pipelineStatus)}
           />
         )}
         {subTab === "Chapter Assembly" && (

--- a/frontend/src/components/AudiobookPipeline.jsx
+++ b/frontend/src/components/AudiobookPipeline.jsx
@@ -15,6 +15,7 @@ import CharacterRoster from "./audiobook/CharacterRoster";
 import ScriptEditor from "./audiobook/ScriptEditor";
 import ChapterAssembly from "./audiobook/ChapterAssembly";
 import AnalysisOverview from "./audiobook/AnalysisOverview";
+import AudiobookReader from "./audiobook/AudiobookReader";
 
 const PIPELINE_STEPS = [
   { status: "ingesting", label: "Ingesting" },
@@ -113,6 +114,7 @@ const SUB_TABS = [
   "Analysis",
   "Characters",
   "Script Editor",
+  "Listen & Read",
   "Chapter Assembly",
 ];
 
@@ -141,9 +143,12 @@ function AudiobookPipeline({ book }) {
   const { data: chapters = [] } = useQuery({
     queryKey: ["audiobook-chapters", bookId],
     queryFn: () => getAudiobookChapters(bookId),
-    refetchInterval: () => {
+    refetchInterval: ({ state }) => {
       const s = statusData?.pipeline_status;
-      return s && isActive(s) ? 5000 : false;
+      const previewActive = state.data?.some((chapter) =>
+        ["queued", "generating"].includes(chapter.preview_status),
+      );
+      return (s && isActive(s)) || previewActive ? 3000 : false;
     },
   });
 
@@ -370,6 +375,7 @@ function AudiobookPipeline({ book }) {
             characters={characters}
             bookId={bookId}
             pipelineStatus={pipelineStatus}
+            series={book.series}
           />
         )}
         {subTab === "Script Editor" && (
@@ -380,7 +386,18 @@ function AudiobookPipeline({ book }) {
           />
         )}
         {subTab === "Chapter Assembly" && (
-          <ChapterAssembly chapters={chapters} bookId={bookId} />
+          <ChapterAssembly
+            chapters={chapters}
+            bookId={bookId}
+            pipelineActive={isActive(pipelineStatus)}
+          />
+        )}
+        {subTab === "Listen & Read" && (
+          <AudiobookReader
+            chapters={chapters}
+            characters={characters}
+            bookId={bookId}
+          />
         )}
       </div>
     </div>

--- a/frontend/src/components/AudiobookPipeline.test.jsx
+++ b/frontend/src/components/AudiobookPipeline.test.jsx
@@ -148,4 +148,106 @@ describe("AudiobookPipeline", () => {
       );
     });
   });
+
+  it("queues a manual chapter preview and exposes playable text and audio", async () => {
+    const chapter = {
+      id: 9,
+      chapter_number: 1,
+      sentence_count: 2,
+      processed_sentence_count: 2,
+      audio_generated_count: 0,
+      low_confidence_count: 0,
+      summary: "The opening scene.",
+      preview_status: null,
+      preview_error: null,
+      audio_file_path: "audiobooks/11/chapter_1.mp3",
+      smil_file_path: "audiobooks/11/chapter_1.smil",
+      needs_reassembly: false,
+    };
+    const fetchMock = vi.fn((url, options) => {
+      if (url === "/api/books/11/audiobook/status") {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              pipeline_status: "paused",
+              next_phase: "audio_gen",
+              pause_requested: false,
+              sentence_counts: { pending_audio: 2 },
+            }),
+        });
+      }
+      if (url === "/api/books/11/audiobook/characters") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([{ id: 4, name: "Avery" }]),
+        });
+      }
+      if (url === "/api/books/11/audiobook/chapters") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([chapter]),
+        });
+      }
+      if (
+        url === "/api/books/11/audiobook/chapters/9/preview-audio" &&
+        options?.method === "POST"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ queued: true }),
+        });
+      }
+      if (
+        url ===
+        "/api/books/11/audiobook/sentences?page=1&limit=1000&chapter_id=9"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              items: [
+                {
+                  id: 1,
+                  original_text: "Avery opened the door.",
+                  character_id: 4,
+                },
+                {
+                  id: 2,
+                  original_text: "The hall was quiet.",
+                  character_id: null,
+                },
+              ],
+            }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+    globalThis.fetch = fetchMock;
+
+    const { container } = renderWithClient(
+      <AudiobookPipeline book={{ id: 11, series: "The Saga" }} />,
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Chapter Assembly" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Rebuild Preview" }));
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/books/11/audiobook/chapters/9/preview-audio",
+        { method: "POST" },
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Listen & Read" }));
+    expect(
+      await screen.findByText("Avery opened the door."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("The hall was quiet.")).toBeInTheDocument();
+    expect(container.querySelector("audio")).toHaveAttribute(
+      "src",
+      "/api/books/11/audiobook/chapters/9/audio",
+    );
+  });
 });

--- a/frontend/src/components/AudiobookPipeline.test.jsx
+++ b/frontend/src/components/AudiobookPipeline.test.jsx
@@ -250,4 +250,97 @@ describe("AudiobookPipeline", () => {
       "/api/books/11/audiobook/chapters/9/audio",
     );
   });
+
+  it("queues one ready sentence from the Script Editor and shows its state", async () => {
+    const fetchMock = vi.fn((url, options) => {
+      if (url === "/api/books/11/audiobook/status") {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              pipeline_status: "paused",
+              next_phase: "audio_gen",
+              pause_requested: false,
+              sentence_counts: { ready_for_audio: 1 },
+            }),
+        });
+      }
+      if (url === "/api/books/11/audiobook/characters") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([{ id: 4, name: "Avery" }]),
+        });
+      }
+      if (url === "/api/books/11/audiobook/chapters") {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve([
+              {
+                id: 9,
+                chapter_number: 1,
+                sentence_count: 1,
+                processed_sentence_count: 1,
+              },
+            ]),
+        });
+      }
+      if (
+        url === "/api/books/11/audiobook/sentences?page=1&limit=50" ||
+        url === "/api/books/11/audiobook/sentences?page=1&limit=50&chapter_id=9"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              items: [
+                {
+                  id: 31,
+                  chapter_id: 9,
+                  character_id: 4,
+                  sequence_order: 0,
+                  original_text: "Avery opened the door.",
+                  tagged_text: "Avery opened the door.",
+                  speaker_confidence: 0.96,
+                  speaker_reason: "Explicit attribution",
+                  status: "ready_for_audio",
+                },
+              ],
+              total: 1,
+            }),
+        });
+      }
+      if (
+        url === "/api/books/11/audiobook/sentences/31/generate-audio" &&
+        options?.method === "POST"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              status: "audio_queued",
+              queued: true,
+              sentence_id: 31,
+            }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+    globalThis.fetch = fetchMock;
+
+    renderWithClient(<AudiobookPipeline book={{ id: 11 }} />);
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Script Editor" }),
+    );
+    expect(await screen.findByText("Ready for audio")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Generate audio" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/books/11/audiobook/sentences/31/generate-audio",
+        { method: "POST" },
+      );
+    });
+  });
 });

--- a/frontend/src/components/BookList.jsx
+++ b/frontend/src/components/BookList.jsx
@@ -56,7 +56,12 @@ function getWebNovelStatus(book) {
   };
 }
 
-function LibraryFilters({ reviewFilter, onReviewFilterChange }) {
+function LibraryFilters({
+  reviewFilter,
+  onReviewFilterChange,
+  audiobookFilter,
+  onAudiobookFilterChange,
+}) {
   return (
     <div className="library-filters" aria-label="Library filters">
       <label>
@@ -69,6 +74,17 @@ function LibraryFilters({ reviewFilter, onReviewFilterChange }) {
           <option value="missing-series">Missing series</option>
           <option value="refreshing">Refreshing or queued</option>
           <option value="refresh-error">Refresh needs attention</option>
+        </select>
+      </label>
+      <label>
+        Audiobook
+        <select
+          value={audiobookFilter}
+          onChange={(event) => onAudiobookFilterChange(event.target.value)}
+        >
+          <option value="">All books</option>
+          <option value="enabled">Enabled</option>
+          <option value="disabled">Not enabled</option>
         </select>
       </label>
     </div>
@@ -147,6 +163,7 @@ function BookList({
   const [showStandaloneSeriesEdit, setShowStandaloneSeriesEdit] =
     useState(false);
   const [reviewFilter, setReviewFilter] = useState("");
+  const [audiobookFilter, setAudiobookFilter] = useState("");
 
   const { data: allSeries = [] } = useQuery({
     queryKey: ["series"],
@@ -172,6 +189,12 @@ function BookList({
   const filteredBooks = useMemo(
     () =>
       books.filter((book) => {
+        if (audiobookFilter === "enabled" && !book.audiobook_enabled) {
+          return false;
+        }
+        if (audiobookFilter === "disabled" && book.audiobook_enabled) {
+          return false;
+        }
         if (reviewFilter === "missing-series") {
           return (
             !book.series && book.source_type !== "web" && !book.download_status
@@ -185,7 +208,7 @@ function BookList({
         }
         return true;
       }),
-    [books, reviewFilter],
+    [audiobookFilter, books, reviewFilter],
   );
 
   const { seriesMap, sortedSeries, standaloneBooks, webBooks, counts } =
@@ -225,6 +248,8 @@ function BookList({
       <LibraryFilters
         reviewFilter={reviewFilter}
         onReviewFilterChange={handleReviewFilterChange}
+        audiobookFilter={audiobookFilter}
+        onAudiobookFilterChange={setAudiobookFilter}
       />
       <div className="library-results-summary" role="status">
         Showing {filteredBooks.length} of {books.length} books

--- a/frontend/src/components/BookSettings.jsx
+++ b/frontend/src/components/BookSettings.jsx
@@ -345,7 +345,13 @@ function BookSettings({ book: initialBook, onBack }) {
     book.source_type === "web" && book.immutable_path && book.current_path;
 
   return (
-    <div className="book-settings">
+    <div
+      className={`book-settings${
+        book.audiobook_enabled && bookTab === "audiobook"
+          ? " book-settings--wide"
+          : ""
+      }`}
+    >
       <div className="settings-header">
         <button
           className="btn-text"

--- a/frontend/src/components/audiobook/AudiobookReader.jsx
+++ b/frontend/src/components/audiobook/AudiobookReader.jsx
@@ -1,0 +1,118 @@
+import { useEffect, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { getChapterAudioUrl, getSentences } from "../../api/audiobook";
+
+function AudiobookReader({ chapters = [], characters = [], bookId }) {
+  const playable = useMemo(
+    () =>
+      chapters.filter(
+        (chapter) => chapter.audio_file_path && !chapter.needs_reassembly,
+      ),
+    [chapters],
+  );
+  const [chapterId, setChapterId] = useState(playable[0]?.id ?? null);
+
+  useEffect(() => {
+    if (!playable.some((chapter) => chapter.id === chapterId)) {
+      setChapterId(playable[0]?.id ?? null);
+    }
+  }, [chapterId, playable]);
+
+  const selectedIndex = playable.findIndex(
+    (chapter) => chapter.id === chapterId,
+  );
+  const selected = selectedIndex >= 0 ? playable[selectedIndex] : null;
+  const { data, isLoading } = useQuery({
+    queryKey: ["audiobook-reader-sentences", bookId, chapterId],
+    queryFn: () => getSentences(bookId, { chapterId, limit: 1000 }),
+    enabled: chapterId != null,
+  });
+  const characterNames = useMemo(
+    () =>
+      new Map(characters.map((character) => [character.id, character.name])),
+    [characters],
+  );
+
+  if (!playable.length) {
+    return (
+      <p className="empty-state">
+        No playable chapters yet. Fully analyze a chapter, then use Generate
+        Preview in Chapter Assembly.
+      </p>
+    );
+  }
+
+  return (
+    <div className="audiobook-reader">
+      <aside
+        className="audiobook-reader-chapters"
+        aria-label="Playable chapters"
+      >
+        {playable.map((chapter) => (
+          <button
+            type="button"
+            key={chapter.id}
+            className={chapter.id === chapterId ? "active" : ""}
+            onClick={() => setChapterId(chapter.id)}
+          >
+            Chapter {chapter.chapter_number}
+            <small>{chapter.sentence_count} sentences</small>
+          </button>
+        ))}
+      </aside>
+      <main className="audiobook-reader-content">
+        <div className="audiobook-reader-heading">
+          <div>
+            <span className="metric-label">Listen & read</span>
+            <h3>Chapter {selected?.chapter_number}</h3>
+          </div>
+          <div className="audiobook-reader-nav">
+            <button
+              type="button"
+              disabled={selectedIndex <= 0}
+              onClick={() => setChapterId(playable[selectedIndex - 1].id)}
+            >
+              Previous
+            </button>
+            <button
+              type="button"
+              disabled={selectedIndex >= playable.length - 1}
+              onClick={() => setChapterId(playable[selectedIndex + 1].id)}
+            >
+              Next
+            </button>
+          </div>
+        </div>
+        <audio
+          key={chapterId}
+          controls
+          src={getChapterAudioUrl(bookId, chapterId)}
+          preload="metadata"
+          className="audiobook-reader-player"
+        />
+        {selected?.summary && (
+          <p className="audiobook-reader-summary">{selected.summary}</p>
+        )}
+        {isLoading ? (
+          <p>Loading chapter text…</p>
+        ) : (
+          <div className="audiobook-reader-text">
+            {(data?.items || []).map((sentence) => (
+              <span
+                key={sentence.id}
+                title={
+                  characterNames.get(sentence.character_id) || "Unassigned"
+                }
+              >
+                {sentence.original_text}{" "}
+              </span>
+            ))}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}
+
+export default AudiobookReader;

--- a/frontend/src/components/audiobook/ChapterAssembly.jsx
+++ b/frontend/src/components/audiobook/ChapterAssembly.jsx
@@ -1,6 +1,20 @@
-import { getChapterAudioUrl } from "../../api/audiobook";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  generateChapterPreview,
+  getChapterAudioUrl,
+} from "../../api/audiobook";
 
-function ChapterAssembly({ chapters, bookId }) {
+function ChapterAssembly({ chapters, bookId, pipelineActive = false }) {
+  const queryClient = useQueryClient();
+  const previewMutation = useMutation({
+    mutationFn: (chapterId) => generateChapterPreview(bookId, chapterId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["audiobook-chapters", bookId],
+      });
+      queryClient.invalidateQueries({ queryKey: ["audiobook-status", bookId] });
+    },
+  });
   if (!chapters || chapters.length === 0) {
     return (
       <p className="empty-state">
@@ -17,47 +31,116 @@ function ChapterAssembly({ chapters, bookId }) {
             <th>Chapter</th>
             <th>Assembly Status</th>
             <th>Audio Preview</th>
+            <th>Manual Action</th>
             <th>SMIL</th>
           </tr>
         </thead>
         <tbody>
-          {chapters.map((chapter) => (
-            <tr key={chapter.id}>
-              <td>Chapter {chapter.chapter_number}</td>
-              <td>
-                {chapter.needs_reassembly ? (
-                  <span className="badge badge--warning">Rebuild Pending</span>
-                ) : chapter.audio_file_path ? (
-                  <span className="badge badge--success">Assembled</span>
-                ) : (
-                  <span className="badge badge--neutral">Not yet assembled</span>
-                )}
-              </td>
-              <td>
-                {chapter.audio_file_path && !chapter.needs_reassembly && (
-                  <audio
-                    controls
-                    src={getChapterAudioUrl(bookId, chapter.id)}
-                    preload="none"
-                    style={{ height: "28px" }}
-                  />
-                )}
-              </td>
-              <td>
-                {chapter.smil_file_path && !chapter.needs_reassembly && (
-                  <a
-                    href={`/library/audiobooks/${bookId}/${chapter.smil_file_path.split("/").pop()}`}
-                    download
-                    className="btn-text"
+          {chapters.map((chapter) => {
+            const analyzed =
+              chapter.sentence_count > 0 &&
+              chapter.processed_sentence_count === chapter.sentence_count;
+            const previewBusy = ["queued", "generating"].includes(
+              chapter.preview_status,
+            );
+            const previewReady =
+              chapter.audio_file_path && !chapter.needs_reassembly;
+            return (
+              <tr key={chapter.id}>
+                <td>Chapter {chapter.chapter_number}</td>
+                <td>
+                  {previewBusy ? (
+                    <span className="badge badge--warning">
+                      {chapter.preview_status === "queued"
+                        ? "Queued"
+                        : "Generating"}{" "}
+                      · {chapter.audio_generated_count}/{chapter.sentence_count}
+                    </span>
+                  ) : chapter.preview_status === "error" ? (
+                    <span className="badge badge--error">Preview failed</span>
+                  ) : chapter.needs_reassembly ? (
+                    <span className="badge badge--warning">
+                      Rebuild Pending
+                    </span>
+                  ) : chapter.audio_file_path ? (
+                    <span className="badge badge--success">Assembled</span>
+                  ) : (
+                    <span className="badge badge--neutral">
+                      Not yet assembled
+                    </span>
+                  )}
+                </td>
+                <td>
+                  {previewReady && (
+                    <audio
+                      controls
+                      src={getChapterAudioUrl(bookId, chapter.id)}
+                      preload="none"
+                      style={{ height: "28px" }}
+                    />
+                  )}
+                </td>
+                <td>
+                  <button
+                    type="button"
+                    className="btn btn-sm"
+                    onClick={() => previewMutation.mutate(chapter.id)}
+                    disabled={
+                      !analyzed ||
+                      pipelineActive ||
+                      previewBusy ||
+                      previewMutation.isPending
+                    }
+                    title={
+                      !analyzed
+                        ? `Analyze all ${chapter.sentence_count} sentences first`
+                        : pipelineActive
+                          ? "Pause the full-book pipeline first"
+                          : "Generate audio using the current voice profiles"
+                    }
                   >
-                    Download SMIL
-                  </a>
-                )}
-              </td>
-            </tr>
-          ))}
+                    {previewBusy
+                      ? "Working…"
+                      : previewReady
+                        ? "Rebuild Preview"
+                        : "Generate Preview"}
+                  </button>
+                  {!analyzed && (
+                    <small className="chapter-preview-hint">
+                      {chapter.processed_sentence_count}/
+                      {chapter.sentence_count} analyzed
+                    </small>
+                  )}
+                  {chapter.preview_error && (
+                    <small className="error chapter-preview-error">
+                      {chapter.preview_error}
+                    </small>
+                  )}
+                </td>
+                <td>
+                  {chapter.smil_file_path && !chapter.needs_reassembly && (
+                    <a
+                      href={`/library/audiobooks/${bookId}/${chapter.smil_file_path.split("/").pop()}`}
+                      download
+                      className="btn-text"
+                    >
+                      Download SMIL
+                    </a>
+                  )}
+                </td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
+      <p className="chapter-preview-note">
+        Chapter previews are manual and use the current shared voice profiles.
+        Rebuild a preview after tuning a voice; the full audiobook remains
+        paused.
+      </p>
+      {previewMutation.isError && (
+        <p className="error">{previewMutation.error?.message}</p>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/audiobook/CharacterRoster.jsx
+++ b/frontend/src/components/audiobook/CharacterRoster.jsx
@@ -1,6 +1,10 @@
 import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { rebuildCharacterRoster, updateCharacter } from "../../api/audiobook";
+import {
+  rebuildCharacterRoster,
+  shareCharacterRosterWithSeries,
+  updateCharacter,
+} from "../../api/audiobook";
 
 const ACTIVE_STATUSES = new Set([
   "ingesting",
@@ -38,6 +42,14 @@ function CharacterCard({ character, bookId }) {
       <div className="character-card-header">
         <strong>{character.name}</strong>
         {character.is_narrator && <span className="badge">Narrator</span>}
+        {character.shared_series_name && (
+          <span
+            className="badge badge--success"
+            title={`Shared across ${character.shared_series_name}`}
+          >
+            Series profile
+          </span>
+        )}
       </div>
       {character.description && (
         <p className="character-description">{character.description}</p>
@@ -88,7 +100,8 @@ function CharacterCard({ character, bookId }) {
       )}
       {saved && (
         <p className="success">
-          Saved — audio for this character will be regenerated.
+          Saved across the series. Existing clips were invalidated; use a
+          chapter preview when you are ready to compare the voice.
         </p>
       )}
       <button onClick={handleSave} disabled={mutation.isPending}>
@@ -98,7 +111,7 @@ function CharacterCard({ character, bookId }) {
   );
 }
 
-function CharacterRoster({ characters, bookId, pipelineStatus }) {
+function CharacterRoster({ characters, bookId, pipelineStatus, series }) {
   const queryClient = useQueryClient();
   const [confirmRegenerate, setConfirmRegenerate] = useState(false);
   const regenerateMutation = useMutation({
@@ -111,6 +124,14 @@ function CharacterRoster({ characters, bookId, pipelineStatus }) {
       });
       queryClient.invalidateQueries({
         queryKey: ["audiobook-chapters", bookId],
+      });
+    },
+  });
+  const shareMutation = useMutation({
+    mutationFn: () => shareCharacterRosterWithSeries(bookId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["audiobook-characters", bookId],
       });
     },
   });
@@ -129,8 +150,18 @@ function CharacterRoster({ characters, bookId, pipelineStatus }) {
         <span>
           {characters.length} voice profiles. Regenerating preserves EPUB
           ingestion but clears speaker assignments and invalidates generated
-          snippets.
+          snippets. {series ? `Profiles can be shared across ${series}.` : ""}
         </span>
+        {series && (
+          <button
+            onClick={() => shareMutation.mutate()}
+            disabled={
+              shareMutation.isPending || ACTIVE_STATUSES.has(pipelineStatus)
+            }
+          >
+            {shareMutation.isPending ? "Syncing series…" : "Sync Series Roster"}
+          </button>
+        )}
         {!confirmRegenerate ? (
           <button
             onClick={() => setConfirmRegenerate(true)}
@@ -160,6 +191,14 @@ function CharacterRoster({ characters, bookId, pipelineStatus }) {
         )}
         {regenerateMutation.isError && (
           <span className="error">{regenerateMutation.error?.message}</span>
+        )}
+        {shareMutation.isSuccess && (
+          <span className="success">
+            Shared profiles are now linked across {series}.
+          </span>
+        )}
+        {shareMutation.isError && (
+          <span className="error">{shareMutation.error?.message}</span>
         )}
       </div>
       <div className="character-roster">

--- a/frontend/src/components/audiobook/ScriptEditor.jsx
+++ b/frontend/src/components/audiobook/ScriptEditor.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
+  generateSentenceAudio,
   getSentences,
   updateSentence,
   getSentenceAudioUrl,
@@ -9,11 +10,13 @@ import {
 const STATUS_ICONS = {
   pending_diarization: { icon: "⏳", label: "Pending diarization" },
   ready_for_audio: { icon: "🎙", label: "Ready for audio" },
+  audio_queued: { icon: "⏱", label: "Audio queued" },
+  audio_generating: { icon: "🔊", label: "Generating audio" },
   audio_generated: { icon: "✅", label: "Audio generated" },
   error: { icon: "❌", label: "Error" },
 };
 
-function SentenceRow({ sentence, characters, bookId }) {
+function SentenceRow({ sentence, characters, bookId, pipelineActive }) {
   const queryClient = useQueryClient();
   const [tags, setTags] = useState(
     sentence.tagged_text || sentence.original_text,
@@ -29,6 +32,19 @@ function SentenceRow({ sentence, characters, bookId }) {
         queryKey: ["audiobook-sentences", bookId],
       });
       queryClient.invalidateQueries({ queryKey: ["audiobook-status", bookId] });
+    },
+  });
+
+  const audioMutation = useMutation({
+    mutationFn: () => generateSentenceAudio(bookId, sentence.id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["audiobook-sentences", bookId],
+      });
+      queryClient.invalidateQueries({ queryKey: ["audiobook-status", bookId] });
+      queryClient.invalidateQueries({
+        queryKey: ["audiobook-chapters", bookId],
+      });
     },
   });
 
@@ -99,16 +115,54 @@ function SentenceRow({ sentence, characters, bookId }) {
         )}
       </td>
       <td className="sentence-status" title={statusInfo.label}>
-        {statusInfo.icon}
+        <span aria-hidden="true">{statusInfo.icon}</span>
+        <span>{statusInfo.label}</span>
       </td>
       <td className="sentence-audio">
-        {audioUrl && (
+        {audioUrl ? (
           <audio
             controls
             src={audioUrl}
             preload="none"
             style={{ height: "24px" }}
           />
+        ) : sentence.status === "ready_for_audio" ||
+          sentence.status === "error" ? (
+          <button
+            type="button"
+            className="btn-small"
+            onClick={() => audioMutation.mutate()}
+            disabled={
+              audioMutation.isPending ||
+              pipelineActive ||
+              editing ||
+              characterId === ""
+            }
+            title={
+              pipelineActive
+                ? "Pause the full-book pipeline first"
+                : editing
+                  ? "Save sentence edits before generating audio"
+                  : characterId === ""
+                    ? "Assign a speaker first"
+                    : "Generate only this sentence with its current voice profile"
+            }
+          >
+            {audioMutation.isPending
+              ? "Queueing…"
+              : sentence.status === "error"
+                ? "Retry audio"
+                : "Generate audio"}
+          </button>
+        ) : ["audio_queued", "audio_generating"].includes(sentence.status) ? (
+          <span className="sentence-audio-progress">
+            {sentence.status === "audio_queued" ? "Waiting…" : "Working…"}
+          </span>
+        ) : null}
+        {audioMutation.isError && (
+          <span className="error sentence-audio-error">
+            {audioMutation.error?.message}
+          </span>
         )}
       </td>
       <td className="sentence-actions">
@@ -141,7 +195,12 @@ function SentenceRow({ sentence, characters, bookId }) {
   );
 }
 
-function ScriptEditor({ bookId, characters, chapters = [] }) {
+function ScriptEditor({
+  bookId,
+  characters,
+  chapters = [],
+  pipelineActive = false,
+}) {
   const [page, setPage] = useState(1);
   const [chapterFilter, setChapterFilter] = useState("");
   const [reviewOnly, setReviewOnly] = useState(false);
@@ -157,6 +216,12 @@ function ScriptEditor({ bookId, characters, chapters = [] }) {
         reviewOnly,
       }),
     keepPreviousData: true,
+    refetchInterval: ({ state }) =>
+      state.data?.items?.some((sentence) =>
+        ["audio_queued", "audio_generating"].includes(sentence.status),
+      )
+        ? 1500
+        : false,
   });
 
   if (isLoading) return <p>Loading sentences…</p>;
@@ -246,6 +311,7 @@ function ScriptEditor({ bookId, characters, chapters = [] }) {
                   sentence={sentence}
                   characters={characters}
                   bookId={bookId}
+                  pipelineActive={pipelineActive}
                 />
               ))}
             </tbody>

--- a/frontend/src/components/book-list/BookCards.jsx
+++ b/frontend/src/components/book-list/BookCards.jsx
@@ -23,6 +23,20 @@ export function GenreTagList({ tags, className = "" }) {
   );
 }
 
+export function AudiobookBadge({ book }) {
+  if (!book.audiobook_enabled) return null;
+  const status = book.audiobook_pipeline_status;
+  return (
+    <span
+      className="badge-audiobook"
+      title={status ? `Audiobook: ${status}` : "Audiobook enabled"}
+    >
+      <span aria-hidden="true">🎧</span>{" "}
+      {status === "complete" ? "Audiobook ready" : "Audiobook"}
+    </span>
+  );
+}
+
 export function BookCard({ book, onEdit }) {
   const isPending = book.download_status === "pending";
   const isError = book.download_status === "error";
@@ -115,6 +129,7 @@ export function BookCard({ book, onEdit }) {
         {book.source_type === "web" && !isPending && (
           <span className="badge-web">Web</span>
         )}
+        {!isPending && <AudiobookBadge book={book} />}
         {isError && book.source_url && (
           <p className="book-error-url" title={book.source_url}>
             {book.source_url.length > 40
@@ -174,6 +189,7 @@ export function BookRow({
             {book.source_type === "web" && (
               <span className="badge-web">Web</span>
             )}
+            <AudiobookBadge book={book} />
           </div>
           {subtitle && <div className="book-row-subtitle">{subtitle}</div>}
           {status && (

--- a/frontend/src/components/book-list/SeriesSummaryRow.jsx
+++ b/frontend/src/components/book-list/SeriesSummaryRow.jsx
@@ -108,6 +108,8 @@ export default function SeriesSummaryRow({ series, books, onEdit, allSeries }) {
       authors,
       totalWords,
       hasWebNovel: orderedBooks.some((book) => book.source_type === "web"),
+      audiobookCount: orderedBooks.filter((book) => book.audiobook_enabled)
+        .length,
       coverBook,
       coverBooks,
       latestUpdate: latestUpdate.getTime() > 0 ? latestUpdate : null,
@@ -191,6 +193,12 @@ export default function SeriesSummaryRow({ series, books, onEdit, allSeries }) {
           <div className="series-summary-topline">
             <span className="series-name">{series}</span>
             {summary.hasWebNovel && <span className="badge-web">Web</span>}
+            {summary.audiobookCount > 0 && (
+              <span className="badge-audiobook">
+                <span aria-hidden="true">🎧</span> {summary.audiobookCount}/
+                {books.length}
+              </span>
+            )}
           </div>
           <div className="series-meta">
             <span className="series-meta-author">

--- a/frontend/src/lib/catalogGrouping.js
+++ b/frontend/src/lib/catalogGrouping.js
@@ -13,6 +13,32 @@ export function compareSeriesBooks(left, right) {
   return left.id - right.id;
 }
 
+function compareCatalogBooks(left, right, sortBy, sortOrder) {
+  const dir = sortOrder === "desc" ? -1 : 1;
+  let comparison;
+  if (sortBy === "author") {
+    comparison = (left.author || "").localeCompare(right.author || "");
+  } else if (sortBy === "word_count") {
+    comparison =
+      (left.current_word_count || 0) - (right.current_word_count || 0);
+  } else if (sortBy === "updated_at") {
+    comparison =
+      new Date(left.updated_at || 0).getTime() -
+      new Date(right.updated_at || 0).getTime();
+  } else if (sortBy === "audiobook_enabled") {
+    comparison =
+      Number(Boolean(left.audiobook_enabled)) -
+      Number(Boolean(right.audiobook_enabled));
+  } else {
+    comparison = (left.title || "").localeCompare(right.title || "");
+  }
+
+  if (comparison !== 0) return dir * comparison;
+  const byTitle = (left.title || "").localeCompare(right.title || "");
+  if (byTitle !== 0) return byTitle;
+  return left.id - right.id;
+}
+
 export function buildCatalogGroups(books, sortBy = "title", sortOrder = "asc") {
   const seriesMap = {};
   const standaloneBooks = [];
@@ -36,6 +62,13 @@ export function buildCatalogGroups(books, sortBy = "title", sortOrder = "asc") {
   for (const seriesBooks of Object.values(seriesMap)) {
     seriesBooks.sort(compareSeriesBooks);
   }
+
+  standaloneBooks.sort((left, right) =>
+    compareCatalogBooks(left, right, sortBy, sortOrder),
+  );
+  webBooks.sort((left, right) =>
+    compareCatalogBooks(left, right, sortBy, sortOrder),
+  );
 
   const dir = sortOrder === "desc" ? -1 : 1;
   const sortedSeries = Object.keys(seriesMap).sort((a, b) => {
@@ -65,6 +98,12 @@ export function buildCatalogGroups(books, sortBy = "title", sortOrder = "asc") {
         ...booksB.map((bk) => new Date(bk.updated_at || 0).getTime()),
       );
       return dir * (latestA - latestB);
+    }
+    if (sortBy === "audiobook_enabled") {
+      const enabledA = booksA.some((book) => book.audiobook_enabled);
+      const enabledB = booksB.some((book) => book.audiobook_enabled);
+      const byEnabled = Number(enabledA) - Number(enabledB);
+      return byEnabled !== 0 ? dir * byEnabled : a.localeCompare(b);
     }
     return dir * a.localeCompare(b);
   });

--- a/frontend/src/lib/catalogGrouping.test.js
+++ b/frontend/src/lib/catalogGrouping.test.js
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { buildCatalogGroups } from "./catalogGrouping";
+
+describe("buildCatalogGroups", () => {
+  it("keeps audiobook-enabled series and standalone books first", () => {
+    const books = [
+      {
+        id: 1,
+        title: "Alpha Text",
+        author: "Author",
+        series: "Alpha Series",
+        source_type: "epub",
+        audiobook_enabled: false,
+      },
+      {
+        id: 2,
+        title: "Zeta Audio",
+        author: "Author",
+        series: "Zeta Series",
+        source_type: "epub",
+        audiobook_enabled: true,
+      },
+      {
+        id: 3,
+        title: "Alpha Standalone",
+        author: "Author",
+        series: null,
+        source_type: "epub",
+        audiobook_enabled: false,
+      },
+      {
+        id: 4,
+        title: "Zeta Standalone",
+        author: "Author",
+        series: null,
+        source_type: "epub",
+        audiobook_enabled: true,
+      },
+    ];
+
+    const grouped = buildCatalogGroups(books, "audiobook_enabled", "desc");
+
+    expect(grouped.sortedSeries).toEqual(["Zeta Series", "Alpha Series"]);
+    expect(grouped.standaloneBooks.map((book) => book.id)).toEqual([4, 3]);
+  });
+});


### PR DESCRIPTION
## Stack

Part 5 of 6. Depends on the observable-analysis PR. Base: `agent/audiobook-observable-analysis`.

## What changed

- Adds migration 0021 and durable series-level character/voice profiles.
- Reconciles profiles across series renames and sibling books.
- Adds explicit sentence and chapter preview jobs plus Listen & Read playback.
- Adds audiobook catalog badges, filtering, grouping, and sorting.
- Invalidates stale packaged EPUBs when voices, sentence assignments, or previews change, returning completed books to a resumable paused state.

## Why

Series sharing, previews, and reader/catalog UI form one user-facing layer that depends on the core analysis and speech state.

## Validation

- Backend focused suite: 170 passed.
- Frontend tests: 38 passed.
- Black and ESLint passed.
- PostgreSQL migration validation is delegated to GitHub Actions because Docker was unavailable locally.