### PR TITLE
Make audiobook generation resilient and expose it to Reader clients

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,22 @@ test-migrations:
 	docker exec story-manager-migration-test psql -v ON_ERROR_STOP=1 -U postgres -d story_manager \
 		-c "DO \$$\$$ BEGIN IF (SELECT COUNT(*) FROM book_metadata_matches) <> 1 THEN RAISE EXCEPTION 'downgrade did not preserve exactly one match'; END IF; END \$$\$$;"; \
 	DATABASE_URL="postgresql+psycopg://postgres:postgres@localhost:5433/story_manager" \
+	PYTHONPATH=. .venv/bin/alembic -c backend/alembic.ini upgrade head; \
+	DATABASE_URL="postgresql+psycopg://postgres:postgres@localhost:5433/story_manager" \
+	PYTHONPATH=. .venv/bin/alembic -c backend/alembic.ini downgrade 0022; \
+	docker exec story-manager-migration-test psql -v ON_ERROR_STOP=1 -U postgres -d story_manager \
+		-c "UPDATE books SET audiobook_enabled = true, audiobook_pipeline_status = 'complete', content_version = 3 WHERE title = 'Migration Test';" \
+		-c "INSERT INTO audiobook_chapters (book_id, chapter_number, content_file_name, audio_file_path, smil_file_path, needs_reassembly) SELECT id, 1, 'Text/existing.xhtml', 'library/existing.mp3', 'library/existing.smil', false FROM books WHERE title = 'Migration Test';" \
+		-c "INSERT INTO audiobook_sentences (chapter_id, html_element_id, sequence_order, original_text, audio_duration_ms, status) SELECT id, 'existing-sentence', 0, 'Existing sentence.', 1250, 'audio_generated' FROM audiobook_chapters WHERE content_file_name = 'Text/existing.xhtml';"; \
+	DATABASE_URL="postgresql+psycopg://postgres:postgres@localhost:5433/story_manager" \
+	PYTHONPATH=. .venv/bin/alembic -c backend/alembic.ini upgrade head; \
+	docker exec story-manager-migration-test psql -v ON_ERROR_STOP=1 -U postgres -d story_manager \
+		-c "DO \$$\$$ BEGIN IF NOT EXISTS (SELECT 1 FROM audiobook_chapters WHERE stable_chapter_key IS NOT NULL AND generation_state = 'ready' AND audio_revision = 1 AND duration_ms = 1250) THEN RAISE EXCEPTION 'existing audiobook chapter was not backfilled'; END IF; IF NOT EXISTS (SELECT 1 FROM books WHERE title = 'Migration Test' AND audiobook_publication_state = 'complete' AND audiobook_text_content_version = 3) THEN RAISE EXCEPTION 'existing audiobook book metadata was not backfilled'; END IF; END \$$\$$;"; \
+	DATABASE_URL="postgresql+psycopg://postgres:postgres@localhost:5433/story_manager" \
+	PYTHONPATH=. .venv/bin/alembic -c backend/alembic.ini downgrade 0022; \
+	docker exec story-manager-migration-test psql -v ON_ERROR_STOP=1 -U postgres -d story_manager \
+		-c "DO \$$\$$ BEGIN IF NOT EXISTS (SELECT 1 FROM audiobook_chapters WHERE content_file_name = 'Text/existing.xhtml') THEN RAISE EXCEPTION 'audiobook downgrade removed existing chapter'; END IF; END \$$\$$;"; \
+	DATABASE_URL="postgresql+psycopg://postgres:postgres@localhost:5433/story_manager" \
 	PYTHONPATH=. .venv/bin/alembic -c backend/alembic.ini upgrade head
 
 e2e:

--- a/backend/alembic/versions/0023_reader_audiobook_publication.py
+++ b/backend/alembic/versions/0023_reader_audiobook_publication.py
@@ -1,0 +1,251 @@
+"""add durable reader audiobook publication metadata
+
+Revision ID: 0023
+Revises: 0022
+Create Date: 2026-07-21 00:00:00
+"""
+
+from __future__ import annotations
+
+import hashlib
+import posixpath
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0023"
+down_revision = "0022"
+branch_labels = None
+depends_on = None
+
+
+BOOK_COLUMNS = (
+    sa.Column("audiobook_revision", sa.Integer(), nullable=False, server_default="0"),
+    sa.Column("audiobook_source_content_version", sa.Integer(), nullable=True),
+    sa.Column("audiobook_text_content_version", sa.Integer(), nullable=True),
+    sa.Column("audiobook_pending_content_version", sa.Integer(), nullable=True),
+    sa.Column("audiobook_publication_state", sa.String(), nullable=True),
+    sa.Column("audiobook_text_file_path", sa.String(), nullable=True),
+    sa.Column("audiobook_text_size_bytes", sa.BigInteger(), nullable=True),
+    sa.Column("audiobook_text_sha256", sa.String(length=64), nullable=True),
+    sa.Column("audiobook_publication_error", sa.Text(), nullable=True),
+)
+
+CHAPTER_COLUMNS = (
+    sa.Column("stable_chapter_key", sa.String(), nullable=True),
+    sa.Column("source_href", sa.String(), nullable=True),
+    sa.Column("source_content_hash", sa.String(length=64), nullable=True),
+    sa.Column("title", sa.String(), nullable=True),
+    sa.Column("spine_order", sa.Integer(), nullable=True),
+    sa.Column("generation_state", sa.String(), nullable=False, server_default="pending"),
+    sa.Column("audio_revision", sa.Integer(), nullable=False, server_default="0"),
+    sa.Column("reader_audio_file_path", sa.String(), nullable=True),
+    sa.Column("reader_smil_file_path", sa.String(), nullable=True),
+    sa.Column("audio_size_bytes", sa.BigInteger(), nullable=True),
+    sa.Column("audio_sha256", sa.String(length=64), nullable=True),
+    sa.Column("smil_size_bytes", sa.BigInteger(), nullable=True),
+    sa.Column("smil_sha256", sa.String(length=64), nullable=True),
+    sa.Column("duration_ms", sa.BigInteger(), nullable=True),
+)
+
+
+def _columns(conn, table_name: str) -> set[str]:
+    inspector = sa.inspect(conn)
+    if not inspector.has_table(table_name):
+        return set()
+    return {column["name"] for column in inspector.get_columns(table_name)}
+
+
+def _normalized_href(raw: str | None, chapter_number: int) -> str:
+    value = (raw or f"chapter{chapter_number:04d}.xhtml").replace("\\", "/").lstrip("/")
+    normalized = posixpath.normpath(value)
+    return normalized.removeprefix("./")
+
+
+def _stable_key(href: str) -> str:
+    return f"src-{hashlib.sha256(href.encode('utf-8')).hexdigest()[:16]}"
+
+
+def upgrade():
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    if not inspector.has_table("books"):
+        return
+
+    book_columns = _columns(conn, "books")
+    for column in BOOK_COLUMNS:
+        if column.name not in book_columns:
+            op.add_column("books", column.copy())
+
+    if not inspector.has_table("audiobook_chapters"):
+        op.create_table(
+            "audiobook_chapters",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("book_id", sa.Integer(), sa.ForeignKey("books.id", ondelete="CASCADE"), nullable=False),
+            sa.Column("chapter_number", sa.Integer(), nullable=False),
+            sa.Column("content_file_name", sa.String(), nullable=True),
+            sa.Column("smil_file_path", sa.String(), nullable=True),
+            sa.Column("audio_file_path", sa.String(), nullable=True),
+            sa.Column("needs_reassembly", sa.Boolean(), nullable=False, server_default="false"),
+            *[column.copy() for column in CHAPTER_COLUMNS],
+        )
+        op.create_index("ix_audiobook_chapters_book_id", "audiobook_chapters", ["book_id"])
+    else:
+        chapter_columns = _columns(conn, "audiobook_chapters")
+        for column in CHAPTER_COLUMNS:
+            if column.name not in chapter_columns:
+                op.add_column("audiobook_chapters", column.copy())
+
+    books = sa.table(
+        "books",
+        sa.column("id", sa.Integer()),
+        sa.column("content_version", sa.Integer()),
+        sa.column("audiobook_enabled", sa.Boolean()),
+        sa.column("audiobook_pipeline_status", sa.String()),
+        sa.column("audiobook_last_error", sa.Text()),
+        sa.column("audiobook_revision", sa.Integer()),
+        sa.column("audiobook_source_content_version", sa.Integer()),
+        sa.column("audiobook_text_content_version", sa.Integer()),
+        sa.column("audiobook_publication_state", sa.String()),
+        sa.column("audiobook_text_file_path", sa.String()),
+        sa.column("audiobook_publication_error", sa.Text()),
+    )
+    chapters = sa.table(
+        "audiobook_chapters",
+        sa.column("id", sa.Integer()),
+        sa.column("book_id", sa.Integer()),
+        sa.column("chapter_number", sa.Integer()),
+        sa.column("content_file_name", sa.String()),
+        sa.column("audio_file_path", sa.String()),
+        sa.column("smil_file_path", sa.String()),
+        sa.column("stable_chapter_key", sa.String()),
+        sa.column("source_href", sa.String()),
+        sa.column("title", sa.String()),
+        sa.column("spine_order", sa.Integer()),
+        sa.column("generation_state", sa.String()),
+        sa.column("audio_revision", sa.Integer()),
+        sa.column("reader_audio_file_path", sa.String()),
+        sa.column("reader_smil_file_path", sa.String()),
+        sa.column("duration_ms", sa.BigInteger()),
+    )
+
+    durations: dict[int, int] = {}
+    if sa.inspect(conn).has_table("audiobook_sentences"):
+        sentences = sa.table(
+            "audiobook_sentences",
+            sa.column("chapter_id", sa.Integer()),
+            sa.column("audio_duration_ms", sa.Integer()),
+        )
+        durations = {
+            row.chapter_id: int(row.duration_ms or 0)
+            for row in conn.execute(
+                sa.select(
+                    sentences.c.chapter_id,
+                    sa.func.sum(sentences.c.audio_duration_ms).label("duration_ms"),
+                ).group_by(sentences.c.chapter_id)
+            ).fetchall()
+        }
+
+    used_keys: dict[int, set[str]] = {}
+    chapter_rows = conn.execute(
+        sa.select(
+            chapters.c.id,
+            chapters.c.book_id,
+            chapters.c.chapter_number,
+            chapters.c.content_file_name,
+            chapters.c.audio_file_path,
+            chapters.c.smil_file_path,
+            chapters.c.stable_chapter_key,
+        ).order_by(chapters.c.book_id, chapters.c.chapter_number)
+    ).fetchall()
+    chapter_counts: dict[int, tuple[int, int]] = {}
+    for row in chapter_rows:
+        href = _normalized_href(row.content_file_name, row.chapter_number)
+        key = row.stable_chapter_key or _stable_key(href)
+        keys = used_keys.setdefault(row.book_id, set())
+        candidate = key
+        suffix = 2
+        while candidate in keys:
+            candidate = f"{key}-{suffix}"
+            suffix += 1
+        keys.add(candidate)
+        ready = bool(row.audio_file_path and row.smil_file_path)
+        total, ready_count = chapter_counts.get(row.book_id, (0, 0))
+        chapter_counts[row.book_id] = (total + 1, ready_count + int(ready))
+        conn.execute(
+            chapters.update()
+            .where(chapters.c.id == row.id)
+            .values(
+                stable_chapter_key=candidate,
+                source_href=href,
+                title=f"Chapter {row.chapter_number}",
+                spine_order=max(0, row.chapter_number - 1),
+                generation_state="ready" if ready else "pending",
+                audio_revision=1 if ready else 0,
+                reader_audio_file_path=row.audio_file_path,
+                reader_smil_file_path=row.smil_file_path,
+                duration_ms=durations.get(row.id),
+            )
+        )
+
+    for row in conn.execute(
+        sa.select(
+            books.c.id,
+            books.c.content_version,
+            books.c.audiobook_enabled,
+            books.c.audiobook_pipeline_status,
+            books.c.audiobook_last_error,
+        )
+    ).fetchall():
+        if not row.audiobook_enabled:
+            continue
+        total, ready = chapter_counts.get(row.id, (0, 0))
+        if row.audiobook_pipeline_status == "error":
+            state = "error"
+        elif total and ready == total and row.audiobook_pipeline_status == "complete":
+            state = "complete"
+        elif ready:
+            state = "partial"
+        else:
+            state = "processing"
+        content_version = row.content_version or 1
+        conn.execute(
+            books.update()
+            .where(books.c.id == row.id)
+            .values(
+                audiobook_revision=1 if total else 0,
+                audiobook_source_content_version=content_version,
+                audiobook_text_content_version=content_version if total else None,
+                audiobook_publication_state=state,
+                audiobook_text_file_path=(f"library/audiobooks/{row.id}/working.epub" if total else None),
+                audiobook_publication_error=row.audiobook_last_error,
+            )
+        )
+
+    inspector = sa.inspect(conn)
+    unique_names = {constraint.get("name") for constraint in inspector.get_unique_constraints("audiobook_chapters")}
+    if "uq_audiobook_chapter_stable_key" not in unique_names:
+        op.create_unique_constraint(
+            "uq_audiobook_chapter_stable_key",
+            "audiobook_chapters",
+            ["book_id", "stable_chapter_key"],
+        )
+
+
+def downgrade():
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    if inspector.has_table("audiobook_chapters"):
+        unique_names = {constraint.get("name") for constraint in inspector.get_unique_constraints("audiobook_chapters")}
+        if "uq_audiobook_chapter_stable_key" in unique_names:
+            op.drop_constraint("uq_audiobook_chapter_stable_key", "audiobook_chapters", type_="unique")
+        chapter_columns = _columns(conn, "audiobook_chapters")
+        for column in reversed(CHAPTER_COLUMNS):
+            if column.name in chapter_columns:
+                op.drop_column("audiobook_chapters", column.name)
+
+    if inspector.has_table("books"):
+        book_columns = _columns(conn, "books")
+        for column in reversed(BOOK_COLUMNS):
+            if column.name in book_columns:
+                op.drop_column("books", column.name)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -7,4 +7,9 @@ APP_DIR = Path(__file__).parent.resolve()
 # Absolute path to the library/ directory at the project root
 LIBRARY_PATH = (APP_DIR / ".." / ".." / "library").resolve()
 
+# Rename this marker whenever chapter concatenation semantics change. A
+# missing marker makes existing packages resumable at assembly without a
+# database migration or destructive audio regeneration.
+AUDIOBOOK_ASSEMBLY_MARKER = ".epub3-overlay-v3"
+
 GOOGLE_BOOKS_API_KEY = os.getenv("GOOGLE_BOOKS_API_KEY")

--- a/backend/app/crud/audiobook.py
+++ b/backend/app/crud/audiobook.py
@@ -224,7 +224,16 @@ async def get_in_progress_audiobook_books(db: AsyncSession) -> list[Book]:
     result = await db.execute(
         select(Book).where(
             Book.audiobook_enabled.is_(True),
-            Book.audiobook_pipeline_status.in_(active_statuses),
+            or_(
+                Book.audiobook_pipeline_status.in_(active_statuses),
+                and_(
+                    Book.audiobook_pending_content_version.is_not(None),
+                    or_(
+                        Book.audiobook_source_content_version.is_(None),
+                        Book.audiobook_pending_content_version > Book.audiobook_source_content_version,
+                    ),
+                ),
+            ),
         )
     )
     return list(result.scalars().all())
@@ -252,6 +261,34 @@ async def get_chapters_for_book(db: AsyncSession, book_id: int) -> list[Audioboo
         select(AudiobookChapter).where(AudiobookChapter.book_id == book_id).order_by(AudiobookChapter.chapter_number)
     )
     return list(result.scalars().all())
+
+
+async def get_chapters_for_books(db: AsyncSession, book_ids: list[int]) -> dict[int, list[AudiobookChapter]]:
+    if not book_ids:
+        return {}
+    result = await db.execute(
+        select(AudiobookChapter)
+        .where(AudiobookChapter.book_id.in_(book_ids))
+        .order_by(
+            AudiobookChapter.book_id,
+            AudiobookChapter.spine_order,
+            AudiobookChapter.chapter_number,
+        )
+    )
+    grouped: dict[int, list[AudiobookChapter]] = {book_id: [] for book_id in book_ids}
+    for chapter in result.scalars().all():
+        grouped.setdefault(chapter.book_id, []).append(chapter)
+    return grouped
+
+
+async def get_chapter_by_stable_key(db: AsyncSession, book_id: int, stable_chapter_key: str) -> Optional[AudiobookChapter]:
+    result = await db.execute(
+        select(AudiobookChapter).where(
+            AudiobookChapter.book_id == book_id,
+            AudiobookChapter.stable_chapter_key == stable_chapter_key,
+        )
+    )
+    return result.scalar_one_or_none()
 
 
 async def get_chapters_needing_reassembly(db: AsyncSession, book_id: int) -> list[AudiobookChapter]:

--- a/backend/app/crud/audiobook.py
+++ b/backend/app/crud/audiobook.py
@@ -8,7 +8,7 @@ from typing import Optional
 from sqlalchemy import and_, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from ..config import LIBRARY_PATH
+from ..config import AUDIOBOOK_ASSEMBLY_MARKER, LIBRARY_PATH
 from ..models import (
     AudiobookSettings,
     AudiobookChapter,
@@ -775,6 +775,31 @@ async def update_sentence_diarization(
     await db.commit()
 
 
+async def mark_sentences_as_narration(
+    db: AsyncSession,
+    sentence_ids: list[int],
+    narrator_id: Optional[int],
+) -> None:
+    """Bulk-complete sentences known to be prose outside a dialogue span."""
+    if not sentence_ids:
+        return
+    await db.execute(
+        update(AudiobookSentence)
+        .where(
+            AudiobookSentence.id.in_(sentence_ids),
+            AudiobookSentence.status == "pending_diarization",
+        )
+        .values(
+            character_id=narrator_id,
+            tagged_text=AudiobookSentence.original_text,
+            speaker_confidence=1.0,
+            speaker_reason="Deterministic prose outside dialogue",
+            status="ready_for_audio",
+        )
+    )
+    await db.commit()
+
+
 async def update_sentence_audio(db: AsyncSession, sentence_id: int, audio_file_path: str, audio_duration_ms: int) -> None:
     await db.execute(
         update(AudiobookSentence)
@@ -921,8 +946,10 @@ async def infer_audiobook_resume_status(db: AsyncSession, book_id: int) -> str:
     total = sum(counts.values())
     if total > 0 and counts.get("audio_generated", 0) == total:
         pending_chapters = await get_chapters_pending_assembly(db, book_id)
-        packaged_epub = LIBRARY_PATH / "audiobooks" / str(book_id) / "audiobook.epub"
-        return "assembling" if pending_chapters or not packaged_epub.is_file() else "complete"
+        output_dir = LIBRARY_PATH / "audiobooks" / str(book_id)
+        packaged_epub = output_dir / "audiobook.epub"
+        assembly_marker = output_dir / AUDIOBOOK_ASSEMBLY_MARKER
+        return "assembling" if pending_chapters or not packaged_epub.is_file() or not assembly_marker.is_file() else "complete"
 
     return "ingesting"
 

--- a/backend/app/crud/books.py
+++ b/backend/app/crud/books.py
@@ -198,6 +198,11 @@ async def detach_book_source(db: AsyncSession, book: models.Book) -> models.Book
 async def touch_book_content(db: AsyncSession, book: models.Book) -> None:
     book.content_updated_at = datetime.now(timezone.utc)
     book.content_version = (book.content_version or 0) + 1
+    if book.audiobook_enabled:
+        book.audiobook_pending_content_version = max(
+            book.audiobook_pending_content_version or 0,
+            book.content_version,
+        )
 
 
 async def get_books_by_author(db: AsyncSession, author: str, skip: int = 0, limit: int = 100) -> List[models.Book]:

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,4 +1,5 @@
 from sqlalchemy import (
+    BigInteger,
     Boolean,
     Column,
     Integer,
@@ -70,6 +71,18 @@ class Book(Base):
     audiobook_pipeline_updated_at = Column(DateTime(timezone=True), nullable=True)
     audiobook_batch_limit = Column(Integer, nullable=True)
     audiobook_llm_requests = Column(Integer, nullable=False, default=0, server_default="0")
+    # Reader-facing audiobook publication state. These fields describe the
+    # last atomically published modular rendition, independently of work that
+    # may still be in progress in the generation pipeline.
+    audiobook_revision = Column(Integer, nullable=False, default=0, server_default="0")
+    audiobook_source_content_version = Column(Integer, nullable=True)
+    audiobook_text_content_version = Column(Integer, nullable=True)
+    audiobook_pending_content_version = Column(Integer, nullable=True)
+    audiobook_publication_state = Column(String, nullable=True)
+    audiobook_text_file_path = Column(String, nullable=True)
+    audiobook_text_size_bytes = Column(BigInteger, nullable=True)
+    audiobook_text_sha256 = Column(String(64), nullable=True)
+    audiobook_publication_error = Column(Text, nullable=True)
 
     # Timestamps
     created_at = Column(DateTime(timezone=True), server_default=func.now())
@@ -213,6 +226,7 @@ class AudiobookSettings(Base):
 
 class AudiobookChapter(Base):
     __tablename__ = "audiobook_chapters"
+    __table_args__ = (UniqueConstraint("book_id", "stable_chapter_key", name="uq_audiobook_chapter_stable_key"),)
 
     id = Column(Integer, primary_key=True, index=True)
     book_id = Column(Integer, ForeignKey("books.id", ondelete="CASCADE"), nullable=False, index=True)
@@ -227,6 +241,20 @@ class AudiobookChapter(Base):
     # Values: None, queued, generating, ready, error.
     preview_status = Column(String, nullable=True)
     preview_error = Column(Text, nullable=True)
+    stable_chapter_key = Column(String, nullable=True)
+    source_href = Column(String, nullable=True)
+    source_content_hash = Column(String(64), nullable=True)
+    title = Column(String, nullable=True)
+    spine_order = Column(Integer, nullable=True)
+    generation_state = Column(String, nullable=False, default="pending", server_default="pending")
+    audio_revision = Column(Integer, nullable=False, default=0, server_default="0")
+    reader_audio_file_path = Column(String, nullable=True)
+    reader_smil_file_path = Column(String, nullable=True)
+    audio_size_bytes = Column(BigInteger, nullable=True)
+    audio_sha256 = Column(String(64), nullable=True)
+    smil_size_bytes = Column(BigInteger, nullable=True)
+    smil_sha256 = Column(String(64), nullable=True)
+    duration_ms = Column(BigInteger, nullable=True)
 
 
 class AudiobookSeriesCharacter(Base):

--- a/backend/app/routers/reader.py
+++ b/backend/app/routers/reader.py
@@ -2,23 +2,37 @@
 
 from __future__ import annotations
 
+import json
+import re
 import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterator
 from urllib.parse import quote
 
 from fastapi import APIRouter, Depends, HTTPException, Request
-from fastapi.responses import FileResponse, Response
+from fastapi.responses import FileResponse, JSONResponse, Response, StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import crud, models, schemas
 from ..auth import get_reader_api_key
 from ..config import LIBRARY_PATH
 from ..database import get_db
+from ..services.audiobook_publication import (
+    chapter_reader_audio_path,
+    chapter_reader_smil_bytes,
+    normalize_resource_href,
+    sha256_bytes,
+    sha256_file,
+    stable_chapter_key,
+    text_reader_path,
+)
 
 router = APIRouter(dependencies=[Depends(get_reader_api_key)])
 
 _ATOM_NS = "http://www.w3.org/2005/Atom"
 _OPDS_NS = "http://opds-spec.org/2010/catalog"
+_RANGE_RE = re.compile(r"^bytes=(\d*)-(\d*)$")
 
 ET.register_namespace("", _ATOM_NS)
 ET.register_namespace("opds", _OPDS_NS)
@@ -105,6 +119,7 @@ def _reader_book_payload(
     request: Request,
     *,
     series_user_genre_tags: list[str] | None = None,
+    audiobook_chapters: list[models.AudiobookChapter] | None = None,
 ) -> dict:
     base_url = str(request.base_url).rstrip("/")
     return {
@@ -121,6 +136,51 @@ def _reader_book_payload(
         "effective_genre_tags": _effective_genre_tags(book, series_user_genre_tags),
         "download_url": f"{base_url}/reader/books/{book.id}/download",
         "cover_url": f"{base_url}/reader/covers/{book.id}" if book.cover_path else None,
+        "audiobook": _reader_audiobook_capability(book, audiobook_chapters or []),
+    }
+
+
+def _reader_audiobook_status(book: models.Book, ready: int, total: int) -> str:
+    if book.audiobook_publication_state in {"processing", "partial", "complete", "error"}:
+        return book.audiobook_publication_state
+    if book.audiobook_pipeline_status == "error":
+        return "error"
+    if total and ready == total and book.audiobook_pipeline_status == "complete":
+        return "complete"
+    return "partial" if ready else "processing"
+
+
+def _reader_audiobook_capability(
+    book: models.Book,
+    chapters: list[models.AudiobookChapter],
+) -> dict | None:
+    if not book.audiobook_enabled:
+        return None
+    if not book.audiobook_pipeline_status and not book.audiobook_revision and not chapters:
+        return None
+    ready_chapters = [
+        chapter
+        for chapter in chapters
+        if chapter.generation_state == "ready" and chapter_reader_audio_path(chapter) is not None
+    ]
+    ready_bytes = 0
+    for chapter in ready_chapters:
+        if chapter.audio_size_bytes is not None:
+            ready_bytes += chapter.audio_size_bytes
+            continue
+        audio_path = chapter_reader_audio_path(chapter)
+        if audio_path and audio_path.is_file():
+            ready_bytes += audio_path.stat().st_size
+    content_version = book.content_version or 1
+    return {
+        "status": _reader_audiobook_status(book, len(ready_chapters), len(chapters)),
+        "revision": book.audiobook_revision or 0,
+        "source_content_version": book.audiobook_source_content_version or content_version,
+        "text_content_version": book.audiobook_text_content_version or content_version,
+        "ready_chapter_count": len(ready_chapters),
+        "total_chapter_count": len(chapters),
+        "ready_audio_bytes": ready_bytes,
+        "manifest_url": f"/reader/books/{book.id}/audiobook/manifest",
     }
 
 
@@ -292,6 +352,7 @@ async def _series_metadata_map(db: AsyncSession, books: list[models.Book]) -> di
 
 async def _reader_books_response(books: list[models.Book], request: Request, db: AsyncSession) -> list[schemas.ReaderBook]:
     metadata_map = await _series_metadata_map(db, books)
+    chapters_by_book = await crud.audiobook.get_chapters_for_books(db, [book.id for book in books])
     return [
         schemas.ReaderBook.model_validate(
             _reader_book_payload(
@@ -300,6 +361,7 @@ async def _reader_books_response(books: list[models.Book], request: Request, db:
                 series_user_genre_tags=(
                     metadata_map[book.series].user_genre_tags if book.series and book.series in metadata_map else None
                 ),
+                audiobook_chapters=chapters_by_book.get(book.id, []),
             )
         )
         for book in books
@@ -341,6 +403,256 @@ async def get_reader_updates(
 ) -> list[schemas.ReaderBook]:
     books = await crud.get_reader_updates(db, since)
     return await _reader_books_response(books, request, db)
+
+
+async def _reader_audiobook_book(book_id: int, db: AsyncSession) -> models.Book:
+    book = await crud.get_reader_book(db, book_id)
+    if not book.audiobook_enabled or (not book.audiobook_pipeline_status and not book.audiobook_revision):
+        raise HTTPException(status_code=404, detail="Generated audiobook is not available")
+    return book
+
+
+def _etag(value: str) -> str:
+    return f'"{value}"'
+
+
+def _etag_matches(request: Request, etag: str) -> bool:
+    candidates = {value.strip().removeprefix("W/") for value in request.headers.get("if-none-match", "").split(",")}
+    return "*" in candidates or etag in candidates
+
+
+def _asset_headers(etag: str, size: int, *, ranges: bool = False) -> dict[str, str]:
+    headers = {
+        "ETag": etag,
+        "Content-Length": str(size),
+        "Cache-Control": "private, max-age=0, must-revalidate",
+        "X-Content-Type-Options": "nosniff",
+    }
+    if ranges:
+        headers["Accept-Ranges"] = "bytes"
+    return headers
+
+
+def _manifest_chapter(chapter: models.AudiobookChapter, book_id: int) -> dict:
+    href = normalize_resource_href(chapter.source_href or chapter.content_file_name, chapter.chapter_number)
+    key = chapter.stable_chapter_key or stable_chapter_key(href)
+    audio_path = chapter_reader_audio_path(chapter)
+    smil_content = chapter_reader_smil_bytes(chapter)
+    is_ready = (
+        chapter.generation_state == "ready"
+        and audio_path is not None
+        and audio_path.is_file()
+        and smil_content is not None
+        and (chapter.audio_revision or 0) > 0
+    )
+    state = chapter.generation_state if chapter.generation_state in {"pending", "processing", "error"} else "ready"
+    payload = {
+        "key": key,
+        "title": chapter.title or f"Chapter {chapter.chapter_number}",
+        "href": href,
+        "state": "ready" if is_ready else state,
+        "audio_version": None,
+        "duration_ms": None,
+        "audio_size_bytes": None,
+        "audio_sha256": None,
+        "smil_size_bytes": None,
+        "smil_sha256": None,
+        "audio_url": None,
+        "smil_url": None,
+    }
+    if not is_ready:
+        return payload
+    version = chapter.audio_revision
+    payload.update(
+        {
+            "audio_version": version,
+            "duration_ms": chapter.duration_ms,
+            "audio_size_bytes": chapter.audio_size_bytes or audio_path.stat().st_size,
+            "audio_sha256": chapter.audio_sha256 or sha256_file(audio_path),
+            "smil_size_bytes": chapter.smil_size_bytes or len(smil_content),
+            "smil_sha256": chapter.smil_sha256 or sha256_bytes(smil_content),
+            "audio_url": f"/reader/books/{book_id}/audiobook/chapters/{key}/audio?version={version}",
+            "smil_url": f"/reader/books/{book_id}/audiobook/chapters/{key}/smil?version={version}",
+        }
+    )
+    return payload
+
+
+@router.get(
+    "/reader/books/{book_id}/audiobook/manifest",
+    response_model=schemas.ReaderAudiobookManifest,
+)
+async def reader_audiobook_manifest(
+    book_id: int,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    book = await _reader_audiobook_book(book_id, db)
+    text_path = text_reader_path(book)
+    if text_path is None:
+        raise HTTPException(status_code=404, detail="Audiobook text rendition is not available")
+    chapters = await crud.audiobook.get_chapters_for_book(db, book_id)
+    text_size = book.audiobook_text_size_bytes or text_path.stat().st_size
+    text_sha = book.audiobook_text_sha256 or sha256_file(text_path)
+    content_version = book.audiobook_text_content_version or book.content_version or 1
+    manifest = {
+        "revision": book.audiobook_revision or 0,
+        "source_content_version": book.audiobook_source_content_version or book.content_version or 1,
+        "text": {
+            "content_version": content_version,
+            "size_bytes": text_size,
+            "sha256": text_sha,
+            "url": f"/reader/books/{book_id}/audiobook/text",
+        },
+        "chapters": [_manifest_chapter(chapter, book_id) for chapter in chapters],
+    }
+    body = json.dumps(manifest, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    etag = _etag(sha256_bytes(body))
+    if _etag_matches(request, etag):
+        return Response(status_code=304, headers={"ETag": etag})
+    return Response(
+        content=body,
+        media_type="application/json",
+        headers=_asset_headers(etag, len(body)),
+    )
+
+
+@router.get("/reader/books/{book_id}/audiobook/text")
+async def reader_audiobook_text(
+    book_id: int,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    book = await _reader_audiobook_book(book_id, db)
+    path = text_reader_path(book)
+    if path is None:
+        raise HTTPException(status_code=404, detail="Audiobook text rendition is not available")
+    sha = book.audiobook_text_sha256 or sha256_file(path)
+    etag = _etag(sha)
+    if _etag_matches(request, etag):
+        return Response(status_code=304, headers={"ETag": etag})
+    return FileResponse(
+        path,
+        media_type="application/epub+zip",
+        headers=_asset_headers(etag, path.stat().st_size),
+    )
+
+
+def _stale_audiobook_revision(current_revision: int) -> JSONResponse:
+    return JSONResponse(
+        status_code=409,
+        content={
+            "error": "stale_audiobook_revision",
+            "message": "Refresh the audiobook manifest before downloading this chapter.",
+            "current_revision": current_revision,
+        },
+    )
+
+
+async def _reader_audiobook_chapter(
+    book_id: int,
+    chapter_key: str,
+    version: int,
+    db: AsyncSession,
+) -> models.AudiobookChapter | JSONResponse:
+    await _reader_audiobook_book(book_id, db)
+    chapter = await crud.audiobook.get_chapter_by_stable_key(db, book_id, chapter_key)
+    if chapter is None or chapter.generation_state != "ready":
+        raise HTTPException(status_code=404, detail="Audiobook chapter is not available")
+    if version != chapter.audio_revision:
+        return _stale_audiobook_revision(chapter.audio_revision or 0)
+    return chapter
+
+
+def _iter_file_range(path: Path, start: int, length: int) -> Iterator[bytes]:
+    remaining = length
+    with path.open("rb") as source:
+        source.seek(start)
+        while remaining:
+            chunk = source.read(min(1024 * 1024, remaining))
+            if not chunk:
+                break
+            remaining -= len(chunk)
+            yield chunk
+
+
+@router.get("/reader/books/{book_id}/audiobook/chapters/{chapter_key}/audio")
+async def reader_audiobook_chapter_audio(
+    book_id: int,
+    chapter_key: str,
+    version: int,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    result = await _reader_audiobook_chapter(book_id, chapter_key, version, db)
+    if isinstance(result, JSONResponse):
+        return result
+    path = chapter_reader_audio_path(result)
+    if path is None or not path.is_file():
+        raise HTTPException(status_code=404, detail="Audiobook audio file is not available")
+    size = path.stat().st_size
+    sha = result.audio_sha256 or sha256_file(path)
+    etag = _etag(sha)
+    if _etag_matches(request, etag):
+        return Response(status_code=304, headers={"ETag": etag, "Accept-Ranges": "bytes"})
+    range_header = request.headers.get("range")
+    if not range_header:
+        return FileResponse(
+            path,
+            media_type="audio/mpeg",
+            headers=_asset_headers(etag, size, ranges=True),
+        )
+    match = _RANGE_RE.fullmatch(range_header.strip())
+    if not match:
+        return Response(status_code=416, headers={"Content-Range": f"bytes */{size}", "Accept-Ranges": "bytes"})
+    first, last = match.groups()
+    if not first and not last:
+        return Response(status_code=416, headers={"Content-Range": f"bytes */{size}", "Accept-Ranges": "bytes"})
+    if first:
+        start = int(first)
+        end = min(int(last), size - 1) if last else size - 1
+    else:
+        suffix = int(last)
+        if suffix <= 0:
+            return Response(status_code=416, headers={"Content-Range": f"bytes */{size}", "Accept-Ranges": "bytes"})
+        start = max(0, size - suffix)
+        end = size - 1
+    if start >= size or end < start:
+        return Response(status_code=416, headers={"Content-Range": f"bytes */{size}", "Accept-Ranges": "bytes"})
+    length = end - start + 1
+    headers = _asset_headers(etag, length, ranges=True)
+    headers["Content-Range"] = f"bytes {start}-{end}/{size}"
+    return StreamingResponse(
+        _iter_file_range(path, start, length),
+        status_code=206,
+        media_type="audio/mpeg",
+        headers=headers,
+    )
+
+
+@router.get("/reader/books/{book_id}/audiobook/chapters/{chapter_key}/smil")
+async def reader_audiobook_chapter_smil(
+    book_id: int,
+    chapter_key: str,
+    version: int,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    result = await _reader_audiobook_chapter(book_id, chapter_key, version, db)
+    if isinstance(result, JSONResponse):
+        return result
+    content = chapter_reader_smil_bytes(result)
+    if content is None:
+        raise HTTPException(status_code=404, detail="Audiobook SMIL file is not available")
+    sha = result.smil_sha256 or sha256_bytes(content)
+    etag = _etag(sha)
+    if _etag_matches(request, etag):
+        return Response(status_code=304, headers={"ETag": etag})
+    return Response(
+        content=content,
+        media_type="application/smil+xml",
+        headers=_asset_headers(etag, len(content)),
+    )
 
 
 @router.get("/reader/books/{book_id}/download")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel, ConfigDict, Field, HttpUrl, field_validator
 from datetime import datetime
-from typing import Optional, List
+from typing import Literal, Optional, List
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from .models import SourceType
 
@@ -256,6 +256,46 @@ class SeriesMetadataSummary(BaseModel):
     user_genre_tags: List[str] = Field(default_factory=list)
 
 
+class ReaderAudiobookCapability(BaseModel):
+    status: Literal["processing", "partial", "complete", "error"]
+    revision: int
+    source_content_version: int
+    text_content_version: int
+    ready_chapter_count: int
+    total_chapter_count: int
+    ready_audio_bytes: int
+    manifest_url: str
+
+
+class ReaderAudiobookTextAsset(BaseModel):
+    content_version: int
+    size_bytes: int
+    sha256: str
+    url: str
+
+
+class ReaderAudiobookChapter(BaseModel):
+    key: str
+    title: Optional[str] = None
+    href: str
+    state: Literal["pending", "processing", "ready", "error"]
+    audio_version: Optional[int] = None
+    duration_ms: Optional[int] = None
+    audio_size_bytes: Optional[int] = None
+    audio_sha256: Optional[str] = None
+    smil_size_bytes: Optional[int] = None
+    smil_sha256: Optional[str] = None
+    audio_url: Optional[str] = None
+    smil_url: Optional[str] = None
+
+
+class ReaderAudiobookManifest(BaseModel):
+    revision: int
+    source_content_version: int
+    text: ReaderAudiobookTextAsset
+    chapters: List[ReaderAudiobookChapter]
+
+
 class ReaderBook(BaseModel):
     id: int
     title: str
@@ -270,6 +310,7 @@ class ReaderBook(BaseModel):
     effective_genre_tags: List[str] = Field(default_factory=list)
     download_url: str
     cover_url: Optional[str] = None
+    audiobook: Optional[ReaderAudiobookCapability] = None
 
 
 class ReaderSeriesSummary(BaseModel):

--- a/backend/app/services/audiobook_assembly.py
+++ b/backend/app/services/audiobook_assembly.py
@@ -9,14 +9,19 @@ import shutil
 import tempfile
 from xml.etree import ElementTree as ET
 
+from bs4 import BeautifulSoup
 from ebooklib import epub
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import crud
-from ..config import LIBRARY_PATH
+from ..config import AUDIOBOOK_ASSEMBLY_MARKER, LIBRARY_PATH
 from ..models import AudiobookChapter
 
 logger = logging.getLogger(__name__)
+
+_DC_NAMESPACE = "http://purl.org/dc/elements/1.1/"
+_OPF_NAMESPACE = "http://www.idpf.org/2007/opf"
+_CALIBRE_NAMESPACE = "http://calibre.kovidgoyal.net/2009/metadata"
 
 
 def _relative_path(full_path: Path) -> str:
@@ -42,6 +47,60 @@ def _ensure_toc_link_ids(toc_items, prefix: str = "toc") -> None:
                 section.uid = uid
             if len(item) > 1:
                 _ensure_toc_link_ids(item[1], uid)
+
+
+def _sanitize_epub3_metadata(ebook) -> None:
+    """Remove EPUB 2-only metadata syntax that is invalid in an EPUB 3 package."""
+    ebook.metadata.pop(_CALIBRE_NAMESPACE, None)
+    for entries in ebook.metadata.get(_DC_NAMESPACE, {}).values():
+        for _, attributes in entries:
+            if not attributes:
+                continue
+            for name in list(attributes):
+                if name.startswith(f"{{{_OPF_NAMESPACE}}}"):
+                    del attributes[name]
+
+
+def _document_ids(ebook) -> dict[str, set[str]]:
+    ids_by_name: dict[str, set[str]] = {}
+    for item in ebook.get_items_of_type(ebooklib.ITEM_DOCUMENT):
+        soup = BeautifulSoup(item.content, "html.parser")
+        ids_by_name[item.get_name()] = {
+            str(node.get("id"))
+            for node in soup.find_all(attrs={"id": True})
+        }
+    return ids_by_name
+
+
+def _sanitize_toc_targets(toc_items, ids_by_name: dict[str, set[str]]) -> None:
+    """Strip only fragments that do not exist in their target XHTML document."""
+    for item in toc_items or []:
+        target = item[0] if isinstance(item, (tuple, list)) and item else item
+        if isinstance(target, (epub.Link, epub.Section)) and "#" in target.href:
+            file_name, fragment = target.href.split("#", 1)
+            if file_name in ids_by_name and fragment not in ids_by_name[file_name]:
+                target.href = file_name
+        if isinstance(item, (tuple, list)) and len(item) > 1:
+            _sanitize_toc_targets(item[1], ids_by_name)
+
+
+def _prepare_epub3_documents(ebook) -> None:
+    """Supply required document titles and declare embedded SVG content."""
+    fallback_title = ebook.title or "Audiobook"
+    for item in ebook.get_items_of_type(ebooklib.ITEM_DOCUMENT):
+        if isinstance(item, epub.EpubNav):
+            continue
+        soup = BeautifulSoup(item.content, "html.parser")
+        if not item.title:
+            heading = soup.find(["h1", "h2", "h3"])
+            item.title = heading.get_text(" ", strip=True) if heading else fallback_title
+        if soup.find("svg") is not None and "svg" not in item.properties:
+            item.properties.append("svg")
+
+
+def _ensure_epub3_navigation(ebook) -> None:
+    if not any(isinstance(item, epub.EpubNav) for item in ebook.get_items()):
+        ebook.add_item(epub.EpubNav(uid="nav", file_name="nav.xhtml", title="Navigation"))
 
 
 def _build_smil(chapter, sentences: list, audio_filename: str) -> str:
@@ -96,6 +155,32 @@ async def _assemble_chapter(book_id: int, chapter, sentences: list, output_dir: 
             raise RuntimeError(f"Snippet file missing for sentence {sentence.id}: {snippet_full}")
         snippet_paths.append(snippet_full)
 
+    # Treat the MP3 artifacts as authoritative. Older pipeline versions trusted
+    # provider-reported durations, which accumulated into visibly incorrect
+    # SMIL timelines. Rounding cumulative frame durations preserves both every
+    # intermediate boundary and the exact rounded chapter total.
+    from mutagen.mp3 import MP3
+
+    cumulative_exact_ms = 0.0
+    previous_boundary_ms = 0
+    corrected_durations = 0
+    for sentence, snippet_path in zip(sentences, snippet_paths, strict=True):
+        snippet = MP3(str(snippet_path))
+        cumulative_exact_ms += snippet.info.length * 1000
+        next_boundary_ms = round(cumulative_exact_ms)
+        duration_ms = next_boundary_ms - previous_boundary_ms
+        if sentence.audio_duration_ms != duration_ms:
+            sentence.audio_duration_ms = duration_ms
+            corrected_durations += 1
+        previous_boundary_ms = next_boundary_ms
+    if corrected_durations:
+        await db.commit()
+        logger.info(
+            "Corrected %d legacy sentence duration(s) in chapter %s.",
+            corrected_durations,
+            chapter.id,
+        )
+
     audio_filename = f"ch{chapter.chapter_number:04d}.mp3"
     audio_path = output_dir / audio_filename
     ffmpeg = shutil.which("ffmpeg")
@@ -117,9 +202,7 @@ async def _assemble_chapter(book_id: int, chapter, sentences: list, output_dir: 
             "-i",
             manifest.name,
             "-codec:a",
-            "libmp3lame",
-            "-b:a",
-            "64k",
+            "copy",
             "-y",
             str(audio_path),
             stdout=asyncio.subprocess.PIPE,
@@ -177,7 +260,13 @@ async def assemble_book(book_id: int, db: AsyncSession) -> None:
         raise RuntimeError(f"Cannot assemble book {book_id}: not all sentences have generated audio.")
 
     audiobook_epub_path = output_dir / "audiobook.epub"
-    chapters = await crud.audiobook.get_chapters_pending_assembly(db, book_id)
+    assembly_marker = output_dir / AUDIOBOOK_ASSEMBLY_MARKER
+    if assembly_marker.is_file():
+        chapters = await crud.audiobook.get_chapters_pending_assembly(db, book_id)
+    else:
+        # Existing outputs were assembled with timeline-shortening re-encoding.
+        # Rebuild every chapter once with frame-copy concatenation.
+        chapters = await crud.audiobook.get_chapters_for_book(db, book_id)
     if chapters:
         # Once chapter state changes, an older package is no longer a valid
         # completion marker. Removing it makes an interrupted package step
@@ -213,8 +302,13 @@ async def assemble_book(book_id: int, db: AsyncSession) -> None:
         raise RuntimeError(f"Working EPUB not found for book {book_id}; run ingestion again.")
 
     ebook = epub.read_epub(str(working_epub_path))
+    _sanitize_epub3_metadata(ebook)
+    _prepare_epub3_documents(ebook)
+    _sanitize_toc_targets(ebook.toc, _document_ids(ebook))
+    _ensure_epub3_navigation(ebook)
 
     all_chapters = await crud.audiobook.get_chapters_for_book(db, book_id)
+    total_duration_ms = 0
     for chapter in all_chapters:
         if not chapter.smil_file_path:
             raise RuntimeError(f"Missing SMIL path for book {book_id}, chapter {chapter.id}.")
@@ -240,17 +334,35 @@ async def assemble_book(book_id: int, db: AsyncSession) -> None:
         )
         ebook.add_item(smil_item)
 
+        sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
+        chapter_duration_ms = sum(sentence.audio_duration_ms or 0 for sentence in sentences)
+        total_duration_ms += chapter_duration_ms
+        ebook.add_metadata(
+            "OPF",
+            "meta",
+            _ms_to_clock(chapter_duration_ms),
+            {"property": "media:duration", "refines": f"#{smil_item.id}"},
+        )
+
         # Attach media-overlay to the matching spine item
         for item in ebook.get_items_of_type(ebooklib.ITEM_DOCUMENT):
             if item.get_name() == chapter.content_file_name:
                 item.media_overlay = smil_item.id
                 break
 
+    ebook.add_metadata(
+        "OPF",
+        "meta",
+        _ms_to_clock(total_duration_ms),
+        {"property": "media:duration"},
+    )
+
     temporary_epub_path = output_dir / "audiobook.tmp.epub"
     temporary_epub_path.unlink(missing_ok=True)
     _ensure_toc_link_ids(ebook.toc)
     epub.write_epub(str(temporary_epub_path), ebook)
     temporary_epub_path.replace(audiobook_epub_path)
+    assembly_marker.write_text("EPUB 3 media-overlay package with frame-copy audio\n", encoding="utf-8")
     logger.info("Repackaged audiobook EPUB: %s", audiobook_epub_path)
 
     if not await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):

--- a/backend/app/services/audiobook_assembly.py
+++ b/backend/app/services/audiobook_assembly.py
@@ -65,10 +65,7 @@ def _document_ids(ebook) -> dict[str, set[str]]:
     ids_by_name: dict[str, set[str]] = {}
     for item in ebook.get_items_of_type(ebooklib.ITEM_DOCUMENT):
         soup = BeautifulSoup(item.content, "html.parser")
-        ids_by_name[item.get_name()] = {
-            str(node.get("id"))
-            for node in soup.find_all(attrs={"id": True})
-        }
+        ids_by_name[item.get_name()] = {str(node.get("id")) for node in soup.find_all(attrs={"id": True})}
     return ids_by_name
 
 

--- a/backend/app/services/audiobook_assembly.py
+++ b/backend/app/services/audiobook_assembly.py
@@ -16,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from .. import crud
 from ..config import AUDIOBOOK_ASSEMBLY_MARKER, LIBRARY_PATH
 from ..models import AudiobookChapter
+from .audiobook_publication import publish_reader_audiobook
 
 logger = logging.getLogger(__name__)
 
@@ -360,6 +361,7 @@ async def assemble_book(book_id: int, db: AsyncSession) -> None:
     epub.write_epub(str(temporary_epub_path), ebook)
     temporary_epub_path.replace(audiobook_epub_path)
     assembly_marker.write_text("EPUB 3 media-overlay package with frame-copy audio\n", encoding="utf-8")
+    await publish_reader_audiobook(db, book_id)
     logger.info("Repackaged audiobook EPUB: %s", audiobook_epub_path)
 
     if not await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):

--- a/backend/app/services/audiobook_ingestion.py
+++ b/backend/app/services/audiobook_ingestion.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+import hashlib
 import logging
+import shutil
+import tempfile
+from collections import Counter
+from pathlib import Path
 
 import ebooklib
 from ebooklib import epub
@@ -11,7 +16,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import crud
 from ..config import LIBRARY_PATH
-from ..models import Book
+from ..models import AudiobookChapter, AudiobookSentence, Book
+from .audiobook_publication import (
+    normalize_resource_href,
+    stable_chapter_key,
+    stage_reader_text_rendition,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -77,7 +87,19 @@ def _ensure_toc_link_ids(toc_items, prefix: str = "toc") -> None:
                 _ensure_toc_link_ids(item[1], uid)
 
 
-def _inject_spans_into_text_node(text_node: NavigableString, chapter_num: int, start_seq: int) -> tuple[int, list[dict]]:
+def _stable_sentence_id(chapter_key: str, text: str, occurrence: int) -> str:
+    normalized = " ".join(text.split()).casefold()
+    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:12]
+    return f"{chapter_key}-{digest}-{occurrence}"
+
+
+def _inject_spans_into_text_node(
+    text_node: NavigableString,
+    chapter_key: str,
+    start_seq: int,
+    occurrences: Counter[str],
+    existing_ids: list[str] | None = None,
+) -> tuple[int, list[dict]]:
     """Wrap one text node's sentences without disturbing surrounding markup.
 
     Returns (next_sequence_number, list_of_sentence_dicts).
@@ -104,7 +126,14 @@ def _inject_spans_into_text_node(text_node: NavigableString, chapter_num: int, s
     for index, sent_text in enumerate(sentences):
         if index > 0:
             replacement_nodes.append(NavigableString(" "))
-        span_id = f"ch{chapter_num}_s{seq}"
+        normalized = " ".join(sent_text.split()).casefold()
+        occurrence = occurrences[normalized]
+        occurrences[normalized] += 1
+        span_id = (
+            existing_ids[seq]
+            if existing_ids is not None and seq < len(existing_ids)
+            else _stable_sentence_id(chapter_key, sent_text, occurrence)
+        )
         replacement_nodes.append(_span_for_sentence(span_id, sent_text))
 
         sentences_data.append(
@@ -125,13 +154,56 @@ def _inject_spans_into_text_node(text_node: NavigableString, chapter_num: int, s
     return seq, sentences_data
 
 
+def _source_content_hash(soup: BeautifulSoup) -> str:
+    return hashlib.sha256(str(soup).encode("utf-8")).hexdigest()
+
+
+def _chapter_title(item, soup: BeautifulSoup, chapter_number: int) -> str:
+    title = (getattr(item, "title", None) or "").strip()
+    if title:
+        return title
+    heading = soup.find(["h1", "h2", "h3"])
+    if heading:
+        value = heading.get_text(" ", strip=True)
+        if value:
+            return value[:500]
+    return f"Chapter {chapter_number}"
+
+
+def _sentence_texts(soup: BeautifulSoup) -> list[str]:
+    texts: list[str] = []
+    container = soup.body or soup
+    for text_node in list(container.find_all(string=True)):
+        stripped = str(text_node).strip()
+        if stripped and not _should_skip_text_node(text_node):
+            texts.extend(_tokenize_text(stripped))
+    return texts
+
+
+def _chapter_artifact_paths(chapter: AudiobookChapter, sentences: list[AudiobookSentence]) -> set[Path]:
+    paths: set[Path] = set()
+    for relative_path in (
+        chapter.audio_file_path,
+        chapter.smil_file_path,
+        chapter.reader_audio_file_path,
+        chapter.reader_smil_file_path,
+        *(sentence.audio_file_path for sentence in sentences),
+    ):
+        if relative_path:
+            path = (LIBRARY_PATH.parent / relative_path).resolve()
+            if path.is_relative_to(LIBRARY_PATH.parent.resolve()):
+                paths.add(path)
+    return paths
+
+
 async def ingest_epub(book_id: int, db: AsyncSession) -> None:
-    """Parse the book's EPUB, inject span IDs, populate chapters and sentences tables."""
+    """Diff the current EPUB into stable chapters and publish its text rendition."""
     book: Book = await db.get(Book, book_id)
     if book is None:
         raise ValueError(f"Book {book_id} not found")
 
     epub_path = (LIBRARY_PATH.parent / book.current_path).resolve()
+    ingested_content_version = book.content_version or 1
     logger.info("Ingesting EPUB for book %s from %s", book_id, epub_path)
 
     output_dir = LIBRARY_PATH.parent / "library" / "audiobooks" / str(book_id)
@@ -139,9 +211,26 @@ async def ingest_epub(book_id: int, db: AsyncSession) -> None:
     snippets_dir = output_dir / "snippets"
     snippets_dir.mkdir(exist_ok=True)
 
-    ebook = epub.read_epub(str(epub_path))
-    await crud.audiobook.delete_chapters_for_book(db, book_id)
-    await crud.audiobook.delete_characters_for_book(db, book_id)
+    with tempfile.NamedTemporaryFile(dir=output_dir, suffix=".source.epub", delete=False) as handle:
+        source_snapshot = Path(handle.name)
+    try:
+        shutil.copyfile(epub_path, source_snapshot)
+        ebook = epub.read_epub(str(source_snapshot))
+    finally:
+        source_snapshot.unlink(missing_ok=True)
+    existing_chapters = await crud.audiobook.get_chapters_for_book(db, book_id)
+    existing_chapter_ids = {chapter.id for chapter in existing_chapters}
+    existing_sentences = {
+        chapter.id: await crud.audiobook.get_sentences_for_chapter(db, chapter.id) for chapter in existing_chapters
+    }
+    by_href = {
+        normalize_resource_href(chapter.source_href or chapter.content_file_name, chapter.chapter_number): chapter
+        for chapter in existing_chapters
+    }
+    by_hash: dict[str, list[AudiobookChapter]] = {}
+    for chapter in existing_chapters:
+        if chapter.source_content_hash:
+            by_hash.setdefault(chapter.source_content_hash, []).append(chapter)
 
     # Collect spine items in order
     spine_items = []
@@ -151,63 +240,180 @@ async def ingest_epub(book_id: int, db: AsyncSession) -> None:
             spine_items.append(item)
 
     all_chapter_records = []
+    matched_ids: set[int] = set()
+    used_keys = {chapter.stable_chapter_key for chapter in existing_chapters if chapter.stable_chapter_key}
+    changed_chapter_ids: set[int] = set()
+    new_chapter_count = 0
+    obsolete_paths: set[Path] = set()
 
     for chapter_num, item in enumerate(spine_items, start=1):
         content = item.get_content()
         soup = BeautifulSoup(content, "html.parser")
+        href = normalize_resource_href(item.get_name(), chapter_num)
+        content_hash = _source_content_hash(soup)
+        sentence_texts = _sentence_texts(soup)
+
+        chapter = by_href.get(href)
+        if chapter is not None and chapter.id in matched_ids:
+            chapter = None
+        if chapter is None:
+            chapter = next(
+                (candidate for candidate in by_hash.get(content_hash, []) if candidate.id not in matched_ids),
+                None,
+            )
+
+        if chapter is None:
+            base_key = stable_chapter_key(href)
+            key = base_key
+            suffix = 2
+            while key in used_keys:
+                key = f"{base_key}-{suffix}"
+                suffix += 1
+            used_keys.add(key)
+            chapter = AudiobookChapter(
+                book_id=book_id,
+                chapter_number=chapter_num,
+                content_file_name=href,
+                stable_chapter_key=key,
+                source_href=href,
+                source_content_hash=content_hash,
+                title=_chapter_title(item, soup, chapter_num),
+                spine_order=chapter_num - 1,
+                generation_state="pending",
+                needs_reassembly=True,
+            )
+            db.add(chapter)
+            await db.flush()
+            previous_sentences: list[AudiobookSentence] = []
+            unchanged = False
+            new_chapter_count += 1
+        else:
+            matched_ids.add(chapter.id)
+            previous_sentences = existing_sentences[chapter.id]
+            unchanged = chapter.source_content_hash == content_hash or (
+                chapter.source_content_hash is None
+                and [sentence.original_text for sentence in previous_sentences] == sentence_texts
+            )
+            if not unchanged:
+                changed_chapter_ids.add(chapter.id)
+
+        key = chapter.stable_chapter_key or stable_chapter_key(href)
+        existing_ids = [sentence.html_element_id for sentence in previous_sentences] if unchanged else None
 
         chapter_sentences: list[dict] = []
         seq = 0
+        occurrences: Counter[str] = Counter()
 
         # Process text nodes in document order. This preserves existing block and
         # inline structure while adding stable sentence-level anchors.
         container = soup.body or soup
         for text_node in list(container.find_all(string=True)):
-            seq, new_sentences = _inject_spans_into_text_node(text_node, chapter_num, seq)
+            seq, new_sentences = _inject_spans_into_text_node(
+                text_node,
+                key,
+                seq,
+                occurrences,
+                existing_ids,
+            )
             chapter_sentences.extend(new_sentences)
 
         # Save modified XHTML back into the ebook item
         item.set_content(str(soup).encode("utf-8"))
-        all_chapter_records.append((chapter_num, item, chapter_sentences))
+        if not chapter_sentences:
+            if chapter.id not in existing_chapter_ids:
+                await db.delete(chapter)
+            continue
+
+        chapter.chapter_number = chapter_num
+        chapter.content_file_name = href
+        chapter.stable_chapter_key = key
+        chapter.source_href = href
+        chapter.source_content_hash = content_hash
+        chapter.title = _chapter_title(item, soup, chapter_num)
+        chapter.spine_order = chapter_num - 1
+
+        if not unchanged:
+            obsolete_paths.update(_chapter_artifact_paths(chapter, previous_sentences))
+            for sentence in previous_sentences:
+                await db.delete(sentence)
+            chapter.audio_file_path = None
+            chapter.smil_file_path = None
+            chapter.reader_audio_file_path = None
+            chapter.reader_smil_file_path = None
+            chapter.audio_size_bytes = None
+            chapter.audio_sha256 = None
+            chapter.smil_size_bytes = None
+            chapter.smil_sha256 = None
+            chapter.duration_ms = None
+            chapter.needs_reassembly = True
+            chapter.generation_state = "pending"
+            chapter.summary = None
+            chapter.summary_updated_at = None
+            db.add_all([AudiobookSentence(chapter_id=chapter.id, **sentence) for sentence in chapter_sentences])
+        all_chapter_records.append((chapter, unchanged))
 
     # Write modified EPUB to working copy
     working_epub_path = output_dir / "working.epub"
     _ensure_toc_link_ids(ebook.toc)
-    epub.write_epub(str(working_epub_path), ebook)
+    with tempfile.NamedTemporaryFile(dir=output_dir, suffix=".epub", delete=False) as handle:
+        temporary_epub = Path(handle.name)
+    try:
+        epub.write_epub(str(temporary_epub), ebook)
+        temporary_epub.replace(working_epub_path)
+    finally:
+        temporary_epub.unlink(missing_ok=True)
     logger.info("Wrote span-injected EPUB to %s", working_epub_path)
 
-    # Persist to database
-    persisted_chapters = 0
-    total_chapters = sum(1 for _chapter_num, _item, sentences in all_chapter_records if sentences)
-    await crud.audiobook.update_book_pipeline_progress(
-        db,
-        book_id,
-        current=0,
-        total=total_chapters,
-        detail=f"Tokenized EPUB; saving {total_chapters} narratable sections",
-    )
-    for chapter_num, item, chapter_sentences in all_chapter_records:
-        if not chapter_sentences:
-            continue
-        chapter = await crud.audiobook.create_chapter(
-            db,
-            book_id=book_id,
-            chapter_number=chapter_num,
-            content_file_name=item.get_name(),
-        )
-        await crud.audiobook.create_sentences_bulk(db, chapter_id=chapter.id, sentences_data=chapter_sentences)
-        persisted_chapters += 1
-        await crud.audiobook.update_book_pipeline_progress(
-            db,
-            book_id,
-            current=persisted_chapters,
-            total=total_chapters,
-            detail=f"Saved section {persisted_chapters} of {total_chapters}",
-        )
+    retained_existing_ids = {chapter.id for chapter, _unchanged in all_chapter_records if chapter.id in existing_chapter_ids}
+    removed_chapters = [chapter for chapter in existing_chapters if chapter.id not in retained_existing_ids]
+    for chapter in removed_chapters:
+        obsolete_paths.update(_chapter_artifact_paths(chapter, existing_sentences[chapter.id]))
+        await db.delete(chapter)
 
-    await db.commit()
+    persisted_chapters = len(all_chapter_records)
     if persisted_chapters == 0:
+        await db.rollback()
         raise RuntimeError(f"EPUB for book {book_id} contains no narratable text.")
-    if not await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):
-        await crud.audiobook.set_book_pipeline_status(db, book_id, "roster_gen")
-    logger.info("Ingestion complete for book %s: %d chapters processed", book_id, persisted_chapters)
+
+    text_path, text_size, text_sha = stage_reader_text_rendition(
+        book_id,
+        ingested_content_version,
+        working_epub_path,
+    )
+    await db.refresh(
+        book,
+        attribute_names=["content_version", "audiobook_pending_content_version"],
+    )
+    latest_content_version = book.content_version or ingested_content_version
+    characters = await crud.audiobook.get_characters_for_book(db, book_id)
+    ready_count = sum(1 for chapter, _ in all_chapter_records if chapter.generation_state == "ready")
+    book.audiobook_revision = (book.audiobook_revision or 0) + 1
+    book.audiobook_source_content_version = ingested_content_version
+    book.audiobook_text_content_version = ingested_content_version
+    book.audiobook_pending_content_version = (
+        latest_content_version if latest_content_version > ingested_content_version else None
+    )
+    book.audiobook_text_file_path = text_path
+    book.audiobook_text_size_bytes = text_size
+    book.audiobook_text_sha256 = text_sha
+    book.audiobook_publication_state = "partial" if ready_count else "processing"
+    book.audiobook_publication_error = None
+    book.audiobook_pipeline_status = "diarizing" if characters else "roster_gen"
+    book.audiobook_progress_current = persisted_chapters
+    book.audiobook_progress_total = persisted_chapters
+    book.audiobook_progress_detail = (
+        f"Ingested {persisted_chapters} sections: {new_chapter_count} new, "
+        f"{len(changed_chapter_ids)} changed, {len(removed_chapters)} removed"
+    )
+    await db.commit()
+    for path in obsolete_paths:
+        path.unlink(missing_ok=True)
+    (output_dir / "audiobook.epub").unlink(missing_ok=True)
+    logger.info(
+        "Ingestion complete for book %s: %d sections (%d new, %d changed, %d removed)",
+        book_id,
+        persisted_chapters,
+        new_chapter_count,
+        len(changed_chapter_ids),
+        len(removed_chapters),
+    )

--- a/backend/app/services/audiobook_llm.py
+++ b/backend/app/services/audiobook_llm.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
+import copy
 import json
 import logging
 import re
 from collections import Counter
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 import httpx
@@ -17,6 +20,8 @@ from ..models import AudiobookSettings, Book
 logger = logging.getLogger(__name__)
 
 STUB_PROVIDER = "stub"
+DIARIZATION_BATCH_SIZE = 40
+STORY_CHAPTER_MIN_SENTENCES = 40
 
 DEFAULT_ROSTER_PROMPT = """\
 You are a literary analyst preparing a cast list for an audiobook. Analyze the sampled excerpts from across the \
@@ -71,22 +76,18 @@ Chapter summary so far:
 Previous context (last 8 sentences):
 {context}
 
-Sentences to process (JSON array with id and text):
+Sentences to process (JSON array with id, text, and its immediate previous/next context):
 {sentences_json}
 
-For each sentence return:
-- id: the sentence id (integer)
-- character_id: the character id from the roster (use the narrator's id for narration; null if uncertain)
-- tagged_text: the sentence text with optional non-verbal tags like [laughter], [sigh], [whisper], [shout], or null
-  when no tag is needed (do not repeat unchanged text)
-- confidence: a number from 0 to 1 for the speaker assignment
-- reason: a brief evidence-based reason, such as an adjacent dialogue tag or turn-taking context
+For each sentence return (exactly {assignment_count} assignments total, one per input sentence in the same order;
+do not omit or duplicate an id). Assign only the `text`; use `previous_text` and `next_text` solely to resolve
+speaker attribution:
+- i: the sentence id (integer)
+- c: the character id from the roster (use the narrator's id for narration; null if uncertain)
+- e: one of "laughter", "sigh", "whisper", "shout", or null. Do not repeat the sentence text.
 
-Also return chapter_summary: an updated spoiler-light summary incorporating this batch and the prior summary.
-The roster descriptions are identity hints only and may be inaccurate. Ground the chapter summary exclusively in the
-sentence text and prior chapter summary; never import plot events, body changes, relationships, or backstory from a
-character description.
-Return JSON with keys assignments and chapter_summary. No markdown or explanation.
+Return minified, single-line JSON with the key assignments. Do not add whitespace, markdown, explanation, repeated
+sentence text, or chapter summary.
 """
 
 _ALLOWED_EXPRESSION_TAGS = {"laughter", "sigh", "whisper", "shout"}
@@ -99,6 +100,14 @@ _NARRATION_REASON_RE = re.compile(
     r"\b(?:narrat(?:or|ion|ive)|internal|reflection|action description|monologue|observation|recounting)\b",
     re.IGNORECASE,
 )
+_DIARIZATION_REASON_LABELS = {
+    "explicit_attribution": "Explicit dialogue attribution",
+    "adjacent_attribution": "Adjacent dialogue attribution",
+    "turn_taking": "Conversational turn-taking",
+    "narration": "Narrative prose",
+    "minor_speaker": "Unnamed or one-scene speaker",
+    "uncertain": "Model was uncertain",
+}
 
 ROSTER_SCHEMA = {
     "type": "object",
@@ -147,18 +156,58 @@ DIARIZATION_SCHEMA = {
             "items": {
                 "type": "object",
                 "properties": {
-                    "id": {"type": "integer"},
-                    "character_id": {"type": ["integer", "null"]},
-                    "tagged_text": {"type": ["string", "null"]},
-                    "confidence": {"type": "number", "minimum": 0, "maximum": 1},
-                    "reason": {"type": "string"},
+                    "i": {"type": "integer"},
+                    "c": {"type": ["integer", "null"]},
+                    "e": {
+                        "type": ["string", "null"],
+                        "enum": [None, "laughter", "sigh", "whisper", "shout"],
+                    },
                 },
-                "required": ["id", "character_id", "tagged_text", "confidence", "reason"],
+                "required": ["i", "c", "e"],
             },
         },
-        "chapter_summary": {"type": "string"},
     },
-    "required": ["assignments", "chapter_summary"],
+    "required": ["assignments"],
+}
+
+
+def _diarization_schema(assignment_count: int) -> dict[str, Any]:
+    """Constrain structured output to one result per requested sentence."""
+    schema = copy.deepcopy(DIARIZATION_SCHEMA)
+    assignments = schema["properties"]["assignments"]
+    assignments["minItems"] = assignment_count
+    assignments["maxItems"] = assignment_count
+    return schema
+
+
+def _sentence_ids_requiring_diarization(sentences: list[Any]) -> set[int]:
+    """Keep quoted spans for the model; prose outside them is narrator-owned."""
+    in_dialogue = False
+    requiring_model: set[int] = set()
+    for sentence in sentences:
+        starts_in_dialogue = in_dialogue
+        contains_quote = False
+        for character in sentence.original_text:
+            if character == "“":
+                in_dialogue = True
+                contains_quote = True
+            elif character == "”":
+                in_dialogue = False
+                contains_quote = True
+            elif character == '"':
+                in_dialogue = not in_dialogue
+                contains_quote = True
+        if starts_in_dialogue or contains_quote or in_dialogue:
+            requiring_model.add(sentence.id)
+    return requiring_model
+
+
+CHAPTER_SUMMARY_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "summary": {"type": "string", "maxLength": 1200},
+    },
+    "required": ["summary"],
 }
 
 
@@ -167,6 +216,7 @@ async def _call_llm(
     messages: list[dict[str, Any]],
     *,
     response_schema: dict[str, Any] | None = None,
+    progress_callback: Callable[[int], Awaitable[None]] | None = None,
 ) -> str:
     """Route to the configured LLM provider and return the text response."""
     provider = (settings.llm_provider or "openai").lower()
@@ -182,17 +232,45 @@ async def _call_llm(
         payload: dict[str, Any] = {
             "model": model,
             "messages": messages,
-            "stream": False,
+            "stream": progress_callback is not None,
             "think": False,
             "format": response_schema or "json",
-            "options": {"temperature": 0, "num_ctx": 32768, "num_predict": 4096},
+            # A structured batch response can legitimately exceed 4K tokens.
+            # Keep enough headroom to close the JSON document; the
+            # diarization loop also shrinks the batch if a provider still
+            # returns malformed or incomplete output.
+            "options": {"temperature": 0, "num_ctx": 32768, "num_predict": 8192},
             "keep_alive": "30m",
         }
         timeout = httpx.Timeout(600.0, connect=10.0)
         async with httpx.AsyncClient(timeout=timeout) as client:
+            if progress_callback is not None:
+                chunks: list[str] = []
+                received_chars = 0
+                last_reported_chars = 0
+                async with client.stream("POST", url, json=payload, headers=headers) as resp:
+                    if resp.is_error:
+                        await resp.aread()
+                        resp.raise_for_status()
+                    async for line in resp.aiter_lines():
+                        if not line:
+                            continue
+                        try:
+                            event = json.loads(line)
+                        except json.JSONDecodeError:
+                            logger.warning("Ignoring malformed Ollama stream event: %s", line[:200])
+                            continue
+                        content = event.get("message", {}).get("content") or ""
+                        if content:
+                            chunks.append(content)
+                            received_chars += len(content)
+                        if received_chars - last_reported_chars >= 1024 or event.get("done"):
+                            await progress_callback(received_chars)
+                            last_reported_chars = received_chars
+                return "".join(chunks)
             resp = await client.post(url, json=payload, headers=headers)
             if resp.is_error:
-                raise RuntimeError(f"Ollama returned HTTP {resp.status_code}: {resp.text[:1000]}")
+                resp.raise_for_status()
             data = resp.json()
         return data["message"]["content"]
 
@@ -242,6 +320,116 @@ def _extract_json(raw: str) -> Any:
         # Drop first and last fence lines
         text = "\n".join(lines[1:-1] if lines[-1].strip() == "```" else lines[1:])
     return json.loads(text)
+
+
+class _DiarizationResponseError(ValueError):
+    """The model response cannot safely be applied to a diarization batch."""
+
+
+def _salvage_complete_assignments(raw: str) -> list[dict[str, Any]]:
+    """Recover complete assignment objects from a truncated JSON array."""
+    match = re.search(r'"assignments"\s*:\s*\[', raw)
+    if match is None:
+        return []
+
+    assignments: list[dict[str, Any]] = []
+    object_start: int | None = None
+    object_depth = 0
+    in_string = False
+    escaped = False
+    for index in range(match.end(), len(raw)):
+        char = raw[index]
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            continue
+        if char == '"':
+            in_string = True
+            continue
+        if char == "{":
+            if object_depth == 0:
+                object_start = index
+            object_depth += 1
+            continue
+        if char != "}" or object_depth == 0:
+            continue
+        object_depth -= 1
+        if object_depth or object_start is None:
+            continue
+        object_end = index + 1
+        try:
+            assignment = json.loads(raw[object_start:object_end])
+        except json.JSONDecodeError:
+            object_start = None
+            continue
+        if isinstance(assignment, dict):
+            assignments.append(assignment)
+        object_start = None
+    return assignments
+
+
+def _parse_diarization_response(
+    raw: str,
+    expected_ids: list[int],
+) -> tuple[dict[str, Any], set[int], bool]:
+    """Parse, de-duplicate, and salvage any safe diarization assignments."""
+    salvaged = False
+    try:
+        result = _extract_json(raw)
+    except json.JSONDecodeError as exc:
+        assignments = _salvage_complete_assignments(raw)
+        if not assignments:
+            raise _DiarizationResponseError(str(exc)) from exc
+        result = {"assignments": assignments, "chapter_summary": None}
+        salvaged = True
+
+    if isinstance(result, list):
+        result = {"assignments": result, "chapter_summary": None}
+    if not isinstance(result, dict) or not isinstance(result.get("assignments"), list):
+        raise _DiarizationResponseError(f"expected an assignments array, got {type(result).__name__}")
+
+    expected_id_set = set(expected_ids)
+    by_id: dict[int, dict[str, Any]] = {}
+    for assignment in result["assignments"]:
+        if not isinstance(assignment, dict):
+            continue
+        sentence_id = assignment.get("id", assignment.get("i"))
+        if not isinstance(sentence_id, int) or sentence_id not in expected_id_set:
+            continue
+        normalized = {
+            **assignment,
+            "id": sentence_id,
+            "character_id": assignment.get(
+                "character_id",
+                assignment.get("c"),
+            ),
+            "expression": assignment.get(
+                "expression",
+                assignment.get("e"),
+            ),
+        }
+        current = by_id.get(sentence_id)
+        try:
+            candidate_confidence = float(normalized.get("confidence") or 0)
+        except (TypeError, ValueError):
+            candidate_confidence = 0
+        try:
+            current_confidence = float(current.get("confidence") or 0) if current else -1
+        except (TypeError, ValueError):
+            current_confidence = 0
+        if current is None or candidate_confidence >= current_confidence:
+            by_id[sentence_id] = normalized
+
+    if not by_id:
+        raise _DiarizationResponseError("response did not contain any requested sentence ids")
+
+    result["assignments"] = [by_id[sentence_id] for sentence_id in expected_ids if sentence_id in by_id]
+    missing_ids = expected_id_set - set(by_id)
+    return result, missing_ids, salvaged
 
 
 def _sanitize_tagged_text(original: str, tagged: Any) -> str:
@@ -732,7 +920,94 @@ async def generate_character_roster(book_id: int, db: AsyncSession) -> None:
         await crud.audiobook.set_book_pipeline_status(db, book_id, "diarizing")
 
 
-async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
+def _chapter_summary_excerpt(chapter_sentences: list[Any], max_chars: int = 12_000) -> str:
+    """Sample contiguous beginning, middle, and ending text for one summary call."""
+    texts = [sentence.original_text for sentence in chapter_sentences if sentence.original_text.strip()]
+    complete = "\n".join(texts)
+    if len(complete) <= max_chars:
+        return complete
+
+    section_chars = max_chars // 3
+
+    def take_section(section: list[str], *, reverse: bool = False) -> str:
+        selected = []
+        used = 0
+        items = reversed(section) if reverse else iter(section)
+        for text in items:
+            if selected and used + len(text) + 1 > section_chars:
+                break
+            selected.append(text)
+            used += len(text) + 1
+        if reverse:
+            selected.reverse()
+        return "\n".join(selected)
+
+    midpoint = len(texts) // 2
+    middle_start = max(0, midpoint - len(texts) // 6)
+    return "\n\n[...]\n\n".join(
+        [
+            take_section(texts),
+            take_section(texts[middle_start:]),
+            take_section(texts, reverse=True),
+        ]
+    )
+
+
+async def _generate_chapter_summary(
+    settings: AudiobookSettings,
+    chapter: Any,
+    chapter_sentences: list[Any],
+    db: AsyncSession,
+    *,
+    book_id: int,
+    processed: int,
+    total: int,
+) -> None:
+    """Generate one non-critical chapter summary after attribution completes."""
+    excerpt = _chapter_summary_excerpt(chapter_sentences)
+    if not excerpt:
+        return
+    prompt = (
+        "Write a spoiler-light 2-4 sentence summary grounded only in the chapter text below. "
+        "Do not use character-roster descriptions or outside knowledge. Return JSON with the key summary.\n\n"
+        f"Chapter text:\n{excerpt}"
+    )
+    await crud.audiobook.update_book_pipeline_progress(
+        db,
+        book_id,
+        current=processed,
+        total=total,
+        detail=f"Summarizing chapter {chapter.chapter_number}",
+        llm_request_increment=1,
+    )
+    try:
+        raw = await _call_llm(
+            settings,
+            [{"role": "user", "content": prompt}],
+            response_schema=CHAPTER_SUMMARY_SCHEMA,
+        )
+        result = _extract_json(raw)
+        summary = str(result.get("summary") or "").strip() if isinstance(result, dict) else ""
+        if summary:
+            await crud.audiobook.update_chapter_summary(db, chapter.id, summary[:4000])
+            chapter.summary = summary[:4000]
+    except Exception as exc:
+        # Summaries help review but are not required to synthesize or assemble
+        # the audiobook, so never strand a completed attribution phase here.
+        logger.warning(
+            "Unable to summarize book %s chapter %s; continuing conversion: %s",
+            book_id,
+            chapter.chapter_number,
+            exc,
+        )
+
+
+async def diarize_sentences(
+    book_id: int,
+    db: AsyncSession,
+    *,
+    on_sentences_ready: Callable[[list[int]], Awaitable[None]] | None = None,
+) -> None:
     """Phase 3: batch-assign speakers and expression tags to all pending sentences."""
     settings = await crud.audiobook.get_audiobook_settings(db)
     provider = (settings.llm_provider or STUB_PROVIDER).lower() if settings else STUB_PROVIDER
@@ -751,7 +1026,9 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
     counts = await crud.audiobook.count_sentences_by_status(db, book_id)
     total = sum(counts.values())
     processed = total - counts.get("pending_diarization", 0)
-    batch_size = 40
+    batch_size = DIARIZATION_BATCH_SIZE
+    request_batch_size = batch_size
+    singleton_parse_failures = 0
     await crud.audiobook.update_book_pipeline_progress(
         db, book_id, current=processed, total=total, detail="Preparing dialogue attribution"
     )
@@ -763,16 +1040,30 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
             return
 
         chapter_sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
+        sentence_lengths = {sentence.id: len(sentence.tagged_text or sentence.original_text) for sentence in chapter_sentences}
         pending = [sentence for sentence in chapter_sentences if sentence.status == "pending_diarization"]
         if not pending:
+            if provider != STUB_PROVIDER and chapter.summary is None and chapter_sentences:
+                await _generate_chapter_summary(
+                    settings,
+                    chapter,
+                    chapter_sentences,
+                    db,
+                    book_id=book_id,
+                    processed=processed,
+                    total=total,
+                )
             continue
 
         # Treat short files before the first substantial chapter as front matter.
         # Once the story begins, retain short chapters and only skip tiny dividers.
-        if len(chapter_sentences) >= batch_size:
+        if len(chapter_sentences) >= STORY_CHAPTER_MIN_SENTENCES:
             story_started = True
-        is_front_matter = (not story_started and len(chapter_sentences) < batch_size) or len(chapter_sentences) < 20
+        is_front_matter = (not story_started and len(chapter_sentences) < STORY_CHAPTER_MIN_SENTENCES) or len(
+            chapter_sentences
+        ) < 20
         if is_front_matter:
+            ready_sentence_ids = []
             for sentence in pending:
                 await crud.audiobook.update_sentence_diarization(
                     db,
@@ -782,6 +1073,10 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
                     speaker_confidence=0.99,
                     speaker_reason="Front matter narration",
                 )
+                ready_sentence_ids.append(sentence.id)
+            if on_sentences_ready and ready_sentence_ids:
+                ready_sentence_ids.sort(key=sentence_lengths.get)
+                await on_sentences_ready(ready_sentence_ids)
             processed += len(pending)
             await crud.audiobook.update_chapter_summary(db, chapter.id, "Front matter or section divider.")
             await crud.audiobook.update_book_pipeline_progress(
@@ -793,18 +1088,69 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
             )
             continue
 
+        if provider != STUB_PROVIDER:
+            model_sentence_ids = _sentence_ids_requiring_diarization(chapter_sentences)
+            narration_ids = [sentence.id for sentence in pending if sentence.id not in model_sentence_ids]
+            if narration_ids:
+                narration_ids.sort(key=sentence_lengths.get)
+                await crud.audiobook.mark_sentences_as_narration(
+                    db,
+                    narration_ids,
+                    narrator_id,
+                )
+                if on_sentences_ready:
+                    await on_sentences_ready(narration_ids)
+                processed += len(narration_ids)
+                pending = [sentence for sentence in pending if sentence.id in model_sentence_ids]
+                await crud.audiobook.update_book_pipeline_progress(
+                    db,
+                    book_id,
+                    current=processed,
+                    total=total,
+                    detail=(
+                        f"Chapter {chapter.chapter_number}: attributed "
+                        f"{len(narration_ids)} deterministic narration sentences"
+                    ),
+                )
+
+        chapter_positions = {sentence.id: index for index, sentence in enumerate(chapter_sentences)}
         context_window = [
             sentence.original_text for sentence in chapter_sentences if sentence.status != "pending_diarization"
         ][-8:]
         while True:
+            if await crud.audiobook.pause_book_pipeline_if_requested(
+                db,
+                book_id,
+            ):
+                logger.info(
+                    "Book %s paused before the next diarization batch.",
+                    book_id,
+                )
+                return
             batch = await crud.audiobook.get_sentences_pending_diarization(
-                db, book_id, limit=batch_size, chapter_id=chapter.id
+                db, book_id, limit=request_batch_size, chapter_id=chapter.id
             )
             if not batch:
                 break
 
             sentences_json = json.dumps(
-                [{"id": s.id, "text": s.original_text} for s in batch],
+                [
+                    {
+                        "id": sentence.id,
+                        "text": sentence.original_text,
+                        "previous_text": (
+                            chapter_sentences[chapter_positions[sentence.id] - 1].original_text
+                            if chapter_positions[sentence.id] > 0
+                            else None
+                        ),
+                        "next_text": (
+                            chapter_sentences[chapter_positions[sentence.id] + 1].original_text
+                            if chapter_positions[sentence.id] + 1 < len(chapter_sentences)
+                            else None
+                        ),
+                    }
+                    for sentence in batch
+                ],
                 ensure_ascii=False,
             )
             context_str = "\n".join(context_window[-8:]) if context_window else "(none)"
@@ -840,58 +1186,182 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
                     chapter_summary=chapter.summary or "(none yet)",
                     context=context_str,
                     sentences_json=sentences_json,
+                    assignment_count=len(batch),
                 )
                 logger.debug("Diarizing %d sentences for book %s.", len(batch), book_id)
-                await crud.audiobook.update_book_pipeline_progress(
-                    db,
-                    book_id,
-                    current=processed,
-                    total=total,
-                    detail=f"Waiting for {settings.llm_model or provider}: chapter {chapter.chapter_number}",
-                    llm_request_increment=1,
-                )
-                raw = await _call_llm(
-                    settings,
-                    [{"role": "user", "content": prompt}],
-                    response_schema=DIARIZATION_SCHEMA,
-                )
+                raw = None
+                for request_attempt in range(1, 4):
+                    await crud.audiobook.update_book_pipeline_progress(
+                        db,
+                        book_id,
+                        current=processed,
+                        total=total,
+                        detail=(
+                            f"Waiting for {settings.llm_model or provider}: chapter "
+                            f"{chapter.chapter_number}, request {request_attempt}"
+                        ),
+                        llm_request_increment=1,
+                    )
+                    try:
+                        raw = await _call_llm(
+                            settings,
+                            [{"role": "user", "content": prompt}],
+                            response_schema=_diarization_schema(len(batch)),
+                            progress_callback=lambda received_chars: crud.audiobook.update_book_pipeline_progress(
+                                db,
+                                book_id,
+                                current=processed,
+                                total=total,
+                                detail=(
+                                    f"Chapter {chapter.chapter_number}: receiving " f"{received_chars:,} response characters"
+                                ),
+                            ),
+                        )
+                        break
+                    except httpx.HTTPError as exc:
+                        status_code = exc.response.status_code if isinstance(exc, httpx.HTTPStatusError) else 0
+                        if request_attempt == 3 or (status_code and status_code < 500 and status_code != 429):
+                            raise
+                        logger.warning(
+                            "Transient LLM request failure for book %s chapter %s (%d/3): %s",
+                            book_id,
+                            chapter.chapter_number,
+                            request_attempt,
+                            exc,
+                        )
+                        await crud.audiobook.update_book_pipeline_progress(
+                            db,
+                            book_id,
+                            current=processed,
+                            total=total,
+                            detail=(
+                                f"Chapter {chapter.chapter_number}: model connection failed; "
+                                f"retrying request {request_attempt + 1} of 3"
+                            ),
+                        )
+                        await asyncio.sleep(2 ** (request_attempt - 1))
+                if raw is None:
+                    raise RuntimeError("LLM request completed without a response.")
                 try:
-                    batch_result = _extract_json(raw)
-                except json.JSONDecodeError as exc:
-                    raise RuntimeError(f"LLM returned invalid JSON for diarization: {exc}\nRaw: {raw[:500]}") from exc
+                    batch_result, missing_ids, salvaged = _parse_diarization_response(
+                        raw,
+                        [sentence.id for sentence in batch],
+                    )
+                except _DiarizationResponseError as exc:
+                    if len(batch) > 1:
+                        request_batch_size = max(1, len(batch) // 2)
+                        singleton_parse_failures = 0
+                        logger.warning(
+                            "Invalid diarization response for book %s chapter %s (%d sentences): %s. "
+                            "Retrying with batches of %d.",
+                            book_id,
+                            chapter.chapter_number,
+                            len(batch),
+                            exc,
+                            request_batch_size,
+                        )
+                        await crud.audiobook.update_book_pipeline_progress(
+                            db,
+                            book_id,
+                            current=processed,
+                            total=total,
+                            detail=(
+                                f"Model response was incomplete; retrying chapter {chapter.chapter_number} "
+                                f"with {request_batch_size}-sentence batches"
+                            ),
+                        )
+                        continue
 
-            if isinstance(batch_result, list):
-                batch_result = {"assignments": batch_result, "chapter_summary": chapter.summary}
-            if not isinstance(batch_result, dict) or not isinstance(batch_result.get("assignments"), list):
-                raise RuntimeError(f"Expected a JSON object from diarization, got: {type(batch_result)}")
+                    singleton_parse_failures += 1
+                    if singleton_parse_failures < 2:
+                        logger.warning(
+                            "Invalid diarization response for sentence %s: %s. Retrying once.",
+                            batch[0].id,
+                            exc,
+                        )
+                        continue
+                    logger.error(
+                        "Falling back to narrator for sentence %s after repeated invalid model responses: %s",
+                        batch[0].id,
+                        exc,
+                    )
+                    batch_result = {
+                        "assignments": [
+                            {
+                                "id": batch[0].id,
+                                "character_id": narrator_id,
+                                "tagged_text": None,
+                                "confidence": 0,
+                                "reason": "Fallback after repeated invalid model responses",
+                                "_fallback": True,
+                            }
+                        ],
+                        "chapter_summary": chapter.summary,
+                    }
+                    missing_ids = set()
+                    salvaged = False
+
+                if missing_ids:
+                    request_batch_size = max(1, min(len(missing_ids), request_batch_size // 2))
+                    logger.warning(
+                        "Diarization response for book %s chapter %s was %s and omitted %d sentence(s). "
+                        "Persisting %d valid assignment(s) and retrying the remainder in batches of %d.",
+                        book_id,
+                        chapter.chapter_number,
+                        "truncated" if salvaged else "incomplete",
+                        len(missing_ids),
+                        len(batch_result["assignments"]),
+                        request_batch_size,
+                    )
+                elif request_batch_size < batch_size:
+                    # A smaller batch succeeded, so cautiously reclaim
+                    # throughput instead of throttling the rest of the book
+                    # because of one malformed or incomplete response.
+                    request_batch_size = min(
+                        batch_size,
+                        request_batch_size * 2,
+                    )
+
+            singleton_parse_failures = 0
             results = batch_result["assignments"]
 
             result_map = {r["id"]: r for r in results if isinstance(r, dict) and isinstance(r.get("id"), int)}
 
+            completed_count = 0
+            ready_sentence_ids = []
             for sentence_index, sentence in enumerate(batch):
-                result = result_map.get(sentence.id, {})
+                result = result_map.get(sentence.id)
+                if result is None:
+                    continue
                 char_id = result.get("character_id")
                 if char_id not in character_ids:
                     char_id = narrator_id
-                tagged = _sanitize_tagged_text(sentence.original_text, result.get("tagged_text"))
-                confidence = result.get("confidence")
+                expression = result.get("expression")
+                if expression in _ALLOWED_EXPRESSION_TAGS:
+                    tagged = f"[{expression}] {sentence.original_text}"
+                else:
+                    tagged = _sanitize_tagged_text(sentence.original_text, result.get("tagged_text"))
+                confidence = result.get("confidence", 0.9)
                 try:
                     confidence = max(0.0, min(1.0, float(confidence)))
                 except (TypeError, ValueError):
                     confidence = 0.0
-                reason = str(result.get("reason") or "No model rationale returned")[:500]
-                next_text = batch[sentence_index + 1].original_text if sentence_index + 1 < len(batch) else ""
-                char_id, reason, guardrail_confidence = _apply_speaker_guardrails(
-                    text=sentence.original_text,
-                    next_text=next_text,
-                    character_id=char_id,
-                    narrator_id=narrator_id,
-                    minor_female_id=minor_female_id,
-                    minor_male_id=minor_male_id,
-                    reason=reason,
-                )
-                if guardrail_confidence is not None:
-                    confidence = guardrail_confidence
+                raw_reason = str(result.get("reason") or "Model speaker assignment")
+                reason = _DIARIZATION_REASON_LABELS.get(raw_reason, raw_reason)[:500]
+                position = chapter_positions[sentence.id]
+                next_text = chapter_sentences[position + 1].original_text if position + 1 < len(chapter_sentences) else ""
+                if not result.get("_fallback"):
+                    char_id, reason, guardrail_confidence = _apply_speaker_guardrails(
+                        text=sentence.original_text,
+                        next_text=next_text,
+                        character_id=char_id,
+                        narrator_id=narrator_id,
+                        minor_female_id=minor_female_id,
+                        minor_male_id=minor_male_id,
+                        reason=reason,
+                    )
+                    if guardrail_confidence is not None:
+                        confidence = guardrail_confidence
                 await crud.audiobook.update_sentence_diarization(
                     db,
                     sentence.id,
@@ -901,11 +1371,17 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
                     speaker_reason=reason,
                 )
                 context_window.append(sentence.original_text)
+                completed_count += 1
+                ready_sentence_ids.append(sentence.id)
+
+            if on_sentences_ready and ready_sentence_ids:
+                ready_sentence_ids.sort(key=sentence_lengths.get)
+                await on_sentences_ready(ready_sentence_ids)
 
             chapter_summary = str(batch_result.get("chapter_summary") or chapter.summary or "")[:4000]
             await crud.audiobook.update_chapter_summary(db, chapter.id, chapter_summary or None)
             chapter.summary = chapter_summary or None
-            processed += len(batch)
+            processed += completed_count
             await crud.audiobook.update_book_pipeline_progress(
                 db,
                 book_id,
@@ -916,6 +1392,17 @@ async def diarize_sentences(book_id: int, db: AsyncSession) -> None:
             if await crud.audiobook.consume_book_batch_limit(db, book_id):
                 logger.info("Book %s paused after one diarization batch.", book_id)
                 return
+
+        if provider != STUB_PROVIDER and chapter.summary is None:
+            await _generate_chapter_summary(
+                settings,
+                chapter,
+                chapter_sentences,
+                db,
+                book_id=book_id,
+                processed=processed,
+                total=total,
+            )
 
     logger.info("Diarization complete for book %s.", book_id)
     if not await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):

--- a/backend/app/services/audiobook_publication.py
+++ b/backend/app/services/audiobook_publication.py
@@ -1,0 +1,197 @@
+"""Durable modular audiobook publication for authenticated Reader clients."""
+
+from __future__ import annotations
+
+import hashlib
+import posixpath
+import shutil
+import tempfile
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import crud
+from ..config import LIBRARY_PATH
+from ..models import AudiobookChapter, Book
+
+
+def normalize_resource_href(raw: str | None, chapter_number: int = 0) -> str:
+    fallback = f"chapter{chapter_number:04d}.xhtml"
+    value = (raw or fallback).replace("\\", "/").lstrip("/")
+    return posixpath.normpath(value).removeprefix("./")
+
+
+def stable_chapter_key(href: str) -> str:
+    normalized = normalize_resource_href(href)
+    return f"src-{hashlib.sha256(normalized.encode('utf-8')).hexdigest()[:16]}"
+
+
+def sha256_bytes(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def reader_smil_bytes(source: bytes, text_href: str) -> bytes:
+    """Make SMIL references relative to the reader's rendition href.
+
+    The Android reader parses the overlay using ``<text href>.smil`` as its
+    logical base. Package SMIL files often repeat the full XHTML href, which
+    would resolve to a duplicated directory under that base.
+    """
+    root = ET.fromstring(source)
+    smil_namespace = "{http://www.w3.org/ns/SMIL}"
+    normalized_href = normalize_resource_href(text_href)
+    logical_smil_href = f"{normalized_href}.smil"
+    base_dir = posixpath.dirname(logical_smil_href) or "."
+    relative_text_href = posixpath.relpath(normalized_href, base_dir)
+    for text in root.findall(f".//{smil_namespace}text"):
+        fragment = text.attrib.get("src", "").partition("#")[2]
+        text.set("src", f"{relative_text_href}#{fragment}" if fragment else relative_text_href)
+    for audio in root.findall(f".//{smil_namespace}audio"):
+        audio.set("src", "audio.mp3")
+    ET.indent(root, space="  ")
+    return ('<?xml version="1.0" encoding="UTF-8"?>\n' + ET.tostring(root, encoding="unicode")).encode("utf-8")
+
+
+def _resolved(relative_path: str | None) -> Path | None:
+    if not relative_path:
+        return None
+    candidate = (LIBRARY_PATH.parent / relative_path).resolve()
+    try:
+        candidate.relative_to(LIBRARY_PATH.parent.resolve())
+    except ValueError:
+        return None
+    return candidate
+
+
+def _relative(path: Path) -> str:
+    return str(path.resolve().relative_to(LIBRARY_PATH.parent.resolve()))
+
+
+def _atomic_copy(source: Path, target: Path) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(dir=target.parent, prefix=f".{target.name}.", delete=False) as handle:
+        temporary = Path(handle.name)
+    try:
+        shutil.copyfile(source, temporary)
+        temporary.replace(target)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _atomic_write(content: bytes, target: Path) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(dir=target.parent, prefix=f".{target.name}.", delete=False) as handle:
+        temporary = Path(handle.name)
+        handle.write(content)
+        handle.flush()
+    try:
+        temporary.replace(target)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def chapter_reader_audio_path(chapter: AudiobookChapter) -> Path | None:
+    return _resolved(chapter.reader_audio_file_path or chapter.audio_file_path)
+
+
+def chapter_reader_smil_bytes(chapter: AudiobookChapter) -> bytes | None:
+    path = _resolved(chapter.reader_smil_file_path or chapter.smil_file_path)
+    if path is None or not path.is_file():
+        return None
+    return reader_smil_bytes(path.read_bytes(), chapter.source_href or chapter.content_file_name or "")
+
+
+def text_reader_path(book: Book) -> Path | None:
+    explicit = _resolved(book.audiobook_text_file_path)
+    if explicit and explicit.is_file():
+        return explicit
+    legacy = LIBRARY_PATH / "audiobooks" / str(book.id) / "working.epub"
+    return legacy if legacy.is_file() else None
+
+
+def stage_reader_text_rendition(book_id: int, content_version: int, source: Path) -> tuple[str, int, str]:
+    """Atomically stage a versioned text rendition before its metadata commits."""
+    target = LIBRARY_PATH / "audiobooks" / str(book_id) / "reader" / f"text-v{content_version}.epub"
+    _atomic_copy(source, target)
+    return _relative(target), target.stat().st_size, sha256_file(target)
+
+
+async def publish_reader_audiobook(db: AsyncSession, book_id: int) -> None:
+    """Publish verified text/audio/SMIL files, then commit visible metadata once."""
+    book = await db.get(Book, book_id)
+    if book is None:
+        raise RuntimeError(f"Book {book_id} not found while publishing reader audiobook")
+    chapters = await crud.audiobook.get_chapters_for_book(db, book_id)
+    source_text = text_reader_path(book)
+    if source_text is None or not source_text.is_file():
+        raise RuntimeError(f"Reader text rendition is missing for book {book_id}")
+
+    content_version = book.audiobook_source_content_version or book.content_version or 1
+    publication_root = LIBRARY_PATH / "audiobooks" / str(book_id) / "reader"
+    text_target = publication_root / f"text-v{content_version}.epub"
+    _atomic_copy(source_text, text_target)
+    text_size = text_target.stat().st_size
+    text_sha = sha256_file(text_target)
+
+    ready_count = 0
+    for chapter in chapters:
+        source_audio = _resolved(chapter.audio_file_path)
+        source_smil = _resolved(chapter.smil_file_path)
+        if source_audio is None or source_smil is None or not source_audio.is_file() or not source_smil.is_file():
+            chapter.generation_state = "pending"
+            continue
+
+        href = normalize_resource_href(chapter.source_href or chapter.content_file_name, chapter.chapter_number)
+        key = chapter.stable_chapter_key or stable_chapter_key(href)
+        chapter.stable_chapter_key = key
+        chapter.source_href = href
+        audio_sha = sha256_file(source_audio)
+        smil_content = reader_smil_bytes(source_smil.read_bytes(), href)
+        smil_sha = sha256_bytes(smil_content)
+        changed = chapter.audio_sha256 != audio_sha or chapter.smil_sha256 != smil_sha
+        revision = max(1, (chapter.audio_revision or 0) + int(changed))
+        chapter_dir = publication_root / "chapters" / key
+        audio_target = chapter_dir / f"audio-v{revision}.mp3"
+        smil_target = chapter_dir / f"overlay-v{revision}.smil"
+        if changed or not audio_target.is_file():
+            _atomic_copy(source_audio, audio_target)
+        if changed or not smil_target.is_file():
+            _atomic_write(smil_content, smil_target)
+
+        sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
+        chapter.audio_revision = revision
+        chapter.reader_audio_file_path = _relative(audio_target)
+        chapter.reader_smil_file_path = _relative(smil_target)
+        chapter.audio_size_bytes = audio_target.stat().st_size
+        chapter.audio_sha256 = audio_sha
+        chapter.smil_size_bytes = len(smil_content)
+        chapter.smil_sha256 = smil_sha
+        chapter.duration_ms = sum(sentence.audio_duration_ms or 0 for sentence in sentences)
+        chapter.generation_state = "ready"
+        ready_count += 1
+
+    book.audiobook_revision = (book.audiobook_revision or 0) + 1
+    pending_content_version = max(
+        book.audiobook_pending_content_version or 0,
+        (book.content_version or content_version) if (book.content_version or content_version) > content_version else 0,
+    )
+    book.audiobook_source_content_version = content_version
+    book.audiobook_text_content_version = content_version
+    book.audiobook_pending_content_version = pending_content_version or None
+    book.audiobook_publication_state = (
+        "complete" if chapters and ready_count == len(chapters) and not pending_content_version else "partial"
+    )
+    book.audiobook_text_file_path = _relative(text_target)
+    book.audiobook_text_size_bytes = text_size
+    book.audiobook_text_sha256 = text_sha
+    book.audiobook_publication_error = None
+    await db.commit()

--- a/backend/app/services/audiobook_queue.py
+++ b/backend/app/services/audiobook_queue.py
@@ -3,15 +3,22 @@
 from __future__ import annotations
 
 import asyncio
+import itertools
 import logging
+import os
 from typing import Optional
 
 from .. import crud
 from ..database import SessionLocal
 from .audiobook_ingestion import ingest_epub
 from .audiobook_llm import generate_character_roster, diarize_sentences
-from .audiobook_tts import generate_audio_for_book, generate_audio_for_sentence
-from .audiobook_tts import generate_audio_for_chapter_preview
+from .audiobook_tts import (
+    TTS_BATCH_SIZE,
+    generate_audio_for_book,
+    generate_audio_for_chapter_preview,
+    generate_audio_for_sentence,
+    generate_audio_for_sentences,
+)
 from .audiobook_assembly import assemble_book, assemble_chapter_preview
 
 logger = logging.getLogger(__name__)
@@ -31,6 +38,10 @@ class AudiobookQueue:
 
     def __init__(self) -> None:
         self._queue: asyncio.Queue[Optional[int | tuple[str, int, int]]] = asyncio.Queue()
+        self._background_audio_queue: asyncio.PriorityQueue[tuple[int, int, tuple[int, list[int], bool]]] = (
+            asyncio.PriorityQueue()
+        )
+        self._background_audio_sequence = itertools.count()
         self._queued_book_ids: set[int] = set()
         # A pipeline mutation may arrive while a book is already running. Keep
         # one follow-up job so the mutation is not lost when the current worker
@@ -39,22 +50,40 @@ class AudiobookQueue:
         self._queued_preview_ids: set[int] = set()
         self._queued_sentence_ids: set[int] = set()
         self._worker_task: Optional[asyncio.Task[None]] = None
+        self._background_audio_tasks: list[asyncio.Task[None]] = []
+        self._background_audio_ids: dict[int, set[int]] = {}
+        self._background_audio_condition = asyncio.Condition()
 
     async def start(self) -> None:
         if self._worker_task and not self._worker_task.done():
             return
         self._worker_task = asyncio.create_task(self._run(), name="audiobook-worker")
+        worker_count = max(1, int(os.getenv("AUDIOBOOK_TTS_WORKERS", "1")))
+        self._background_audio_tasks = [
+            asyncio.create_task(
+                self._run_background_audio(),
+                name=f"audiobook-tts-worker-{index + 1}",
+            )
+            for index in range(worker_count)
+        ]
 
     async def stop(self) -> None:
         if not self._worker_task:
             return
-        await self._queue.put(None)
-        await self._worker_task
+        tasks = [self._worker_task, *self._background_audio_tasks]
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
         self._worker_task = None
+        self._background_audio_tasks.clear()
+        self._queue = asyncio.Queue()
+        self._background_audio_queue = asyncio.PriorityQueue()
+        self._background_audio_sequence = itertools.count()
         self._queued_book_ids.clear()
         self._rerun_book_ids.clear()
         self._queued_preview_ids.clear()
         self._queued_sentence_ids.clear()
+        self._background_audio_ids.clear()
 
     async def enqueue(self, book_id: int) -> bool:
         if book_id in self._queued_book_ids:
@@ -79,8 +108,128 @@ class AudiobookQueue:
         if sentence_id in self._queued_sentence_ids:
             return False
         self._queued_sentence_ids.add(sentence_id)
-        await self._queue.put(("sentence", book_id, sentence_id))
+        await self._background_audio_queue.put((0, next(self._background_audio_sequence), (book_id, [sentence_id], True)))
         return True
+
+    async def enqueue_background_audio(self, book_id: int, sentence_ids: list[int]) -> None:
+        """Queue durable, analyzed sentences for the pipelined TTS lane."""
+        async with self._background_audio_condition:
+            queued_ids = self._background_audio_ids.setdefault(book_id, set())
+            new_ids = []
+            for sentence_id in sentence_ids:
+                if sentence_id in queued_ids:
+                    continue
+                queued_ids.add(sentence_id)
+                new_ids.append(sentence_id)
+            for start in range(0, len(new_ids), TTS_BATCH_SIZE):
+                batch_ids = new_ids[slice(start, start + TTS_BATCH_SIZE)]
+                await self._background_audio_queue.put(
+                    (
+                        1,
+                        next(self._background_audio_sequence),
+                        (book_id, batch_ids, False),
+                    )
+                )
+
+    async def _wait_for_background_audio(self, book_id: int) -> None:
+        """Wait for pipelined TTS while publishing phase-accurate progress."""
+        while True:
+            async with self._background_audio_condition:
+                queued_count = len(self._background_audio_ids.get(book_id, ()))
+                if not queued_count:
+                    return
+
+            async with SessionLocal() as db:
+                counts = await crud.audiobook.count_sentences_by_status(db, book_id)
+                generated_count = counts.get("audio_generated", 0)
+                total_count = sum(counts.values())
+                await crud.audiobook.update_book_pipeline_progress(
+                    db,
+                    book_id,
+                    current=generated_count,
+                    total=total_count,
+                    detail=(f"Generating speech: {generated_count:,} of {total_count:,} clips " f"({queued_count:,} queued)"),
+                )
+
+            async with self._background_audio_condition:
+                await self._background_audio_condition.wait_for(
+                    lambda: len(self._background_audio_ids.get(book_id, ())) < queued_count
+                )
+
+    async def _run_background_audio(self) -> None:
+        while True:
+            _priority, _sequence, item = await self._background_audio_queue.get()
+            try:
+                book_id, sentence_ids, manual_request = item
+                eligible_ids = []
+                try:
+                    async with SessionLocal() as db:
+                        from ..models import AudiobookSentence, Book
+
+                        book = await db.get(Book, book_id)
+                        if book is None:
+                            continue
+                        if not manual_request and (
+                            book.audiobook_pause_requested or book.audiobook_pipeline_status not in ("diarizing", "audio_gen")
+                        ):
+                            continue
+                        for sentence_id in sentence_ids:
+                            sentence = await db.get(AudiobookSentence, sentence_id)
+                            if sentence is None:
+                                continue
+                            allowed_statuses = (
+                                ("ready_for_audio", "audio_queued", "audio_generating")
+                                if manual_request
+                                else ("ready_for_audio",)
+                            )
+                            if sentence.status not in allowed_statuses:
+                                continue
+                            await crud.audiobook.set_sentence_status(
+                                db,
+                                sentence_id,
+                                "audio_generating",
+                            )
+                            eligible_ids.append(sentence_id)
+                        if not eligible_ids:
+                            continue
+                        if manual_request:
+                            await generate_audio_for_sentence(book_id, eligible_ids[0], db)
+                            failures = {}
+                        else:
+                            failures = await generate_audio_for_sentences(
+                                book_id,
+                                eligible_ids,
+                                db,
+                            )
+                        for sentence_id, error in failures.items():
+                            logger.error(
+                                "Pipelined TTS failed for sentence %s in book %s: %s",
+                                sentence_id,
+                                book_id,
+                                error,
+                            )
+                            await crud.audiobook.mark_sentence_error(db, sentence_id)
+                except Exception:
+                    logger.exception(
+                        "Pipelined TTS batch failed for sentences %s in book %s.",
+                        eligible_ids or sentence_ids,
+                        book_id,
+                    )
+                    async with SessionLocal() as db:
+                        for sentence_id in eligible_ids:
+                            await crud.audiobook.mark_sentence_error(db, sentence_id)
+            finally:
+                book_id, sentence_ids, manual_request = item
+                if manual_request:
+                    self._queued_sentence_ids.difference_update(sentence_ids)
+                async with self._background_audio_condition:
+                    queued_ids = self._background_audio_ids.get(book_id)
+                    if queued_ids is not None:
+                        queued_ids.difference_update(sentence_ids)
+                        if not queued_ids:
+                            self._background_audio_ids.pop(book_id, None)
+                    self._background_audio_condition.notify_all()
+                self._background_audio_queue.task_done()
 
     async def requeue_in_progress(self) -> int:
         async with SessionLocal() as db:
@@ -190,8 +339,69 @@ class AudiobookQueue:
                 elif phase == "roster_gen":
                     await generate_character_roster(book_id, db)
                 elif phase == "diarizing":
-                    await diarize_sentences(book_id, db)
+                    recovered = await crud.audiobook.reset_error_sentences_for_book(
+                        db,
+                        book_id,
+                    )
+                    if recovered:
+                        logger.warning(
+                            "Book %s: automatically retrying %d failed speech clips.",
+                            book_id,
+                            recovered,
+                        )
+                    ready_sentences = await crud.audiobook.get_sentences_ready_for_audio(
+                        db,
+                        book_id,
+                        limit=100_000,
+                    )
+                    await self.enqueue_background_audio(
+                        book_id,
+                        [
+                            sentence.id
+                            for sentence in sorted(
+                                ready_sentences,
+                                key=lambda sentence: len(sentence.tagged_text or sentence.original_text),
+                            )
+                        ],
+                    )
+                    await diarize_sentences(
+                        book_id,
+                        db,
+                        on_sentences_ready=lambda sentence_ids: self.enqueue_background_audio(
+                            book_id,
+                            sentence_ids,
+                        ),
+                    )
                 elif phase == "audio_gen":
+                    # A process restart can resume directly in this phase, after
+                    # the in-memory TTS queue has been lost. Rebuild it from
+                    # durable sentence state and preserve length bucketing.
+                    ready_sentences = await crud.audiobook.get_sentences_ready_for_audio(
+                        db,
+                        book_id,
+                        limit=100_000,
+                    )
+                    await self.enqueue_background_audio(
+                        book_id,
+                        [
+                            sentence.id
+                            for sentence in sorted(
+                                ready_sentences,
+                                key=lambda sentence: len(sentence.tagged_text or sentence.original_text),
+                            )
+                        ],
+                    )
+                    await self._wait_for_background_audio(book_id)
+                    recovered = await crud.audiobook.reset_error_sentences_for_book(
+                        db,
+                        book_id,
+                    )
+                    if recovered:
+                        logger.warning(
+                            "Book %s: retrying %d failed speech clips before assembly.",
+                            book_id,
+                            recovered,
+                        )
                     await generate_audio_for_book(book_id, db)
                 elif phase == "assembling":
                     await assemble_book(book_id, db)

--- a/backend/app/services/audiobook_queue.py
+++ b/backend/app/services/audiobook_queue.py
@@ -308,6 +308,23 @@ class AudiobookQueue:
             await crud.audiobook.set_sentence_status(db, sentence_id, "audio_generating")
             await generate_audio_for_sentence(book_id, sentence_id, db)
 
+    async def _restart_for_pending_content(self, book_id: int) -> bool:
+        """Move a refresh received mid-build to the next durable boundary."""
+        async with SessionLocal() as db:
+            from ..models import Book
+
+            book = await db.get(Book, book_id)
+            if book is None or book.audiobook_pending_content_version is None:
+                return False
+            if (
+                book.audiobook_source_content_version is not None
+                and book.audiobook_pending_content_version <= book.audiobook_source_content_version
+            ):
+                return False
+            book.audiobook_pipeline_status = "ingesting"
+            await db.commit()
+            return True
+
     async def _process(self, book_id: int) -> None:
         """Run the pipeline from the book's current status to completion."""
         async with SessionLocal() as db:
@@ -421,6 +438,10 @@ class AudiobookQueue:
                 if await crud.audiobook.pause_book_pipeline_after_phase(db, book_id, phase):
                     logger.info("Book %s stopped for review after phase '%s'.", book_id, phase)
                     return
+
+            if await self._restart_for_pending_content(book_id):
+                logger.info("Book %s: restarting ingestion for pending refreshed content.", book_id)
+                return await self._process(book_id)
 
         logger.info("Audiobook pipeline complete for book %s.", book_id)
 

--- a/backend/app/services/audiobook_tts.py
+++ b/backend/app/services/audiobook_tts.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import os
 from pathlib import Path
 
 import httpx
@@ -11,9 +13,17 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from .. import crud
 from ..config import LIBRARY_PATH
 from ..models import AudiobookChapter, AudiobookCharacter, AudiobookSentence, AudiobookSettings
-from .tts_providers import DEFAULT_VOICE_PROMPT, TTSRequest, synthesize_speech, tts_provider_name
+from .tts_providers import (
+    DEFAULT_VOICE_PROMPT,
+    TTSRequest,
+    TTSResult,
+    synthesize_speech,
+    synthesize_speech_batch,
+    tts_provider_name,
+)
 
 logger = logging.getLogger(__name__)
+TTS_BATCH_SIZE = max(1, int(os.getenv("AUDIOBOOK_TTS_BATCH_SIZE", "4")))
 
 
 def _snippet_path(book_id: int, sentence_id: int) -> Path:
@@ -28,7 +38,7 @@ def _get_mp3_duration_ms(path: Path) -> int:
     from mutagen.mp3 import MP3
 
     audio = MP3(str(path))
-    return int(audio.info.length * 1000)
+    return round(audio.info.length * 1000)
 
 
 def _voice_id_for_provider(
@@ -46,6 +56,21 @@ async def _generate_sentence_clip(
     sentence: AudiobookSentence,
     db: AsyncSession,
 ) -> None:
+    request = await _build_sentence_request(settings, sentence, db)
+    audio_bytes = await _synthesize_with_retries(settings, sentence.id, request)
+    await _persist_sentence_audio(
+        book_id,
+        sentence,
+        TTSResult(audio_bytes=audio_bytes),
+        db,
+    )
+
+
+async def _build_sentence_request(
+    settings: AudiobookSettings | None,
+    sentence: AudiobookSentence,
+    db: AsyncSession,
+) -> TTSRequest:
     voice_prompt = DEFAULT_VOICE_PROMPT
     voice_id = None
     if sentence.character_id is not None:
@@ -54,24 +79,161 @@ async def _generate_sentence_clip(
             voice_prompt = char.voice_prompt or voice_prompt
             voice_id = _voice_id_for_provider(settings, char)
 
-    audio_bytes = await synthesize_speech(
-        settings,
-        TTSRequest(
-            text=sentence.tagged_text or sentence.original_text,
-            voice_prompt=voice_prompt,
-            voice_id=voice_id,
-        ),
+    return TTSRequest(
+        text=sentence.tagged_text or sentence.original_text,
+        voice_prompt=voice_prompt,
+        voice_id=voice_id,
     )
+
+
+async def _synthesize_with_retries(
+    settings: AudiobookSettings | None,
+    sentence_id: int,
+    request: TTSRequest,
+) -> bytes:
+    audio_bytes = None
+    for attempt in range(1, 4):
+        try:
+            audio_bytes = await synthesize_speech(settings, request)
+            break
+        except httpx.HTTPStatusError as exc:
+            status_code = exc.response.status_code if exc.response is not None else 0
+            if attempt == 3 or (status_code and status_code < 500 and status_code != 429):
+                raise
+            logger.warning(
+                "TTS request for sentence %s returned HTTP %s; retrying (%d/3).",
+                sentence_id,
+                status_code or "unknown",
+                attempt + 1,
+            )
+        except (httpx.TimeoutException, httpx.TransportError) as exc:
+            if attempt == 3:
+                raise
+            logger.warning(
+                "TTS request for sentence %s failed transiently (%s); retrying (%d/3).",
+                sentence_id,
+                exc,
+                attempt + 1,
+            )
+        await asyncio.sleep(2 ** (attempt - 1))
+    if audio_bytes is None:
+        raise RuntimeError(f"TTS returned no audio for sentence {sentence_id}.")
+    return audio_bytes
+
+
+async def _persist_sentence_audio(
+    book_id: int,
+    sentence: AudiobookSentence,
+    result: TTSResult,
+    db: AsyncSession,
+) -> None:
     out_path = _snippet_path(book_id, sentence.id)
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    out_path.write_bytes(audio_bytes)
+    out_path.write_bytes(result.audio_bytes)
+    # Always inspect the artifact we actually wrote. Provider metadata is
+    # useful for transport, but accepting it without parsing could defer a
+    # corrupt/empty MP3 failure until final chapter assembly.
     duration_ms = _get_mp3_duration_ms(out_path)
+    if result.duration_ms and abs(result.duration_ms - duration_ms) > 1_000:
+        logger.warning(
+            "Sentence %s reported %d ms of audio but the MP3 contains %d ms.",
+            sentence.id,
+            result.duration_ms,
+            duration_ms,
+        )
     await crud.audiobook.update_sentence_audio(
         db,
         sentence.id,
         _relative_path(out_path),
         duration_ms,
     )
+
+
+async def _generate_sentence_clips(
+    settings: AudiobookSettings | None,
+    book_id: int,
+    sentences: list[AudiobookSentence],
+    db: AsyncSession,
+) -> dict[int, Exception]:
+    """Generate a provider-native batch and isolate any batch failure by sentence."""
+    if not sentences:
+        return {}
+    if len(sentences) == 1 or tts_provider_name(settings) != "omnivoice":
+        failures = {}
+        for sentence in sentences:
+            try:
+                await _generate_sentence_clip(settings, book_id, sentence, db)
+            except Exception as exc:
+                failures[sentence.id] = exc
+        return failures
+
+    requests = [await _build_sentence_request(settings, sentence, db) for sentence in sentences]
+    results = None
+    for attempt in range(1, 4):
+        try:
+            results = await synthesize_speech_batch(settings, requests)
+            break
+        except httpx.HTTPStatusError as exc:
+            status_code = exc.response.status_code if exc.response is not None else 0
+            if attempt == 3 or (status_code and status_code < 500 and status_code != 429):
+                break
+            logger.warning(
+                "TTS batch returned HTTP %s; retrying (%d/3).",
+                status_code or "unknown",
+                attempt + 1,
+            )
+        except (httpx.TimeoutException, httpx.TransportError, RuntimeError) as exc:
+            if attempt == 3:
+                break
+            logger.warning(
+                "TTS batch failed transiently (%s); retrying (%d/3).",
+                exc,
+                attempt + 1,
+            )
+        await asyncio.sleep(2 ** (attempt - 1))
+
+    if results is None:
+        logger.warning(
+            "TTS batch for %d sentences failed; retrying each sentence independently.",
+            len(sentences),
+        )
+        failures = {}
+        for sentence in sentences:
+            try:
+                await _generate_sentence_clip(settings, book_id, sentence, db)
+            except Exception as exc:
+                failures[sentence.id] = exc
+        return failures
+
+    failures = {}
+    for sentence, result in zip(sentences, results, strict=True):
+        try:
+            await _persist_sentence_audio(book_id, sentence, result, db)
+        except Exception as exc:
+            failures[sentence.id] = exc
+    return failures
+
+
+async def generate_audio_for_sentences(
+    book_id: int,
+    sentence_ids: list[int],
+    db: AsyncSession,
+) -> dict[int, Exception]:
+    """Generate a durable batch for the background speech lane."""
+    settings = await crud.audiobook.get_audiobook_settings(db)
+    sentences = []
+    for sentence_id in sentence_ids:
+        sentence = await db.get(AudiobookSentence, sentence_id)
+        if sentence is None:
+            continue
+        chapter = await db.get(AudiobookChapter, sentence.chapter_id)
+        if chapter is None or chapter.book_id != book_id:
+            continue
+        sentences.append(sentence)
+    failures = await _generate_sentence_clips(settings, book_id, sentences, db)
+    for chapter_id in {sentence.chapter_id for sentence in sentences if sentence.id not in failures}:
+        await crud.audiobook.flag_chapter_for_reassembly(db, chapter_id)
+    return failures
 
 
 async def generate_audio_for_sentence(
@@ -102,59 +264,49 @@ async def generate_audio_for_book(book_id: int, db: AsyncSession) -> None:
     snippets_dir = LIBRARY_PATH.parent / "library" / "audiobooks" / str(book_id) / "snippets"
     snippets_dir.mkdir(parents=True, exist_ok=True)
 
-    processed = 0
-    failed = 0
     counts = await crud.audiobook.count_sentences_by_status(db, book_id)
-    total = counts.get("ready_for_audio", 0)
+    processed = counts.get("audio_generated", 0)
+    total = sum(counts.values())
+    failed = 0
     await crud.audiobook.update_book_pipeline_progress(
-        db, book_id, current=0, total=total, detail=f"Preparing speech for {total} sentences"
+        db,
+        book_id,
+        current=processed,
+        total=total,
+        detail=f"Preparing remaining speech ({processed:,} of {total:,} clips generated)",
     )
     while True:
         if await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):
             logger.info("Book %s paused during TTS generation.", book_id)
             return
 
-        batch = await crud.audiobook.get_sentences_ready_for_audio(db, book_id, limit=20)
+        batch = await crud.audiobook.get_sentences_ready_for_audio(
+            db,
+            book_id,
+            limit=TTS_BATCH_SIZE,
+        )
         if not batch:
             break
 
+        failures = await _generate_sentence_clips(settings, book_id, batch, db)
         for sentence in batch:
-            if await crud.audiobook.pause_book_pipeline_if_requested(db, book_id):
-                logger.info("Book %s paused during TTS generation.", book_id)
-                return
-
-            logger.debug("Generating audio for sentence %s (book %s).", sentence.id, book_id)
-            try:
-                await _generate_sentence_clip(settings, book_id, sentence, db)
-            except httpx.HTTPStatusError as exc:
-                response_text = exc.response.text[:200] if exc.response is not None else ""
+            if error := failures.get(sentence.id):
                 logger.error(
-                    "TTS provider error for sentence %s: %s %s",
+                    "Unable to generate audio for sentence %s: %s",
                     sentence.id,
-                    exc.response.status_code if exc.response is not None else "unknown",
-                    response_text,
+                    error,
                 )
                 await crud.audiobook.mark_sentence_error(db, sentence.id)
                 failed += 1
-                continue
-            except Exception as exc:
-                logger.exception(
-                    "Unable to generate or inspect audio for sentence %s: %s",
-                    sentence.id,
-                    exc,
+            else:
+                processed += 1
+                await crud.audiobook.update_book_pipeline_progress(
+                    db,
+                    book_id,
+                    current=processed,
+                    total=total,
+                    detail=f"Generated speech for {processed} of {total} sentences",
                 )
-                await crud.audiobook.mark_sentence_error(db, sentence.id)
-                failed += 1
-                continue
-
-            processed += 1
-            await crud.audiobook.update_book_pipeline_progress(
-                db,
-                book_id,
-                current=processed,
-                total=total,
-                detail=f"Generated speech for {processed} of {total} sentences",
-            )
 
             # Flag chapter for reassembly if all its sentences are done
             if await crud.audiobook.chapter_all_audio_generated(db, sentence.chapter_id):

--- a/backend/app/services/tts_providers.py
+++ b/backend/app/services/tts_providers.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import base64
+import binascii
 from dataclasses import dataclass
 import re
 import shutil
@@ -32,6 +34,12 @@ class TTSRequest:
     text: str
     voice_prompt: str = DEFAULT_VOICE_PROMPT
     voice_id: str | None = None
+
+
+@dataclass(frozen=True)
+class TTSResult:
+    audio_bytes: bytes
+    duration_ms: int | None = None
 
 
 def _profile_tokens(prompt: str) -> dict[str, str]:
@@ -216,3 +224,49 @@ async def synthesize_speech(
         )
         response.raise_for_status()
         return response.content
+
+
+async def synthesize_speech_batch(
+    settings: AudiobookSettings | None,
+    requests: list[TTSRequest],
+) -> list[TTSResult]:
+    """Generate a true model batch when supported, with a sequential fallback."""
+    if not requests:
+        return []
+    if tts_provider_name(settings) != "omnivoice":
+        return [TTSResult(await synthesize_speech(settings, request)) for request in requests]
+    if settings is None or not settings.tts_base_url:
+        raise RuntimeError("OmniVoice base URL is required in Audio Settings.")
+
+    root = settings.tts_base_url.rstrip("/")
+    if root.endswith("/generate"):
+        root = root[: -len("/generate")]
+    url = f"{root}/generate-batch"
+    timeout = httpx.Timeout(600.0, connect=10.0)
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        response = await client.post(
+            url,
+            json={"requests": [{"voice": request.voice_prompt, "text": request.text} for request in requests]},
+            headers={"Accept": "application/json"},
+        )
+        response.raise_for_status()
+        payload = response.json()
+
+    items = payload.get("items")
+    if not isinstance(items, list) or len(items) != len(requests):
+        raise RuntimeError(
+            f"OmniVoice returned {len(items) if isinstance(items, list) else 0} "
+            f"batch results for {len(requests)} requests."
+        )
+
+    results: list[TTSResult] = []
+    for item in items:
+        try:
+            audio_bytes = base64.b64decode(item["audio_base64"], validate=True)
+            duration_ms = int(item["duration_ms"])
+        except (KeyError, TypeError, ValueError, binascii.Error) as exc:
+            raise RuntimeError("OmniVoice returned an invalid batch result.") from exc
+        if not audio_bytes or duration_ms <= 0:
+            raise RuntimeError("OmniVoice returned an empty batch result.")
+        results.append(TTSResult(audio_bytes=audio_bytes, duration_ms=duration_ms))
+    return results

--- a/backend/app/services/web_novel.py
+++ b/backend/app/services/web_novel.py
@@ -35,6 +35,28 @@ logger = logging.getLogger(__name__)
 _fff_lock = asyncio.Lock()
 
 
+async def _enqueue_audiobook_refresh(book: models.Book, db) -> None:
+    """Persist and enqueue refreshed content without losing an active build."""
+    if not book.audiobook_enabled:
+        return
+    await db.refresh(book)
+    content_version = book.content_version or 1
+    book.audiobook_pending_content_version = max(
+        book.audiobook_pending_content_version or 0,
+        content_version,
+    )
+    active_statuses = {"ingesting", "roster_gen", "diarizing", "audio_gen", "assembling"}
+    if book.audiobook_pipeline_status not in active_statuses:
+        book.audiobook_pipeline_status = "ingesting"
+    await db.commit()
+
+    from .audiobook_queue import get_audiobook_queue
+
+    queue = get_audiobook_queue()
+    if not queue.has_book_job(book.id):
+        await queue.enqueue(book.id)
+
+
 def _run_fff_main(args: List[str]) -> int:
     """Wrapper for fff_main that converts SystemExit into a return code."""
     from fanficfare.cli import main as fff_main
@@ -318,6 +340,7 @@ async def finish_web_novel_download(book_id: int, source_url: str) -> None:
         await crud.create_book_log(db, log_entry)
         await db.refresh(db_book)
         await epub_editor.apply_book_cleaning(db_book, db)
+        await _enqueue_audiobook_refresh(db_book, db)
         await queue_metadata_sync_job(db, trigger="new_book", book_ids=[db_book.id])
 
 
@@ -378,6 +401,7 @@ async def run_book_refresh(book_id: int) -> None:
                 )
                 await crud.create_book_log(db, log_entry)
                 await epub_editor.apply_book_cleaning(updated_book, db)
+                await _enqueue_audiobook_refresh(updated_book, db)
                 await queue_metadata_sync_job(db, trigger="book_update", book_ids=[updated_book.id])
 
                 updated_book.refresh_status = None
@@ -426,6 +450,7 @@ async def run_book_refresh(book_id: int) -> None:
             await db.refresh(updated_book)
 
             await epub_editor.apply_book_cleaning(updated_book, db)
+            await _enqueue_audiobook_refresh(updated_book, db)
             await queue_metadata_sync_job(db, trigger="book_update", book_ids=[updated_book.id])
 
             updated_book.refresh_status = None
@@ -509,8 +534,6 @@ async def update_web_novels() -> None:
                     )
                     book.master_word_count = new_word_count
                     book.current_word_count = new_word_count
-                    await crud.touch_book_content(db, book)
-                    await db.commit()
                 else:
                     logger.info(f"No new chapters for {book.title}.")
                     log_entry = schemas.BookLogCreate(
@@ -520,8 +543,13 @@ async def update_web_novels() -> None:
                         new_chapter_count=new_chapter_count,
                         words_added=0,
                     )
+                book.master_word_count = new_word_count
+                book.current_word_count = new_word_count
+                await crud.touch_book_content(db, book)
+                await db.commit()
                 await crud.create_book_log(db, log_entry)
                 await epub_editor.apply_book_cleaning(book, db)
+                await _enqueue_audiobook_refresh(book, db)
             except Exception as e:
                 had_book_failures = True
                 logger.error(f"Failed to update {book.title}: {e}\n{traceback.format_exc()}")

--- a/backend/tests/test_audiobook_pipeline.py
+++ b/backend/tests/test_audiobook_pipeline.py
@@ -13,7 +13,14 @@ from mutagen.mp3 import MP3
 
 from backend.app import crud, models
 from backend.app.routers import audiobook as audiobook_router
-from backend.app.services import audiobook_assembly, audiobook_ingestion, audiobook_llm, audiobook_tts
+from backend.app.services import (
+    audiobook_assembly,
+    audiobook_ingestion,
+    audiobook_llm,
+    audiobook_publication,
+    audiobook_tts,
+    web_novel,
+)
 from backend.app.services import audiobook_queue
 from backend.app.services.audiobook_queue import AudiobookQueue
 
@@ -651,11 +658,71 @@ async def test_requeue_candidates_only_include_enabled_audiobooks(db):
     disabled.audiobook_pipeline_status = "audio_gen"
     enabled = await _make_book(db, title="Enabled Audio", audiobook_enabled=True)
     enabled.audiobook_pipeline_status = "audio_gen"
+    refreshed = await _make_book(
+        db,
+        title="Refreshed Audio",
+        audiobook_enabled=True,
+        audiobook_pipeline_status="complete",
+        audiobook_source_content_version=1,
+    )
+    await crud.touch_book_content(db, refreshed)
     await db.commit()
 
     pending = await crud.audiobook.get_in_progress_audiobook_books(db)
 
-    assert [book.id for book in pending] == [enabled.id]
+    assert [book.id for book in pending] == [enabled.id, refreshed.id]
+    assert refreshed.audiobook_pending_content_version == refreshed.content_version
+
+
+@pytest.mark.asyncio
+async def test_queue_restarts_ingestion_for_refresh_received_during_generation(db, sqlite_sessionmaker, monkeypatch):
+    book = await _make_book(
+        db,
+        audiobook_enabled=True,
+        audiobook_pipeline_status="audio_gen",
+        audiobook_source_content_version=1,
+    )
+    await crud.touch_book_content(db, book)
+    await db.commit()
+    monkeypatch.setattr(audiobook_queue, "SessionLocal", sqlite_sessionmaker)
+
+    restarted = await AudiobookQueue()._restart_for_pending_content(book.id)
+
+    await db.refresh(book)
+    assert restarted is True
+    assert book.audiobook_pipeline_status == "ingesting"
+    assert book.audiobook_pending_content_version == book.content_version
+
+
+@pytest.mark.asyncio
+async def test_web_refresh_enqueues_enabled_audiobook_without_duplicate_active_job(db, monkeypatch):
+    queued_book = await _make_book(
+        db,
+        audiobook_enabled=True,
+        audiobook_pipeline_status="complete",
+        audiobook_source_content_version=1,
+    )
+    active_book = await _make_book(
+        db,
+        title="Already Building",
+        audiobook_enabled=True,
+        audiobook_pipeline_status="diarizing",
+        audiobook_source_content_version=1,
+    )
+    await crud.touch_book_content(db, queued_book)
+    await crud.touch_book_content(db, active_book)
+    await db.commit()
+    queue = _FakeQueue(active_book_ids={active_book.id})
+    monkeypatch.setattr(audiobook_queue, "get_audiobook_queue", lambda: queue)
+
+    await web_novel._enqueue_audiobook_refresh(queued_book, db)
+    await web_novel._enqueue_audiobook_refresh(active_book, db)
+
+    await db.refresh(queued_book)
+    await db.refresh(active_book)
+    assert queued_book.audiobook_pipeline_status == "ingesting"
+    assert active_book.audiobook_pipeline_status == "diarizing"
+    assert queue.enqueued == [queued_book.id]
 
 
 @pytest.mark.asyncio
@@ -1165,6 +1232,53 @@ def _write_nested_epub(path: Path) -> None:
     epub.write_epub(path, book, {})
 
 
+def _write_incremental_epub(path: Path, chapters: list[tuple[str, str, str]]) -> None:
+    book = epub.EpubBook()
+    book.set_identifier("incremental-test")
+    book.set_title("Incremental")
+    book.set_language("en")
+    book.add_author("Author")
+    spine = ["nav"]
+    toc = []
+    for index, (href, title, content) in enumerate(chapters, start=1):
+        chapter = epub.EpubHtml(title=title, file_name=href, lang="en")
+        chapter.content = f"<html><body><h1>{title}</h1><p>{content}</p></body></html>"
+        book.add_item(chapter)
+        spine.append(chapter)
+        toc.append(epub.Link(href, title, f"chapter-{index}"))
+    book.add_item(epub.EpubNcx())
+    book.add_item(epub.EpubNav())
+    book.spine = spine
+    book.toc = tuple(toc)
+    epub.write_epub(path, book, {})
+
+
+async def _mark_incremental_chapter_ready(db, library_path: Path, chapter, revision: int) -> tuple[Path, Path]:
+    chapter_dir = library_path / "audiobooks" / str(chapter.book_id) / "seed" / chapter.stable_chapter_key
+    chapter_dir.mkdir(parents=True, exist_ok=True)
+    audio_path = chapter_dir / "audio.mp3"
+    smil_path = chapter_dir / "overlay.smil"
+    audio_path.write_bytes(f"audio-{chapter.id}".encode())
+    smil_path.write_text("<smil/>", encoding="utf-8")
+    chapter.audio_file_path = str(audio_path.relative_to(library_path.parent))
+    chapter.smil_file_path = str(smil_path.relative_to(library_path.parent))
+    chapter.reader_audio_file_path = chapter.audio_file_path
+    chapter.reader_smil_file_path = chapter.smil_file_path
+    chapter.audio_revision = revision
+    chapter.generation_state = "ready"
+    chapter.audio_size_bytes = audio_path.stat().st_size
+    chapter.audio_sha256 = "a" * 64
+    chapter.smil_size_bytes = smil_path.stat().st_size
+    chapter.smil_sha256 = "b" * 64
+    chapter.duration_ms = 1000
+    sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
+    for sentence in sentences:
+        sentence.status = "audio_generated"
+        sentence.audio_duration_ms = 1000
+    await db.commit()
+    return audio_path, smil_path
+
+
 def _simple_sentence_split(text: str) -> list[str]:
     if "." not in text:
         return [text.strip()]
@@ -1183,6 +1297,7 @@ async def test_ingestion_preserves_nested_markup_and_records_spine_file(db, tmp_
         current_path=str(epub_path.relative_to(library_path.parent)),
     )
     monkeypatch.setattr(audiobook_ingestion, "LIBRARY_PATH", library_path)
+    monkeypatch.setattr(audiobook_publication, "LIBRARY_PATH", library_path)
     monkeypatch.setattr(audiobook_ingestion, "_tokenize_text", _simple_sentence_split)
 
     await audiobook_ingestion.ingest_epub(book.id, db)
@@ -1202,8 +1317,143 @@ async def test_ingestion_preserves_nested_markup_and_records_spine_file(db, tmp_
     assert soup.find("p") is not None
     assert soup.find("em") is not None
     assert soup.find("a", href="next.xhtml") is not None
-    assert soup.find("span", id="ch1_s0") is not None
-    assert soup.find("span", id="ch1_s1") is not None
+    sentences = await crud.audiobook.get_sentences_for_chapter(db, chapters[0].id)
+    assert len(sentences) >= 2
+    assert all(sentence.html_element_id.startswith(f"{chapters[0].stable_chapter_key}-") for sentence in sentences)
+    assert all(soup.find("span", id=sentence.html_element_id) is not None for sentence in sentences)
+
+
+@pytest.mark.asyncio
+async def test_incremental_ingestion_appends_chapter_without_invalidating_ready_audio(db, tmp_path, monkeypatch):
+    library_path = tmp_path / "library"
+    library_path.mkdir()
+    epub_path = library_path / "incremental.epub"
+    initial = [
+        ("Text/one.xhtml", "One", "First original sentence."),
+        ("Text/two.xhtml", "Two", "Second original sentence."),
+    ]
+    _write_incremental_epub(epub_path, initial)
+    book = await _make_book(
+        db,
+        audiobook_enabled=True,
+        immutable_path=str(epub_path.relative_to(library_path.parent)),
+        current_path=str(epub_path.relative_to(library_path.parent)),
+    )
+    monkeypatch.setattr(audiobook_ingestion, "LIBRARY_PATH", library_path)
+    monkeypatch.setattr(audiobook_publication, "LIBRARY_PATH", library_path)
+    monkeypatch.setattr(audiobook_ingestion, "_tokenize_text", _simple_sentence_split)
+
+    await audiobook_ingestion.ingest_epub(book.id, db)
+    original = await crud.audiobook.get_chapters_for_book(db, book.id)
+    original_state = []
+    for revision, chapter in enumerate(original, start=4):
+        await _mark_incremental_chapter_ready(db, library_path, chapter, revision)
+        sentence_ids = [
+            sentence.html_element_id for sentence in await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
+        ]
+        original_state.append((chapter.id, chapter.stable_chapter_key, revision, chapter.audio_file_path, sentence_ids))
+
+    _write_incremental_epub(
+        epub_path,
+        [*initial, ("Text/three.xhtml", "Three", "A newly appended sentence.")],
+    )
+    await crud.touch_book_content(db, book)
+    await db.commit()
+    await audiobook_ingestion.ingest_epub(book.id, db)
+
+    chapters = await crud.audiobook.get_chapters_for_book(db, book.id)
+    assert len(chapters) == 3
+    for chapter, expected in zip(chapters[:2], original_state, strict=True):
+        chapter_id, key, revision, audio_path, sentence_ids = expected
+        assert (chapter.id, chapter.stable_chapter_key, chapter.audio_revision) == (chapter_id, key, revision)
+        assert chapter.audio_file_path == audio_path
+        assert chapter.generation_state == "ready"
+        assert [
+            sentence.html_element_id for sentence in await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
+        ] == sentence_ids
+    assert chapters[2].generation_state == "pending"
+
+
+@pytest.mark.asyncio
+async def test_incremental_ingestion_invalidates_only_edited_chapter(db, tmp_path, monkeypatch):
+    library_path = tmp_path / "library"
+    library_path.mkdir()
+    epub_path = library_path / "incremental.epub"
+    initial = [
+        ("Text/one.xhtml", "One", "First original sentence."),
+        ("Text/two.xhtml", "Two", "Second original sentence."),
+    ]
+    _write_incremental_epub(epub_path, initial)
+    book = await _make_book(
+        db,
+        audiobook_enabled=True,
+        immutable_path=str(epub_path.relative_to(library_path.parent)),
+        current_path=str(epub_path.relative_to(library_path.parent)),
+    )
+    monkeypatch.setattr(audiobook_ingestion, "LIBRARY_PATH", library_path)
+    monkeypatch.setattr(audiobook_publication, "LIBRARY_PATH", library_path)
+    monkeypatch.setattr(audiobook_ingestion, "_tokenize_text", _simple_sentence_split)
+
+    await audiobook_ingestion.ingest_epub(book.id, db)
+    original = await crud.audiobook.get_chapters_for_book(db, book.id)
+    first_assets = await _mark_incremental_chapter_ready(db, library_path, original[0], 7)
+    edited_assets = await _mark_incremental_chapter_ready(db, library_path, original[1], 8)
+
+    _write_incremental_epub(
+        epub_path,
+        [initial[0], ("Text/two.xhtml", "Two", "This sentence was edited.")],
+    )
+    await crud.touch_book_content(db, book)
+    await db.commit()
+    await audiobook_ingestion.ingest_epub(book.id, db)
+
+    chapters = await crud.audiobook.get_chapters_for_book(db, book.id)
+    assert chapters[0].id == original[0].id
+    assert chapters[0].audio_revision == 7
+    assert chapters[0].generation_state == "ready"
+    assert all(path.exists() for path in first_assets)
+    assert chapters[1].id == original[1].id
+    assert chapters[1].audio_revision == 8
+    assert chapters[1].generation_state == "pending"
+    assert chapters[1].audio_file_path is None
+    assert chapters[1].reader_audio_file_path is None
+    assert all(not path.exists() for path in edited_assets)
+
+
+@pytest.mark.asyncio
+async def test_incremental_ingestion_removes_deleted_chapter_and_assets(db, tmp_path, monkeypatch):
+    library_path = tmp_path / "library"
+    library_path.mkdir()
+    epub_path = library_path / "incremental.epub"
+    initial = [
+        ("Text/one.xhtml", "One", "First original sentence."),
+        ("Text/two.xhtml", "Two", "Second original sentence."),
+    ]
+    _write_incremental_epub(epub_path, initial)
+    book = await _make_book(
+        db,
+        audiobook_enabled=True,
+        immutable_path=str(epub_path.relative_to(library_path.parent)),
+        current_path=str(epub_path.relative_to(library_path.parent)),
+    )
+    monkeypatch.setattr(audiobook_ingestion, "LIBRARY_PATH", library_path)
+    monkeypatch.setattr(audiobook_publication, "LIBRARY_PATH", library_path)
+    monkeypatch.setattr(audiobook_ingestion, "_tokenize_text", _simple_sentence_split)
+
+    await audiobook_ingestion.ingest_epub(book.id, db)
+    original = await crud.audiobook.get_chapters_for_book(db, book.id)
+    await _mark_incremental_chapter_ready(db, library_path, original[0], 2)
+    removed_assets = await _mark_incremental_chapter_ready(db, library_path, original[1], 3)
+
+    _write_incremental_epub(epub_path, initial[:1])
+    await crud.touch_book_content(db, book)
+    await db.commit()
+    await audiobook_ingestion.ingest_epub(book.id, db)
+
+    chapters = await crud.audiobook.get_chapters_for_book(db, book.id)
+    assert [chapter.id for chapter in chapters] == [original[0].id]
+    assert chapters[0].generation_state == "ready"
+    assert all(not path.exists() for path in removed_assets)
 
 
 @pytest.mark.asyncio
@@ -1514,7 +1764,7 @@ async def test_offline_harness_builds_downloadable_media_overlay_epub(db, tmp_pa
         immutable_path=str(epub_path.relative_to(library_path.parent)),
         current_path=str(epub_path.relative_to(library_path.parent)),
     )
-    for module in (audiobook_ingestion, audiobook_tts, audiobook_assembly):
+    for module in (audiobook_ingestion, audiobook_publication, audiobook_tts, audiobook_assembly):
         monkeypatch.setattr(module, "LIBRARY_PATH", library_path)
     monkeypatch.setattr(audiobook_ingestion, "_tokenize_text", _simple_sentence_split)
 

--- a/backend/tests/test_audiobook_pipeline.py
+++ b/backend/tests/test_audiobook_pipeline.py
@@ -3,11 +3,13 @@ import json
 import shutil
 import zipfile
 from pathlib import Path
+from types import SimpleNamespace
 
 import httpx
 import pytest
 from bs4 import BeautifulSoup
 from ebooklib import epub
+from mutagen.mp3 import MP3
 
 from backend.app import crud, models
 from backend.app.routers import audiobook as audiobook_router
@@ -105,6 +107,42 @@ def test_default_roster_prompt_formats_voice_token_examples():
     assert "A story excerpt." in prompt
 
 
+def test_diarization_schema_keeps_model_output_compact():
+    properties = audiobook_llm.DIARIZATION_SCHEMA["properties"]["assignments"]["items"]["properties"]
+
+    assert set(properties) == {"i", "c", "e"}
+    assert "tagged_text" not in properties
+    assert "confidence" not in properties
+    assert "reason" not in properties
+    assert properties["e"]["enum"] == [None, "laughter", "sigh", "whisper", "shout"]
+    assert "chapter_summary" not in audiobook_llm.DIARIZATION_SCHEMA["properties"]
+
+
+def test_diarization_schema_requires_exact_assignment_count():
+    schema = audiobook_llm._diarization_schema(7)
+    assignments = schema["properties"]["assignments"]
+
+    assert assignments["minItems"] == 7
+    assert assignments["maxItems"] == 7
+    assert "minItems" not in audiobook_llm.DIARIZATION_SCHEMA["properties"]["assignments"]
+
+
+def test_only_quoted_spans_require_model_diarization():
+    sentences = [
+        SimpleNamespace(id=1, original_text="Plain narration."),
+        SimpleNamespace(id=2, original_text="“This dialogue starts"),
+        SimpleNamespace(id=3, original_text="and continues across a sentence"),
+        SimpleNamespace(id=4, original_text="before ending here.”"),
+        SimpleNamespace(id=5, original_text="Narration resumes."),
+    ]
+
+    assert audiobook_llm._sentence_ids_requiring_diarization(sentences) == {
+        2,
+        3,
+        4,
+    }
+
+
 def test_tagged_text_sanitizer_only_accepts_supported_insertions():
     original = "Take your time, I said."
 
@@ -113,6 +151,59 @@ def test_tagged_text_sanitizer_only_accepts_supported_insertions():
     )
     assert audiobook_llm._sanitize_tagged_text(original, "[fade in] Take your time, I said.") == original
     assert audiobook_llm._sanitize_tagged_text(original, "I completely rewrote this sentence.") == original
+
+
+def test_diarization_parser_deduplicates_repeated_sentence_ids():
+    raw = json.dumps(
+        {
+            "assignments": [
+                {"id": 7, "character_id": 1, "confidence": 0.4, "reason": "First"},
+                {"id": 7, "character_id": 2, "confidence": 0.9, "reason": "Better"},
+            ],
+            "chapter_summary": "Summary",
+        }
+    )
+
+    result, missing_ids, salvaged = audiobook_llm._parse_diarization_response(raw, [7])
+
+    assert result["assignments"][0]["id"] == 7
+    assert result["assignments"][0]["character_id"] == 2
+    assert result["assignments"][0]["confidence"] == 0.9
+    assert result["assignments"][0]["reason"] == "Better"
+    assert missing_ids == set()
+    assert salvaged is False
+
+
+def test_diarization_parser_normalizes_compact_wire_keys():
+    raw = json.dumps(
+        {
+            "assignments": [
+                {"i": 7, "c": 11, "e": "whisper"},
+            ]
+        }
+    )
+
+    result, missing_ids, salvaged = audiobook_llm._parse_diarization_response(raw, [7])
+
+    assert result["assignments"][0]["id"] == 7
+    assert result["assignments"][0]["character_id"] == 11
+    assert result["assignments"][0]["expression"] == "whisper"
+    assert missing_ids == set()
+    assert salvaged is False
+
+
+def test_diarization_parser_salvages_complete_assignments_from_truncated_json():
+    raw = (
+        '{"assignments":['
+        '{"id":7,"character_id":1,"tagged_text":null,"confidence":0.9,"reason":"Narration"},'
+        '{"id":8,"character_id":'
+    )
+
+    result, missing_ids, salvaged = audiobook_llm._parse_diarization_response(raw, [7, 8])
+
+    assert [assignment["id"] for assignment in result["assignments"]] == [7]
+    assert missing_ids == {8}
+    assert salvaged is True
 
 
 def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
@@ -199,6 +290,201 @@ async def test_ollama_call_requests_schema_constrained_non_thinking_json(monkeyp
     assert payload["think"] is False
     assert payload["format"] == schema
     assert payload["options"]["temperature"] == 0
+    assert payload["options"]["num_predict"] == 8192
+
+
+@pytest.mark.asyncio
+async def test_ollama_call_streams_progress_when_callback_is_provided(monkeypatch):
+    captured = {}
+
+    class FakeResponse:
+        is_error = False
+        status_code = 200
+        text = ""
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def aiter_lines(self):
+            yield json.dumps({"message": {"content": "a" * 1024}, "done": False})
+            yield json.dumps({"message": {"content": "finished"}, "done": True})
+
+        async def aread(self):
+            return b""
+
+    class FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        def __init__(self, **_kwargs):
+            pass
+
+        def stream(self, method, url, **kwargs):
+            captured["method"] = method
+            captured["url"] = url
+            captured["request"] = kwargs
+            return FakeResponse()
+
+    monkeypatch.setattr(audiobook_llm.httpx, "AsyncClient", FakeClient)
+    settings = models.AudiobookSettings(
+        llm_provider="ollama",
+        llm_base_url="http://127.0.0.1:11434",
+        llm_model="qwen3.5:9b",
+    )
+    progress = []
+
+    raw = await audiobook_llm._call_llm(
+        settings,
+        [{"role": "user", "content": "stream"}],
+        response_schema={"type": "object"},
+        progress_callback=lambda received: _record_progress(progress, received),
+    )
+
+    assert raw == ("a" * 1024) + "finished"
+    assert progress == [1024, 1032]
+    assert captured["method"] == "POST"
+    assert captured["request"]["json"]["stream"] is True
+
+
+@pytest.mark.asyncio
+async def test_ollama_call_preserves_retryable_http_status(monkeypatch):
+    class FakeResponse:
+        is_error = True
+
+        def raise_for_status(self):
+            request = httpx.Request("POST", "http://ollama.test/api/chat")
+            response = httpx.Response(503, request=request)
+            raise httpx.HTTPStatusError("service unavailable", request=request, response=response)
+
+    class FakeClient:
+        def __init__(self, **_kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def post(self, _url, **_kwargs):
+            return FakeResponse()
+
+    monkeypatch.setattr(audiobook_llm.httpx, "AsyncClient", FakeClient)
+    settings = models.AudiobookSettings(
+        llm_provider="ollama",
+        llm_base_url="http://ollama.test",
+        llm_model="qwen-test",
+    )
+
+    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+        await audiobook_llm._call_llm(
+            settings,
+            [{"role": "user", "content": "retry"}],
+        )
+
+    assert exc_info.value.response.status_code == 503
+
+
+async def _record_progress(progress, received):
+    progress.append(received)
+
+
+@pytest.mark.asyncio
+async def test_diarization_retries_truncated_output_with_smaller_batches(db, monkeypatch):
+    monkeypatch.setattr(audiobook_llm, "DIARIZATION_BATCH_SIZE", 40)
+    book = await _make_book(
+        db,
+        audiobook_enabled=True,
+        audiobook_pipeline_status="diarizing",
+    )
+    settings = models.AudiobookSettings(
+        llm_provider="ollama",
+        llm_base_url="http://ollama.test",
+        llm_model="qwen-test",
+    )
+    db.add(settings)
+    chapter = await crud.audiobook.create_chapter(db, book.id, 1, "story.xhtml")
+    narrator = (
+        await crud.audiobook.create_characters_bulk(
+            db,
+            book.id,
+            [
+                {
+                    "name": "Narrator",
+                    "description": "Primary narrator",
+                    "voice_prompt": "[gender-neutral][pitch-medium][speed-normal]",
+                    "is_narrator": True,
+                }
+            ],
+        )
+    )[0]
+    await crud.audiobook.create_sentences_bulk(
+        db,
+        chapter.id,
+        [
+            {
+                "html_element_id": f"story_{index}",
+                "sequence_order": index,
+                "original_text": f"“Story sentence {index}.”",
+                "status": "pending_diarization",
+            }
+            for index in range(80)
+        ],
+    )
+    request_sizes = []
+
+    async def fake_call(_settings, messages, **_kwargs):
+        prompt = messages[0]["content"]
+        sentences_text = prompt.split(
+            "Sentences to process (JSON array with id, text, and its immediate previous/next context):\n",
+            1,
+        )[1].split("\n\nFor each sentence", 1)[0]
+        sentences = json.loads(sentences_text)
+        request_sizes.append(len(sentences))
+        if len(sentences) == 40 and request_sizes.count(40) == 1:
+            return '{"assignments":[{"id":' + str(sentences[0]["id"]) + ',"reason":"truncated'
+        return json.dumps(
+            {
+                "assignments": [
+                    {
+                        "id": sentence["id"],
+                        "character_id": narrator.id,
+                        "tagged_text": None,
+                        "confidence": 0.95,
+                        "reason": "Narration",
+                    }
+                    for sentence in sentences
+                ],
+                "chapter_summary": "The story continues.",
+            }
+        )
+
+    monkeypatch.setattr(audiobook_llm, "_call_llm", fake_call)
+    ready_batches = []
+
+    async def record_ready(sentence_ids):
+        ready_batches.append(sentence_ids)
+
+    await audiobook_llm.diarize_sentences(
+        book.id,
+        db,
+        on_sentences_ready=record_ready,
+    )
+
+    await db.refresh(book)
+    sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
+    assert request_sizes == [40, 20, 40, 20]
+    assert {sentence.status for sentence in sentences} == {"ready_for_audio"}
+    assert {sentence.character_id for sentence in sentences} == {narrator.id}
+    assert book.audiobook_pipeline_status == "audio_gen"
+    assert book.audiobook_llm_requests == 4
+    assert [len(sentence_ids) for sentence_ids in ready_batches] == [20, 40, 20]
 
 
 @pytest.mark.asyncio
@@ -228,6 +514,94 @@ async def test_queue_schedules_one_rerun_for_changes_during_processing(monkeypat
         assert processed == [42, 42]
     finally:
         await queue.stop()
+
+
+@pytest.mark.asyncio
+async def test_queue_stop_cancels_long_running_pipeline_work(monkeypatch):
+    queue = AudiobookQueue()
+    started = asyncio.Event()
+    never_finishes = asyncio.Event()
+
+    async def process(_book_id: int) -> None:
+        started.set()
+        await never_finishes.wait()
+
+    monkeypatch.setattr(queue, "_process", process)
+    await queue.start()
+    await queue.enqueue(42)
+    await started.wait()
+
+    await asyncio.wait_for(queue.stop(), timeout=1)
+
+    assert queue._worker_task is None
+    assert queue._background_audio_tasks == []
+
+
+@pytest.mark.asyncio
+async def test_manual_sentence_audio_uses_independent_tts_lane():
+    queue = AudiobookQueue()
+
+    assert await queue.enqueue_sentence_audio(7, 42) is True
+
+    assert queue._queue.empty()
+    assert (await queue._background_audio_queue.get())[2] == (7, [42], True)
+    queue._background_audio_queue.task_done()
+
+
+@pytest.mark.asyncio
+async def test_pipeline_audio_is_queued_in_model_batches(monkeypatch):
+    monkeypatch.setattr(audiobook_queue, "TTS_BATCH_SIZE", 3)
+    queue = AudiobookQueue()
+
+    await queue.enqueue_background_audio(7, [10, 11, 12, 13, 14, 15, 16])
+
+    batches = [(await queue._background_audio_queue.get())[2] for _ in range(3)]
+    assert batches == [
+        (7, [10, 11, 12], False),
+        (7, [13, 14, 15], False),
+        (7, [16], False),
+    ]
+    assert queue._background_audio_ids == {7: {10, 11, 12, 13, 14, 15, 16}}
+    for _ in batches:
+        queue._background_audio_queue.task_done()
+
+
+@pytest.mark.asyncio
+async def test_waiting_audio_lane_publishes_phase_accurate_progress(
+    db,
+    sqlite_sessionmaker,
+    monkeypatch,
+):
+    book = await _make_book(
+        db,
+        audiobook_enabled=True,
+        audiobook_pipeline_status="audio_gen",
+    )
+    _chapter, _character, sentence = await _seed_audio_chapter(
+        db,
+        book.id,
+        sentence_status="ready_for_audio",
+    )
+    monkeypatch.setattr(audiobook_queue, "SessionLocal", sqlite_sessionmaker)
+    queue = AudiobookQueue()
+    queue._background_audio_ids = {book.id: {sentence.id}}
+
+    waiter = asyncio.create_task(queue._wait_for_background_audio(book.id))
+    try:
+        for _ in range(50):
+            await db.refresh(book)
+            if book.audiobook_progress_detail and book.audiobook_progress_detail.startswith("Generating speech:"):
+                break
+            await asyncio.sleep(0.01)
+
+        assert book.audiobook_progress_current == 0
+        assert book.audiobook_progress_total == 1
+        assert book.audiobook_progress_detail == "Generating speech: 0 of 1 clips (1 queued)"
+    finally:
+        async with queue._background_audio_condition:
+            queue._background_audio_ids.pop(book.id, None)
+            queue._background_audio_condition.notify_all()
+        await waiter
 
 
 @pytest.mark.asyncio
@@ -519,6 +893,45 @@ async def test_queue_stops_for_review_after_requested_phase(db, sqlite_sessionma
     assert phases == ["ingesting"]
     assert book.audiobook_pipeline_status == "paused"
     assert book.audiobook_stop_after_phase is None
+
+
+@pytest.mark.asyncio
+async def test_restarted_audio_phase_rebuilds_length_bucketed_background_queue(
+    db,
+    sqlite_sessionmaker,
+    monkeypatch,
+):
+    book = await _make_book(
+        db,
+        audiobook_enabled=True,
+        audiobook_pipeline_status="audio_gen",
+        audiobook_stop_after_phase="audio_gen",
+    )
+    _chapter, _character, sentence = await _seed_audio_chapter(
+        db,
+        book.id,
+        sentence_status="ready_for_audio",
+    )
+    queue = AudiobookQueue()
+    enqueued: list[tuple[int, list[int]]] = []
+
+    async def record_background_audio(book_id, sentence_ids):
+        enqueued.append((book_id, sentence_ids))
+
+    async def finish_audio(book_id, phase_db):
+        await crud.audiobook.set_book_pipeline_status(phase_db, book_id, "assembling")
+
+    async def wait_for_audio(_book_id):
+        return None
+
+    monkeypatch.setattr(audiobook_queue, "SessionLocal", sqlite_sessionmaker)
+    monkeypatch.setattr(queue, "enqueue_background_audio", record_background_audio)
+    monkeypatch.setattr(queue, "_wait_for_background_audio", wait_for_audio)
+    monkeypatch.setattr(audiobook_queue, "generate_audio_for_book", finish_audio)
+
+    await queue._process(book.id)
+
+    assert enqueued == [(book.id, [sentence.id])]
 
 
 @pytest.mark.asyncio
@@ -1043,7 +1456,21 @@ async def test_manual_chapter_preview_generates_playable_audio(db, tmp_path, mon
     library_path = tmp_path / "library"
     library_path.mkdir()
     book = await _make_book(db, audiobook_enabled=True, audiobook_pipeline_status="complete")
-    chapter, _character, _sentence = await _seed_audio_chapter(db, book.id)
+    chapter, character, _sentence = await _seed_audio_chapter(db, book.id)
+    await crud.audiobook.create_sentences_bulk(
+        db,
+        chapter.id,
+        [
+            {
+                "html_element_id": "ch1_s1",
+                "sequence_order": 1,
+                "original_text": "A second sentence verifies concatenated timing.",
+                "tagged_text": "A second sentence verifies concatenated timing.",
+                "character_id": character.id,
+                "status": "ready_for_audio",
+            }
+        ],
+    )
     monkeypatch.setattr(audiobook_tts, "LIBRARY_PATH", library_path)
     monkeypatch.setattr(audiobook_assembly, "LIBRARY_PATH", library_path)
     monkeypatch.setattr(crud.audiobook, "LIBRARY_PATH", library_path)
@@ -1052,13 +1479,24 @@ async def test_manual_chapter_preview_generates_playable_audio(db, tmp_path, mon
     packaged_epub.write_bytes(b"stale package")
 
     await audiobook_tts.generate_audio_for_chapter_preview(book.id, chapter.id, db)
+    legacy_sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
+    for legacy_sentence in legacy_sentences:
+        legacy_sentence.audio_duration_ms += 50
+    await db.commit()
     await audiobook_assembly.assemble_chapter_preview(book.id, chapter.id, db)
     await db.refresh(chapter)
     await db.refresh(book)
 
     assert chapter.audio_file_path
-    assert (library_path.parent / chapter.audio_file_path).exists()
+    chapter_audio_path = library_path.parent / chapter.audio_file_path
+    assert chapter_audio_path.exists()
     assert chapter.smil_file_path
+    sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
+    expected_duration_ms = sum(sentence.audio_duration_ms for sentence in sentences)
+    actual_duration_ms = round(MP3(chapter_audio_path).info.length * 1000)
+    assert abs(actual_duration_ms - expected_duration_ms) <= 1
+    smil_xml = (library_path.parent / chapter.smil_file_path).read_text(encoding="utf-8")
+    assert f'clipEnd="{audiobook_assembly._ms_to_clock(expected_duration_ms)}"' in smil_xml
     assert packaged_epub.exists() is False
     assert book.audiobook_pipeline_status == "paused"
 
@@ -1099,9 +1537,13 @@ async def test_offline_harness_builds_downloadable_media_overlay_epub(db, tmp_pa
         names = archive.namelist()
         assert "EPUB/ch0001.mp3" in names
         assert "EPUB/ch0001.smil" in names
+        assert "EPUB/nav.xhtml" in names
         package = archive.read("EPUB/content.opf").decode("utf-8")
         assert 'media-type="application/smil+xml"' in package
         assert 'media-overlay="smil_ch0001"' in package
+        assert 'properties="nav"' in package
+        assert package.count('property="media:duration"') == 3
+        assert 'property="media:duration">00:00:' in package
 
     monkeypatch.setattr(audiobook_router, "LIBRARY_PATH", library_path)
     response = await audiobook_router.download_audiobook(book.id, db)

--- a/backend/tests/test_reader_audiobook.py
+++ b/backend/tests/test_reader_audiobook.py
@@ -1,0 +1,268 @@
+"""Reader API contract tests for modular generated audiobooks."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from backend.app import models
+from backend.app.routers import reader
+from backend.app.services import audiobook_publication
+
+
+def _relative(root: Path, path: Path) -> str:
+    return str(path.relative_to(root.parent))
+
+
+@pytest.mark.asyncio
+async def test_reader_audiobook_capability_and_assets(
+    app_client,
+    sqlite_sessionmaker,
+    tmp_path,
+    monkeypatch,
+):
+    library = tmp_path / "library"
+    output = library / "audiobooks" / "839"
+    output.mkdir(parents=True)
+    text_path = output / "working.epub"
+    audio_path = output / "ch0001.mp3"
+    smil_path = output / "ch0001.smil"
+    text_content = b"reader-text-epub"
+    audio_content = b"0123456789abcdef"
+    smil_content = b"""<?xml version="1.0" encoding="UTF-8"?>
+    <smil xmlns="http://www.w3.org/ns/SMIL" version="3.0"><body><seq>
+      <par><text src="Text/chapter.xhtml#sentence-1"/>
+      <audio src="ch0001.mp3" clipBegin="00:00:00.000" clipEnd="00:00:01.250"/></par>
+    </seq></body></smil>"""
+    text_path.write_bytes(text_content)
+    audio_path.write_bytes(audio_content)
+    smil_path.write_bytes(smil_content)
+    reader_smil = audiobook_publication.reader_smil_bytes(smil_content, "Text/chapter.xhtml")
+
+    monkeypatch.setattr(reader, "LIBRARY_PATH", library)
+    monkeypatch.setattr(audiobook_publication, "LIBRARY_PATH", library)
+
+    async with sqlite_sessionmaker() as db:
+        book = models.Book(
+            id=839,
+            title="Complete Audio",
+            author="Reader",
+            series="Reader Series",
+            source_type=models.SourceType.epub,
+            immutable_path="library/source.epub",
+            current_path="library/current.epub",
+            content_version=14,
+            audiobook_enabled=True,
+            audiobook_pipeline_status="complete",
+            audiobook_revision=7,
+            audiobook_source_content_version=14,
+            audiobook_text_content_version=14,
+            audiobook_publication_state="complete",
+            audiobook_text_file_path=_relative(library, text_path),
+            audiobook_text_size_bytes=len(text_content),
+            audiobook_text_sha256=hashlib.sha256(text_content).hexdigest(),
+        )
+        db.add(book)
+        db.add(
+            models.AudiobookChapter(
+                book_id=839,
+                chapter_number=1,
+                stable_chapter_key="src-chapter-one",
+                source_href="Text/chapter.xhtml",
+                content_file_name="Text/chapter.xhtml",
+                title="Chapter One",
+                spine_order=0,
+                generation_state="ready",
+                audio_revision=3,
+                audio_file_path=_relative(library, audio_path),
+                smil_file_path=_relative(library, smil_path),
+                reader_audio_file_path=_relative(library, audio_path),
+                reader_smil_file_path=_relative(library, smil_path),
+                audio_size_bytes=len(audio_content),
+                audio_sha256=hashlib.sha256(audio_content).hexdigest(),
+                smil_size_bytes=len(reader_smil),
+                smil_sha256=hashlib.sha256(reader_smil).hexdigest(),
+                duration_ms=1250,
+            )
+        )
+        db.add(
+            models.Book(
+                id=840,
+                title="Complete Standalone Audio",
+                author="Reader",
+                source_type=models.SourceType.epub,
+                immutable_path="library/standalone-source.epub",
+                current_path="library/standalone-current.epub",
+                content_version=14,
+                audiobook_enabled=True,
+                audiobook_pipeline_status="complete",
+                audiobook_revision=7,
+                audiobook_source_content_version=14,
+                audiobook_text_content_version=14,
+                audiobook_publication_state="complete",
+                audiobook_text_file_path=_relative(library, text_path),
+            )
+        )
+        db.add(
+            models.AudiobookChapter(
+                book_id=840,
+                chapter_number=1,
+                stable_chapter_key="src-chapter-one",
+                source_href="Text/chapter.xhtml",
+                generation_state="ready",
+                audio_revision=3,
+                reader_audio_file_path=_relative(library, audio_path),
+                reader_smil_file_path=_relative(library, smil_path),
+                audio_size_bytes=len(audio_content),
+            )
+        )
+        await db.commit()
+
+    protected_urls = [
+        "/reader/books/839/audiobook/manifest",
+        "/reader/books/839/audiobook/text",
+        "/reader/books/839/audiobook/chapters/src-chapter-one/audio?version=3",
+        "/reader/books/839/audiobook/chapters/src-chapter-one/smil?version=3",
+    ]
+    for url in protected_urls:
+        assert app_client.get(url).status_code == 401
+
+    key_response = app_client.post("/api/reader-keys", json={"label": "Audiobook Reader"})
+    token = key_response.json()["token"]
+    auth = ("reader", token)
+
+    listing_urls = {
+        "/reader/books/all": 839,
+        "/reader/books/standalone": 840,
+        "/reader/updates": 839,
+        "/reader/series/Reader%20Series/books": 839,
+    }
+    for url, expected_book_id in listing_urls.items():
+        payload = app_client.get(url, auth=auth).json()
+        audiobook = next(item for item in payload if item["id"] == expected_book_id)["audiobook"]
+        assert audiobook == {
+            "status": "complete",
+            "revision": 7,
+            "source_content_version": 14,
+            "text_content_version": 14,
+            "ready_chapter_count": 1,
+            "total_chapter_count": 1,
+            "ready_audio_bytes": len(audio_content),
+            "manifest_url": f"/reader/books/{expected_book_id}/audiobook/manifest",
+        }
+    single = app_client.get("/reader/books/839", auth=auth).json()
+    assert single["audiobook"]["status"] == "complete"
+
+    manifest_response = app_client.get(protected_urls[0], auth=auth)
+    assert manifest_response.status_code == 200
+    assert manifest_response.headers["content-type"].startswith("application/json")
+    assert int(manifest_response.headers["content-length"]) == len(manifest_response.content)
+    manifest = manifest_response.json()
+    assert manifest["revision"] == 7
+    assert manifest["text"]["sha256"] == hashlib.sha256(text_content).hexdigest()
+    assert manifest["chapters"] == [
+        {
+            "key": "src-chapter-one",
+            "title": "Chapter One",
+            "href": "Text/chapter.xhtml",
+            "state": "ready",
+            "audio_version": 3,
+            "duration_ms": 1250,
+            "audio_size_bytes": len(audio_content),
+            "audio_sha256": hashlib.sha256(audio_content).hexdigest(),
+            "smil_size_bytes": len(reader_smil),
+            "smil_sha256": hashlib.sha256(reader_smil).hexdigest(),
+            "audio_url": "/reader/books/839/audiobook/chapters/src-chapter-one/audio?version=3",
+            "smil_url": "/reader/books/839/audiobook/chapters/src-chapter-one/smil?version=3",
+        }
+    ]
+    assert (
+        app_client.get(
+            protected_urls[0],
+            auth=auth,
+            headers={"If-None-Match": manifest_response.headers["etag"]},
+        ).status_code
+        == 304
+    )
+
+    text_response = app_client.get(protected_urls[1], auth=auth)
+    assert text_response.content == text_content
+    assert text_response.headers["content-type"].startswith("application/epub+zip")
+    assert (
+        app_client.get(
+            protected_urls[1],
+            auth=auth,
+            headers={"If-None-Match": text_response.headers["etag"]},
+        ).status_code
+        == 304
+    )
+
+    audio_url = protected_urls[2]
+    audio_response = app_client.get(audio_url, auth=auth)
+    assert audio_response.content == audio_content
+    assert audio_response.headers["accept-ranges"] == "bytes"
+    partial = app_client.get(audio_url, auth=auth, headers={"Range": "bytes=2-5"})
+    assert partial.status_code == 206
+    assert partial.content == audio_content[2:6]
+    assert partial.headers["content-range"] == f"bytes 2-5/{len(audio_content)}"
+    suffix = app_client.get(audio_url, auth=auth, headers={"Range": "bytes=-4"})
+    assert suffix.status_code == 206
+    assert suffix.content == audio_content[-4:]
+    invalid = app_client.get(audio_url, auth=auth, headers={"Range": "bytes=999-1000"})
+    assert invalid.status_code == 416
+    assert invalid.headers["content-range"] == f"bytes */{len(audio_content)}"
+    stale = app_client.get(audio_url.replace("version=3", "version=2"), auth=auth)
+    assert stale.status_code == 409
+    assert stale.json() == {
+        "error": "stale_audiobook_revision",
+        "message": "Refresh the audiobook manifest before downloading this chapter.",
+        "current_revision": 3,
+    }
+
+    smil_response = app_client.get(protected_urls[3], auth=auth)
+    assert smil_response.content == reader_smil
+    assert b'src="chapter.xhtml#sentence-1"' in smil_response.content
+    assert b'src="audio.mp3"' in smil_response.content
+
+
+@pytest.mark.asyncio
+async def test_reader_book_omits_audiobook_for_legacy_book(app_client, sqlite_sessionmaker):
+    async with sqlite_sessionmaker() as db:
+        db.add(
+            models.Book(
+                title="Legacy Book",
+                author="Reader",
+                source_type=models.SourceType.epub,
+                immutable_path="library/legacy-source.epub",
+                current_path="library/legacy.epub",
+                content_version=1,
+                audiobook_enabled=False,
+            )
+        )
+        await db.commit()
+    key_response = app_client.post("/api/reader-keys", json={"label": "Legacy Reader"})
+    auth = ("reader", key_response.json()["token"])
+    book = app_client.get("/reader/books/all", auth=auth).json()[0]
+    assert book["audiobook"] is None
+    assert app_client.get(f"/reader/books/{book['id']}/audiobook/manifest", auth=auth).status_code == 404
+
+
+def test_reader_audiobook_capability_supports_all_publication_states():
+    chapters = [
+        models.AudiobookChapter(
+            generation_state="pending",
+            chapter_number=1,
+        )
+    ]
+    for state in ("processing", "partial", "complete", "error"):
+        book = models.Book(
+            id=1,
+            content_version=1,
+            audiobook_enabled=True,
+            audiobook_pipeline_status="audio_gen",
+            audiobook_revision=2,
+            audiobook_publication_state=state,
+        )
+        assert reader._reader_audiobook_capability(book, chapters)["status"] == state

--- a/backend/tests/test_tts_providers.py
+++ b/backend/tests/test_tts_providers.py
@@ -1,3 +1,5 @@
+import base64
+
 import pytest
 
 from backend.app import models
@@ -10,6 +12,20 @@ class _Response:
 
     def raise_for_status(self):
         return None
+
+    def json(self):
+        return {
+            "items": [
+                {
+                    "audio_base64": base64.b64encode(b"first-mp3").decode(),
+                    "duration_ms": 1100,
+                },
+                {
+                    "audio_base64": base64.b64encode(b"second-mp3").decode(),
+                    "duration_ms": 2200,
+                },
+            ]
+        }
 
 
 class _Client:
@@ -56,6 +72,35 @@ async def test_omnivoice_uses_descriptive_profile_and_expression_tags():
     assert request["json"] == {
         "voice": "[gender-female][pitch-low][speed-slow]",
         "text": "[whisper] Keep quiet.",
+    }
+
+
+@pytest.mark.asyncio
+async def test_omnivoice_batches_multiple_sentences_in_one_model_request():
+    settings = models.AudiobookSettings(
+        tts_provider="omnivoice",
+        tts_base_url="http://omnivoice:8001/generate",
+    )
+
+    results = await tts_providers.synthesize_speech_batch(
+        settings,
+        [
+            TTSRequest(text="First.", voice_prompt="[gender-female]"),
+            TTSRequest(text="Second.", voice_prompt="[gender-male]"),
+        ],
+    )
+
+    assert [(result.audio_bytes, result.duration_ms) for result in results] == [
+        (b"first-mp3", 1100),
+        (b"second-mp3", 2200),
+    ]
+    url, request = _Client.calls[0]
+    assert url == "http://omnivoice:8001/generate-batch"
+    assert request["json"] == {
+        "requests": [
+            {"voice": "[gender-female]", "text": "First."},
+            {"voice": "[gender-male]", "text": "Second."},
+        ]
     }
 
 

--- a/docs/READER_AUDIOBOOK_INTEGRATION.md
+++ b/docs/READER_AUDIOBOOK_INTEGRATION.md
@@ -1,0 +1,207 @@
+# Reader Audiobook Integration Contract
+
+This document specifies the Story Manager work required by the Android reader's
+optional generated-audio feature. The existing self-contained `audiobook.epub`
+remains the admin/export artifact. Reader clients use a small text rendition and
+independently cacheable chapter audio/SMIL assets.
+
+## Observed local integration blocker (book 839)
+
+As of 2026-07-20, local book 839 (`Old Man's War`) is a concrete acceptance
+fixture for this contract:
+
+- the admin API reports `audiobook_enabled: true` and
+  `audiobook_pipeline_status: "complete"`;
+- `library/audiobooks/839/audiobook.epub`, `working.epub`, chapter MP3 files,
+  and chapter SMIL files exist;
+- the running Reader OpenAPI advertises none of the audiobook routes below;
+- the current `ReaderBook` schema and `_reader_book_payload` omit `audiobook`.
+
+Consequently, the Android app correctly displays **Unavailable**. The admin
+generation status and self-contained export EPUB are not Reader API capability
+signals. The first backend integration milestone is complete only when an
+authenticated `GET /reader/books/839` includes the optional `audiobook` object
+and its `manifest_url` returns a valid modular manifest. This should be verified
+before debugging Android playback or cache behavior.
+
+## Compatibility and authentication
+
+- All new fields are optional and all new routes use the same reader-key
+  authentication and authorization rules as the existing `/reader` API.
+- Existing reader responses remain valid. A book without generated audio omits
+  `audiobook` or returns it as `null`.
+- The reader never changes generation state. These endpoints are read-only.
+- Reader asset URLs may be relative or absolute, but must remain under the
+  configured Story Manager origin.
+
+## ReaderBook capability
+
+Add an optional `audiobook` object to every endpoint that returns `ReaderBook`,
+including `/reader/books/all`, series/standalone lists, and `/reader/updates`.
+
+```json
+{
+  "audiobook": {
+    "status": "partial",
+    "revision": 7,
+    "source_content_version": 14,
+    "text_content_version": 14,
+    "ready_chapter_count": 11,
+    "total_chapter_count": 18,
+    "ready_audio_bytes": 82944000,
+    "manifest_url": "/reader/books/941/audiobook/manifest"
+  }
+}
+```
+
+`status` is one of `processing`, `partial`, `complete`, or `error`. `revision`
+is monotonically increasing and changes only after the manifest and referenced
+asset state have committed. `text_content_version` identifies the normal EPUB
+content version to which the span-anchored text rendition corresponds.
+
+## Reader endpoints
+
+Add:
+
+- `GET /reader/books/{id}/audiobook/manifest`
+- `GET /reader/books/{id}/audiobook/text`
+- `GET /reader/books/{id}/audiobook/chapters/{chapter_key}/audio?version=N`
+- `GET /reader/books/{id}/audiobook/chapters/{chapter_key}/smil?version=N`
+
+Return `404` when the book has no audiobook capability. Return `409 Conflict`
+for a chapter-version request that is no longer current, with a machine-readable
+response instructing the client to refresh the manifest:
+
+```json
+{
+  "error": "stale_audiobook_revision",
+  "message": "Refresh the audiobook manifest before downloading this chapter.",
+  "current_revision": 8
+}
+```
+
+The text and chapter asset endpoints must:
+
+- provide `Content-Length`, `ETag`, and a useful content type;
+- honor `If-None-Match`;
+- support byte ranges for MP3 responses, including `Accept-Ranges`,
+  `Content-Range`, `206`, and `416`;
+- expose only completely written files by publishing through atomic rename;
+- keep an old version readable until the new manifest revision commits, or
+  return the explicit stale-version conflict above.
+
+## Manifest
+
+Example:
+
+```json
+{
+  "revision": 7,
+  "source_content_version": 14,
+  "text": {
+    "content_version": 14,
+    "size_bytes": 482301,
+    "sha256": "9ab1...",
+    "url": "/reader/books/941/audiobook/text"
+  },
+  "chapters": [
+    {
+      "key": "src-4d58c7",
+      "title": "Chapter 12",
+      "href": "Text/chapter-12.xhtml",
+      "state": "ready",
+      "audio_version": 3,
+      "duration_ms": 844312,
+      "audio_size_bytes": 12664680,
+      "audio_sha256": "c07e...",
+      "smil_size_bytes": 22104,
+      "smil_sha256": "9cd2...",
+      "audio_url": "/reader/books/941/audiobook/chapters/src-4d58c7/audio?version=3",
+      "smil_url": "/reader/books/941/audiobook/chapters/src-4d58c7/smil?version=3"
+    }
+  ]
+}
+```
+
+Requirements:
+
+- `chapters` is in spine order.
+- `key` is opaque, stable across web-story refreshes, and URL safe.
+- `href` is the normalized XHTML resource href in the text rendition.
+- `state` is `pending`, `processing`, `ready`, or `error`.
+- Asset URLs, versions, sizes, and hashes are required for `ready` chapters and
+  may be null otherwise.
+- Hashes are lowercase SHA-256 hex strings over the response body.
+- SMIL text references resolve to stable fragment IDs in the text rendition;
+  audio references resolve to the chapter audio response.
+
+## Durable data model and migration
+
+Use an Alembic migration with a complete downgrade and test it against
+PostgreSQL with representative existing audiobook data. Add durable storage for:
+
+- a stable chapter source identity;
+- normalized source/spine href and source-content hash;
+- title and spine order;
+- chapter audio revision and generation state;
+- MP3/SMIL path, size, hash, and duration;
+- book-level audiobook revision, source-content version, text-content version,
+  pending-content version, enabled flag, state, text path/size/hash, and errors.
+
+The migration must not assume any table is empty or that audiobook tables were
+created by a previous Alembic migration. Preserve existing generated chapters
+and final EPUB records whenever they can be associated safely.
+
+Recommended invariants:
+
+- `(book_id, stable_chapter_key)` is unique.
+- A ready chapter has committed MP3 and SMIL metadata for the same
+  `audio_revision`.
+- A published manifest never points at a temporary or partial file.
+- The reader-visible book revision increments in the same transaction that
+  commits its visible chapter/text metadata.
+
+## Incremental web-story ingestion
+
+Replace destructive audiobook re-ingestion for refreshed web stories with a
+diff:
+
+1. Parse the refreshed EPUB and compute a normalized href and normalized content
+   hash for each reading-order resource.
+2. Match prior chapters by normalized spine href first. If the source moved,
+   match an otherwise-unmatched chapter by unchanged content hash.
+3. Preserve the stable key, character assignments, sentence analysis, generated
+   audio, hashes, and audio revision for unchanged chapters.
+4. Invalidate only changed chapters, create new chapter records, and remove
+   deleted chapters and their unreferenced assets.
+5. Generate XHTML span IDs from the stable chapter key plus stable sentence
+   identity, not mutable spine position.
+6. Publish the refreshed span-anchored text EPUB immediately after ingestion.
+   New and changed chapters appear in the manifest as pending while unchanged
+   chapters remain ready.
+7. When `audiobook_enabled` is true, enqueue only new or changed chapters.
+8. If a refresh lands during active generation, persist `pending_content_version`
+   and process it at the next durable chapter/job boundary. Do not lose either
+   refresh or completed work.
+9. Increment the reader-visible audiobook revision only after all visible
+   manifest and asset metadata has committed.
+
+The generated text EPUB should preserve reading-order hrefs wherever possible so
+the Android reader can carry rendition-neutral locators between the normal and
+span-anchored renditions.
+
+## Backend tests
+
+Add tests for:
+
+- legacy and audiobook-capable `ReaderBook` payloads on every reader listing;
+- reader-key authentication and book authorization for every new route;
+- processing, partial, complete, and error manifests;
+- ETag/`304`, valid and invalid MP3 ranges, `Content-Length`, and stale versions;
+- PostgreSQL upgrade/downgrade with existing audiobook rows;
+- append-one-chapter preserving every previous audio revision and file;
+- edit-one-chapter invalidating only that chapter;
+- chapter removal cleaning unreferenced assets;
+- a web refresh arriving during generation and resuming from the pending version;
+- atomic publication: no manifest can reference an incomplete text, MP3, or SMIL
+  file.

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1589,9 +1589,169 @@
 }
 
 .analysis-overview,
-.character-roster {
+.character-roster,
+.progress-dashboard {
   display: grid;
   gap: 0.8rem;
+}
+
+.progress-live-card,
+.progress-metric,
+.progress-chapters,
+.progress-error-detail,
+.pipeline-error-summary {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+}
+
+.progress-live-card,
+.progress-chapters {
+  padding: 1rem;
+}
+
+.progress-live-heading,
+.progress-metric-heading,
+.progress-chapter-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
+}
+
+.progress-live-heading h3 {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  margin: 0.2rem 0 0;
+  text-transform: capitalize;
+}
+
+.progress-live-pulse {
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 999px;
+  background: var(--accent);
+  box-shadow: 0 0 0 0 rgba(98, 114, 234, 0.4);
+  animation: progress-pulse 1.6s infinite;
+}
+
+@keyframes progress-pulse {
+  70% {
+    box-shadow: 0 0 0 0.5rem rgba(98, 114, 234, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(98, 114, 234, 0);
+  }
+}
+
+.progress-live-detail {
+  margin: 0.9rem 0;
+  font-size: 1rem;
+}
+
+.progress-live-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  color: var(--text-muted);
+  font-size: 0.78rem;
+}
+
+.progress-metric-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.8rem;
+}
+
+.progress-metric {
+  display: grid;
+  gap: 0.55rem;
+  padding: 0.85rem;
+}
+
+.progress-metric progress,
+.progress-chapter-row progress {
+  width: 100%;
+  accent-color: var(--accent);
+}
+
+.progress-metric > span,
+.progress-chapter-row span {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+}
+
+.progress-warning {
+  margin: 0;
+  padding: 0.75rem 0.9rem;
+  border: 1px solid var(--warning);
+  border-radius: var(--radius);
+  background: color-mix(in srgb, var(--warning) 10%, var(--surface));
+}
+
+.progress-error-detail,
+.pipeline-error-summary {
+  padding: 0.75rem 0.9rem;
+}
+
+.progress-error-detail summary,
+.pipeline-error-summary summary {
+  cursor: pointer;
+  color: var(--danger);
+  font-weight: 600;
+}
+
+.progress-error-detail pre,
+.pipeline-error-summary pre {
+  max-height: 14rem;
+  margin: 0.75rem 0 0;
+  overflow: auto;
+  white-space: pre-wrap;
+  font-size: 0.72rem;
+}
+
+.pipeline-error-summary {
+  flex-basis: 100%;
+}
+
+.progress-chapter-list {
+  display: grid;
+  gap: 0.55rem;
+  margin-top: 0.9rem;
+}
+
+.progress-chapter-row {
+  display: grid;
+  grid-template-columns:
+    minmax(7rem, 0.7fr) minmax(10rem, 1fr) minmax(10rem, 1fr)
+    minmax(6rem, auto);
+  padding: 0.65rem 0;
+  border-top: 1px solid var(--border);
+}
+
+.progress-chapter-row > div {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.progress-chapter-state {
+  justify-self: end;
+}
+
+@media (max-width: 900px) {
+  .progress-metric-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .progress-chapter-row {
+    grid-template-columns: 1fr;
+    align-items: stretch;
+  }
+
+  .progress-chapter-state {
+    justify-self: start;
+  }
 }
 
 .roster-controls {

--- a/frontend/src/components/AudiobookPipeline.jsx
+++ b/frontend/src/components/AudiobookPipeline.jsx
@@ -16,6 +16,7 @@ import ScriptEditor from "./audiobook/ScriptEditor";
 import ChapterAssembly from "./audiobook/ChapterAssembly";
 import AnalysisOverview from "./audiobook/AnalysisOverview";
 import AudiobookReader from "./audiobook/AudiobookReader";
+import ProgressDashboard from "./audiobook/ProgressDashboard";
 
 const PIPELINE_STEPS = [
   { status: "ingesting", label: "Ingesting" },
@@ -111,6 +112,7 @@ function JobInspector({ statusData, totalSentences, doneCount }) {
 }
 
 const SUB_TABS = [
+  "Progress",
   "Analysis",
   "Characters",
   "Script Editor",
@@ -121,7 +123,7 @@ const SUB_TABS = [
 function AudiobookPipeline({ book }) {
   const bookId = book.id;
   const queryClient = useQueryClient();
-  const [subTab, setSubTab] = useState("Analysis");
+  const [subTab, setSubTab] = useState("Progress");
   const [confirmRebuild, setConfirmRebuild] = useState(false);
 
   const isActive = (status) => ACTIVE_STATUSES.has(status);
@@ -131,7 +133,9 @@ function AudiobookPipeline({ book }) {
     queryFn: () => getAudiobookStatus(bookId),
     refetchInterval: ({ state }) => {
       const s = state.data?.pipeline_status;
-      return s && isActive(s) ? 3000 : false;
+      const audioStillFinishing =
+        (state.data?.sentence_counts?.audio_generating ?? 0) > 0;
+      return (s && isActive(s)) || audioStillFinishing ? 1000 : false;
     },
   });
 
@@ -148,7 +152,11 @@ function AudiobookPipeline({ book }) {
       const previewActive = state.data?.some((chapter) =>
         ["queued", "generating"].includes(chapter.preview_status),
       );
-      return (s && isActive(s)) || previewActive ? 3000 : false;
+      const audioStillFinishing =
+        (statusData?.sentence_counts?.audio_generating ?? 0) > 0;
+      return (s && isActive(s)) || previewActive || audioStillFinishing
+        ? 1000
+        : false;
     },
   });
 
@@ -242,7 +250,10 @@ function AudiobookPipeline({ book }) {
             <span className="badge badge--warning">Pause requested…</span>
           )}
           {statusData?.last_error && (
-            <p className="error">{statusData.last_error}</p>
+            <details className="pipeline-error-summary">
+              <summary>Last pipeline error</summary>
+              <pre>{statusData.last_error}</pre>
+            </details>
           )}
         </div>
 
@@ -367,6 +378,9 @@ function AudiobookPipeline({ book }) {
       </nav>
 
       <div className="sub-tab-content">
+        {subTab === "Progress" && (
+          <ProgressDashboard status={statusData} chapters={chapters} />
+        )}
         {subTab === "Analysis" && (
           <AnalysisOverview status={statusData} chapters={chapters} />
         )}

--- a/frontend/src/components/AudiobookPipeline.test.jsx
+++ b/frontend/src/components/AudiobookPipeline.test.jsx
@@ -52,8 +52,8 @@ describe("AudiobookPipeline", () => {
     renderWithClient(<AudiobookPipeline book={{ id: 11 }} />);
 
     expect(
-      await screen.findByText("EPUB contains no narratable text."),
-    ).toBeInTheDocument();
+      await screen.findAllByText("EPUB contains no narratable text."),
+    ).toHaveLength(2);
     fireEvent.click(
       screen.getByRole("button", { name: "Run Next Stage: Ingesting" }),
     );
@@ -77,7 +77,10 @@ describe("AudiobookPipeline", () => {
               pause_requested: false,
               stop_after_phase: null,
               last_error: null,
-              sentence_counts: { pending_diarization: 100 },
+              sentence_counts: {
+                pending_diarization: 60,
+                ready_for_audio: 40,
+              },
               review_counts: {
                 low_confidence: 2,
                 unassigned: 100,
@@ -133,6 +136,9 @@ describe("AudiobookPipeline", () => {
     renderWithClient(<AudiobookPipeline book={{ id: 11 }} />);
 
     expect(await screen.findByText("ollama / qwen3.5:27b")).toBeInTheDocument();
+    expect(screen.getByText("Speaker analysis")).toBeInTheDocument();
+    expect(screen.getByText("40%")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Analysis" }));
     expect(screen.getAllByText("A test story summary.")).toHaveLength(2);
     expect(screen.getByText("The story begins.")).toBeInTheDocument();
     expect(

--- a/frontend/src/components/audiobook/ProgressDashboard.jsx
+++ b/frontend/src/components/audiobook/ProgressDashboard.jsx
@@ -1,0 +1,250 @@
+import { useEffect, useRef, useState } from "react";
+
+const ACTIVE_STATUSES = new Set([
+  "ingesting",
+  "roster_gen",
+  "diarizing",
+  "audio_gen",
+  "assembling",
+]);
+
+function percent(current, total) {
+  return total ? Math.round((current * 1000) / total) / 10 : 0;
+}
+
+function formatRate(rate) {
+  return rate > 0 ? `${rate.toFixed(1)} sentences/min` : "Measuring…";
+}
+
+function formatEta(remaining, rate) {
+  if (!(rate > 0) || remaining <= 0)
+    return remaining <= 0 ? "Complete" : "ETA pending";
+  const minutes = remaining / rate;
+  if (minutes < 1) return "< 1 min remaining";
+  if (minutes < 60) return `~${Math.ceil(minutes)} min remaining`;
+  return `~${(minutes / 60).toFixed(1)} hr remaining`;
+}
+
+function useProgressRates(analyzed, audio) {
+  const samples = useRef([]);
+  const [rates, setRates] = useState({ analysis: 0, audio: 0 });
+
+  useEffect(() => {
+    const now = Date.now();
+    samples.current.push({ now, analyzed, audio });
+    samples.current = samples.current.filter(
+      (sample) => now - sample.now <= 120_000,
+    );
+    const baseline = samples.current[0];
+    const elapsedMinutes = (now - baseline.now) / 60_000;
+    if (elapsedMinutes <= 0) return;
+    setRates({
+      analysis: Math.max(0, (analyzed - baseline.analyzed) / elapsedMinutes),
+      audio: Math.max(0, (audio - baseline.audio) / elapsedMinutes),
+    });
+  }, [analyzed, audio]);
+
+  return rates;
+}
+
+function ProgressMetric({ label, current, total, detail }) {
+  const value = percent(current, total);
+  return (
+    <article className="progress-metric">
+      <div className="progress-metric-heading">
+        <span className="metric-label">{label}</span>
+        <strong>{value}%</strong>
+      </div>
+      <progress value={current} max={Math.max(1, total)} />
+      <span>
+        {current.toLocaleString()} / {total.toLocaleString()} {detail}
+      </span>
+    </article>
+  );
+}
+
+function ProgressDashboard({ status, chapters = [] }) {
+  const counts = status?.sentence_counts ?? {};
+  const totalSentences = Object.values(counts).reduce(
+    (sum, count) => sum + count,
+    0,
+  );
+  const pendingAnalysis = counts.pending_diarization ?? 0;
+  const analyzedSentences = Math.max(0, totalSentences - pendingAnalysis);
+  const generatedAudio = counts.audio_generated ?? 0;
+  const failedAudio = counts.error ?? 0;
+  const analyzedChapters = chapters.filter(
+    (chapter) =>
+      chapter.sentence_count > 0 &&
+      chapter.processed_sentence_count >= chapter.sentence_count,
+  ).length;
+  const assembledChapters = chapters.filter(
+    (chapter) =>
+      chapter.sentence_count > 0 &&
+      chapter.audio_generated_count >= chapter.sentence_count &&
+      chapter.audio_file_path &&
+      chapter.smil_file_path,
+  ).length;
+  const active = ACTIVE_STATUSES.has(status?.pipeline_status);
+  const rates = useProgressRates(analyzedSentences, generatedAudio);
+  const receiving = status?.progress_detail?.includes("receiving ");
+  const startedAt = status?.pipeline_started_at
+    ? new Date(status.pipeline_started_at)
+    : null;
+  const updatedAt = status?.pipeline_updated_at
+    ? new Date(status.pipeline_updated_at)
+    : null;
+
+  return (
+    <div className="progress-dashboard">
+      <section className="progress-live-card">
+        <div className="progress-live-heading">
+          <div>
+            <span className="metric-label">Current activity</span>
+            <h3>
+              {status?.pipeline_status || "Not started"}
+              {active && (
+                <span className="progress-live-pulse" aria-label="working" />
+              )}
+            </h3>
+          </div>
+          <span
+            className={`badge ${
+              status?.pipeline_status === "error"
+                ? "badge--error"
+                : active
+                  ? "badge--success"
+                  : "badge--neutral"
+            }`}
+          >
+            {receiving
+              ? "Streaming model response"
+              : status?.pipeline_status || "idle"}
+          </span>
+        </div>
+        <p className="progress-live-detail">
+          {status?.progress_detail || "Waiting for the next pipeline action."}
+        </p>
+        <div className="progress-live-meta">
+          <span>{status?.llm_requests ?? 0} model requests this run</span>
+          <span>
+            Analysis: {formatRate(rates.analysis)} ·{" "}
+            {formatEta(totalSentences - analyzedSentences, rates.analysis)}
+          </span>
+          <span>
+            Audio: {formatRate(rates.audio)} ·{" "}
+            {formatEta(totalSentences - generatedAudio, rates.audio)}
+          </span>
+          {status?.pipeline_status === "diarizing" && (
+            <span>Analysis and speech lanes are running concurrently</span>
+          )}
+          {startedAt && <span>Started {startedAt.toLocaleString()}</span>}
+          {updatedAt && <span>Updated {updatedAt.toLocaleTimeString()}</span>}
+        </div>
+      </section>
+
+      <section className="progress-metric-grid" aria-label="Pipeline totals">
+        <ProgressMetric
+          label="Speaker analysis"
+          current={analyzedSentences}
+          total={totalSentences}
+          detail="sentences attributed"
+        />
+        <ProgressMetric
+          label="Speech generation"
+          current={generatedAudio}
+          total={totalSentences}
+          detail="sentence clips ready"
+        />
+        <ProgressMetric
+          label="Chapter analysis"
+          current={analyzedChapters}
+          total={chapters.length}
+          detail="chapters analyzed"
+        />
+        <ProgressMetric
+          label="Chapter assembly"
+          current={assembledChapters}
+          total={chapters.length}
+          detail="chapters assembled"
+        />
+      </section>
+
+      {failedAudio > 0 && (
+        <p className="progress-warning">
+          {failedAudio} sentence{failedAudio === 1 ? "" : "s"} currently need an
+          audio retry.
+        </p>
+      )}
+
+      {status?.last_error && (
+        <details className="progress-error-detail">
+          <summary>Most recent recoverable pipeline error</summary>
+          <pre>{status.last_error}</pre>
+        </details>
+      )}
+
+      <section className="progress-chapters">
+        <div className="analysis-section-heading">
+          <div>
+            <span className="metric-label">Per-chapter work</span>
+            <h3>Analysis and audio progress</h3>
+          </div>
+        </div>
+        <div className="progress-chapter-list">
+          {chapters.map((chapter) => (
+            <article className="progress-chapter-row" key={chapter.id}>
+              <strong>Chapter {chapter.chapter_number}</strong>
+              <div>
+                <span>
+                  Analysis{" "}
+                  {percent(
+                    chapter.processed_sentence_count,
+                    chapter.sentence_count,
+                  )}
+                  %
+                </span>
+                <progress
+                  value={chapter.processed_sentence_count}
+                  max={Math.max(1, chapter.sentence_count)}
+                />
+              </div>
+              <div>
+                <span>
+                  Audio{" "}
+                  {percent(
+                    chapter.audio_generated_count,
+                    chapter.sentence_count,
+                  )}
+                  %
+                </span>
+                <progress
+                  value={chapter.audio_generated_count}
+                  max={Math.max(1, chapter.sentence_count)}
+                />
+              </div>
+              <span className="progress-chapter-state">
+                {chapter.sentence_count > 0 &&
+                chapter.audio_generated_count >= chapter.sentence_count &&
+                chapter.audio_file_path &&
+                chapter.smil_file_path
+                  ? "Assembled"
+                  : chapter.audio_generated_count
+                    ? "Generating audio"
+                    : chapter.sentence_count > 0 &&
+                        chapter.processed_sentence_count >=
+                          chapter.sentence_count
+                      ? "Ready for audio"
+                      : chapter.processed_sentence_count
+                        ? "Analyzing"
+                        : "Waiting"}
+              </span>
+            </article>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+export default ProgressDashboard;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -12,6 +12,7 @@
   --danger: #d94f4f;
   --danger-hover: #e96060;
   --success: #4caf7d;
+  --warning: #d68f2c;
   --radius: 8px;
   --radius-sm: 5px;
   --radius-lg: 12px;

--- a/services/omnivoice/README.md
+++ b/services/omnivoice/README.md
@@ -2,7 +2,9 @@
 
 This service wraps the official Apache-2.0
 [`k2-fsa/OmniVoice`](https://github.com/k2-fsa/OmniVoice) 0.2.0 model in Story Manager's
-`POST /generate` HTTP contract. It keeps the model loaded between sentence requests and returns MP3 bytes.
+`POST /generate` HTTP contract. It keeps the model loaded between sentence requests and returns MP3 bytes. It also
+offers `POST /generate-batch` for accelerators where native model batching improves throughput; Story Manager falls
+back to isolated sentence requests if a batch fails.
 
 ## Run
 
@@ -60,7 +62,13 @@ The image is rebuilt and published only when files under `services/omnivoice/` o
 | `OMNIVOICE_DEVICE` | `auto` | Force `mps`, `cuda`, `xpu`, or `cpu` |
 | `OMNIVOICE_NUM_STEPS` | `16` | Diffusion steps; use `32` for higher quality/slower output |
 | `OMNIVOICE_MP3_BITRATE` | `96k` | Returned MP3 bitrate |
+| `OMNIVOICE_MAX_BATCH_SIZE` | `8` | Maximum items accepted by `POST /generate-batch` |
 | `OMNIVOICE_PORT` | `8001` | Port used by the Make target |
+
+Story Manager controls submitted batch size with `AUDIOBOOK_TTS_BATCH_SIZE` (default `4`) and length-buckets
+independent clips before submission. Bucketing matters on Apple MPS because every native batch is padded to its
+longest item; mixed-length batches can be slower than single inference. `AUDIOBOOK_TTS_WORKERS` defaults to `1`;
+analysis and speech still run concurrently in separate pipeline lanes.
 
 Legacy Story Manager profiles such as `[gender-female][pitch-low][speed-normal]` are translated into the official
 comma-separated voice-design attributes. Official instructions such as `female, middle-aged, low pitch` are also

--- a/services/omnivoice/server.py
+++ b/services/omnivoice/server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 from contextlib import asynccontextmanager
 from io import BytesIO
 import logging
@@ -13,16 +14,16 @@ import threading
 # long audiobook run. This must be set before importing torch.
 os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
 
-import numpy as np
-from fastapi import FastAPI, HTTPException
-from fastapi.responses import Response
-from omnivoice import OmniVoice
-from omnivoice.utils.common import get_best_device
-from pydantic import BaseModel, Field
-from pydub import AudioSegment
-import torch
+import numpy as np  # noqa: E402
+from fastapi import FastAPI, HTTPException  # noqa: E402
+from fastapi.responses import Response  # noqa: E402
+from omnivoice import OmniVoice  # noqa: E402
+from omnivoice.utils.common import get_best_device  # noqa: E402
+from pydantic import BaseModel, Field  # noqa: E402
+from pydub import AudioSegment  # noqa: E402
+import torch  # noqa: E402
 
-from .prompt import translate_generation_prompt
+from .prompt import translate_generation_prompt  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
@@ -30,12 +31,39 @@ MODEL_ID = os.getenv("OMNIVOICE_MODEL", "k2-fsa/OmniVoice")
 DEVICE = os.getenv("OMNIVOICE_DEVICE", "auto")
 NUM_STEPS = int(os.getenv("OMNIVOICE_NUM_STEPS", "16"))
 MP3_BITRATE = os.getenv("OMNIVOICE_MP3_BITRATE", "96k")
+MAX_BATCH_SIZE = max(1, int(os.getenv("OMNIVOICE_MAX_BATCH_SIZE", "8")))
 
 
 class GenerateRequest(BaseModel):
     text: str = Field(min_length=1, max_length=4000)
     voice: str | None = None
     language: str | None = None
+
+
+class BatchGenerateRequest(BaseModel):
+    requests: list[GenerateRequest] = Field(min_length=1, max_length=MAX_BATCH_SIZE)
+
+
+class BatchGenerateItem(BaseModel):
+    audio_base64: str
+    duration_ms: int
+
+
+class BatchGenerateResponse(BaseModel):
+    items: list[BatchGenerateItem]
+
+
+def _encode_audio(audio: np.ndarray, sampling_rate: int) -> tuple[bytes, int]:
+    pcm = np.clip(audio * 32767, -32768, 32767).astype(np.int16)
+    segment = AudioSegment(
+        pcm.tobytes(),
+        frame_rate=sampling_rate,
+        sample_width=2,
+        channels=1,
+    )
+    output = BytesIO()
+    segment.export(output, format="mp3", bitrate=MP3_BITRATE)
+    return output.getvalue(), len(segment)
 
 
 class OmniVoiceRuntime:
@@ -56,31 +84,25 @@ class OmniVoiceRuntime:
         logger.info("OmniVoice ready at %s Hz.", self.model.sampling_rate)
 
     def generate(self, request: GenerateRequest) -> tuple[bytes, int]:
+        return self.generate_batch([request])[0]
+
+    def generate_batch(self, requests: list[GenerateRequest]) -> list[tuple[bytes, int]]:
         if self.model is None:
             raise RuntimeError("OmniVoice model is not loaded")
 
-        prompt = translate_generation_prompt(request.voice, request.text)
+        prompts = [translate_generation_prompt(request.voice, request.text) for request in requests]
         with self._generate_lock:
-            audio = self.model.generate(
-                text=prompt.text,
-                language=request.language,
-                instruct=prompt.instruct,
-                speed=prompt.speed,
+            audios = self.model.generate(
+                text=[prompt.text for prompt in prompts],
+                language=[request.language for request in requests],
+                instruct=[prompt.instruct for prompt in prompts],
+                speed=[prompt.speed for prompt in prompts],
                 num_step=NUM_STEPS,
                 class_temperature=0.0,
                 postprocess_output=True,
-            )[0]
+            )
 
-        pcm = np.clip(audio * 32767, -32768, 32767).astype(np.int16)
-        segment = AudioSegment(
-            pcm.tobytes(),
-            frame_rate=self.model.sampling_rate,
-            sample_width=2,
-            channels=1,
-        )
-        output = BytesIO()
-        segment.export(output, format="mp3", bitrate=MP3_BITRATE)
-        return output.getvalue(), len(segment)
+        return [_encode_audio(audio, self.model.sampling_rate) for audio in audios]
 
 
 runtime = OmniVoiceRuntime()
@@ -102,6 +124,7 @@ async def health() -> dict[str, object]:
         "model": MODEL_ID,
         "device": runtime.device,
         "num_steps": NUM_STEPS,
+        "max_batch_size": MAX_BATCH_SIZE,
     }
 
 
@@ -119,4 +142,22 @@ async def generate(request: GenerateRequest) -> Response:
             "X-Audio-Duration-Ms": str(duration_ms),
             "X-OmniVoice-Device": runtime.device,
         },
+    )
+
+
+@app.post("/generate-batch", response_model=BatchGenerateResponse)
+async def generate_batch(request: BatchGenerateRequest) -> BatchGenerateResponse:
+    try:
+        generated = await asyncio.to_thread(runtime.generate_batch, request.requests)
+    except Exception as exc:
+        logger.exception("OmniVoice batch generation failed.")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    return BatchGenerateResponse(
+        items=[
+            BatchGenerateItem(
+                audio_base64=base64.b64encode(audio).decode("ascii"),
+                duration_ms=duration_ms,
+            )
+            for audio, duration_ms in generated
+        ]
     )


### PR DESCRIPTION
## Summary

- stream and recover malformed or truncated LLM diarization responses, retrying only missing sentence IDs
- run durable, concurrent TTS generation with adaptive batching and resumable assembly
- expose generated audiobooks through authenticated Reader capability, manifest, text, MP3, and SMIL endpoints
- publish versioned Reader assets atomically with ETags, hashes, sizes, MP3 range support, and stale-version conflicts
- preserve unchanged audiobook chapters across web-story refreshes while invalidating only edited or removed content
- persist pending content versions and restart active builds at durable phase boundaries
- add durable publication metadata with a reversible PostgreSQL migration
- add detailed pipeline progress and exact EPUB 3 media-overlay timelines

## Root cause

Long diarization responses could be truncated mid-JSON, aborting an entire batch. Separately, completed audiobook files existed only as admin/export artifacts: ReaderBook responses omitted audiobook capability metadata and the Reader asset routes did not exist, so Android correctly displayed **Unavailable**.

## Impact

Audiobook builds retain valid partial LLM work, resume safely, and generate speech concurrently. Completed and partially generated audiobooks are now discoverable by Reader clients. Web-story refreshes immediately publish a span-anchored text rendition, preserve unchanged audio, and queue only new or changed chapters.

Book 839 now reports a complete Reader audiobook with 30/30 chapters ready and 417,006,054 bytes of available audio.

## Validation

- 294 backend tests passed
- 39 frontend tests passed
- backend formatting, autoflake, and flake8 passed
- frontend ESLint passed
- PostgreSQL upgrade/downgrade passed, including representative existing audiobook rows
- Playwright E2E passed
- Android Reader `testDebugUnitTest` passed
- all GitHub CI, E2E, migration, audit, preview-image, and OmniVoice-image checks passed
- Book 839 Reader capability, manifest, text, MP3 range, and SMIL endpoints verified live
- Book 839 EPUBCheck: 0 errors and 0 warnings
