### PR TITLE
Harden audiobook dialogue attribution

### DIFF
--- a/backend/app/crud/audiobook.py
+++ b/backend/app/crud/audiobook.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Optional
 
-from sqlalchemy import and_, func, or_, select, update
+from sqlalchemy import and_, delete, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..config import LIBRARY_PATH
@@ -17,7 +17,6 @@ from ..models import (
     AudiobookSentence,
     Book,
 )
-
 
 async def invalidate_packaged_audiobook(db: AsyncSession, book_id: int) -> None:
     """Remove a stale EPUB package and make a completed book resumable."""
@@ -33,6 +32,8 @@ async def invalidate_packaged_audiobook(db: AsyncSession, book_id: int) -> None:
     )
     await db.commit()
 
+
+ROSTER_REFRESH_STOP_MARKER = "roster_gen:refresh_series_metadata"
 
 # ---------------------------------------------------------------------------
 # Settings
@@ -187,7 +188,8 @@ async def pause_book_pipeline_after_phase(db: AsyncSession, book_id: int, phase:
         select(Book.audiobook_stop_after_phase, Book.audiobook_pipeline_status).where(Book.id == book_id)
     )
     row = result.one_or_none()
-    if row is None or row.audiobook_stop_after_phase != phase or row.audiobook_pipeline_status == "complete":
+    requested_phase = row.audiobook_stop_after_phase.split(":", 1)[0] if row and row.audiobook_stop_after_phase else None
+    if row is None or requested_phase != phase or row.audiobook_pipeline_status == "complete":
         return False
     await db.execute(
         update(Book)
@@ -390,6 +392,40 @@ async def get_series_characters(db: AsyncSession, series_name: str) -> list[Audi
     return list(result.scalars().all())
 
 
+async def get_sibling_series_characters(
+    db: AsyncSession, series_name: str, current_book_id: int
+) -> list[AudiobookSeriesCharacter]:
+    """Return profiles backed by another book, excluding current-book-only guesses."""
+    linked_profile_ids = select(AudiobookCharacter.series_character_id).where(
+        AudiobookCharacter.book_id != current_book_id,
+        AudiobookCharacter.series_character_id.is_not(None),
+    )
+    result = await db.execute(
+        select(AudiobookSeriesCharacter)
+        .where(
+            func.lower(AudiobookSeriesCharacter.series_name) == series_name.lower(),
+            AudiobookSeriesCharacter.id.in_(linked_profile_ids),
+        )
+        .order_by(AudiobookSeriesCharacter.is_narrator.desc(), AudiobookSeriesCharacter.name)
+    )
+    return list(result.scalars().all())
+
+
+async def delete_orphaned_series_characters(db: AsyncSession, series_name: str) -> int:
+    """Remove stale profiles left behind by an explicit roster refresh."""
+    linked_profile_ids = select(AudiobookCharacter.series_character_id).where(
+        AudiobookCharacter.series_character_id.is_not(None)
+    )
+    result = await db.execute(
+        delete(AudiobookSeriesCharacter).where(
+            func.lower(AudiobookSeriesCharacter.series_name) == series_name.lower(),
+            AudiobookSeriesCharacter.id.not_in(linked_profile_ids),
+        )
+    )
+    await db.commit()
+    return result.rowcount or 0
+
+
 def _copy_series_profile_to_book_character(
     profile: AudiobookSeriesCharacter,
     character: AudiobookCharacter,
@@ -416,6 +452,8 @@ async def sync_book_roster_with_series(
 
     profiles = await get_series_characters(db, book.series)
     by_name = {profile.canonical_name: profile for profile in profiles}
+    refreshed_profiles: dict[int, AudiobookSeriesCharacter] = {}
+    voice_changed_profiles: set[int] = set()
     linked = 0
     for character in characters:
         canonical = _canonical_character_name(character.name)
@@ -436,10 +474,37 @@ async def sync_book_roster_with_series(
             by_name[canonical] = profile
         elif prefer_series:
             _copy_series_profile_to_book_character(profile, character)
+        else:
+            # An explicit roster rebuild refreshes shared analysis while
+            # retaining the established cross-book voice unless it was empty.
+            profile.name = character.name
+            profile.description = character.description
+            profile.aliases = character.aliases or []
+            profile.evidence = character.evidence or []
+            profile.is_narrator = character.is_narrator
+            if character.voice_design_prompt and profile.voice_design_prompt != character.voice_design_prompt:
+                profile.voice_design_prompt = character.voice_design_prompt
+                voice_changed_profiles.add(profile.id)
+            refreshed_profiles[profile.id] = profile
         character.series_character_id = profile.id
         linked += 1
 
+    changed_voice_character_ids: list[int] = []
+    if refreshed_profiles:
+        result = await db.execute(
+            select(AudiobookCharacter).where(AudiobookCharacter.series_character_id.in_(list(refreshed_profiles)))
+        )
+        for linked_character in result.scalars().all():
+            _copy_series_profile_to_book_character(
+                refreshed_profiles[linked_character.series_character_id],
+                linked_character,
+            )
+            if linked_character.series_character_id in voice_changed_profiles:
+                changed_voice_character_ids.append(linked_character.id)
+
     await db.commit()
+    for character_id in changed_voice_character_ids:
+        await cascade_voice_change(db, character_id)
     return linked
 
 

--- a/backend/app/crud/audiobook.py
+++ b/backend/app/crud/audiobook.py
@@ -18,6 +18,7 @@ from ..models import (
     Book,
 )
 
+
 async def invalidate_packaged_audiobook(db: AsyncSession, book_id: int) -> None:
     """Remove a stale EPUB package and make a completed book resumable."""
     packaged_epub = LIBRARY_PATH / "audiobooks" / str(book_id) / "audiobook.epub"

--- a/backend/app/routers/audiobook.py
+++ b/backend/app/routers/audiobook.py
@@ -287,7 +287,7 @@ async def rebuild_character_roster(book_id: int, db: AsyncSession = Depends(get_
         db,
         book_id,
         status="roster_gen",
-        stop_after_phase="roster_gen",
+        stop_after_phase=crud.audiobook.ROSTER_REFRESH_STOP_MARKER,
     )
     queued = await get_audiobook_queue().enqueue(book_id)
     return {"status": "roster_gen", "queued": queued, "stop_after_phase": "roster_gen"}

--- a/backend/app/services/audiobook_llm.py
+++ b/backend/app/services/audiobook_llm.py
@@ -85,7 +85,8 @@ For each sentence return:
 - reason: a brief evidence-based reason, such as an adjacent dialogue tag or turn-taking context
   (12 words or fewer)
 
-Also return chapter_summary: an updated spoiler-light summary incorporating this batch and the prior summary.
+Also return chapter_summary: an updated spoiler-light summary incorporating this batch and the prior summary, using
+no more than 100 words.
 The roster descriptions are identity hints only and may be inaccurate. Ground the chapter summary exclusively in the
 sentence text and prior chapter summary; never import plot events, body changes, relationships, or backstory from a
 character description.
@@ -95,15 +96,21 @@ Return JSON with keys assignments and chapter_summary. No markdown or explanatio
 _ALLOWED_EXPRESSION_TAGS = {"laughter", "sigh", "whisper", "shout"}
 _BRACKET_TAG_RE = re.compile(r"\[([^\[\]]+)\]")
 _GENDERED_ATTRIBUTION_RE = re.compile(
-    r"\b(she|he)\s+(?:said|asked|replied|yelled|shouted|whispered|muttered|added|continued|answered|snapped)\b",
+    r"\b(she|he)\s+(?:said|asked|replied|yelled|shouted|whispered|muttered|added|continued|answered|snapped|"
+    r"repeated|remarked|responded|interrupted)\b",
+    re.IGNORECASE,
+)
+_FIRST_PERSON_ATTRIBUTION_RE = re.compile(
+    r"\bI\s+(?:said|asked|replied|yelled|shouted|whispered|muttered|added|continued|answered|snapped|reminded)\b",
     re.IGNORECASE,
 )
 _DIALOGUE_ATTRIBUTION_IN_SENTENCE_RE = re.compile(
     r"\b(?:said|asked|replied|yelled|shouted|whispered|muttered|added|continued|answered|snapped)\b" r"[^“\"]{0,80}[“\"]",
     re.IGNORECASE,
 )
-MAX_DIARIZATION_BATCH_SIZE = 40
+MAX_DIARIZATION_BATCH_SIZE = 10
 MIN_DIARIZATION_BATCH_SIZE = 5
+MIN_STORY_CHAPTER_SENTENCES = 40
 
 ROSTER_SCHEMA = {
     "type": "object",
@@ -156,12 +163,12 @@ DIARIZATION_SCHEMA = {
                     "character_id": {"type": ["integer", "null"]},
                     "tagged_text": {"type": ["string", "null"]},
                     "confidence": {"type": "number", "minimum": 0, "maximum": 1},
-                    "reason": {"type": "string"},
+                    "reason": {"type": "string", "maxLength": 160},
                 },
                 "required": ["id", "character_id", "tagged_text", "confidence", "reason"],
             },
         },
-        "chapter_summary": {"type": "string"},
+        "chapter_summary": {"type": "string", "maxLength": 1200},
     },
     "required": ["assignments", "chapter_summary"],
 }
@@ -348,26 +355,63 @@ def _apply_speaker_guardrails(
     next_text: str,
     character_id: int | None,
     narrator_id: int | None,
+    protagonist_id: int | None,
     minor_female_id: int | None,
     minor_male_id: int | None,
     reason: str,
 ) -> tuple[int | None, str, float | None]:
     """Correct two common local-model ID errors without inventing named speakers."""
     starts_with_quote = text.lstrip().startswith(("“", '"'))
+    has_quote = any(quote in text for quote in ("“", "”", '"'))
     has_dialogue = starts_with_quote or bool(_DIALOGUE_ATTRIBUTION_IN_SENTENCE_RE.search(text))
 
-    if character_id == narrator_id and has_dialogue:
-        attribution = _GENDERED_ATTRIBUTION_RE.search(f"{text} {next_text}")
-        if attribution:
-            gender = attribution.group(1).casefold()
-            fallback_id = minor_female_id if gender == "she" else minor_male_id
-            if fallback_id is not None:
-                return fallback_id, f"Deterministic {gender} dialogue attribution to minor voice", 0.98
+    current_first_person = _FIRST_PERSON_ATTRIBUTION_RE.search(text)
+    next_first_person = starts_with_quote and _FIRST_PERSON_ATTRIBUTION_RE.match(next_text.lstrip())
+    if protagonist_id is not None and has_quote and (current_first_person or next_first_person):
+        return protagonist_id, "Deterministic first-person dialogue attribution", 0.99
+
+    current_gender = _GENDERED_ATTRIBUTION_RE.search(text)
+    next_gender = starts_with_quote and _GENDERED_ATTRIBUTION_RE.match(next_text.lstrip())
+    attribution = current_gender or next_gender
+    if has_quote and attribution:
+        gender = attribution.group(1).casefold()
+        fallback_id = minor_female_id if gender == "she" else minor_male_id
+        if fallback_id is not None:
+            return fallback_id, f"Deterministic {gender} dialogue attribution to minor voice", 0.98
+
+    if character_id == narrator_id and starts_with_quote and protagonist_id is not None:
+        return protagonist_id, "Deterministic first-person dialogue fallback", 0.75
 
     if character_id != narrator_id and not has_dialogue:
         return narrator_id, "Deterministic prose/narration guardrail", 0.98
 
     return character_id, reason, None
+
+
+def _advance_open_dialogue_speaker(
+    text: str,
+    resolved_character_id: int | None,
+    *,
+    narrator_id: int | None,
+    minor_female_id: int | None,
+    minor_male_id: int | None,
+    current_open_speaker_id: int | None,
+) -> int | None:
+    """Track a curly-quoted utterance split across sentence records."""
+    opens = text.count("“")
+    closes = text.count("”")
+    if opens > closes:
+        prefix = text.rsplit("“", 1)[0]
+        pronouns = re.findall(r"\b(she|her|he|him)\b", prefix[-120:], re.IGNORECASE)
+        if pronouns:
+            gender = pronouns[-1].casefold()
+            return minor_female_id if gender in {"she", "her"} else minor_male_id
+        if resolved_character_id != narrator_id:
+            return resolved_character_id
+        return None
+    if closes > opens:
+        return None
+    return current_open_speaker_id
 
 
 async def _build_roster_excerpt(chapters, db: AsyncSession) -> str:
@@ -991,6 +1035,10 @@ async def generate_character_roster(
                 character["voice_design_prompt"] = _normalise_voice_prompt(
                     character.get("voice_design_prompt"), gender=first_person_gender
                 )
+                character["description"] = (
+                    "First-person protagonist; spoken dialogue voice is separate from the Narrator. "
+                    f"{character['description']}"
+                )
 
     def character_tokens(character: dict) -> set[str]:
         values = [character["name"], *character["aliases"]]
@@ -1128,6 +1176,14 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
     characters = await crud.audiobook.get_characters_for_book(db, book_id)
     character_ids = {character.id for character in characters}
     narrator_id = next((character.id for character in characters if character.is_narrator), None)
+    protagonist_id = next(
+        (
+            character.id
+            for character in characters
+            if "first-person protagonist" in str(character.description or "").casefold()
+        ),
+        None,
+    )
     minor_female_id = next((character.id for character in characters if character.name == "Minor Female Voice"), None)
     minor_male_id = next((character.id for character in characters if character.name == "Minor Male Voice"), None)
     roster_json = json.dumps(
@@ -1167,9 +1223,11 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
 
         # Treat short files before the first substantial chapter as front matter.
         # Once the story begins, retain short chapters and only skip tiny dividers.
-        if len(chapter_sentences) >= batch_size:
+        if len(chapter_sentences) >= MIN_STORY_CHAPTER_SENTENCES:
             story_started = True
-        is_front_matter = (not story_started and len(chapter_sentences) < batch_size) or len(chapter_sentences) < 20
+        is_front_matter = (not story_started and len(chapter_sentences) < MIN_STORY_CHAPTER_SENTENCES) or len(
+            chapter_sentences
+        ) < 20
         if is_front_matter:
             for sentence in pending:
                 await crud.audiobook.update_sentence_diarization(
@@ -1194,6 +1252,18 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
         context_window = [
             sentence.original_text for sentence in chapter_sentences if sentence.status != "pending_diarization"
         ][-8:]
+        open_dialogue_speaker_id = None
+        for previous_sentence in chapter_sentences:
+            if previous_sentence.status == "pending_diarization":
+                break
+            open_dialogue_speaker_id = _advance_open_dialogue_speaker(
+                previous_sentence.original_text,
+                previous_sentence.character_id,
+                narrator_id=narrator_id,
+                minor_female_id=minor_female_id,
+                minor_male_id=minor_male_id,
+                current_open_speaker_id=open_dialogue_speaker_id,
+            )
         while True:
             batch = await crud.audiobook.get_sentences_pending_diarization(
                 db, book_id, limit=batch_size, chapter_id=chapter.id
@@ -1334,12 +1404,25 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
                     next_text=next_text,
                     character_id=char_id,
                     narrator_id=narrator_id,
+                    protagonist_id=protagonist_id,
                     minor_female_id=minor_female_id,
                     minor_male_id=minor_male_id,
                     reason=reason,
                 )
                 if guardrail_confidence is not None:
                     confidence = guardrail_confidence
+                if open_dialogue_speaker_id is not None and char_id == narrator_id:
+                    char_id = open_dialogue_speaker_id
+                    reason = "Deterministic continuation of open quoted dialogue"
+                    confidence = 0.95
+                open_dialogue_speaker_id = _advance_open_dialogue_speaker(
+                    sentence.original_text,
+                    char_id,
+                    narrator_id=narrator_id,
+                    minor_female_id=minor_female_id,
+                    minor_male_id=minor_male_id,
+                    current_open_speaker_id=open_dialogue_speaker_id,
+                )
                 await crud.audiobook.update_sentence_diarization(
                     db,
                     sentence.id,
@@ -1350,7 +1433,7 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
                 )
                 context_window.append(sentence.original_text)
 
-            chapter_summary = str(batch_result.get("chapter_summary") or chapter.summary or "")[:4000]
+            chapter_summary = str(batch_result.get("chapter_summary") or chapter.summary or "")[:1200]
             await crud.audiobook.update_chapter_summary(db, chapter.id, chapter_summary or None)
             chapter.summary = chapter_summary or None
             processed += len(batch)

--- a/backend/app/services/audiobook_llm.py
+++ b/backend/app/services/audiobook_llm.py
@@ -417,6 +417,11 @@ def _apply_speaker_guardrails(
         if last_dialogue_speaker_id is not None:
             return last_dialogue_speaker_id, "Deterministic recurring role dialogue attribution", 0.9
 
+    if has_quote and re.match(r'^\s*[“"]?Paragraph\s+(?:one|two|three|four|five|six|\d+)\b', text, re.I):
+        recruiter_id = role_speaker_ids.get("recruiter")
+        if recruiter_id is not None:
+            return recruiter_id, "Deterministic grounded recruiter enumeration", 0.98
+
     if (
         starts_with_quote
         and protagonist_id is not None
@@ -1564,7 +1569,11 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
                 )
                 if guardrail_confidence is not None:
                     confidence = guardrail_confidence
-                if open_dialogue_speaker_id is not None and char_id != open_dialogue_speaker_id:
+                if (
+                    open_dialogue_speaker_id is not None
+                    and char_id != open_dialogue_speaker_id
+                    and (guardrail_confidence is None or guardrail_confidence < 0.9)
+                ):
                     char_id = open_dialogue_speaker_id
                     reason = "Deterministic continuation of open quoted dialogue"
                     confidence = 0.95

--- a/backend/app/services/audiobook_llm.py
+++ b/backend/app/services/audiobook_llm.py
@@ -23,17 +23,19 @@ You are a literary analyst preparing a cast list for an audiobook. Analyze the s
 book and identify the primary narrator plus the major or recurring speaking characters. Merge aliases, titles, and \
 surname-only references into one character. Do not include authors, publishers, places, organizations, unnamed \
 crowds, or one-line background figures. Prefer people with repeated mentions across the book and omit one-scene \
-figures even if they appear in an excerpt. Return no more than 15 characters.
+figures even if they appear in an excerpt. Return no more than 18 characters.
 
 For each character produce:
 - name: canonical full name; use "Narrator" for the narrative prose voice
 - aliases: other names, surnames, nicknames, ranks, or titles used for this person
 - description: a concise description of their personality, relationships, and role
-- evidence: 1-3 short quotations or explicit textual facts supporting the identification
+- evidence: 1-3 short exact quotations from the supplied text supporting the identification
 - voice_design_prompt: an OmniVoice voice parameter string using ONLY these tokens:
   [gender-{{male|female|neutral}}] [pitch-{{low|medium|high}}] [speed-{{slow|normal|fast}}]
   Optional: [accent-{{british|american|australian}}] [age-{{young|middle|old}}]
   Example: [gender-male][pitch-low][speed-normal][age-middle]
+  Always include gender, pitch, speed, and age. Use the textual evidence to make recurring characters distinct;
+  do not give every character the same generic profile. Add an accent only when the text supports it.
 - is_narrator: true only for an entry named exactly "Narrator". In first-person books, the protagonist must be a \
   separate character with is_narrator false so their spoken dialogue has a distinct voice.
 
@@ -81,6 +83,7 @@ For each sentence return:
   when no tag is needed (do not repeat unchanged text)
 - confidence: a number from 0 to 1 for the speaker assignment
 - reason: a brief evidence-based reason, such as an adjacent dialogue tag or turn-taking context
+  (12 words or fewer)
 
 Also return chapter_summary: an updated spoiler-light summary incorporating this batch and the prior summary.
 The roster descriptions are identity hints only and may be inaccurate. Ground the chapter summary exclusively in the
@@ -95,10 +98,12 @@ _GENDERED_ATTRIBUTION_RE = re.compile(
     r"\b(she|he)\s+(?:said|asked|replied|yelled|shouted|whispered|muttered|added|continued|answered|snapped)\b",
     re.IGNORECASE,
 )
-_NARRATION_REASON_RE = re.compile(
-    r"\b(?:narrat(?:or|ion|ive)|internal|reflection|action description|monologue|observation|recounting)\b",
+_DIALOGUE_ATTRIBUTION_IN_SENTENCE_RE = re.compile(
+    r"\b(?:said|asked|replied|yelled|shouted|whispered|muttered|added|continued|answered|snapped)\b" r"[^“\"]{0,80}[“\"]",
     re.IGNORECASE,
 )
+MAX_DIARIZATION_BATCH_SIZE = 40
+MIN_DIARIZATION_BATCH_SIZE = 5
 
 ROSTER_SCHEMA = {
     "type": "object",
@@ -106,7 +111,7 @@ ROSTER_SCHEMA = {
         "book_summary": {"type": "string"},
         "characters": {
             "type": "array",
-            "maxItems": 15,
+            "maxItems": 18,
             "items": {
                 "type": "object",
                 "properties": {
@@ -185,7 +190,7 @@ async def _call_llm(
             "stream": False,
             "think": False,
             "format": response_schema or "json",
-            "options": {"temperature": 0, "num_ctx": 32768, "num_predict": 4096},
+            "options": {"temperature": 0, "num_ctx": 32768, "num_predict": 8192},
             "keep_alive": "30m",
         }
         timeout = httpx.Timeout(600.0, connect=10.0)
@@ -234,14 +239,86 @@ async def _call_llm(
         return data["choices"][0]["message"]["content"]
 
 
-def _extract_json(raw: str) -> Any:
-    """Strip markdown code fences if present and parse JSON."""
+def _strip_json_fence(raw: str) -> str:
     text = raw.strip()
     if text.startswith("```"):
         lines = text.splitlines()
         # Drop first and last fence lines
         text = "\n".join(lines[1:-1] if lines[-1].strip() == "```" else lines[1:])
-    return json.loads(text)
+    return text
+
+
+def _remove_trailing_json_commas(text: str) -> str:
+    """Remove commas immediately before ] or } without changing JSON strings."""
+    output: list[str] = []
+    in_string = False
+    escaped = False
+    for char in text:
+        if in_string:
+            output.append(char)
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            continue
+        if char == '"':
+            in_string = True
+            output.append(char)
+            continue
+        if char in "]}":
+            previous = len(output) - 1
+            while previous >= 0 and output[previous].isspace():
+                previous -= 1
+            if previous >= 0 and output[previous] == ",":
+                del output[previous]
+        output.append(char)
+    return "".join(output)
+
+
+def _extract_json(raw: str) -> Any:
+    """Parse structured output and repair common local-model trailing commas."""
+    text = _strip_json_fence(raw)
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as original_error:
+        repaired = _remove_trailing_json_commas(text)
+        if repaired == text:
+            raise
+        try:
+            return json.loads(repaired)
+        except json.JSONDecodeError:
+            raise original_error
+
+
+def _normalise_diarization_result(batch_result: Any, expected_ids: set[int]) -> dict[str, Any]:
+    """Require exactly one assignment for every requested sentence."""
+    if isinstance(batch_result, list):
+        batch_result = {"assignments": batch_result, "chapter_summary": None}
+    if not isinstance(batch_result, dict) or not isinstance(batch_result.get("assignments"), list):
+        raise ValueError(f"Expected a JSON object with assignments, got {type(batch_result).__name__}")
+
+    result_ids = [
+        result.get("id")
+        for result in batch_result["assignments"]
+        if isinstance(result, dict) and isinstance(result.get("id"), int)
+    ]
+    result_id_set = set(result_ids)
+    missing = sorted(expected_ids - result_id_set)
+    unexpected = sorted(result_id_set - expected_ids)
+    duplicates = sorted(
+        sentence_id for sentence_id, count in Counter(result_ids).items() if sentence_id in expected_ids and count > 1
+    )
+    if missing or duplicates or len(result_ids) != len(batch_result["assignments"]):
+        raise ValueError(
+            "Invalid assignment coverage: "
+            f"missing={missing[:10]}, unexpected={unexpected[:10]}, duplicates={duplicates[:10]}"
+        )
+    if unexpected:
+        logger.warning("Ignoring %d unsolicited diarization assignments: %s", len(unexpected), unexpected[:10])
+        batch_result["assignments"] = [result for result in batch_result["assignments"] if result.get("id") in expected_ids]
+    return batch_result
 
 
 def _sanitize_tagged_text(original: str, tagged: Any) -> str:
@@ -276,9 +353,8 @@ def _apply_speaker_guardrails(
     reason: str,
 ) -> tuple[int | None, str, float | None]:
     """Correct two common local-model ID errors without inventing named speakers."""
-    has_closing_quote = "”" in text or ('"' in text and not text.rstrip().endswith('"'))
     starts_with_quote = text.lstrip().startswith(("“", '"'))
-    has_dialogue = has_closing_quote or starts_with_quote
+    has_dialogue = starts_with_quote or bool(_DIALOGUE_ATTRIBUTION_IN_SENTENCE_RE.search(text))
 
     if character_id == narrator_id and has_dialogue:
         attribution = _GENDERED_ATTRIBUTION_RE.search(f"{text} {next_text}")
@@ -288,7 +364,7 @@ def _apply_speaker_guardrails(
             if fallback_id is not None:
                 return fallback_id, f"Deterministic {gender} dialogue attribution to minor voice", 0.98
 
-    if character_id != narrator_id and not has_dialogue and _NARRATION_REASON_RE.search(reason):
+    if character_id != narrator_id and not has_dialogue:
         return narrator_id, "Deterministic prose/narration guardrail", 0.98
 
     return character_id, reason, None
@@ -299,12 +375,16 @@ async def _build_roster_excerpt(chapters, db: AsyncSession) -> str:
     candidates: list[tuple[Any, list[Any]]] = []
     for chapter in chapters:
         sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
+        if _starts_back_matter(sentences):
+            break
         if len(sentences) >= 40:
             candidates.append((chapter, sentences))
 
     if not candidates:
         for chapter in chapters:
             sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
+            if _starts_back_matter(sentences):
+                break
             if sentences:
                 candidates.append((chapter, sentences))
 
@@ -322,6 +402,7 @@ async def _build_roster_excerpt(chapters, db: AsyncSession) -> str:
 
 
 _CANDIDATE_TOKEN_RE = re.compile(r"\b[A-Z][a-z]{2,}\b")
+_FULL_NAME_RE = re.compile(r"\b([A-Z][a-z]{2,})\s+([A-Z][a-z]{2,})\b")
 _DIALOGUE_TAG_RE = re.compile(
     r"\b([A-Z][a-z]{2,})\s+(?:said|asked|replied|yelled|shouted|whispered|added|continued|noted|answered|"
     r"snapped|muttered|called|agreed|insisted)\b|\b(?:said|asked|replied|yelled|shouted|whispered|added|"
@@ -398,6 +479,111 @@ _CANDIDATE_STOP_WORDS = {
     "You",
     "Your",
 }
+_NAME_TITLE_WORDS = {
+    "Administrator",
+    "Admiral",
+    "Captain",
+    "Colonel",
+    "Corporal",
+    "Doctor",
+    "Doubtful",
+    "General",
+    "Lieutenant",
+    "Major",
+    "Master",
+    "Mister",
+    "Private",
+    "Professor",
+    "Sergeant",
+}
+_BACK_MATTER_HEADINGS = (
+    "ACKNOWLEDGMENTS",
+    "ACKNOWLEDGEMENTS",
+    "ABOUT THE AUTHOR",
+    "ALSO BY ",
+    "EXCERPT FROM",
+    "THIS IS A WORK OF FICTION",
+    "TOR BOOKS BY ",
+)
+_FIRST_PERSON_GENDER_RE = re.compile(
+    r"\bI(?:'m| am| was)\s+(?:an?\s+)?(?:old\s+|young\s+)?(man|male|widower|woman|female|widow)\b",
+    re.IGNORECASE,
+)
+
+
+def _starts_back_matter(sentences: list[Any]) -> bool:
+    if not sentences:
+        return False
+    heading = " ".join(str(sentences[0].original_text).split()).upper()
+    return any(heading.startswith(marker) for marker in _BACK_MATTER_HEADINGS)
+
+
+async def _infer_first_person_gender(chapters, db: AsyncSession) -> str | None:
+    counts: Counter[str] = Counter()
+    for chapter in chapters:
+        sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
+        if _starts_back_matter(sentences):
+            break
+        for sentence in sentences:
+            for match in _FIRST_PERSON_GENDER_RE.finditer(sentence.original_text):
+                token = match.group(1).casefold()
+                counts["male" if token in {"man", "male", "widower"} else "female"] += 1
+    if counts["male"] >= 1 and counts["male"] >= counts["female"] * 2:
+        return "male"
+    if counts["female"] >= 1 and counts["female"] >= counts["male"] * 2:
+        return "female"
+    return None
+
+
+def _infer_candidate_gender(texts: list[str], names: set[str]) -> str | None:
+    """Infer gender only when repeated, local pronoun evidence is decisive."""
+    pronouns: Counter[str] = Counter()
+    patterns = [re.compile(rf"\b{re.escape(name)}\b", re.IGNORECASE) for name in names if name]
+    self_intro_patterns = [
+        re.compile(
+            rf"^\s*[“\"]?{re.escape(name)}\s*[,.”\"]+\s*(she|he)\s+" r"(?:said|replied|answered)\b",
+            re.IGNORECASE,
+        )
+        for name in names
+        if " " in name
+    ]
+    for text in texts:
+        for pattern in self_intro_patterns:
+            match = pattern.search(text)
+            if match:
+                return "female" if match.group(1).casefold() == "she" else "male"
+        if not any(pattern.search(text) for pattern in patterns):
+            continue
+        pronouns.update(token.casefold() for token in re.findall(r"\b(?:he|him|his|she|her|hers)\b", text, re.I))
+    male = sum(pronouns[token] for token in ("he", "him", "his"))
+    female = sum(pronouns[token] for token in ("she", "her", "hers"))
+    if male >= 3 and male >= female * 2:
+        return "male"
+    if female >= 3 and female >= male * 2:
+        return "female"
+    return None
+
+
+def _normalise_voice_prompt(value: Any, *, gender: str | None = None) -> str:
+    """Keep OmniVoice parameters valid and apply evidence-backed gender."""
+    text = str(value or "")
+
+    def token(kind: str, allowed: set[str], default: str) -> str:
+        match = re.search(rf"\[{kind}-([^\]]+)\]", text, re.IGNORECASE)
+        candidate = match.group(1).casefold() if match else default
+        return candidate if candidate in allowed else default
+
+    selected_gender = gender or token("gender", {"male", "female", "neutral"}, "neutral")
+    parts = [
+        f"[gender-{selected_gender}]",
+        f"[pitch-{token('pitch', {'low', 'medium', 'high'}, 'medium')}]",
+        f"[speed-{token('speed', {'slow', 'normal', 'fast'}, 'normal')}]",
+    ]
+    accent = token("accent", {"british", "american", "australian"}, "")
+    if accent:
+        parts.append(f"[accent-{accent}]")
+    parts.append(f"[age-{token('age', {'young', 'middle', 'old'}, 'middle')}]")
+    return "".join(parts)
 
 
 async def _build_character_candidate_analysis(chapters, db: AsyncSession) -> tuple[str, list[dict[str, Any]]]:
@@ -406,21 +592,32 @@ async def _build_character_candidate_analysis(chapters, db: AsyncSession) -> tup
     contextual_counts: Counter[str] = Counter()
     dialogue_counts: Counter[str] = Counter()
     dialogue_examples: dict[str, str] = {}
+    full_name_counts: Counter[str] = Counter()
+    all_texts: list[str] = []
     for chapter in chapters:
-        for sentence in await crud.audiobook.get_sentences_for_chapter(db, chapter.id):
-            for match in _CANDIDATE_TOKEN_RE.finditer(sentence.original_text):
+        chapter_sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
+        if _starts_back_matter(chapter_sentences):
+            break
+        for sentence in chapter_sentences:
+            text = sentence.original_text
+            all_texts.append(text)
+            for match in _CANDIDATE_TOKEN_RE.finditer(text):
                 token = match.group(0)
                 if token in _CANDIDATE_STOP_WORDS:
                     continue
                 counts[token] += 1
                 if match.start() > 0:
                     contextual_counts[token] += 1
-            for match in _DIALOGUE_TAG_RE.finditer(sentence.original_text):
+            for match in _FULL_NAME_RE.finditer(text):
+                first, last = match.groups()
+                if first not in _CANDIDATE_STOP_WORDS and last not in _CANDIDATE_STOP_WORDS and first not in _NAME_TITLE_WORDS:
+                    full_name_counts[f"{first} {last}"] += 1
+            for match in _DIALOGUE_TAG_RE.finditer(text):
                 name = match.group(1) or match.group(2)
                 if name in _CANDIDATE_STOP_WORDS:
                     continue
                 dialogue_counts[name] += 1
-                dialogue_examples.setdefault(name, sentence.original_text[:220])
+                dialogue_examples.setdefault(name, text[:220])
 
     candidates = [
         (name, count, contextual_counts[name], dialogue_counts[name])
@@ -434,17 +631,60 @@ async def _build_character_candidate_analysis(chapters, db: AsyncSession) -> tup
         if dialogue_count and name in dialogue_examples:
             line += f'; example: "{dialogue_examples[name]}"'
         lines.append(line)
-    confirmed = [
-        {
-            "name": name,
-            "mention_count": count,
-            "dialogue_count": dialogue_count,
-            "evidence": dialogue_examples.get(name),
-        }
-        for name, count, _, dialogue_count in candidates
-        if dialogue_count >= 5
-    ]
-    required_names = ", ".join(candidate["name"] for candidate in confirmed[:12])
+    confirmed = []
+    for name, count, _, dialogue_count in candidates:
+        if dialogue_count < 5:
+            continue
+        surname_matches = [
+            (full_name, full_count) for full_name, full_count in full_name_counts.items() if full_name.split()[-1] == name
+        ]
+        first_name_matches = [
+            (full_name, full_count) for full_name, full_count in full_name_counts.items() if full_name.split()[0] == name
+        ]
+        matches = surname_matches or first_name_matches
+        canonical_name = max(matches, key=lambda item: (item[1], item[0]))[0] if matches else name
+        identity_names = {canonical_name} if " " in canonical_name else {name}
+        confirmed.append(
+            {
+                "name": name,
+                "canonical_name": canonical_name,
+                "mention_count": count,
+                "dialogue_count": dialogue_count,
+                "evidence": dialogue_examples.get(name),
+                "gender": _infer_candidate_gender(all_texts, identity_names),
+                "required": True,
+            }
+        )
+
+    # Full names are useful for validating an LLM-produced protagonist even
+    # when a first-person book rarely uses their name in dialogue tags. They
+    # are identity metadata only and are not promoted into the roster by
+    # themselves.
+    known_canonical_names = {candidate["canonical_name"].casefold() for candidate in confirmed}
+    for full_name, full_count in full_name_counts.most_common():
+        if full_count < 3 or full_name.casefold() in known_canonical_names:
+            continue
+        first, last = full_name.split()
+        if max(counts[first], counts[last]) < 8:
+            continue
+        confirmed.append(
+            {
+                "name": full_name,
+                "canonical_name": full_name,
+                "mention_count": full_count,
+                "dialogue_count": 0,
+                "evidence": next(
+                    (text[:220] for text in all_texts if re.search(rf"\b{re.escape(full_name)}\b", text)),
+                    None,
+                ),
+                "gender": _infer_candidate_gender(all_texts, {full_name}),
+                "required": False,
+            }
+        )
+        known_canonical_names.add(full_name.casefold())
+
+    required = [candidate for candidate in confirmed if candidate["required"]]
+    required_names = ", ".join(dict.fromkeys(candidate["canonical_name"] for candidate in required[:16]))
     heading = f"REQUIRED confirmed speakers (include all): {required_names}\n" if required_names else ""
     return heading + ("\n".join(lines) or "(none)"), confirmed
 
@@ -454,7 +694,102 @@ async def _build_character_candidate_hints(chapters, db: AsyncSession) -> str:
     return hints
 
 
-async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
+def _canonicalize_roster_characters(
+    characters: list[dict[str, Any]],
+    candidates: list[dict[str, Any]],
+    grounding_corpus: str,
+) -> list[dict[str, Any]]:
+    """Merge split identities and replace speculative biographies with facts."""
+    stats_by_canonical: dict[str, dict[str, Any]] = {}
+    identity_lookup: dict[str, str] = {}
+    for candidate in candidates:
+        canonical_name = str(candidate.get("canonical_name") or candidate["name"]).strip()
+        canonical_key = canonical_name.casefold()
+        stats = stats_by_canonical.setdefault(
+            canonical_key,
+            {
+                "canonical_name": canonical_name,
+                "names": set(),
+                "mention_count": 0,
+                "dialogue_count": 0,
+                "gender": None,
+                "gender_score": -1,
+                "required": False,
+            },
+        )
+        original_name = str(candidate["name"]).strip()
+        stats["names"].update({original_name, canonical_name})
+        stats["mention_count"] = max(stats["mention_count"], int(candidate.get("mention_count") or 0))
+        stats["dialogue_count"] = max(stats["dialogue_count"], int(candidate.get("dialogue_count") or 0))
+        stats["required"] = stats["required"] or bool(candidate.get("required", True))
+        gender = candidate.get("gender")
+        gender_score = int(candidate.get("dialogue_count") or 0) + int(candidate.get("mention_count") or 0)
+        if gender and gender_score > stats["gender_score"]:
+            stats["gender"] = gender
+            stats["gender_score"] = gender_score
+        identity_lookup[original_name.casefold()] = canonical_key
+        identity_lookup[canonical_key] = canonical_key
+
+    merged: dict[str, dict[str, Any]] = {}
+    for character in characters:
+        character = dict(character)
+        original_name = str(character["name"]).strip()
+        lookup_keys = [original_name.casefold(), *(str(alias).strip().casefold() for alias in character["aliases"])]
+        canonical_key = next((identity_lookup[key] for key in lookup_keys if key in identity_lookup), None)
+        stats = stats_by_canonical.get(canonical_key or "")
+        allowed_identity_names: set[str] = set()
+        if stats and not character["is_narrator"]:
+            character["name"] = stats["canonical_name"]
+            allowed_identity_names = {name.casefold() for name in stats["names"]}
+            character["aliases"] = [
+                *character["aliases"],
+                *(name for name in sorted(stats["names"]) if name.casefold() != character["name"].casefold()),
+            ]
+            if original_name.casefold() != character["name"].casefold():
+                character["aliases"] = [*character["aliases"], original_name]
+            dialogue_count = stats["dialogue_count"]
+            mention_count = stats["mention_count"]
+            if dialogue_count:
+                character["description"] = (
+                    f"Recurring speaking character identified from {dialogue_count} explicit dialogue "
+                    f"attributions and {mention_count} name mentions."
+                )
+            else:
+                character["description"] = f"Character identity grounded by {mention_count} full-name mentions."
+            evidence_gender = stats["gender"] or ("neutral" if stats["required"] else None)
+            character["voice_design_prompt"] = _normalise_voice_prompt(
+                character.get("voice_design_prompt"), gender=evidence_gender
+            )
+        elif not character["is_narrator"]:
+            character["description"] = "Speaking character identified from supplied story excerpts."
+            character["voice_design_prompt"] = _normalise_voice_prompt(character.get("voice_design_prompt"))
+
+        grounded_aliases = []
+        for alias in character["aliases"]:
+            value = " ".join(str(alias).split()).strip()
+            if not value or value.casefold() == character["name"].casefold():
+                continue
+            if value.casefold() in allowed_identity_names or value.casefold() in grounding_corpus:
+                grounded_aliases.append(value)
+        character["aliases"] = list(dict.fromkeys(grounded_aliases))[:10]
+
+        merge_key = character["name"].strip().casefold()
+        existing = merged.get(merge_key)
+        if existing is None:
+            merged[merge_key] = character
+            continue
+        existing["aliases"] = list(dict.fromkeys([*existing["aliases"], *character["aliases"]]))[:10]
+        existing["evidence"] = list(dict.fromkeys([*existing["evidence"], *character["evidence"]]))[:3]
+
+    return list(merged.values())
+
+
+async def generate_character_roster(
+    book_id: int,
+    db: AsyncSession,
+    *,
+    refresh_series_metadata: bool = False,
+) -> None:
     """Phase 2: extract characters from book text and persist to audiobook_characters."""
     settings = await crud.audiobook.get_audiobook_settings(db)
     provider = (settings.llm_provider or STUB_PROVIDER).lower() if settings else STUB_PROVIDER
@@ -481,6 +816,10 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
 
     combined_text = await _build_roster_excerpt(context_chapters, db)
     candidate_hints, confirmed_speakers = await _build_character_candidate_analysis(context_chapters, db)
+    first_person_gender = await _infer_first_person_gender(context_chapters, db)
+    prompt_series_profiles = series_profiles
+    if refresh_series_metadata and book.series:
+        prompt_series_profiles = await crud.audiobook.get_sibling_series_characters(db, book.series, book_id)
     series_roster = (
         json.dumps(
             [
@@ -490,11 +829,11 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
                     "description": profile.description,
                     "voice_design_prompt": profile.voice_design_prompt,
                 }
-                for profile in series_profiles
+                for profile in prompt_series_profiles
             ],
             ensure_ascii=False,
         )
-        if series_profiles
+        if prompt_series_profiles
         else "(none yet)"
     )
     await crud.audiobook.update_book_pipeline_progress(
@@ -557,19 +896,36 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
     if not isinstance(characters_data, list):
         raise RuntimeError(f"Expected a JSON array from LLM, got: {type(characters_data)}")
 
+    grounding_corpus = " ".join(combined_text.split()).casefold()
+    grounding_corpus += " " + " ".join(
+        " ".join(str(candidate.get("evidence") or "").split()).casefold() for candidate in confirmed_speakers
+    )
+
+    def grounded_evidence(items: Any) -> list[str]:
+        if not isinstance(items, list):
+            return []
+        grounded = []
+        for item in items:
+            value = " ".join(str(item).split()).strip(' "“”')
+            if len(value) >= 8 and value.casefold() in grounding_corpus:
+                grounded.append(value)
+        return grounded[:3]
+
     # Normalise keys to match our model
     normalised: list[dict] = []
     for c in characters_data:
         if not isinstance(c, dict):
             continue
+        description = c.get("description")
         normalised.append(
             {
                 "name": str(c.get("name", "Unknown")),
                 "aliases": [str(alias) for alias in c.get("aliases", []) if alias],
-                "description": c.get("description"),
-                "evidence": [str(item) for item in c.get("evidence", []) if item][:3],
+                "description": description,
+                "evidence": grounded_evidence(c.get("evidence")),
                 "voice_design_prompt": c.get("voice_design_prompt"),
                 "is_narrator": str(c.get("name", "")).strip().casefold() == "narrator",
+                "_is_protagonist": bool(re.search(r"\b(?:protagonist|first-person)\b", str(description or ""), re.IGNORECASE)),
             }
         )
     if not normalised:
@@ -593,6 +949,7 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
                         "evidence": character["evidence"],
                         "voice_design_prompt": "[gender-male][pitch-medium][speed-normal]",
                         "is_narrator": False,
+                        "_is_protagonist": True,
                     }
                 )
                 existing_names.add(canonical)
@@ -612,36 +969,57 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
                 "evidence": [],
                 "voice_design_prompt": "[gender-neutral][pitch-medium][speed-normal]",
                 "is_narrator": True,
+                "_is_protagonist": False,
             },
         )
+    for character in normalised:
+        if character["is_narrator"]:
+            character["name"] = "Narrator"
+            character["aliases"] = []
+            character["description"] = "Primary narrative voice for prose; not a story character."
+            character["evidence"] = []
+            character["_is_protagonist"] = False
     if promoted_protagonists:
         narrator_index = next(index for index, character in enumerate(normalised) if character["is_narrator"])
         for offset, protagonist in enumerate(promoted_protagonists, start=1):
             normalised.insert(narrator_index + offset, protagonist)
 
+    normalised = _canonicalize_roster_characters(normalised, confirmed_speakers, grounding_corpus)
+    if first_person_gender:
+        for character in normalised:
+            if character.get("_is_protagonist"):
+                character["voice_design_prompt"] = _normalise_voice_prompt(
+                    character.get("voice_design_prompt"), gender=first_person_gender
+                )
+
     def character_tokens(character: dict) -> set[str]:
         values = [character["name"], *character["aliases"]]
         return {token.casefold() for value in values for token in _CANDIDATE_TOKEN_RE.findall(value)}
 
-    represented_tokens = set().union(*(character_tokens(character) for character in normalised))
-    for candidate in confirmed_speakers[:12]:
-        canonical = candidate["name"].casefold()
-        if canonical in represented_tokens:
+    represented_names = {
+        value.strip().casefold() for character in normalised for value in [character["name"], *character["aliases"]]
+    }
+    required_speakers = [candidate for candidate in confirmed_speakers if candidate.get("required", True)][:16]
+    for candidate in required_speakers:
+        candidate_name = str(candidate.get("canonical_name") or candidate["name"])
+        canonical = candidate_name.casefold()
+        if canonical in represented_names:
             continue
         normalised.append(
             {
-                "name": candidate["name"],
-                "aliases": [],
+                "name": candidate_name,
+                "aliases": [candidate["name"]] if candidate["name"].casefold() != canonical else [],
                 "description": (
                     f"Recurring speaking character identified from {candidate['dialogue_count']} explicit "
-                    "dialogue attributions across the book."
+                    f"dialogue attributions and {candidate['mention_count']} name mentions."
                 ),
                 "evidence": [candidate["evidence"]] if candidate["evidence"] else [],
-                "voice_design_prompt": "[gender-neutral][pitch-medium][speed-normal]",
+                "voice_design_prompt": _normalise_voice_prompt(None, gender=candidate.get("gender") or "neutral"),
                 "is_narrator": False,
+                "_is_protagonist": False,
             }
         )
-        represented_tokens.add(canonical)
+        represented_names.update({canonical, candidate["name"].casefold()})
 
     protagonist_names = {character["name"].strip().casefold() for character in promoted_protagonists}
     if protagonist_names:
@@ -652,12 +1030,16 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
                 alias for alias in character["aliases"] if alias.strip().casefold() not in protagonist_names
             ]
 
-    dialogue_scores = {candidate["name"].casefold(): candidate["dialogue_count"] for candidate in confirmed_speakers}
+    dialogue_scores = {
+        name.casefold(): candidate["dialogue_count"]
+        for candidate in confirmed_speakers
+        for name in {candidate["name"], candidate.get("canonical_name") or candidate["name"]}
+    }
 
     def roster_priority(character: dict) -> tuple[int, int, str]:
         if character["is_narrator"]:
             return (3, 0, character["name"])
-        if "protagonist" in str(character.get("description") or "").casefold():
+        if character.get("_is_protagonist"):
             return (2, 0, character["name"])
         score = max((dialogue_scores.get(token, 0) for token in character_tokens(character)), default=0)
         return (1, score, character["name"])
@@ -667,7 +1049,7 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
     if provider != STUB_PROVIDER:
         # Reserve stable voices for one-scene and unnamed dialogue without
         # allowing hundreds of cameos to crowd recurring characters out.
-        normalised = normalised[:13]
+        normalised = normalised[:18]
         normalised.extend(
             [
                 {
@@ -677,6 +1059,7 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
                     "evidence": [],
                     "voice_design_prompt": "[gender-female][pitch-medium][speed-normal]",
                     "is_narrator": False,
+                    "_is_protagonist": False,
                 },
                 {
                     "name": "Minor Male Voice",
@@ -685,6 +1068,7 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
                     "evidence": [],
                     "voice_design_prompt": "[gender-male][pitch-medium][speed-normal]",
                     "is_narrator": False,
+                    "_is_protagonist": False,
                 },
             ]
         )
@@ -694,34 +1078,42 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
         profile = shared_by_name.get(" ".join(character["name"].casefold().split()))
         if profile is None:
             continue
-        character.update(
-            {
-                "series_character_id": profile.id,
-                "name": profile.name,
-                "description": profile.description,
-                "voice_design_prompt": profile.voice_design_prompt,
-                "is_narrator": profile.is_narrator,
-                "aliases": profile.aliases or [],
-                "evidence": profile.evidence or [],
-            }
-        )
+        if refresh_series_metadata:
+            character["series_character_id"] = profile.id
+        else:
+            character.update(
+                {
+                    "series_character_id": profile.id,
+                    "name": profile.name,
+                    "description": profile.description,
+                    "voice_design_prompt": profile.voice_design_prompt,
+                    "is_narrator": profile.is_narrator,
+                    "aliases": profile.aliases or [],
+                    "evidence": profile.evidence or [],
+                }
+            )
+
+    for character in normalised:
+        character.pop("_is_protagonist", None)
 
     await crud.audiobook.delete_characters_for_book(db, book_id)
     created_characters = await crud.audiobook.create_characters_bulk(
         db,
         book_id=book_id,
-        characters_data=normalised[:15],
+        characters_data=normalised[:20],
     )
     if book.series:
         await crud.audiobook.sync_book_roster_with_series(
             db,
             book,
             created_characters,
-            prefer_series=True,
+            prefer_series=not refresh_series_metadata,
         )
+        if refresh_series_metadata:
+            await crud.audiobook.delete_orphaned_series_characters(db, book.series)
     await crud.audiobook.set_book_audiobook_summary(db, book_id, roster_result.get("book_summary"))
     await crud.audiobook.update_book_pipeline_progress(
-        db, book_id, current=1, total=1, detail=f"Created {len(normalised[:15])} character profiles"
+        db, book_id, current=1, total=1, detail=f"Created {len(normalised[:20])} character profiles"
     )
     logger.info("Created %d characters for book %s.", len(normalised), book_id)
     if not await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):
@@ -739,7 +1131,16 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
     minor_female_id = next((character.id for character in characters if character.name == "Minor Female Voice"), None)
     minor_male_id = next((character.id for character in characters if character.name == "Minor Male Voice"), None)
     roster_json = json.dumps(
-        [{"id": c.id, "name": c.name, "description": c.description, "is_narrator": c.is_narrator} for c in characters],
+        [
+            {
+                "id": c.id,
+                "name": c.name,
+                "aliases": c.aliases or [],
+                "description": c.description,
+                "is_narrator": c.is_narrator,
+            }
+            for c in characters
+        ],
         ensure_ascii=False,
     )
 
@@ -747,7 +1148,8 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
     counts = await crud.audiobook.count_sentences_by_status(db, book_id)
     total = sum(counts.values())
     processed = total - counts.get("pending_diarization", 0)
-    batch_size = 40
+    batch_size = MAX_DIARIZATION_BATCH_SIZE
+    smaller_batch_successes = 0
     await crud.audiobook.update_book_pipeline_progress(
         db, book_id, current=processed, total=total, detail="Preparing dialogue attribution"
     )
@@ -854,12 +1256,62 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
                 try:
                     batch_result = _extract_json(raw)
                 except json.JSONDecodeError as exc:
-                    raise RuntimeError(f"LLM returned invalid JSON for diarization: {exc}\nRaw: {raw[:500]}") from exc
+                    if batch_size > MIN_DIARIZATION_BATCH_SIZE:
+                        smaller_batch_size = max(MIN_DIARIZATION_BATCH_SIZE, batch_size // 2)
+                        logger.warning(
+                            "Invalid diarization JSON for book %s at batch size %s; retrying %s sentences: %s",
+                            book_id,
+                            batch_size,
+                            smaller_batch_size,
+                            exc,
+                        )
+                        batch_size = smaller_batch_size
+                        smaller_batch_successes = 0
+                        await crud.audiobook.update_book_pipeline_progress(
+                            db,
+                            book_id,
+                            current=processed,
+                            total=total,
+                            detail=f"Retrying malformed model output with {batch_size} sentences",
+                        )
+                        continue
+                    raw_excerpt = f"{raw[:500]}\n...\n{raw[-500:]}" if len(raw) > 1000 else raw
+                    raise RuntimeError(
+                        f"LLM returned invalid JSON for diarization after smaller-batch retries: {exc}\n" f"Raw: {raw_excerpt}"
+                    ) from exc
 
-            if isinstance(batch_result, list):
-                batch_result = {"assignments": batch_result, "chapter_summary": chapter.summary}
-            if not isinstance(batch_result, dict) or not isinstance(batch_result.get("assignments"), list):
-                raise RuntimeError(f"Expected a JSON object from diarization, got: {type(batch_result)}")
+            try:
+                batch_result = _normalise_diarization_result(
+                    batch_result,
+                    {sentence.id for sentence in batch},
+                )
+            except ValueError as exc:
+                if provider != STUB_PROVIDER and batch_size > MIN_DIARIZATION_BATCH_SIZE:
+                    smaller_batch_size = max(MIN_DIARIZATION_BATCH_SIZE, batch_size // 2)
+                    logger.warning(
+                        "Incomplete diarization response for book %s at batch size %s; retrying %s sentences: %s",
+                        book_id,
+                        batch_size,
+                        smaller_batch_size,
+                        exc,
+                    )
+                    batch_size = smaller_batch_size
+                    smaller_batch_successes = 0
+                    await crud.audiobook.update_book_pipeline_progress(
+                        db,
+                        book_id,
+                        current=processed,
+                        total=total,
+                        detail=f"Retrying incomplete model output with {batch_size} sentences",
+                    )
+                    continue
+                raise RuntimeError(f"Invalid diarization response: {exc}") from exc
+
+            if batch_size < MAX_DIARIZATION_BATCH_SIZE:
+                smaller_batch_successes += 1
+                if smaller_batch_successes >= 2:
+                    batch_size = min(MAX_DIARIZATION_BATCH_SIZE, batch_size * 2)
+                    smaller_batch_successes = 0
             results = batch_result["assignments"]
 
             result_map = {r["id"]: r for r in results if isinstance(r, dict) and isinstance(r.get("id"), int)}

--- a/backend/app/services/audiobook_llm.py
+++ b/backend/app/services/audiobook_llm.py
@@ -108,6 +108,15 @@ _DIALOGUE_ATTRIBUTION_IN_SENTENCE_RE = re.compile(
     r"\b(?:said|asked|replied|yelled|shouted|whispered|muttered|added|continued|answered|snapped)\b" r"[^“\"]{0,80}[“\"]",
     re.IGNORECASE,
 )
+_ATTRIBUTION_VERBS = (
+    "said|asked|replied|yelled|shouted|whispered|muttered|added|continued|answered|snapped|reminded|"
+    "repeated|remarked|responded|interrupted"
+)
+_GENERIC_SPEAKER_ROLES = ("recruiter", "doctor", "nurse", "clerk", "manager", "officer", "soldier", "guard", "pilot")
+_GENERIC_ROLE_ATTRIBUTION_RE = re.compile(
+    rf"\b(?:the\s+)?(?P<role>{'|'.join(_GENERIC_SPEAKER_ROLES)})\s+(?:{_ATTRIBUTION_VERBS})\b",
+    re.IGNORECASE,
+)
 MAX_DIARIZATION_BATCH_SIZE = 10
 MIN_DIARIZATION_BATCH_SIZE = 5
 MIN_STORY_CHAPTER_SENTENCES = 40
@@ -197,7 +206,11 @@ async def _call_llm(
             "stream": False,
             "think": False,
             "format": response_schema or "json",
-            "options": {"temperature": 0, "num_ctx": 32768, "num_predict": 8192},
+            "options": {
+                "temperature": 0,
+                "num_ctx": 32768,
+                "num_predict": 8192 if response_schema is ROSTER_SCHEMA else 2048,
+            },
             "keep_alive": "30m",
         }
         timeout = httpx.Timeout(600.0, connect=10.0)
@@ -356,6 +369,9 @@ def _apply_speaker_guardrails(
     character_id: int | None,
     narrator_id: int | None,
     protagonist_id: int | None,
+    character_name_ids: dict[str, int],
+    role_speaker_ids: dict[str, int],
+    last_dialogue_speaker_id: int | None,
     minor_female_id: int | None,
     minor_male_id: int | None,
     reason: str,
@@ -364,6 +380,16 @@ def _apply_speaker_guardrails(
     starts_with_quote = text.lstrip().startswith(("“", '"'))
     has_quote = any(quote in text for quote in ("“", "”", '"'))
     has_dialogue = starts_with_quote or bool(_DIALOGUE_ATTRIBUTION_IN_SENTENCE_RE.search(text))
+
+    attribution_context = f"{text} {next_text if starts_with_quote else ''}"
+    for name, attributed_character_id in character_name_ids.items():
+        escaped_name = re.escape(name)
+        if re.search(
+            rf"(?:\b{escaped_name}\s+(?:{_ATTRIBUTION_VERBS})\b|\b(?:{_ATTRIBUTION_VERBS})\s+{escaped_name}\b)",
+            attribution_context,
+            re.IGNORECASE,
+        ):
+            return attributed_character_id, f"Deterministic named dialogue attribution to {name}", 0.99
 
     current_first_person = _FIRST_PERSON_ATTRIBUTION_RE.search(text)
     next_first_person = starts_with_quote and _FIRST_PERSON_ATTRIBUTION_RE.match(next_text.lstrip())
@@ -378,6 +404,14 @@ def _apply_speaker_guardrails(
         fallback_id = minor_female_id if gender == "she" else minor_male_id
         if fallback_id is not None:
             return fallback_id, f"Deterministic {gender} dialogue attribution to minor voice", 0.98
+
+    role_attribution = _GENERIC_ROLE_ATTRIBUTION_RE.search(attribution_context) if has_quote else None
+    if role_attribution:
+        role_speaker_id = role_speaker_ids.get(role_attribution.group("role").casefold())
+        if role_speaker_id is not None:
+            return role_speaker_id, "Deterministic grounded role dialogue attribution", 0.98
+        if last_dialogue_speaker_id is not None:
+            return last_dialogue_speaker_id, "Deterministic recurring role dialogue attribution", 0.9
 
     if character_id == narrator_id and starts_with_quote and protagonist_id is not None:
         return protagonist_id, "Deterministic first-person dialogue fallback", 0.75
@@ -412,6 +446,25 @@ def _advance_open_dialogue_speaker(
     if closes > opens:
         return None
     return current_open_speaker_id
+
+
+def _infer_role_speaker_ids(sentences: list[Any], minor_female_id: int | None, minor_male_id: int | None) -> dict[str, int]:
+    """Ground recurring unnamed roles in repeated chapter-local pronouns."""
+    result: dict[str, int] = {}
+    for role in _GENERIC_SPEAKER_ROLES:
+        pronouns: Counter[str] = Counter()
+        role_pattern = re.compile(rf"\b{re.escape(role)}\b", re.IGNORECASE)
+        for sentence in sentences:
+            text = sentence.original_text
+            if role_pattern.search(text):
+                pronouns.update(token.casefold() for token in re.findall(r"\b(?:she|her|he|him|his)\b", text, re.I))
+        female = pronouns["she"] + pronouns["her"]
+        male = pronouns["he"] + pronouns["him"] + pronouns["his"]
+        if minor_female_id is not None and female >= 1 and female >= male * 2:
+            result[role] = minor_female_id
+        elif minor_male_id is not None and male >= 1 and male >= female * 2:
+            result[role] = minor_male_id
+    return result
 
 
 async def _build_roster_excerpt(chapters, db: AsyncSession) -> str:
@@ -1186,6 +1239,13 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
     )
     minor_female_id = next((character.id for character in characters if character.name == "Minor Female Voice"), None)
     minor_male_id = next((character.id for character in characters if character.name == "Minor Male Voice"), None)
+    character_name_ids = {
+        name.casefold(): character.id
+        for character in characters
+        if not character.is_narrator and character.id not in {minor_female_id, minor_male_id}
+        for name in sorted([character.name, *(character.aliases or [])], key=len, reverse=True)
+        if len(name.strip()) >= 3
+    }
     roster_json = json.dumps(
         [
             {
@@ -1217,6 +1277,7 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
             return
 
         chapter_sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
+        role_speaker_ids = _infer_role_speaker_ids(chapter_sentences, minor_female_id, minor_male_id)
         pending = [sentence for sentence in chapter_sentences if sentence.status == "pending_diarization"]
         if not pending:
             continue
@@ -1253,9 +1314,15 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
             sentence.original_text for sentence in chapter_sentences if sentence.status != "pending_diarization"
         ][-8:]
         open_dialogue_speaker_id = None
+        last_dialogue_speaker_id = None
         for previous_sentence in chapter_sentences:
             if previous_sentence.status == "pending_diarization":
                 break
+            was_open_dialogue = open_dialogue_speaker_id is not None
+            if previous_sentence.character_id != narrator_id and (
+                was_open_dialogue or any(quote in previous_sentence.original_text for quote in ("“", "”", '"'))
+            ):
+                last_dialogue_speaker_id = previous_sentence.character_id
             open_dialogue_speaker_id = _advance_open_dialogue_speaker(
                 previous_sentence.original_text,
                 previous_sentence.character_id,
@@ -1270,6 +1337,39 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
             )
             if not batch:
                 break
+
+            # Quote-free prose cannot be a spoken character line. Commit the
+            # unambiguous prefix before asking the local model about the next
+            # dialogue span; long prose should never inflate a dialogue call.
+            deterministic_prefix = []
+            if open_dialogue_speaker_id is None:
+                for sentence in batch:
+                    if any(quote in sentence.original_text for quote in ("“", "”", '"')):
+                        break
+                    deterministic_prefix.append(sentence)
+            if deterministic_prefix:
+                for sentence in deterministic_prefix:
+                    await crud.audiobook.update_sentence_diarization(
+                        db,
+                        sentence.id,
+                        narrator_id,
+                        sentence.original_text,
+                        speaker_confidence=0.99,
+                        speaker_reason="Deterministic quote-free narration",
+                    )
+                    context_window.append(sentence.original_text)
+                processed += len(deterministic_prefix)
+                await crud.audiobook.update_book_pipeline_progress(
+                    db,
+                    book_id,
+                    current=processed,
+                    total=total,
+                    detail=f"Chapter {chapter.chapter_number}: short-circuited quote-free prose",
+                )
+                if await crud.audiobook.consume_book_batch_limit(db, book_id):
+                    logger.info("Book %s paused after one deterministic narration batch.", book_id)
+                    return
+                continue
 
             sentences_json = json.dumps(
                 [{"id": s.id, "text": s.original_text} for s in batch],
@@ -1405,6 +1505,9 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
                     character_id=char_id,
                     narrator_id=narrator_id,
                     protagonist_id=protagonist_id,
+                    character_name_ids=character_name_ids,
+                    role_speaker_ids=role_speaker_ids,
+                    last_dialogue_speaker_id=last_dialogue_speaker_id,
                     minor_female_id=minor_female_id,
                     minor_male_id=minor_male_id,
                     reason=reason,
@@ -1415,6 +1518,10 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
                     char_id = open_dialogue_speaker_id
                     reason = "Deterministic continuation of open quoted dialogue"
                     confidence = 0.95
+                if char_id != narrator_id and (
+                    open_dialogue_speaker_id is not None or any(quote in sentence.original_text for quote in ("“", "”", '"'))
+                ):
+                    last_dialogue_speaker_id = char_id
                 open_dialogue_speaker_id = _advance_open_dialogue_speaker(
                     sentence.original_text,
                     char_id,

--- a/backend/app/services/audiobook_llm.py
+++ b/backend/app/services/audiobook_llm.py
@@ -382,14 +382,19 @@ def _apply_speaker_guardrails(
     has_dialogue = starts_with_quote or bool(_DIALOGUE_ATTRIBUTION_IN_SENTENCE_RE.search(text))
 
     attribution_context = f"{text} {next_text if starts_with_quote else ''}"
-    for name, attributed_character_id in character_name_ids.items():
-        escaped_name = re.escape(name)
-        if re.search(
-            rf"(?:\b{escaped_name}\s+(?:{_ATTRIBUTION_VERBS})\b|\b(?:{_ATTRIBUTION_VERBS})\s+{escaped_name}\b)",
-            attribution_context,
-            re.IGNORECASE,
-        ):
-            return attributed_character_id, f"Deterministic named dialogue attribution to {name}", 0.99
+    named_contexts = [text]
+    if starts_with_quote and next_text:
+        named_contexts.append(next_text)
+    for named_context in named_contexts:
+        for name, attributed_character_id in character_name_ids.items():
+            escaped_name = re.escape(name)
+            if re.search(
+                rf"(?:\b{escaped_name}\s+(?:{_ATTRIBUTION_VERBS})\b|"
+                rf"\b(?:{_ATTRIBUTION_VERBS})\s+{escaped_name}\b)",
+                named_context,
+                re.IGNORECASE,
+            ):
+                return attributed_character_id, f"Deterministic named dialogue attribution to {name}", 0.99
 
     current_first_person = _FIRST_PERSON_ATTRIBUTION_RE.search(text)
     next_first_person = starts_with_quote and _FIRST_PERSON_ATTRIBUTION_RE.match(next_text.lstrip())
@@ -413,6 +418,14 @@ def _apply_speaker_guardrails(
         if last_dialogue_speaker_id is not None:
             return last_dialogue_speaker_id, "Deterministic recurring role dialogue attribution", 0.9
 
+    if (
+        starts_with_quote
+        and protagonist_id is not None
+        and character_id != protagonist_id
+        and last_dialogue_speaker_id in {minor_female_id, minor_male_id}
+    ):
+        return protagonist_id, "Deterministic first-person turn-taking fallback", 0.8
+
     if character_id == narrator_id and starts_with_quote and protagonist_id is not None:
         return protagonist_id, "Deterministic first-person dialogue fallback", 0.75
 
@@ -431,21 +444,44 @@ def _advance_open_dialogue_speaker(
     minor_male_id: int | None,
     current_open_speaker_id: int | None,
 ) -> int | None:
-    """Track a curly-quoted utterance split across sentence records."""
-    opens = text.count("“")
-    closes = text.count("”")
-    if opens > closes:
-        prefix = text.rsplit("“", 1)[0]
-        pronouns = re.findall(r"\b(she|her|he|him)\b", prefix[-120:], re.IGNORECASE)
+    """Track quoted speech in source order, including close-then-reopen lines."""
+    open_speaker_id = current_open_speaker_id
+    for quote in re.finditer("[“”]", text):
+        if quote.group(0) == "”":
+            open_speaker_id = None
+            continue
+
+        # A repeated opening quote while a speaker is already active is the
+        # conventional marker for a new paragraph in the same long speech.
+        if open_speaker_id is not None:
+            continue
+
+        prefix = text[max(0, quote.start() - 120):quote.start()]
+        pronouns = re.findall(r"\b(she|her|he|him)\b", prefix, re.IGNORECASE)
         if pronouns:
             gender = pronouns[-1].casefold()
-            return minor_female_id if gender in {"she", "her"} else minor_male_id
-        if resolved_character_id != narrator_id:
-            return resolved_character_id
-        return None
-    if closes > opens:
-        return None
-    return current_open_speaker_id
+            open_speaker_id = minor_female_id if gender in {"she", "her"} else minor_male_id
+        elif resolved_character_id != narrator_id:
+            open_speaker_id = resolved_character_id
+    return open_speaker_id
+
+
+def _fallback_open_dialogue_speaker(
+    text: str,
+    inferred_open_speaker_id: int | None,
+    *,
+    protagonist_id: int | None,
+    last_dialogue_speaker_id: int | None,
+    last_other_dialogue_speaker_id: int | None,
+) -> int | None:
+    """Resolve an unattributed opening quote from established turn-taking."""
+    if inferred_open_speaker_id is not None or text.count("“") <= text.count("”"):
+        return inferred_open_speaker_id
+    if last_dialogue_speaker_id == protagonist_id and last_other_dialogue_speaker_id is not None:
+        return last_other_dialogue_speaker_id
+    if protagonist_id is not None and last_dialogue_speaker_id not in {None, protagonist_id}:
+        return protagonist_id
+    return None
 
 
 def _infer_role_speaker_ids(sentences: list[Any], minor_female_id: int | None, minor_male_id: int | None) -> dict[str, int]:
@@ -1315,6 +1351,7 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
         ][-8:]
         open_dialogue_speaker_id = None
         last_dialogue_speaker_id = None
+        last_other_dialogue_speaker_id = None
         for previous_sentence in chapter_sentences:
             if previous_sentence.status == "pending_diarization":
                 break
@@ -1323,13 +1360,22 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
                 was_open_dialogue or any(quote in previous_sentence.original_text for quote in ("“", "”", '"'))
             ):
                 last_dialogue_speaker_id = previous_sentence.character_id
-            open_dialogue_speaker_id = _advance_open_dialogue_speaker(
+                if previous_sentence.character_id != protagonist_id:
+                    last_other_dialogue_speaker_id = previous_sentence.character_id
+            inferred_open_speaker_id = _advance_open_dialogue_speaker(
                 previous_sentence.original_text,
                 previous_sentence.character_id,
                 narrator_id=narrator_id,
                 minor_female_id=minor_female_id,
                 minor_male_id=minor_male_id,
                 current_open_speaker_id=open_dialogue_speaker_id,
+            )
+            open_dialogue_speaker_id = _fallback_open_dialogue_speaker(
+                previous_sentence.original_text,
+                inferred_open_speaker_id,
+                protagonist_id=protagonist_id,
+                last_dialogue_speaker_id=last_dialogue_speaker_id,
+                last_other_dialogue_speaker_id=last_other_dialogue_speaker_id,
             )
         while True:
             batch = await crud.audiobook.get_sentences_pending_diarization(
@@ -1366,6 +1412,9 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
                     total=total,
                     detail=f"Chapter {chapter.chapter_number}: short-circuited quote-free prose",
                 )
+                if await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):
+                    logger.info("Book %s paused after a deterministic narration batch.", book_id)
+                    return
                 if await crud.audiobook.consume_book_batch_limit(db, book_id):
                     logger.info("Book %s paused after one deterministic narration batch.", book_id)
                     return
@@ -1514,7 +1563,7 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
                 )
                 if guardrail_confidence is not None:
                     confidence = guardrail_confidence
-                if open_dialogue_speaker_id is not None and char_id == narrator_id:
+                if open_dialogue_speaker_id is not None and char_id != open_dialogue_speaker_id:
                     char_id = open_dialogue_speaker_id
                     reason = "Deterministic continuation of open quoted dialogue"
                     confidence = 0.95
@@ -1522,13 +1571,22 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
                     open_dialogue_speaker_id is not None or any(quote in sentence.original_text for quote in ("“", "”", '"'))
                 ):
                     last_dialogue_speaker_id = char_id
-                open_dialogue_speaker_id = _advance_open_dialogue_speaker(
+                    if char_id != protagonist_id:
+                        last_other_dialogue_speaker_id = char_id
+                inferred_open_speaker_id = _advance_open_dialogue_speaker(
                     sentence.original_text,
                     char_id,
                     narrator_id=narrator_id,
                     minor_female_id=minor_female_id,
                     minor_male_id=minor_male_id,
                     current_open_speaker_id=open_dialogue_speaker_id,
+                )
+                open_dialogue_speaker_id = _fallback_open_dialogue_speaker(
+                    sentence.original_text,
+                    inferred_open_speaker_id,
+                    protagonist_id=protagonist_id,
+                    last_dialogue_speaker_id=last_dialogue_speaker_id,
+                    last_other_dialogue_speaker_id=last_other_dialogue_speaker_id,
                 )
                 await crud.audiobook.update_sentence_diarization(
                     db,
@@ -1551,6 +1609,9 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
                 total=total,
                 detail=f"Chapter {chapter.chapter_number}: attributed {processed} of {total} sentences",
             )
+            if await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):
+                logger.info("Book %s paused after a diarization batch.", book_id)
+                return
             if await crud.audiobook.consume_book_batch_limit(db, book_id):
                 logger.info("Book %s paused after one diarization batch.", book_id)
                 return

--- a/backend/app/services/audiobook_llm.py
+++ b/backend/app/services/audiobook_llm.py
@@ -389,8 +389,7 @@ def _apply_speaker_guardrails(
         for name, attributed_character_id in character_name_ids.items():
             escaped_name = re.escape(name)
             if re.search(
-                rf"(?:\b{escaped_name}\s+(?:{_ATTRIBUTION_VERBS})\b|"
-                rf"\b(?:{_ATTRIBUTION_VERBS})\s+{escaped_name}\b)",
+                rf"(?:\b{escaped_name}\s+(?:{_ATTRIBUTION_VERBS})\b|" rf"\b(?:{_ATTRIBUTION_VERBS})\s+{escaped_name}\b)",
                 named_context,
                 re.IGNORECASE,
             ):
@@ -456,7 +455,9 @@ def _advance_open_dialogue_speaker(
         if open_speaker_id is not None:
             continue
 
-        prefix = text[max(0, quote.start() - 120):quote.start()]
+        prefix_end = quote.start()
+        prefix_start = max(0, prefix_end - 120)
+        prefix = text[prefix_start:prefix_end]
         pronouns = re.findall(r"\b(she|her|he|him)\b", prefix, re.IGNORECASE)
         if pronouns:
             gender = pronouns[-1].casefold()

--- a/backend/app/services/audiobook_queue.py
+++ b/backend/app/services/audiobook_queue.py
@@ -48,9 +48,18 @@ class AudiobookQueue:
     async def stop(self) -> None:
         if not self._worker_task:
             return
-        await self._queue.put(None)
-        await self._worker_task
+        self._worker_task.cancel()
+        try:
+            await self._worker_task
+        except asyncio.CancelledError:
+            logger.info("Audiobook worker cancelled at its durable checkpoint.")
         self._worker_task = None
+        while not self._queue.empty():
+            try:
+                self._queue.get_nowait()
+                self._queue.task_done()
+            except asyncio.QueueEmpty:
+                break
         self._queued_book_ids.clear()
         self._rerun_book_ids.clear()
         self._queued_preview_ids.clear()
@@ -188,7 +197,15 @@ class AudiobookQueue:
                 if phase == "ingesting":
                     await ingest_epub(book_id, db)
                 elif phase == "roster_gen":
-                    await generate_character_roster(book_id, db)
+                    book = await db.get(Book, book_id)
+                    refresh_series_metadata = bool(
+                        book and book.audiobook_stop_after_phase == crud.audiobook.ROSTER_REFRESH_STOP_MARKER
+                    )
+                    await generate_character_roster(
+                        book_id,
+                        db,
+                        refresh_series_metadata=refresh_series_metadata,
+                    )
                 elif phase == "diarizing":
                     await diarize_sentences(book_id, db)
                 elif phase == "audio_gen":

--- a/backend/app/services/audiobook_tts.py
+++ b/backend/app/services/audiobook_tts.py
@@ -34,7 +34,13 @@ def _get_mp3_duration_ms(path: Path) -> int:
     return int(audio.info.length * 1000)
 
 
-async def _call_omnivoice(endpoint: str, voice_prompt: str, tagged_text: str) -> bytes:
+async def _call_omnivoice(
+    endpoint: str,
+    voice_prompt: str,
+    tagged_text: str,
+    *,
+    voice_id: str | None = None,
+) -> bytes:
     if endpoint.startswith("stub://"):
         duration_ms = max(350, min(5000, len(tagged_text.split()) * 260))
         ffmpeg = shutil.which("ffmpeg")
@@ -71,9 +77,12 @@ async def _call_omnivoice(endpoint: str, voice_prompt: str, tagged_text: str) ->
     # kernels warm up. Keep connection failures fast but allow inference time.
     timeout = httpx.Timeout(600.0, connect=10.0)
     async with httpx.AsyncClient(timeout=timeout) as client:
+        request_body = {"voice": voice_prompt, "text": tagged_text}
+        if voice_id:
+            request_body["voice_id"] = voice_id
         resp = await client.post(
             url,
-            json={"voice": voice_prompt, "text": tagged_text},
+            json=request_body,
             headers={"Accept": "audio/mpeg"},
         )
         resp.raise_for_status()
@@ -97,15 +106,23 @@ async def _generate_sentence_clip(
     db: AsyncSession,
 ) -> None:
     voice_prompt = DEFAULT_VOICE_PROMPT
+    voice_id = None
     if sentence.character_id is not None:
         char = await db.get(AudiobookCharacter, sentence.character_id)
-        if char and char.voice_design_prompt:
-            voice_prompt = char.voice_design_prompt
+        if char:
+            if char.voice_design_prompt:
+                voice_prompt = char.voice_design_prompt
+            voice_id = (
+                f"series-character:{char.series_character_id}"
+                if char.series_character_id is not None
+                else f"book:{book_id}:character:{char.id}"
+            )
 
     audio_bytes = await _call_omnivoice(
         endpoint,
         voice_prompt,
         sentence.tagged_text or sentence.original_text,
+        voice_id=voice_id,
     )
     out_path = _snippet_path(book_id, sentence.id)
     out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/backend/tests/test_audiobook_pipeline.py
+++ b/backend/tests/test_audiobook_pipeline.py
@@ -155,6 +155,7 @@ def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
         next_text="",
         character_id=20,
         narrator_id=10,
+        protagonist_id=20,
         minor_female_id=30,
         minor_male_id=40,
         reason="Action description by the protagonist.",
@@ -164,6 +165,7 @@ def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
         next_text="",
         character_id=20,
         narrator_id=10,
+        protagonist_id=20,
         minor_female_id=30,
         minor_male_id=40,
         reason="Expressing deep grief.",
@@ -173,6 +175,7 @@ def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
         next_text="",
         character_id=20,
         narrator_id=10,
+        protagonist_id=20,
         minor_female_id=30,
         minor_male_id=40,
         reason="Recalling her final words.",
@@ -182,15 +185,37 @@ def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
         next_text="she asked without looking up.",
         character_id=10,
         narrator_id=10,
+        protagonist_id=20,
         minor_female_id=30,
         minor_male_id=40,
         reason="Dialogue attributed to the unnamed recruiter.",
+    )
+    first_person_dialogue = audiobook_llm._apply_speaker_guardrails(
+        text="“I could be lonely,” I said.",
+        next_text="“We do not get many,” she said.",
+        character_id=30,
+        narrator_id=10,
+        protagonist_id=20,
+        minor_female_id=30,
+        minor_male_id=40,
+        reason="Model confused the adjacent speaker.",
+    )
+    repeated_dialogue = audiobook_llm._apply_speaker_guardrails(
+        text="“Coming or going,” she repeated. “",
+        next_text="",
+        character_id=50,
+        narrator_id=10,
+        protagonist_id=20,
+        minor_female_id=30,
+        minor_male_id=40,
+        reason="Model selected an unrelated named character.",
     )
     setup = audiobook_llm._apply_speaker_guardrails(
         text="The recruiter looked up. “",
         next_text="Hello,” she said.",
         character_id=10,
         narrator_id=10,
+        protagonist_id=20,
         minor_female_id=30,
         minor_male_id=40,
         reason="Narration setting up dialogue.",
@@ -200,7 +225,43 @@ def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
     assert emotional_prose == (10, "Deterministic prose/narration guardrail", 0.98)
     assert embedded_quote == (10, "Deterministic prose/narration guardrail", 0.98)
     assert dialogue == (30, "Deterministic she dialogue attribution to minor voice", 0.98)
+    assert first_person_dialogue == (20, "Deterministic first-person dialogue attribution", 0.99)
+    assert repeated_dialogue == (30, "Deterministic she dialogue attribution to minor voice", 0.98)
     assert setup == (10, "Narration setting up dialogue.", None)
+
+
+def test_open_dialogue_state_tracks_split_quote_speaker():
+    open_speaker = audiobook_llm._advance_open_dialogue_speaker(
+        "“Take your time,” I said. “",
+        20,
+        narrator_id=10,
+        minor_female_id=30,
+        minor_male_id=40,
+        current_open_speaker_id=None,
+    )
+    assert open_speaker == 20
+    assert (
+        audiobook_llm._advance_open_dialogue_speaker(
+            "I know the place is packed.”",
+            20,
+            narrator_id=10,
+            minor_female_id=30,
+            minor_male_id=40,
+            current_open_speaker_id=open_speaker,
+        )
+        is None
+    )
+    assert (
+        audiobook_llm._advance_open_dialogue_speaker(
+            "She looked back to her computer. “",
+            10,
+            narrator_id=10,
+            minor_female_id=30,
+            minor_male_id=40,
+            current_open_speaker_id=None,
+        )
+        == 30
+    )
 
 
 @pytest.mark.asyncio
@@ -370,7 +431,7 @@ async def test_diarization_retries_malformed_output_in_smaller_batches(db, monke
 
     counts = await crud.audiobook.count_sentences_by_status(db, book.id)
     await db.refresh(book)
-    assert request_sizes == [40, 20, 20, 5]
+    assert request_sizes == [10, 5, 5, 10, 10, 10, 5]
     assert counts == {"ready_for_audio": 45}
     assert book.audiobook_pipeline_status == "audio_gen"
 

--- a/backend/tests/test_audiobook_pipeline.py
+++ b/backend/tests/test_audiobook_pipeline.py
@@ -3,6 +3,7 @@ import json
 import shutil
 import zipfile
 from pathlib import Path
+from types import SimpleNamespace
 
 import httpx
 import pytest
@@ -156,6 +157,9 @@ def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
         character_id=20,
         narrator_id=10,
         protagonist_id=20,
+        character_name_ids={"harry": 50},
+        role_speaker_ids={"recruiter": 30},
+        last_dialogue_speaker_id=None,
         minor_female_id=30,
         minor_male_id=40,
         reason="Action description by the protagonist.",
@@ -166,6 +170,9 @@ def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
         character_id=20,
         narrator_id=10,
         protagonist_id=20,
+        character_name_ids={"harry": 50},
+        role_speaker_ids={"recruiter": 30},
+        last_dialogue_speaker_id=None,
         minor_female_id=30,
         minor_male_id=40,
         reason="Expressing deep grief.",
@@ -176,6 +183,9 @@ def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
         character_id=20,
         narrator_id=10,
         protagonist_id=20,
+        character_name_ids={"harry": 50},
+        role_speaker_ids={"recruiter": 30},
+        last_dialogue_speaker_id=None,
         minor_female_id=30,
         minor_male_id=40,
         reason="Recalling her final words.",
@@ -186,6 +196,9 @@ def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
         character_id=10,
         narrator_id=10,
         protagonist_id=20,
+        character_name_ids={"harry": 50},
+        role_speaker_ids={"recruiter": 30},
+        last_dialogue_speaker_id=None,
         minor_female_id=30,
         minor_male_id=40,
         reason="Dialogue attributed to the unnamed recruiter.",
@@ -196,6 +209,9 @@ def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
         character_id=30,
         narrator_id=10,
         protagonist_id=20,
+        character_name_ids={"harry": 50},
+        role_speaker_ids={"recruiter": 30},
+        last_dialogue_speaker_id=None,
         minor_female_id=30,
         minor_male_id=40,
         reason="Model confused the adjacent speaker.",
@@ -206,9 +222,38 @@ def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
         character_id=50,
         narrator_id=10,
         protagonist_id=20,
+        character_name_ids={"harry": 50},
+        role_speaker_ids={"recruiter": 30},
+        last_dialogue_speaker_id=30,
         minor_female_id=30,
         minor_male_id=40,
         reason="Model selected an unrelated named character.",
+    )
+    role_dialogue = audiobook_llm._apply_speaker_guardrails(
+        text="“Final paragraph,” the recruiter said. “",
+        next_text="",
+        character_id=20,
+        narrator_id=10,
+        protagonist_id=20,
+        character_name_ids={"harry": 50},
+        role_speaker_ids={"recruiter": 30},
+        last_dialogue_speaker_id=30,
+        minor_female_id=30,
+        minor_male_id=40,
+        reason="Model selected the protagonist.",
+    )
+    named_dialogue = audiobook_llm._apply_speaker_guardrails(
+        text="“Physics is lovely,” Harry said.",
+        next_text="",
+        character_id=10,
+        narrator_id=10,
+        protagonist_id=20,
+        character_name_ids={"harry": 50},
+        role_speaker_ids={"recruiter": 30},
+        last_dialogue_speaker_id=20,
+        minor_female_id=30,
+        minor_male_id=40,
+        reason="Model selected narration.",
     )
     setup = audiobook_llm._apply_speaker_guardrails(
         text="The recruiter looked up. “",
@@ -216,6 +261,9 @@ def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
         character_id=10,
         narrator_id=10,
         protagonist_id=20,
+        character_name_ids={"harry": 50},
+        role_speaker_ids={"recruiter": 30},
+        last_dialogue_speaker_id=None,
         minor_female_id=30,
         minor_male_id=40,
         reason="Narration setting up dialogue.",
@@ -227,6 +275,8 @@ def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
     assert dialogue == (30, "Deterministic she dialogue attribution to minor voice", 0.98)
     assert first_person_dialogue == (20, "Deterministic first-person dialogue attribution", 0.99)
     assert repeated_dialogue == (30, "Deterministic she dialogue attribution to minor voice", 0.98)
+    assert role_dialogue == (30, "Deterministic grounded role dialogue attribution", 0.98)
+    assert named_dialogue == (50, "Deterministic named dialogue attribution to harry", 0.99)
     assert setup == (10, "Narration setting up dialogue.", None)
 
 
@@ -262,6 +312,15 @@ def test_open_dialogue_state_tracks_split_quote_speaker():
         )
         == 30
     )
+
+
+def test_role_speaker_grounding_uses_chapter_local_pronouns():
+    sentences = [
+        SimpleNamespace(original_text="I waited for the recruiter while she finished typing."),
+        SimpleNamespace(original_text="“Final paragraph,” the recruiter said."),
+    ]
+
+    assert audiobook_llm._infer_role_speaker_ids(sentences, 30, 40)["recruiter"] == 30
 
 
 @pytest.mark.asyncio
@@ -314,7 +373,7 @@ async def test_ollama_call_requests_schema_constrained_non_thinking_json(monkeyp
     assert payload["think"] is False
     assert payload["format"] == schema
     assert payload["options"]["temperature"] == 0
-    assert payload["options"]["num_predict"] == 8192
+    assert payload["options"]["num_predict"] == 2048
 
 
 @pytest.mark.asyncio
@@ -392,7 +451,7 @@ async def test_diarization_retries_malformed_output_in_smaller_batches(db, monke
             {
                 "html_element_id": f"sentence-{index}",
                 "sequence_order": index,
-                "original_text": f"Sentence {index} has enough text for analysis.",
+                "original_text": f"“Sentence {index} has enough dialogue for analysis.”",
                 "status": "pending_diarization",
             }
             for index in range(45)
@@ -434,6 +493,56 @@ async def test_diarization_retries_malformed_output_in_smaller_batches(db, monke
     assert request_sizes == [10, 5, 5, 10, 10, 10, 5]
     assert counts == {"ready_for_audio": 45}
     assert book.audiobook_pipeline_status == "audio_gen"
+
+
+@pytest.mark.asyncio
+async def test_diarization_short_circuits_quote_free_prose_without_llm(db, monkeypatch):
+    book = await _make_book(db, audiobook_enabled=True, audiobook_pipeline_status="diarizing")
+    settings = models.AudiobookSettings(
+        llm_provider="ollama",
+        llm_base_url="http://127.0.0.1:11434",
+        llm_model="local-test",
+    )
+    db.add(settings)
+    chapter = await crud.audiobook.create_chapter(db, book.id, 1, "Text/prose.xhtml")
+    narrator = (
+        await crud.audiobook.create_characters_bulk(
+            db,
+            book.id,
+            [
+                {
+                    "name": "Narrator",
+                    "voice_design_prompt": "[gender-neutral][pitch-medium][speed-normal][age-middle]",
+                    "is_narrator": True,
+                }
+            ],
+        )
+    )[0]
+    await crud.audiobook.create_sentences_bulk(
+        db,
+        chapter.id,
+        [
+            {
+                "html_element_id": f"prose-{index}",
+                "sequence_order": index,
+                "original_text": f"Narrative sentence {index} contains no dialogue.",
+                "status": "pending_diarization",
+            }
+            for index in range(40)
+        ],
+    )
+
+    async def unexpected_llm(*_args, **_kwargs):
+        raise AssertionError("Quote-free narration should not call the LLM")
+
+    monkeypatch.setattr(audiobook_llm, "_call_llm", unexpected_llm)
+
+    await audiobook_llm.diarize_sentences(book.id, db)
+
+    sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
+    assert {sentence.character_id for sentence in sentences} == {narrator.id}
+    assert {sentence.speaker_reason for sentence in sentences} == {"Deterministic quote-free narration"}
+    assert await crud.audiobook.count_sentences_by_status(db, book.id) == {"ready_for_audio": 40}
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_audiobook_pipeline.py
+++ b/backend/tests/test_audiobook_pipeline.py
@@ -105,6 +105,40 @@ def test_default_roster_prompt_formats_voice_token_examples():
     assert "A story excerpt." in prompt
 
 
+def test_json_extraction_repairs_trailing_commas_from_local_models():
+    raw = """{
+      "assignments": [
+        {"id": 4, "character_id": 1, "tagged_text": null, "confidence": 1.0, "reason": "Narration",},
+      ],
+      "chapter_summary": "A summary",
+    }"""
+
+    result = audiobook_llm._extract_json(raw)
+
+    assert result["assignments"][0]["id"] == 4
+    assert result["chapter_summary"] == "A summary"
+
+
+def test_diarization_result_requires_complete_unique_sentence_coverage():
+    incomplete = {
+        "assignments": [
+            {"id": 1},
+            {"id": 1},
+        ],
+        "chapter_summary": "Summary",
+    }
+
+    with pytest.raises(ValueError, match="missing=\\[2\\].*duplicates=\\[1\\]"):
+        audiobook_llm._normalise_diarization_result(incomplete, {1, 2})
+
+    with_extras = {
+        "assignments": [{"id": 1}, {"id": 2}, {"id": 999}],
+        "chapter_summary": "Summary",
+    }
+    normalised = audiobook_llm._normalise_diarization_result(with_extras, {1, 2})
+    assert [result["id"] for result in normalised["assignments"]] == [1, 2]
+
+
 def test_tagged_text_sanitizer_only_accepts_supported_insertions():
     original = "Take your time, I said."
 
@@ -124,6 +158,24 @@ def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
         minor_female_id=30,
         minor_male_id=40,
         reason="Action description by the protagonist.",
+    )
+    emotional_prose = audiobook_llm._apply_speaker_guardrails(
+        text="I hated visiting the cemetery.",
+        next_text="",
+        character_id=20,
+        narrator_id=10,
+        minor_female_id=30,
+        minor_male_id=40,
+        reason="Expressing deep grief.",
+    )
+    embedded_quote = audiobook_llm._apply_speaker_guardrails(
+        text="I remembered her last words: “Where is the vanilla?”",
+        next_text="",
+        character_id=20,
+        narrator_id=10,
+        minor_female_id=30,
+        minor_male_id=40,
+        reason="Recalling her final words.",
     )
     dialogue = audiobook_llm._apply_speaker_guardrails(
         text="“You coming or going?”",
@@ -145,6 +197,8 @@ def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
     )
 
     assert prose == (10, "Deterministic prose/narration guardrail", 0.98)
+    assert emotional_prose == (10, "Deterministic prose/narration guardrail", 0.98)
+    assert embedded_quote == (10, "Deterministic prose/narration guardrail", 0.98)
     assert dialogue == (30, "Deterministic she dialogue attribution to minor voice", 0.98)
     assert setup == (10, "Narration setting up dialogue.", None)
 
@@ -199,6 +253,126 @@ async def test_ollama_call_requests_schema_constrained_non_thinking_json(monkeyp
     assert payload["think"] is False
     assert payload["format"] == schema
     assert payload["options"]["temperature"] == 0
+    assert payload["options"]["num_predict"] == 8192
+
+
+@pytest.mark.asyncio
+async def test_omnivoice_request_includes_durable_character_identity(monkeypatch):
+    captured = {}
+
+    class FakeResponse:
+        content = b"mp3"
+
+        def raise_for_status(self):
+            return None
+
+    class FakeClient:
+        def __init__(self, **_kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def post(self, url, **kwargs):
+            captured["url"] = url
+            captured["request"] = kwargs
+            return FakeResponse()
+
+    monkeypatch.setattr(audiobook_tts.httpx, "AsyncClient", FakeClient)
+
+    result = await audiobook_tts._call_omnivoice(
+        "http://127.0.0.1:8001",
+        "[gender-male][pitch-low][speed-normal][age-middle]",
+        "A spoken line.",
+        voice_id="series-character:7",
+    )
+
+    assert result == b"mp3"
+    assert captured["url"] == "http://127.0.0.1:8001/generate"
+    assert captured["request"]["json"]["voice_id"] == "series-character:7"
+
+
+@pytest.mark.asyncio
+async def test_diarization_retries_malformed_output_in_smaller_batches(db, monkeypatch):
+    book = await _make_book(db, audiobook_enabled=True, audiobook_pipeline_status="diarizing")
+    settings = models.AudiobookSettings(
+        llm_provider="ollama",
+        llm_base_url="http://127.0.0.1:11434",
+        llm_model="local-test",
+    )
+    db.add(settings)
+    await db.commit()
+    chapter = await crud.audiobook.create_chapter(
+        db,
+        book_id=book.id,
+        chapter_number=1,
+        content_file_name="Text/chapter_1.xhtml",
+    )
+    narrator = (
+        await crud.audiobook.create_characters_bulk(
+            db,
+            book_id=book.id,
+            characters_data=[
+                {
+                    "name": "Narrator",
+                    "voice_design_prompt": "[gender-neutral][pitch-medium][speed-normal][age-middle]",
+                    "is_narrator": True,
+                }
+            ],
+        )
+    )[0]
+    await crud.audiobook.create_sentences_bulk(
+        db,
+        chapter_id=chapter.id,
+        sentences_data=[
+            {
+                "html_element_id": f"sentence-{index}",
+                "sequence_order": index,
+                "original_text": f"Sentence {index} has enough text for analysis.",
+                "status": "pending_diarization",
+            }
+            for index in range(45)
+        ],
+    )
+    request_sizes = []
+
+    async def fake_llm(_settings, messages, **_kwargs):
+        prompt = messages[0]["content"]
+        serialized = prompt.split("Sentences to process (JSON array with id and text):\n", 1)[1].split(
+            "\n\nFor each sentence return:", 1
+        )[0]
+        sentences = json.loads(serialized)
+        request_sizes.append(len(sentences))
+        if len(request_sizes) == 1:
+            return '{"assignments": ['
+        return json.dumps(
+            {
+                "assignments": [
+                    {
+                        "id": sentence["id"],
+                        "character_id": narrator.id,
+                        "tagged_text": None,
+                        "confidence": 1.0,
+                        "reason": "Narrative prose",
+                    }
+                    for sentence in sentences
+                ],
+                "chapter_summary": "A complete test chapter.",
+            }
+        )
+
+    monkeypatch.setattr(audiobook_llm, "_call_llm", fake_llm)
+
+    await audiobook_llm.diarize_sentences(book.id, db)
+
+    counts = await crud.audiobook.count_sentences_by_status(db, book.id)
+    await db.refresh(book)
+    assert request_sizes == [40, 20, 20, 5]
+    assert counts == {"ready_for_audio": 45}
+    assert book.audiobook_pipeline_status == "audio_gen"
 
 
 @pytest.mark.asyncio
@@ -228,6 +402,31 @@ async def test_queue_schedules_one_rerun_for_changes_during_processing(monkeypat
         assert processed == [42, 42]
     finally:
         await queue.stop()
+
+
+@pytest.mark.asyncio
+async def test_queue_stop_cancels_an_in_flight_book_without_waiting(monkeypatch):
+    queue = AudiobookQueue()
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def process(_book_id: int) -> None:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    monkeypatch.setattr(queue, "_process", process)
+    await queue.start()
+    await queue.enqueue(42)
+    await started.wait()
+
+    await asyncio.wait_for(queue.stop(), timeout=1)
+
+    assert cancelled.is_set()
+    assert queue._worker_task is None
 
 
 @pytest.mark.asyncio
@@ -483,6 +682,7 @@ async def test_roster_rebuild_preserves_ingestion_and_clears_derived_analysis(db
         "stop_after_phase": "roster_gen",
     }
     assert book.audiobook_pipeline_status == "roster_gen"
+    assert book.audiobook_stop_after_phase == crud.audiobook.ROSTER_REFRESH_STOP_MARKER
     assert sentence.status == "pending_diarization"
     assert sentence.character_id is None
     assert sentence.speaker_confidence is None
@@ -554,7 +754,7 @@ async def test_tts_failure_marks_book_error_instead_of_advancing_to_assembly(db,
     db.add(settings)
     await db.commit()
 
-    async def fail_omnivoice(endpoint, voice_prompt, tagged_text):
+    async def fail_omnivoice(endpoint, voice_prompt, tagged_text, **_kwargs):
         request = httpx.Request("POST", endpoint)
         raise httpx.ConnectError("connection failed", request=request)
 
@@ -692,6 +892,20 @@ async def test_roster_excerpt_skips_short_front_matter(db):
             for index in range(40)
         ],
     )
+    back_matter = await crud.audiobook.create_chapter(db, book.id, 3, "ads.xhtml")
+    await crud.audiobook.create_sentences_bulk(
+        db,
+        back_matter.id,
+        [
+            {
+                "html_element_id": f"ads_{index}",
+                "sequence_order": index,
+                "original_text": "ACKNOWLEDGMENTS" if index == 0 else f"Advertisement person Thomas Stein {index}.",
+                "status": "pending_diarization",
+            }
+            for index in range(40)
+        ],
+    )
 
     excerpt = await audiobook_llm._build_roster_excerpt(
         await crud.audiobook.get_chapters_for_book(db, book.id),
@@ -701,6 +915,119 @@ async def test_roster_excerpt_skips_short_front_matter(db):
     assert "Copyright page only" not in excerpt
     assert "John and Kathy continue the story" in excerpt
     assert "### Chapter 2" in excerpt
+    assert "Thomas Stein" not in excerpt
+
+
+@pytest.mark.asyncio
+async def test_first_person_gender_uses_explicit_self_identification_and_stops_at_back_matter(db):
+    book = await _make_book(db, audiobook_enabled=True)
+    story = await crud.audiobook.create_chapter(db, book.id, 1, "story.xhtml")
+    await crud.audiobook.create_sentences_bulk(
+        db,
+        story.id,
+        [
+            {
+                "html_element_id": "story_0",
+                "sequence_order": 0,
+                "original_text": "I was a widower and he was a bachelor.",
+                "status": "pending_diarization",
+            }
+        ],
+    )
+    ads = await crud.audiobook.create_chapter(db, book.id, 2, "ads.xhtml")
+    await crud.audiobook.create_sentences_bulk(
+        db,
+        ads.id,
+        [
+            {
+                "html_element_id": "ads_0",
+                "sequence_order": 0,
+                "original_text": "ACKNOWLEDGMENTS",
+                "status": "pending_diarization",
+            },
+            {
+                "html_element_id": "ads_1",
+                "sequence_order": 1,
+                "original_text": "I'm a woman in this unrelated advertisement.",
+                "status": "pending_diarization",
+            },
+        ],
+    )
+
+    assert (
+        await audiobook_llm._infer_first_person_gender(await crud.audiobook.get_chapters_for_book(db, book.id), db) == "male"
+    )
+
+
+def test_roster_canonicalization_merges_full_names_and_removes_speculation():
+    characters = [
+        {
+            "name": "Jane",
+            "aliases": [],
+            "description": "Invented biography.",
+            "evidence": ["Thomas Jane said hello."],
+            "voice_design_prompt": "[gender-female][pitch-high][speed-fast]",
+            "is_narrator": False,
+        },
+        {
+            "name": "Thomas",
+            "aliases": [],
+            "description": "Another invented biography.",
+            "evidence": [],
+            "voice_design_prompt": "[gender-neutral][pitch-low][speed-normal]",
+            "is_narrator": False,
+        },
+        {
+            "name": "Sagan",
+            "aliases": [],
+            "description": "Invented biography.",
+            "evidence": ["Jane Sagan replied."],
+            "voice_design_prompt": "[gender-male][pitch-medium][speed-normal]",
+            "is_narrator": False,
+        },
+    ]
+    candidates = [
+        {
+            "name": "Jane",
+            "canonical_name": "Thomas Jane",
+            "mention_count": 70,
+            "dialogue_count": 30,
+            "gender": "male",
+        },
+        {
+            "name": "Thomas",
+            "canonical_name": "Thomas Jane",
+            "mention_count": 50,
+            "dialogue_count": 20,
+            "gender": "male",
+        },
+        {
+            "name": "Sagan",
+            "canonical_name": "Jane Sagan",
+            "mention_count": 40,
+            "dialogue_count": 25,
+            "gender": "female",
+        },
+    ]
+
+    result = audiobook_llm._canonicalize_roster_characters(
+        characters,
+        candidates,
+        "thomas jane said hello. jane sagan replied.",
+    )
+
+    assert [character["name"] for character in result] == ["Thomas Jane", "Jane Sagan"]
+    assert result[0]["aliases"] == ["Jane", "Thomas"]
+    assert "30 explicit dialogue attributions" in result[0]["description"]
+    assert result[0]["voice_design_prompt"].startswith("[gender-male]")
+    assert result[1]["voice_design_prompt"].startswith("[gender-female]")
+    assert "Invented biography" not in " ".join(character["description"] for character in result)
+
+
+def test_voice_prompt_normalization_adds_required_tokens():
+    assert audiobook_llm._normalise_voice_prompt("[gender-female][pitch-high]", gender="male") == (
+        "[gender-male][pitch-high][speed-normal][age-middle]"
+    )
 
 
 @pytest.mark.asyncio
@@ -807,6 +1134,23 @@ async def test_series_roster_reuses_and_propagates_voice_profiles(db):
     assert second_character.series_character_id == first_character.series_character_id
     assert second_character.voice_design_prompt == "[gender-female][pitch-low][speed-normal]"
 
+    second_character.description = "Fresh grounded series analysis."
+    second_character.voice_design_prompt = "[gender-neutral][pitch-high][speed-fast]"
+    await db.commit()
+    await crud.audiobook.sync_book_roster_with_series(
+        db,
+        second,
+        [second_character],
+        prefer_series=False,
+    )
+    await db.refresh(first_character)
+    await db.refresh(second_character)
+
+    assert first_character.description == "Fresh grounded series analysis."
+    assert second_character.description == "Fresh grounded series analysis."
+    assert first_character.voice_design_prompt == "[gender-neutral][pitch-high][speed-fast]"
+    assert second_character.voice_design_prompt == "[gender-neutral][pitch-high][speed-fast]"
+
     first_character.voice_design_prompt = "[gender-female][pitch-medium][speed-slow]"
     await db.commit()
     linked = await crud.audiobook.propagate_character_profile_across_series(db, first_character)
@@ -836,6 +1180,20 @@ async def test_series_roster_reuses_and_propagates_voice_profiles(db):
     await crud.audiobook.propagate_character_profile_across_series(db, other_character)
     await db.refresh(other_character)
     assert other_character.series_character_id == first_character.series_character_id
+
+    orphan = models.AudiobookSeriesCharacter(
+        series_name="Shared Saga",
+        canonical_name="stale guess",
+        name="Stale Guess",
+    )
+    db.add(orphan)
+    await db.commit()
+    orphan_id = orphan.id
+
+    sibling_profiles = await crud.audiobook.get_sibling_series_characters(db, "Shared Saga", first.id)
+    assert {profile.name for profile in sibling_profiles} == {"Captain Vale"}
+    assert await crud.audiobook.delete_orphaned_series_characters(db, "Shared Saga") == 1
+    assert await db.get(models.AudiobookSeriesCharacter, orphan_id) is None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_audiobook_pipeline.py
+++ b/backend/tests/test_audiobook_pipeline.py
@@ -648,9 +648,11 @@ async def test_diarization_honors_pause_after_current_durable_batch(db, monkeypa
     )
 
     async def fake_llm(_settings, messages, **_kwargs):
-        serialized = messages[0]["content"].split(
-            "Sentences to process (JSON array with id and text):\n", 1
-        )[1].split("\n\nFor each sentence return:", 1)[0]
+        serialized = (
+            messages[0]["content"]
+            .split("Sentences to process (JSON array with id and text):\n", 1)[1]
+            .split("\n\nFor each sentence return:", 1)[0]
+        )
         sentences = json.loads(serialized)
         await crud.audiobook.request_book_pipeline_pause(db, book.id)
         return json.dumps(

--- a/backend/tests/test_audiobook_pipeline.py
+++ b/backend/tests/test_audiobook_pipeline.py
@@ -255,6 +255,32 @@ def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
         minor_male_id=40,
         reason="Model selected narration.",
     )
+    current_named_dialogue = audiobook_llm._apply_speaker_guardrails(
+        text="“I dislike that,” Jesse said.",
+        next_text="“It may be harmless,” Harry said.",
+        character_id=50,
+        narrator_id=10,
+        protagonist_id=20,
+        character_name_ids={"harry": 50, "jesse": 60},
+        role_speaker_ids={"recruiter": 30},
+        last_dialogue_speaker_id=50,
+        minor_female_id=30,
+        minor_male_id=40,
+        reason="Model followed the next sentence's speaker.",
+    )
+    turn_taking_dialogue = audiobook_llm._apply_speaker_guardrails(
+        text="“Does that bother you?”",
+        next_text="“No,” she said.",
+        character_id=50,
+        narrator_id=10,
+        protagonist_id=20,
+        character_name_ids={"harry": 50},
+        role_speaker_ids={"recruiter": 30},
+        last_dialogue_speaker_id=30,
+        minor_female_id=30,
+        minor_male_id=40,
+        reason="Model selected an unrelated named character.",
+    )
     setup = audiobook_llm._apply_speaker_guardrails(
         text="The recruiter looked up. “",
         next_text="Hello,” she said.",
@@ -277,6 +303,8 @@ def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
     assert repeated_dialogue == (30, "Deterministic she dialogue attribution to minor voice", 0.98)
     assert role_dialogue == (30, "Deterministic grounded role dialogue attribution", 0.98)
     assert named_dialogue == (50, "Deterministic named dialogue attribution to harry", 0.99)
+    assert current_named_dialogue == (60, "Deterministic named dialogue attribution to jesse", 0.99)
+    assert turn_taking_dialogue == (20, "Deterministic first-person turn-taking fallback", 0.8)
     assert setup == (10, "Narration setting up dialogue.", None)
 
 
@@ -313,6 +341,29 @@ def test_open_dialogue_state_tracks_split_quote_speaker():
         == 30
     )
 
+    # A close followed by a new opening in one sentence starts another
+    # paragraph of the same resolved speaker's utterance.
+    reopened = audiobook_llm._advance_open_dialogue_speaker(
+        "You were sent refresher materials,” she said. “",
+        30,
+        narrator_id=10,
+        minor_female_id=30,
+        minor_male_id=40,
+        current_open_speaker_id=30,
+    )
+    assert reopened == 30
+    assert (
+        audiobook_llm._advance_open_dialogue_speaker(
+            "Additionally, you have been reminded of your obligations.",
+            30,
+            narrator_id=10,
+            minor_female_id=30,
+            minor_male_id=40,
+            current_open_speaker_id=reopened,
+        )
+        == 30
+    )
+
 
 def test_role_speaker_grounding_uses_chapter_local_pronouns():
     sentences = [
@@ -321,6 +372,19 @@ def test_role_speaker_grounding_uses_chapter_local_pronouns():
     ]
 
     assert audiobook_llm._infer_role_speaker_ids(sentences, 30, 40)["recruiter"] == 30
+
+
+def test_unattributed_open_quote_uses_established_other_speaker():
+    assert (
+        audiobook_llm._fallback_open_dialogue_speaker(
+            "I nodded. “",
+            None,
+            protagonist_id=20,
+            last_dialogue_speaker_id=20,
+            last_other_dialogue_speaker_id=30,
+        )
+        == 30
+    )
 
 
 @pytest.mark.asyncio
@@ -543,6 +607,78 @@ async def test_diarization_short_circuits_quote_free_prose_without_llm(db, monke
     assert {sentence.character_id for sentence in sentences} == {narrator.id}
     assert {sentence.speaker_reason for sentence in sentences} == {"Deterministic quote-free narration"}
     assert await crud.audiobook.count_sentences_by_status(db, book.id) == {"ready_for_audio": 40}
+
+
+@pytest.mark.asyncio
+async def test_diarization_honors_pause_after_current_durable_batch(db, monkeypatch):
+    book = await _make_book(db, audiobook_enabled=True, audiobook_pipeline_status="diarizing")
+    db.add(
+        models.AudiobookSettings(
+            llm_provider="ollama",
+            llm_base_url="http://127.0.0.1:11434",
+            llm_model="local-test",
+        )
+    )
+    chapter = await crud.audiobook.create_chapter(db, book.id, 1, "Text/dialogue.xhtml")
+    narrator = (
+        await crud.audiobook.create_characters_bulk(
+            db,
+            book.id,
+            [
+                {
+                    "name": "Narrator",
+                    "voice_design_prompt": "[gender-neutral][pitch-medium][speed-normal][age-middle]",
+                    "is_narrator": True,
+                }
+            ],
+        )
+    )[0]
+    await crud.audiobook.create_sentences_bulk(
+        db,
+        chapter.id,
+        [
+            {
+                "html_element_id": f"dialogue-{index}",
+                "sequence_order": index,
+                "original_text": f"“Dialogue sentence {index}.”",
+                "status": "pending_diarization",
+            }
+            for index in range(40)
+        ],
+    )
+
+    async def fake_llm(_settings, messages, **_kwargs):
+        serialized = messages[0]["content"].split(
+            "Sentences to process (JSON array with id and text):\n", 1
+        )[1].split("\n\nFor each sentence return:", 1)[0]
+        sentences = json.loads(serialized)
+        await crud.audiobook.request_book_pipeline_pause(db, book.id)
+        return json.dumps(
+            {
+                "assignments": [
+                    {
+                        "id": sentence["id"],
+                        "character_id": narrator.id,
+                        "tagged_text": None,
+                        "confidence": 1.0,
+                        "reason": "Test attribution",
+                    }
+                    for sentence in sentences
+                ]
+            }
+        )
+
+    monkeypatch.setattr(audiobook_llm, "_call_llm", fake_llm)
+
+    await audiobook_llm.diarize_sentences(book.id, db)
+
+    await db.refresh(book)
+    assert await crud.audiobook.count_sentences_by_status(db, book.id) == {
+        "pending_diarization": 30,
+        "ready_for_audio": 10,
+    }
+    assert book.audiobook_pipeline_status == "paused"
+    assert book.audiobook_pause_requested is False
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_audiobook_pipeline.py
+++ b/backend/tests/test_audiobook_pipeline.py
@@ -268,6 +268,19 @@ def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
         minor_male_id=40,
         reason="Model followed the next sentence's speaker.",
     )
+    recruiter_enumeration = audiobook_llm._apply_speaker_guardrails(
+        text="“Paragraph two: I understand that I am volunteering.”",
+        next_text="",
+        character_id=20,
+        narrator_id=10,
+        protagonist_id=20,
+        character_name_ids={"harry": 50},
+        role_speaker_ids={"recruiter": 30},
+        last_dialogue_speaker_id=30,
+        minor_female_id=30,
+        minor_male_id=40,
+        reason="Model selected the protagonist.",
+    )
     turn_taking_dialogue = audiobook_llm._apply_speaker_guardrails(
         text="“Does that bother you?”",
         next_text="“No,” she said.",
@@ -304,6 +317,7 @@ def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
     assert role_dialogue == (30, "Deterministic grounded role dialogue attribution", 0.98)
     assert named_dialogue == (50, "Deterministic named dialogue attribution to harry", 0.99)
     assert current_named_dialogue == (60, "Deterministic named dialogue attribution to jesse", 0.99)
+    assert recruiter_enumeration == (30, "Deterministic grounded recruiter enumeration", 0.98)
     assert turn_taking_dialogue == (20, "Deterministic first-person turn-taking fallback", 0.8)
     assert setup == (10, "Narration setting up dialogue.", None)
 

--- a/docs/AUDIOBOOK_PIPELINE.md
+++ b/docs/AUDIOBOOK_PIPELINE.md
@@ -199,6 +199,7 @@ Accept: audio/mpeg
 
 {
   "voice": "[gender-female][pitch-high][speed-normal]",
+  "voice_id": "series-character:42",
   "text": "She laughed. [laughter] \"I can't believe it,\" she said."
 }
 
@@ -229,7 +230,10 @@ Users can manually edit these values in the Character Roster UI.
 Story Manager includes a native adapter for the official
 [`k2-fsa/OmniVoice`](https://github.com/k2-fsa/OmniVoice) 0.2.0 release. It uses the upstream model directly, keeps it
 resident between requests, translates existing bracket-style voice profiles into official voice-design attributes,
-and converts the 24 kHz output to MP3.
+and converts the 24 kHz output to MP3. Story Manager sends a stable book- or series-character identity with every
+line. The adapter uses that identity to create one seeded calibration voice, caches the upstream reusable
+voice-clone prompt, and conditions every later line on that anchor. Actual sentence decoding disables stochastic
+position selection, improving line-to-line identity consistency while distinct characters retain distinct anchors.
 
 ```bash
 make run-omnivoice
@@ -275,7 +279,9 @@ curl http://127.0.0.1:11434/api/tags
 In **Audio Settings**, click **Use Recommended Local Ollama**, then **Save & Test LLM**. The preset uses provider
 `ollama`, base URL `http://127.0.0.1:11434`, and model `qwen3.5:9b`. Calls use Ollama's schema-constrained structured
 outputs, thinking disabled, temperature 0, and a 32K working context. This makes roster and speaker output directly
-machine-validated instead of relying on best-effort JSON prompting.
+machine-validated instead of relying on best-effort JSON prompting. Common trailing-comma errors are repaired
+locally. Malformed or incomplete assignment sets are retried against the same durable pending sentences with
+progressively smaller batches (40 → 20 → 10 → 5), so one oversized response does not fail an unattended book run.
 
 ## Review and Recovery Controls
 
@@ -286,16 +292,26 @@ has committed. **Pause Safely** is cooperative: diarization pauses between batch
 assembly between chapters. Roster LLM requests and individual external TTS calls finish before the pause is
 acknowledged. Starting or stepping again infers the next safe phase from durable chapter/sentence state, so an app
 restart does not require restarting the entire book.
+Application shutdown cancels the active worker immediately rather than waiting behind the rest of a multi-hour
+book job. Already committed sentence/chapter state remains durable, and startup recovery re-queues the same phase.
 
 Worker exceptions are stored in `audiobook_last_error` and returned by the status endpoint. Retrying clears the
 stale message; failed sentence audio is reset to `ready_for_audio` before TTS resumes.
 
 The Characters tab also offers **Regenerate Character Roster**. It preserves the parsed EPUB and sentence IDs while
 clearing roster, diarization, summaries, and derived audio state. Roster generation samples real story chapters
-across the book and sibling books in the same series. It supplements those excerpts with capitalized-name frequency
-hints and any existing series roster, reducing the chance that front matter or a one-scene cameo displaces a recurring
-speaker. **Sync Series Roster** can promote an already-generated standalone book roster after its series metadata is
-assigned.
+across the book and sibling books in the same series, stopping before acknowledgments, publisher ads, and next-book
+excerpts. It supplements those excerpts with whole-story name and dialogue-tag counts, canonicalizes first-name and
+surname references into grounded full identities, replaces speculative biographies with evidence counts, stores only
+source-grounded quotations, and can retain up to 20 useful voices. Canonical aliases are included in every
+diarization request. An explicit rebuild uses only profiles backed by sibling books, removes orphaned stale guesses,
+and refreshes linked series metadata; shared voice changes invalidate affected clips. **Sync Series Roster** can
+promote an already-generated standalone book roster after its series metadata is assigned.
+
+Speaker guardrails keep quote-free prose on the Narrator even in a first-person story, keep the protagonist's spoken
+dialogue as a separate voice, and route clearly gender-attributed unnamed dialogue to the matching minor voice. This
+prevents emotional first-person narration from drifting onto a character voice merely because a local model's
+rationale describes the protagonist.
 
 ## Manual Voice Evaluation
 

--- a/docs/AUDIOBOOK_PIPELINE.md
+++ b/docs/AUDIOBOOK_PIPELINE.md
@@ -281,12 +281,14 @@ In **Audio Settings**, click **Use Recommended Local Ollama**, then **Save & Tes
 outputs, thinking disabled, temperature 0, and a 32K working context. This makes roster and speaker output directly
 machine-validated instead of relying on best-effort JSON prompting. Common trailing-comma errors are repaired
 locally. Malformed or incomplete assignment sets are retried against the same durable pending sentences with
-progressively smaller batches (40 → 20 → 10 → 5), so one oversized response does not fail an unattended book run.
+progressively smaller batches (10 → 5), so one oversized response does not fail an unattended book run. The
+10-sentence default reflects full-book testing with the recommended 9B model: larger dialogue-heavy responses were
+more likely to omit trailing assignment IDs and cost more time in retries than they saved in request overhead.
 
 ## Review and Recovery Controls
 
 The book UI offers **Run Next Stage** for debugging or reviewing intermediate artifacts, **Run One Batch** for one
-40-sentence diarization batch, one TTS sentence, or one assembly chapter, and **Run to Completion**
+10-sentence diarization batch, one TTS sentence, or one assembly chapter, and **Run to Completion**
 for unattended processing. A single-stage run persists its target phase and moves to `paused` only after that phase
 has committed. **Pause Safely** is cooperative: diarization pauses between batches, TTS between sentences, and
 assembly between chapters. Roster LLM requests and individual external TTS calls finish before the pause is

--- a/services/omnivoice/README.md
+++ b/services/omnivoice/README.md
@@ -35,8 +35,15 @@ LLM provider can remain selected; it will handle roster/diarization locally whil
 | `OMNIVOICE_NUM_STEPS` | `16` | Diffusion steps; use `32` for higher quality/slower output |
 | `OMNIVOICE_MP3_BITRATE` | `96k` | Returned MP3 bitrate |
 | `OMNIVOICE_PORT` | `8001` | Port used by the Make target |
+| `OMNIVOICE_VOICE_ANCHOR_TEXT` | Built-in neutral calibration sentence | Text used to create each stable character voice anchor |
 
 Legacy Story Manager profiles such as `[gender-female][pitch-low][speed-normal]` are translated into the official
 comma-separated voice-design attributes. Official instructions such as `female, middle-aged, low pitch` are also
 accepted directly. Supported OmniVoice non-verbal tags are preserved; unsupported historical tags are removed so
 one bad expression tag cannot fail a full audiobook run.
+
+When `voice_id` is included in a generation request, the adapter deterministically seeds a one-time voice-design
+sample for that identity, converts it into OmniVoice's reusable voice-clone prompt, and caches it in memory. All
+subsequent lines for that identity use the same anchor and deterministic position selection. Story Manager derives
+the identity from the shared series character when available, so a recurring character retains the same voice in
+sibling books. Restarting the adapter recreates the same seeded anchor on first use.

--- a/services/omnivoice/server.py
+++ b/services/omnivoice/server.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from contextlib import asynccontextmanager
 from io import BytesIO
+import hashlib
 import logging
 import os
 import threading
@@ -30,11 +31,17 @@ MODEL_ID = os.getenv("OMNIVOICE_MODEL", "k2-fsa/OmniVoice")
 DEVICE = os.getenv("OMNIVOICE_DEVICE", "auto")
 NUM_STEPS = int(os.getenv("OMNIVOICE_NUM_STEPS", "16"))
 MP3_BITRATE = os.getenv("OMNIVOICE_MP3_BITRATE", "96k")
+VOICE_ANCHOR_VERSION = "v1"
+VOICE_ANCHOR_TEXT = os.getenv(
+    "OMNIVOICE_VOICE_ANCHOR_TEXT",
+    "I speak with a steady, natural voice, clearly carrying each thought from beginning to end.",
+)
 
 
 class GenerateRequest(BaseModel):
     text: str = Field(min_length=1, max_length=4000)
     voice: str | None = None
+    voice_id: str | None = Field(default=None, max_length=200)
     language: str | None = None
 
 
@@ -43,6 +50,7 @@ class OmniVoiceRuntime:
         self.model: OmniVoice | None = None
         self.device = "unloaded"
         self._generate_lock = threading.Lock()
+        self._voice_clone_prompts: dict[str, object] = {}
 
     def load(self) -> None:
         self.device = get_best_device() if DEVICE == "auto" else DEVICE
@@ -55,18 +63,72 @@ class OmniVoiceRuntime:
         )
         logger.info("OmniVoice ready at %s Hz.", self.model.sampling_rate)
 
-    def generate(self, request: GenerateRequest) -> tuple[bytes, int]:
+    @staticmethod
+    def _voice_cache_key(request: GenerateRequest, instruct: str | None, speed: float) -> str:
+        identity = request.voice_id or ""
+        material = "|".join([VOICE_ANCHOR_VERSION, identity, instruct or "", str(speed), request.language or ""])
+        return hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+    def _get_voice_clone_prompt(
+        self,
+        request: GenerateRequest,
+        *,
+        instruct: str | None,
+        speed: float,
+    ) -> object:
+        if self.model is None:
+            raise RuntimeError("OmniVoice model is not loaded")
+        cache_key = self._voice_cache_key(request, instruct, speed)
+        cached = self._voice_clone_prompts.get(cache_key)
+        if cached is not None:
+            return cached
+
+        # The voice-design mode has stochastic position selection. Seed that
+        # one-time choice from the durable character identity, then clone the
+        # resulting calibration voice for every real line.
+        seed = int(cache_key[:16], 16) % (2**31)
+        torch.manual_seed(seed)
+        anchor = self.model.generate(
+            text=VOICE_ANCHOR_TEXT,
+            language=request.language,
+            instruct=instruct,
+            speed=speed,
+            num_step=NUM_STEPS,
+            position_temperature=5.0,
+            class_temperature=0.0,
+            postprocess_output=True,
+        )[0]
+        clone_prompt = self.model.create_voice_clone_prompt(
+            (torch.from_numpy(anchor), self.model.sampling_rate),
+            ref_text=VOICE_ANCHOR_TEXT,
+        )
+        self._voice_clone_prompts[cache_key] = clone_prompt
+        logger.info("Created stable voice anchor for %s.", request.voice_id)
+        return clone_prompt
+
+    def generate(self, request: GenerateRequest) -> tuple[bytes, int, str]:
         if self.model is None:
             raise RuntimeError("OmniVoice model is not loaded")
 
         prompt = translate_generation_prompt(request.voice, request.text)
         with self._generate_lock:
+            clone_prompt = None
+            voice_mode = "deterministic-design"
+            if request.voice_id:
+                clone_prompt = self._get_voice_clone_prompt(
+                    request,
+                    instruct=prompt.instruct,
+                    speed=prompt.speed,
+                )
+                voice_mode = "anchored-clone"
             audio = self.model.generate(
                 text=prompt.text,
                 language=request.language,
+                voice_clone_prompt=clone_prompt,
                 instruct=prompt.instruct,
                 speed=prompt.speed,
                 num_step=NUM_STEPS,
+                position_temperature=0.0,
                 class_temperature=0.0,
                 postprocess_output=True,
             )[0]
@@ -80,7 +142,7 @@ class OmniVoiceRuntime:
         )
         output = BytesIO()
         segment.export(output, format="mp3", bitrate=MP3_BITRATE)
-        return output.getvalue(), len(segment)
+        return output.getvalue(), len(segment), voice_mode
 
 
 runtime = OmniVoiceRuntime()
@@ -102,13 +164,15 @@ async def health() -> dict[str, object]:
         "model": MODEL_ID,
         "device": runtime.device,
         "num_steps": NUM_STEPS,
+        "voice_consistency": "anchored-clone-v1",
+        "cached_voice_anchors": len(runtime._voice_clone_prompts),
     }
 
 
 @app.post("/generate")
 async def generate(request: GenerateRequest) -> Response:
     try:
-        audio, duration_ms = await asyncio.to_thread(runtime.generate, request)
+        audio, duration_ms, voice_mode = await asyncio.to_thread(runtime.generate, request)
     except Exception as exc:
         logger.exception("OmniVoice generation failed.")
         raise HTTPException(status_code=500, detail=str(exc)) from exc
@@ -118,5 +182,6 @@ async def generate(request: GenerateRequest) -> Response:
         headers={
             "X-Audio-Duration-Ms": str(duration_ms),
             "X-OmniVoice-Device": runtime.device,
+            "X-OmniVoice-Voice-Mode": voice_mode,
         },
     )


### PR DESCRIPTION
## Stack

Part 6 of 6. Depends on the series-previews PR. Base: `agent/audiobook-series-previews`.

## What changed

- Adds deterministic shortcuts for quote-free narration.
- Grounds first-person dialogue and open-quote turns across sentence boundaries.
- Improves explicit name, pronoun, role, and neighboring-turn attribution.
- Strengthens roster sampling and malformed-response fallback behavior.
- Preserves explicit dialogue attribution over weaker heuristics.
- Expands regression coverage for full-book analysis behavior.

## Why

These are quality and performance hardening changes that can be reviewed after the underlying pipeline and preview experience are established.

## Validation

- Full backend suite: 276 passed, 1 integration test deselected.
- Full frontend suite: 38 passed.
- Flake8 and ESLint passed.
- PostgreSQL migration testing could not run locally because Docker was unavailable; GitHub Actions will provide that result.