### PR TITLE
Improve Listen & Read playback

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1795,9 +1795,29 @@
   gap: 0.4rem;
 }
 
-.audiobook-reader-player {
-  width: 100%;
+.audiobook-reader-playback {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
   margin: 1rem 0;
+}
+
+.audiobook-reader-player {
+  flex: 1;
+  min-width: 0;
+}
+
+.audiobook-reader-speed {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  white-space: nowrap;
+}
+
+.audiobook-reader-speed select {
+  width: auto;
 }
 
 .audiobook-reader-summary {
@@ -1815,6 +1835,22 @@
   padding-right: 0.75rem;
 }
 
+.audiobook-reader-sentence {
+  border-radius: 0.25rem;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+  transition:
+    background-color 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.audiobook-reader-sentence--active {
+  background: rgba(98, 114, 234, 0.2);
+  box-shadow:
+    0.15rem 0 0 rgba(98, 114, 234, 0.2),
+    -0.15rem 0 0 rgba(98, 114, 234, 0.2);
+}
+
 @media (max-width: 760px) {
   .audiobook-reader {
     grid-template-columns: 1fr;
@@ -1827,6 +1863,15 @@
 
   .audiobook-reader-chapters button {
     min-width: 9rem;
+  }
+
+  .audiobook-reader-playback {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .audiobook-reader-speed {
+    align-self: flex-end;
   }
 }
 

--- a/frontend/src/components/AudiobookPipeline.jsx
+++ b/frontend/src/components/AudiobookPipeline.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   getAudiobookStatus,
@@ -118,7 +118,7 @@ const SUB_TABS = [
   "Chapter Assembly",
 ];
 
-function AudiobookPipeline({ book }) {
+function AudiobookPipeline({ book, epubChapters = [] }) {
   const bookId = book.id;
   const queryClient = useQueryClient();
   const [subTab, setSubTab] = useState("Analysis");
@@ -151,6 +151,17 @@ function AudiobookPipeline({ book }) {
       return (s && isActive(s)) || previewActive ? 3000 : false;
     },
   });
+  const titledChapters = useMemo(() => {
+    const titleByFilename = new Map(
+      epubChapters.map((chapter) => [chapter.filename, chapter.title]),
+    );
+    return chapters.map((chapter) => ({
+      ...chapter,
+      title:
+        titleByFilename.get(chapter.content_file_name)?.trim() ||
+        `Chapter ${chapter.chapter_number}`,
+    }));
+  }, [chapters, epubChapters]);
 
   const invalidateAll = () => {
     queryClient.invalidateQueries({ queryKey: ["audiobook-status", bookId] });
@@ -368,7 +379,7 @@ function AudiobookPipeline({ book }) {
 
       <div className="sub-tab-content">
         {subTab === "Analysis" && (
-          <AnalysisOverview status={statusData} chapters={chapters} />
+          <AnalysisOverview status={statusData} chapters={titledChapters} />
         )}
         {subTab === "Characters" && (
           <CharacterRoster
@@ -382,20 +393,20 @@ function AudiobookPipeline({ book }) {
           <ScriptEditor
             bookId={bookId}
             characters={characters}
-            chapters={chapters}
+            chapters={titledChapters}
             pipelineActive={isActive(pipelineStatus)}
           />
         )}
         {subTab === "Chapter Assembly" && (
           <ChapterAssembly
-            chapters={chapters}
+            chapters={titledChapters}
             bookId={bookId}
             pipelineActive={isActive(pipelineStatus)}
           />
         )}
         {subTab === "Listen & Read" && (
           <AudiobookReader
-            chapters={chapters}
+            chapters={titledChapters}
             characters={characters}
             bookId={bookId}
           />

--- a/frontend/src/components/AudiobookPipeline.test.jsx
+++ b/frontend/src/components/AudiobookPipeline.test.jsx
@@ -153,6 +153,7 @@ describe("AudiobookPipeline", () => {
     const chapter = {
       id: 9,
       chapter_number: 1,
+      content_file_name: "Text/chapter-one.xhtml",
       sentence_count: 2,
       processed_sentence_count: 2,
       audio_generated_count: 0,
@@ -226,12 +227,21 @@ describe("AudiobookPipeline", () => {
     globalThis.fetch = fetchMock;
 
     const { container } = renderWithClient(
-      <AudiobookPipeline book={{ id: 11, series: "The Saga" }} />,
+      <AudiobookPipeline
+        book={{ id: 11, series: "The Saga" }}
+        epubChapters={[
+          {
+            filename: "Text/chapter-one.xhtml",
+            title: "The Door Opens",
+          },
+        ]}
+      />,
     );
 
     fireEvent.click(
       await screen.findByRole("button", { name: "Chapter Assembly" }),
     );
+    expect(screen.getByText("The Door Opens")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Rebuild Preview" }));
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
@@ -241,6 +251,7 @@ describe("AudiobookPipeline", () => {
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Listen & Read" }));
+    expect(screen.getAllByText("The Door Opens")).toHaveLength(2);
     expect(
       await screen.findByText("Avery opened the door."),
     ).toBeInTheDocument();

--- a/frontend/src/components/BookSettings.jsx
+++ b/frontend/src/components/BookSettings.jsx
@@ -389,7 +389,7 @@ function BookSettings({ book: initialBook, onBack }) {
       </nav>
 
       {book.audiobook_enabled && bookTab === "audiobook" && (
-        <AudiobookPipeline book={book} />
+        <AudiobookPipeline book={book} epubChapters={chapters} />
       )}
 
       {bookTab === "details" && (

--- a/frontend/src/components/audiobook/AnalysisOverview.jsx
+++ b/frontend/src/components/audiobook/AnalysisOverview.jsx
@@ -19,7 +19,8 @@ function AnalysisOverview({ status, chapters = [] }) {
         </p>
         {status?.summary && (
           <small className="analysis-review-note">
-            Model-generated working analysis — verify names and plot details before production.
+            Model-generated working analysis — verify names and plot details
+            before production.
           </small>
         )}
       </section>
@@ -35,7 +36,7 @@ function AnalysisOverview({ status, chapters = [] }) {
           return (
             <article className="chapter-analysis-card" key={chapter.id}>
               <div className="chapter-analysis-header">
-                <strong>Chapter {chapter.chapter_number}</strong>
+                <strong>{chapter.title}</strong>
                 <span>{percent}% attributed</span>
               </div>
               <div className="chapter-analysis-counts">

--- a/frontend/src/components/audiobook/AudiobookReader.jsx
+++ b/frontend/src/components/audiobook/AudiobookReader.jsx
@@ -1,7 +1,19 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { getChapterAudioUrl, getSentences } from "../../api/audiobook";
+
+const PLAYBACK_RATES = [0.75, 1, 1.25, 1.5, 1.75, 2];
+
+function activeSentenceAtTime(timeline, currentTimeSeconds) {
+  if (!timeline.length) return null;
+
+  const currentTimeMs = Math.max(0, currentTimeSeconds * 1000);
+  return (
+    timeline.find(({ endMs }) => currentTimeMs < endMs)?.id ??
+    timeline[timeline.length - 1].id
+  );
+}
 
 function AudiobookReader({ chapters = [], characters = [], bookId }) {
   const playable = useMemo(
@@ -12,6 +24,11 @@ function AudiobookReader({ chapters = [], characters = [], bookId }) {
     [chapters],
   );
   const [chapterId, setChapterId] = useState(playable[0]?.id ?? null);
+  const [activeSentenceId, setActiveSentenceId] = useState(null);
+  const [playbackRate, setPlaybackRate] = useState(1);
+  const audioRef = useRef(null);
+  const textRef = useRef(null);
+  const sentenceRefs = useRef(new Map());
 
   useEffect(() => {
     if (!playable.some((chapter) => chapter.id === chapterId)) {
@@ -33,6 +50,55 @@ function AudiobookReader({ chapters = [], characters = [], bookId }) {
       new Map(characters.map((character) => [character.id, character.name])),
     [characters],
   );
+  const sentenceTimeline = useMemo(() => {
+    let elapsedMs = 0;
+    return (data?.items || []).map((sentence) => {
+      const durationMs = Math.max(0, sentence.audio_duration_ms ?? 0);
+      elapsedMs += durationMs;
+      return { id: sentence.id, endMs: elapsedMs };
+    });
+  }, [data?.items]);
+
+  useEffect(() => {
+    setActiveSentenceId(activeSentenceAtTime(sentenceTimeline, 0));
+  }, [chapterId, sentenceTimeline]);
+
+  useEffect(() => {
+    if (audioRef.current) {
+      audioRef.current.playbackRate = playbackRate;
+    }
+  }, [chapterId, playbackRate]);
+
+  useEffect(() => {
+    if (activeSentenceId == null) return;
+
+    const textElement = textRef.current;
+    const sentenceElement = sentenceRefs.current.get(activeSentenceId);
+    if (!textElement || !sentenceElement) return;
+
+    const textRect = textElement.getBoundingClientRect();
+    const sentenceRect = sentenceElement.getBoundingClientRect();
+    const top = sentenceRect.top - textRect.top + textElement.scrollTop;
+
+    if (typeof textElement.scrollTo === "function") {
+      textElement.scrollTo({ top: Math.max(0, top), behavior: "smooth" });
+    }
+  }, [activeSentenceId]);
+
+  const syncActiveSentence = (event) => {
+    const nextSentenceId = activeSentenceAtTime(
+      sentenceTimeline,
+      event.currentTarget.currentTime,
+    );
+    setActiveSentenceId((currentSentenceId) =>
+      currentSentenceId === nextSentenceId ? currentSentenceId : nextSentenceId,
+    );
+  };
+
+  const changePlaybackRate = (event) => {
+    const nextRate = Number.parseFloat(event.target.value);
+    setPlaybackRate(nextRate);
+  };
 
   if (!playable.length) {
     return (
@@ -56,7 +122,7 @@ function AudiobookReader({ chapters = [], characters = [], bookId }) {
             className={chapter.id === chapterId ? "active" : ""}
             onClick={() => setChapterId(chapter.id)}
           >
-            Chapter {chapter.chapter_number}
+            {chapter.title}
             <small>{chapter.sentence_count} sentences</small>
           </button>
         ))}
@@ -65,7 +131,7 @@ function AudiobookReader({ chapters = [], characters = [], bookId }) {
         <div className="audiobook-reader-heading">
           <div>
             <span className="metric-label">Listen & read</span>
-            <h3>Chapter {selected?.chapter_number}</h3>
+            <h3>{selected?.title}</h3>
           </div>
           <div className="audiobook-reader-nav">
             <button
@@ -84,23 +150,57 @@ function AudiobookReader({ chapters = [], characters = [], bookId }) {
             </button>
           </div>
         </div>
-        <audio
-          key={chapterId}
-          controls
-          src={getChapterAudioUrl(bookId, chapterId)}
-          preload="metadata"
-          className="audiobook-reader-player"
-        />
+        <div className="audiobook-reader-playback">
+          <audio
+            key={chapterId}
+            ref={audioRef}
+            controls
+            src={getChapterAudioUrl(bookId, chapterId)}
+            preload="metadata"
+            className="audiobook-reader-player"
+            onLoadedMetadata={(event) => {
+              event.currentTarget.playbackRate = playbackRate;
+              syncActiveSentence(event);
+            }}
+            onTimeUpdate={syncActiveSentence}
+            onSeeked={syncActiveSentence}
+          />
+          <label className="audiobook-reader-speed">
+            Speed
+            <select value={playbackRate} onChange={changePlaybackRate}>
+              {PLAYBACK_RATES.map((rate) => (
+                <option key={rate} value={rate}>
+                  {rate}×
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
         {selected?.summary && (
           <p className="audiobook-reader-summary">{selected.summary}</p>
         )}
         {isLoading ? (
           <p>Loading chapter text…</p>
         ) : (
-          <div className="audiobook-reader-text">
+          <div className="audiobook-reader-text" ref={textRef}>
             {(data?.items || []).map((sentence) => (
               <span
                 key={sentence.id}
+                ref={(element) => {
+                  if (element) {
+                    sentenceRefs.current.set(sentence.id, element);
+                  } else {
+                    sentenceRefs.current.delete(sentence.id);
+                  }
+                }}
+                className={`audiobook-reader-sentence${
+                  sentence.id === activeSentenceId
+                    ? " audiobook-reader-sentence--active"
+                    : ""
+                }`}
+                aria-current={
+                  sentence.id === activeSentenceId ? "true" : undefined
+                }
                 title={
                   characterNames.get(sentence.character_id) || "Unassigned"
                 }

--- a/frontend/src/components/audiobook/AudiobookReader.test.jsx
+++ b/frontend/src/components/audiobook/AudiobookReader.test.jsx
@@ -1,0 +1,94 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderWithClient } from "../../test-utils";
+import AudiobookReader from "./AudiobookReader";
+
+describe("AudiobookReader", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("highlights the sentence at the playback time and scrolls it to the top", async () => {
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            items: [
+              {
+                id: 1,
+                original_text: "The first sentence.",
+                character_id: 4,
+                audio_duration_ms: 1000,
+              },
+              {
+                id: 2,
+                original_text: "The second sentence.",
+                character_id: null,
+                audio_duration_ms: 2000,
+              },
+            ],
+          }),
+      }),
+    );
+
+    const { container } = renderWithClient(
+      <AudiobookReader
+        bookId={11}
+        chapters={[
+          {
+            id: 9,
+            chapter_number: 1,
+            title: "CHAPTER ONE",
+            sentence_count: 2,
+            audio_file_path: "audiobooks/11/chapter_1.mp3",
+            needs_reassembly: false,
+          },
+        ]}
+        characters={[{ id: 4, name: "Avery" }]}
+      />,
+    );
+
+    const firstSentence = await screen.findByText("The first sentence.");
+    const secondSentence = screen.getByText("The second sentence.");
+    expect(screen.getAllByText("CHAPTER ONE")).toHaveLength(2);
+    expect(firstSentence).toHaveAttribute("aria-current", "true");
+    expect(firstSentence).toHaveClass("audiobook-reader-sentence--active");
+
+    const transcript = container.querySelector(".audiobook-reader-text");
+    const audio = container.querySelector("audio");
+    transcript.scrollTo = vi.fn();
+    Object.defineProperty(transcript, "scrollTop", {
+      configurable: true,
+      value: 20,
+    });
+    vi.spyOn(transcript, "getBoundingClientRect").mockReturnValue({
+      top: 100,
+    });
+    vi.spyOn(secondSentence, "getBoundingClientRect").mockReturnValue({
+      top: 260,
+    });
+    Object.defineProperty(audio, "currentTime", {
+      configurable: true,
+      value: 1.25,
+    });
+
+    fireEvent.timeUpdate(audio);
+
+    await waitFor(() => {
+      expect(secondSentence).toHaveAttribute("aria-current", "true");
+    });
+    expect(firstSentence).not.toHaveAttribute("aria-current");
+    expect(secondSentence).toHaveClass("audiobook-reader-sentence--active");
+    expect(transcript.scrollTo).toHaveBeenLastCalledWith({
+      top: 180,
+      behavior: "smooth",
+    });
+
+    fireEvent.change(screen.getByLabelText("Speed"), {
+      target: { value: "1.5" },
+    });
+    expect(audio.playbackRate).toBe(1.5);
+  });
+});

--- a/frontend/src/components/audiobook/ChapterAssembly.jsx
+++ b/frontend/src/components/audiobook/ChapterAssembly.jsx
@@ -47,7 +47,7 @@ function ChapterAssembly({ chapters, bookId, pipelineActive = false }) {
               chapter.audio_file_path && !chapter.needs_reassembly;
             return (
               <tr key={chapter.id}>
-                <td>Chapter {chapter.chapter_number}</td>
+                <td>{chapter.title}</td>
                 <td>
                   {previewBusy ? (
                     <span className="badge badge--warning">

--- a/frontend/src/components/audiobook/ScriptEditor.jsx
+++ b/frontend/src/components/audiobook/ScriptEditor.jsx
@@ -249,7 +249,7 @@ function ScriptEditor({
             <option value="">All</option>
             {chapters.map((chapter) => (
               <option key={chapter.id} value={chapter.id}>
-                {chapter.chapter_number} · {chapter.processed_sentence_count}/
+                {chapter.title} · {chapter.processed_sentence_count}/
                 {chapter.sentence_count}
               </option>
             ))}


### PR DESCRIPTION
## Summary

- highlight the sentence that matches the chapter audio playback position
- automatically keep the active sentence aligned to the top of the transcript
- show EPUB TOC/heading titles instead of audiobook spine positions throughout the audiobook UI
- add 0.75×–2× playback speed controls that persist while switching chapters
- add focused reader and pipeline regression coverage

## Why

Audiobook chapters retain their original EPUB content filename, but the UI previously labeled them with their numeric spine position. Books with front matter therefore displayed misleading labels such as “Chapter 9” for the first real chapter. The existing EPUB metadata already contains the correct title, so this change joins it to audiobook chapters by filename without a migration or pipeline rebuild.

Listen & Read also had sentence-level timing data available but did not use it, leaving readers without a visual indication of the narration position.

## Impact

Existing audiobook books immediately receive accurate chapter titles. During playback or seeking, the current sentence is highlighted and scrolled into view, and readers can select a comfortable narration speed.

This is a stacked PR based on `agent/audiobook-dialogue-hardening` so its diff contains only the reader UI changes.

## Validation

- `npm test -- --run` — 39 tests passed
- `npm run lint`
- live browser verification on book 839: “CHAPTER ONE” appears in Listen & Read and the 1.5× speed selection applies successfully
