### PR TITLE
Improve audiobook attribution and local service startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,6 +178,9 @@ frontend/dist/
 # Docker Compose persistent data
 pgdata/
 
+# Detached local development service logs and PID files
+.run/
+
 .idea
 test-results
 frontend/playwright-report

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup setup-omnivoice run-omnivoice pull-ollama-model run-ui run-api run-db ensure-db migrate fmt lint test test-migrations e2e e2e-debug
+.PHONY: help start start-services services-status setup setup-omnivoice run-omnivoice pull-ollama-model run-ui run-api run-db ensure-db migrate fmt lint test test-migrations e2e e2e-debug
 
 E2E_DB_CONTAINER ?= story-manager-e2e-db
 E2E_DB_PORT ?= 5434
@@ -6,6 +6,8 @@ OMNIVOICE_PORT ?= 8001
 
 help:
 	@echo "Story Manager commands:"
+	@echo "  make start            Start all missing local services"
+	@echo "  make services-status  Show local service health"
 	@echo "  make setup            Install project dependencies"
 	@echo "  make ensure-db        Create or start the local PostgreSQL container"
 	@echo "  make migrate          Run Alembic migrations"
@@ -18,6 +20,14 @@ help:
 	@echo "  make test-migrations  Run migrations against throwaway PostgreSQL"
 	@echo "  make e2e              Run Playwright E2E tests"
 	@echo "  make e2e-debug        Run Playwright E2E tests in debug mode"
+
+start: start-services
+
+start-services:
+	./scripts/start-services.sh start
+
+services-status:
+	./scripts/start-services.sh status
 
 setup:
 	pyenv install -s

--- a/README.md
+++ b/README.md
@@ -254,15 +254,19 @@ uv pip install -e ".[dev]"
 cd frontend && npm ci && cd ..
 ```
 
-Start PostgreSQL and run the app:
+Start every local service with one command:
 
 ```bash
-make ensure-db
-make run-api
-make run-ui
+make start
 ```
 
-The development UI runs at `http://localhost:5173`; the API runs at `http://localhost:8000`.
+The command starts only missing services: PostgreSQL, Ollama, the API, the UI, and OmniVoice. It waits for health
+checks, leaves healthy existing processes alone, and runs detached services with logs under `.run/logs/`. Check
+their current state at any time with `make services-status`.
+
+The development UI runs at `http://localhost:5173`; the API runs at `http://localhost:8000`. The first OmniVoice
+setup can take several minutes. If the recommended Ollama model is missing, install it with
+`make pull-ollama-model`.
 
 Useful commands:
 

--- a/backend/app/routers/audiobook.py
+++ b/backend/app/routers/audiobook.py
@@ -104,6 +104,7 @@ class ChapterResponse(BaseModel):
     id: int
     book_id: int
     chapter_number: int
+    title: Optional[str]
     content_file_name: Optional[str]
     smil_file_path: Optional[str]
     audio_file_path: Optional[str]
@@ -536,6 +537,7 @@ async def list_chapters(book_id: int, db: AsyncSession = Depends(get_db)) -> lis
                 id=chapter.id,
                 book_id=chapter.book_id,
                 chapter_number=chapter.chapter_number,
+                title=chapter.title,
                 content_file_name=chapter.content_file_name,
                 smil_file_path=chapter.smil_file_path,
                 audio_file_path=chapter.audio_file_path,

--- a/backend/app/services/audiobook_ingestion.py
+++ b/backend/app/services/audiobook_ingestion.py
@@ -22,6 +22,7 @@ from .audiobook_publication import (
     stable_chapter_key,
     stage_reader_text_rendition,
 )
+from .audiobook_text import SpeechSegment, split_speech_segments
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +49,38 @@ def _tokenize_text(text: str) -> list[str]:
     nlp = _get_nlp()
     doc = nlp(text)
     return [sent.text.strip() for sent in doc.sents if sent.text.strip()]
+
+
+def _tokenize_speech_units(
+    text: str,
+    quote_state: str | None = None,
+) -> tuple[list[SpeechSegment], str | None]:
+    """Tokenize within quote-aware speaker spans instead of across them."""
+
+    segments, ending_quote_state = split_speech_segments(text, quote_state)
+    units: list[SpeechSegment] = []
+    for segment in segments:
+        tokenized = _tokenize_text(segment.text) if segment.has_speech else []
+        if not tokenized:
+            if units:
+                previous = units[-1]
+                units[-1] = SpeechSegment(
+                    text=f"{previous.text} {segment.text}".strip(),
+                    is_dialogue=previous.is_dialogue,
+                    starts_quote=previous.starts_quote,
+                    ends_quote=segment.ends_quote or previous.ends_quote,
+                )
+            continue
+        for index, value in enumerate(tokenized):
+            units.append(
+                SpeechSegment(
+                    text=value,
+                    is_dialogue=segment.is_dialogue,
+                    starts_quote=segment.starts_quote and index == 0,
+                    ends_quote=segment.ends_quote and index == len(tokenized) - 1,
+                )
+            )
+    return units, ending_quote_state
 
 
 def _span_for_sentence(span_id: str, text: str):
@@ -99,7 +132,8 @@ def _inject_spans_into_text_node(
     start_seq: int,
     occurrences: Counter[str],
     existing_ids: list[str] | None = None,
-) -> tuple[int, list[dict]]:
+    quote_state: str | None = None,
+) -> tuple[int, list[dict], str | None]:
     """Wrap one text node's sentences without disturbing surrounding markup.
 
     Returns (next_sequence_number, list_of_sentence_dicts).
@@ -110,11 +144,11 @@ def _inject_spans_into_text_node(
     raw_text = str(text_node)
     stripped = raw_text.strip()
     if not stripped or _should_skip_text_node(text_node):
-        return seq, sentences_data
+        return seq, sentences_data, quote_state
 
-    sentences = _tokenize_text(stripped)
-    if not sentences:
-        return seq, sentences_data
+    speech_units, quote_state = _tokenize_speech_units(stripped, quote_state)
+    if not speech_units:
+        return seq, sentences_data, quote_state
 
     leading_whitespace = raw_text[: len(raw_text) - len(raw_text.lstrip())]
     trailing_start = len(raw_text.rstrip())
@@ -123,7 +157,8 @@ def _inject_spans_into_text_node(
     if leading_whitespace:
         replacement_nodes.append(NavigableString(leading_whitespace))
 
-    for index, sent_text in enumerate(sentences):
+    for index, speech_unit in enumerate(speech_units):
+        sent_text = speech_unit.text
         if index > 0:
             replacement_nodes.append(NavigableString(" "))
         normalized = " ".join(sent_text.split()).casefold()
@@ -151,14 +186,44 @@ def _inject_spans_into_text_node(
         replacement_nodes.append(NavigableString(trailing_whitespace))
 
     _replace_text_node(text_node, replacement_nodes)
-    return seq, sentences_data
+    return seq, sentences_data, quote_state
 
 
 def _source_content_hash(soup: BeautifulSoup) -> str:
     return hashlib.sha256(str(soup).encode("utf-8")).hexdigest()
 
 
-def _chapter_title(item, soup: BeautifulSoup, chapter_number: int) -> str:
+def _toc_title_map(toc_items) -> dict[str, str]:
+    titles: dict[str, str] = {}
+
+    def visit(items) -> None:
+        for item in items or []:
+            if isinstance(item, (tuple, list)):
+                if item:
+                    visit([item[0]])
+                if len(item) > 1:
+                    visit(item[1])
+                continue
+            href = (getattr(item, "href", None) or "").partition("#")[0]
+            title = (getattr(item, "title", None) or "").strip()
+            if href and title:
+                key = normalize_resource_href(href).casefold()
+                titles.setdefault(key, title[:500])
+
+    visit(toc_items)
+    return titles
+
+
+def _chapter_title(
+    item,
+    soup: BeautifulSoup,
+    chapter_number: int,
+    toc_titles: dict[str, str] | None = None,
+) -> str:
+    href = normalize_resource_href(getattr(item, "file_name", None) or item.get_name()).casefold()
+    toc_title = (toc_titles or {}).get(href, "").strip()
+    if toc_title:
+        return toc_title
     title = (getattr(item, "title", None) or "").strip()
     if title:
         return title
@@ -172,11 +237,13 @@ def _chapter_title(item, soup: BeautifulSoup, chapter_number: int) -> str:
 
 def _sentence_texts(soup: BeautifulSoup) -> list[str]:
     texts: list[str] = []
+    quote_state: str | None = None
     container = soup.body or soup
     for text_node in list(container.find_all(string=True)):
         stripped = str(text_node).strip()
         if stripped and not _should_skip_text_node(text_node):
-            texts.extend(_tokenize_text(stripped))
+            units, quote_state = _tokenize_speech_units(stripped, quote_state)
+            texts.extend(unit.text for unit in units)
     return texts
 
 
@@ -218,6 +285,7 @@ async def ingest_epub(book_id: int, db: AsyncSession) -> None:
         ebook = epub.read_epub(str(source_snapshot))
     finally:
         source_snapshot.unlink(missing_ok=True)
+    toc_titles = _toc_title_map(ebook.toc)
     existing_chapters = await crud.audiobook.get_chapters_for_book(db, book_id)
     existing_chapter_ids = {chapter.id for chapter in existing_chapters}
     existing_sentences = {
@@ -277,7 +345,7 @@ async def ingest_epub(book_id: int, db: AsyncSession) -> None:
                 stable_chapter_key=key,
                 source_href=href,
                 source_content_hash=content_hash,
-                title=_chapter_title(item, soup, chapter_num),
+                title=_chapter_title(item, soup, chapter_num, toc_titles),
                 spine_order=chapter_num - 1,
                 generation_state="pending",
                 needs_reassembly=True,
@@ -303,17 +371,19 @@ async def ingest_epub(book_id: int, db: AsyncSession) -> None:
         chapter_sentences: list[dict] = []
         seq = 0
         occurrences: Counter[str] = Counter()
+        quote_state: str | None = None
 
         # Process text nodes in document order. This preserves existing block and
         # inline structure while adding stable sentence-level anchors.
         container = soup.body or soup
         for text_node in list(container.find_all(string=True)):
-            seq, new_sentences = _inject_spans_into_text_node(
+            seq, new_sentences, quote_state = _inject_spans_into_text_node(
                 text_node,
                 key,
                 seq,
                 occurrences,
                 existing_ids,
+                quote_state,
             )
             chapter_sentences.extend(new_sentences)
 
@@ -329,7 +399,7 @@ async def ingest_epub(book_id: int, db: AsyncSession) -> None:
         chapter.stable_chapter_key = key
         chapter.source_href = href
         chapter.source_content_hash = content_hash
-        chapter.title = _chapter_title(item, soup, chapter_num)
+        chapter.title = _chapter_title(item, soup, chapter_num, toc_titles)
         chapter.spine_order = chapter_num - 1
 
         if not unchanged:

--- a/backend/app/services/audiobook_llm.py
+++ b/backend/app/services/audiobook_llm.py
@@ -16,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import crud
 from ..models import AudiobookSettings, Book
+from .audiobook_text import quote_group_ids, quote_groups
 
 logger = logging.getLogger(__name__)
 
@@ -64,8 +65,10 @@ You are a script editor. Assign each sentence to a speaker from the character ro
 expression tags where appropriate.
 
 Assign quoted dialogue to the person speaking it, even when the attribution (for example, "she asked") is in an
-adjacent sentence. Keep attribution and action prose on Narrator. If an unnamed or one-scene speaker is absent from
-the recurring roster, use "Minor Female Voice" or "Minor Male Voice" when present instead of Narrator.
+adjacent sentence. Sentences with the same non-null `quote_group` are continuations of one uninterrupted quotation
+and MUST receive the same character id. Keep attribution and action prose on Narrator. If an unnamed or one-scene
+speaker is absent from the recurring roster, use "Minor Female Voice" or "Minor Male Voice" when present instead
+of Narrator.
 
 Character roster (JSON):
 {roster_json}
@@ -84,16 +87,43 @@ do not omit or duplicate an id). Assign only the `text`; use `previous_text` and
 speaker attribution:
 - i: the sentence id (integer)
 - c: the character id from the roster (use the narrator's id for narration; null if uncertain)
-- e: one of "laughter", "sigh", "whisper", "shout", or null. Do not repeat the sentence text.
+- e: one of "laughter", "sigh", "whisper", "surprise-oh", "dissatisfaction-hnn", "confirmation-en", or null.
+  Use a non-null value ONLY when the sentence or its immediate context explicitly names that delivery (for example,
+  laughed, sighed, whispered, gasped, grunted, or nodded). Do not infer a sound from the topic, punctuation, mood, or
+  character personality; otherwise use null. Do not repeat the sentence text.
 
 Return minified, single-line JSON with the key assignments. Do not add whitespace, markdown, explanation, repeated
 sentence text, or chapter summary.
 """
 
-_ALLOWED_EXPRESSION_TAGS = {"laughter", "sigh", "whisper", "shout"}
+_EXPRESSION_TAG_CHOICES = (
+    "laughter",
+    "sigh",
+    "whisper",
+    "surprise-oh",
+    "dissatisfaction-hnn",
+    "confirmation-en",
+)
+_ALLOWED_EXPRESSION_TAGS = set(_EXPRESSION_TAG_CHOICES)
+_EXPRESSION_CUES = {
+    "laughter": re.compile(r"\b(?:laugh|chuckl|giggl|snicker)\w*\b", re.IGNORECASE),
+    "sigh": re.compile(r"\bsigh\w*\b", re.IGNORECASE),
+    "whisper": re.compile(r"\b(?:whisper|murmur|mutter)\w*\b|under (?:his|her|their) breath", re.IGNORECASE),
+    "surprise-oh": re.compile(r"\b(?:surpris|gasp|startl|exclaim)\w*\b", re.IGNORECASE),
+    "dissatisfaction-hnn": re.compile(
+        r"\b(?:dissatisf|disapprov|grunt|grumbl|annoy|irritat)\w*\b",
+        re.IGNORECASE,
+    ),
+    "confirmation-en": re.compile(r"\b(?:confirm|nod|affirm)\w*\b", re.IGNORECASE),
+}
 _BRACKET_TAG_RE = re.compile(r"\[([^\[\]]+)\]")
+_VOICE_GENDER_RE = re.compile(r"\[gender-(male|female|neutral)\]", re.IGNORECASE)
 _GENDERED_ATTRIBUTION_RE = re.compile(
     r"\b(she|he)\s+(?:said|asked|replied|yelled|shouted|whispered|muttered|added|continued|answered|snapped)\b",
+    re.IGNORECASE,
+)
+_FIRST_PERSON_ATTRIBUTION_RE = re.compile(
+    r"\bI\s+(?:said|asked|replied|yelled|shouted|whispered|muttered|added|continued|answered|snapped)\b",
     re.IGNORECASE,
 )
 _NARRATION_REASON_RE = re.compile(
@@ -160,7 +190,7 @@ DIARIZATION_SCHEMA = {
                     "c": {"type": ["integer", "null"]},
                     "e": {
                         "type": ["string", "null"],
-                        "enum": [None, "laughter", "sigh", "whisper", "shout"],
+                        "enum": [None, *_EXPRESSION_TAG_CHOICES],
                     },
                 },
                 "required": ["i", "c", "e"],
@@ -200,6 +230,114 @@ def _sentence_ids_requiring_diarization(sentences: list[Any]) -> set[int]:
         if starts_in_dialogue or contains_quote or in_dialogue:
             requiring_model.add(sentence.id)
     return requiring_model
+
+
+def _quote_speaker_overrides(
+    sentences: list[Any],
+    *,
+    narrator_id: int | None,
+    minor_female_id: int | None,
+    minor_male_id: int | None,
+    character_aliases: dict[int, list[str]] | None = None,
+) -> dict[int, int]:
+    """Choose one grounded speaker when a continuous quote is inconsistent."""
+
+    by_id = {sentence.id: sentence for sentence in sentences}
+    overrides: dict[int, int] = {}
+    minor_ids = {minor_female_id, minor_male_id} - {None}
+    sentence_positions = {sentence.id: index for index, sentence in enumerate(sentences)}
+
+    def named_attribution(text: str) -> int | None:
+        for character_id, aliases in (character_aliases or {}).items():
+            for alias in sorted(aliases, key=len, reverse=True):
+                if not alias.strip():
+                    continue
+                name = re.escape(alias.strip())
+                verb = r"(?:said|asked|replied|yelled|shouted|whispered|muttered|added|continued|answered|snapped)"
+                if re.search(rf"\b(?:{name})\s+{verb}\b|\b{verb}\s+(?:{name})\b", text, re.IGNORECASE):
+                    return character_id
+        return None
+
+    groups = quote_groups(sentences)
+    membership_counts = Counter(sentence_id for group in groups for sentence_id in group)
+
+    for sentence_ids in groups:
+        # A sentence such as `"This"—he pointed—"is Earth"` belongs to two
+        # distinct quote spans. Its row-level speaker cannot represent both
+        # spans, so leave that bridge sentence alone and only harmonize the
+        # unambiguous continuation rows around it.
+        harmonized_ids = [sentence_id for sentence_id in sentence_ids if membership_counts[sentence_id] == 1]
+        if len(harmonized_ids) < 2:
+            continue
+        members = [by_id[sentence_id] for sentence_id in harmonized_ids]
+        candidates = [member.character_id for member in members if member.character_id is not None]
+        if len(set(candidates)) < 2:
+            continue
+
+        first_position = sentence_positions[harmonized_ids[0]]
+        last_position_in_chapter = sentence_positions[harmonized_ids[-1]]
+        previous = sentences[first_position - 1] if first_position > 0 else None
+        following = sentences[last_position_in_chapter + 1] if last_position_in_chapter + 1 < len(sentences) else None
+        boundary_members = [members[0], *(members[-1:] if len(members) > 1 else [])]
+        starts_here = members[0].original_text.lstrip().startswith(("“", '"'))
+        attribution_window_start = max(0, first_position - 4)
+        prior_attribution_candidates = (
+            list(reversed(sentences[attribution_window_start:first_position])) if not starts_here else []
+        )
+        attribution_sentences = [*prior_attribution_candidates, *boundary_members]
+        if starts_here and following is not None:
+            attribution_sentences.append(following)
+        attribution_context = " ".join(sentence.original_text for sentence in attribution_sentences)
+
+        anchored: int | None = next(
+            (
+                character_id
+                for sentence in attribution_sentences
+                if (character_id := named_attribution(sentence.original_text)) is not None
+            ),
+            None,
+        )
+        if (
+            anchored is None
+            and not starts_here
+            and previous is not None
+            and previous.character_id is not None
+            and previous.character_id != narrator_id
+            and previous.original_text.rstrip().endswith(("“", '"'))
+        ):
+            anchored = previous.character_id
+        for member in attribution_sentences:
+            if (
+                anchored is None
+                and _FIRST_PERSON_ATTRIBUTION_RE.search(member.original_text)
+                and member.character_id is not None
+                and member.character_id != narrator_id
+            ):
+                anchored = member.character_id
+                break
+
+        gendered = _GENDERED_ATTRIBUTION_RE.search(attribution_context)
+        if anchored is None and gendered:
+            anchored = minor_female_id if gendered.group(1).casefold() == "she" else minor_male_id
+
+        if anchored is None:
+            counts = Counter(candidates)
+            last_position = {candidate: index for index, candidate in enumerate(candidates)}
+
+            def rank(candidate: int) -> tuple[int, int, int]:
+                # Recurring named characters are more grounded than a minor
+                # fallback when the text contains no gendered attribution.
+                specificity = 1 if candidate not in minor_ids and candidate != narrator_id else 0
+                if candidate == narrator_id:
+                    specificity = -1
+                return counts[candidate], specificity, last_position[candidate]
+
+            anchored = max(counts, key=rank)
+
+        if anchored is not None:
+            overrides.update({sentence_id: anchored for sentence_id in harmonized_ids})
+
+    return overrides
 
 
 CHAPTER_SUMMARY_SCHEMA = {
@@ -453,6 +591,27 @@ def _sanitize_tagged_text(original: str, tagged: Any) -> str:
     return cleaned
 
 
+def _grounded_expression(
+    expression: Any,
+    *,
+    text: str,
+    previous_text: str,
+    next_text: str,
+) -> str | None:
+    """Reject model-added sounds that lack an explicit nearby textual cue."""
+
+    evidence = f"{text} {next_text}"
+    if expression in _ALLOWED_EXPRESSION_TAGS:
+        cue = _EXPRESSION_CUES.get(expression)
+        if cue and cue.search(evidence):
+            return expression
+    for candidate in _EXPRESSION_TAG_CHOICES:
+        cue = _EXPRESSION_CUES[candidate]
+        if cue.search(evidence):
+            return candidate
+    return None
+
+
 def _apply_speaker_guardrails(
     *,
     text: str,
@@ -462,18 +621,29 @@ def _apply_speaker_guardrails(
     minor_female_id: int | None,
     minor_male_id: int | None,
     reason: str,
+    character_genders: dict[int, str] | None = None,
 ) -> tuple[int | None, str, float | None]:
     """Correct two common local-model ID errors without inventing named speakers."""
     has_closing_quote = "”" in text or ('"' in text and not text.rstrip().endswith('"'))
     starts_with_quote = text.lstrip().startswith(("“", '"'))
     has_dialogue = has_closing_quote or starts_with_quote
 
-    if character_id == narrator_id and has_dialogue:
-        attribution = _GENDERED_ATTRIBUTION_RE.search(f"{text} {next_text}")
+    if has_dialogue:
+        attribution = _GENDERED_ATTRIBUTION_RE.search(text)
+        if (
+            attribution is None
+            and not _FIRST_PERSON_ATTRIBUTION_RE.search(text)
+            and not any(quote in next_text for quote in ("“", "”", '"'))
+        ):
+            attribution = _GENDERED_ATTRIBUTION_RE.search(next_text)
         if attribution:
             gender = attribution.group(1).casefold()
             fallback_id = minor_female_id if gender == "she" else minor_male_id
-            if fallback_id is not None:
+            selected_gender = (character_genders or {}).get(character_id)
+            gender_conflict = selected_gender in {"male", "female"} and selected_gender != (
+                "female" if gender == "she" else "male"
+            )
+            if fallback_id is not None and (character_id == narrator_id or gender_conflict):
                 return fallback_id, f"Deterministic {gender} dialogue attribution to minor voice", 0.98
 
     if character_id != narrator_id and not has_dialogue and _NARRATION_REASON_RE.search(reason):
@@ -1014,11 +1184,29 @@ async def diarize_sentences(
 
     characters = await crud.audiobook.get_characters_for_book(db, book_id)
     character_ids = {character.id for character in characters}
+    character_names = {character.id: character.name for character in characters}
+    character_genders = {}
+    character_aliases = {
+        character.id: [character.name, *(character.aliases or [])] for character in characters if not character.is_narrator
+    }
+    for character in characters:
+        gender_match = _VOICE_GENDER_RE.search(character.voice_prompt or "")
+        if gender_match:
+            character_genders[character.id] = gender_match.group(1).casefold()
     narrator_id = next((character.id for character in characters if character.is_narrator), None)
     minor_female_id = next((character.id for character in characters if character.name == "Minor Female Voice"), None)
     minor_male_id = next((character.id for character in characters if character.name == "Minor Male Voice"), None)
     roster_json = json.dumps(
-        [{"id": c.id, "name": c.name, "description": c.description, "is_narrator": c.is_narrator} for c in characters],
+        [
+            {
+                "id": c.id,
+                "name": c.name,
+                "aliases": c.aliases or [],
+                "description": c.description,
+                "is_narrator": c.is_narrator,
+            }
+            for c in characters
+        ],
         ensure_ascii=False,
     )
 
@@ -1114,9 +1302,19 @@ async def diarize_sentences(
                 )
 
         chapter_positions = {sentence.id: index for index, sentence in enumerate(chapter_sentences)}
+        chapter_quote_group_ids = quote_group_ids(chapter_sentences)
+        multi_sentence_quote_ids = {
+            sentence_id
+            for sentence_ids in quote_groups(chapter_sentences)
+            if len(sentence_ids) > 1
+            for sentence_id in sentence_ids
+        }
         context_window = [
-            sentence.original_text for sentence in chapter_sentences if sentence.status != "pending_diarization"
+            f"[{character_names.get(sentence.character_id, 'Unassigned')}] {sentence.original_text}"
+            for sentence in chapter_sentences
+            if sentence.status != "pending_diarization"
         ][-8:]
+        chapter_dialogue_ready_ids: list[int] = []
         while True:
             if await crud.audiobook.pause_book_pipeline_if_requested(
                 db,
@@ -1148,6 +1346,13 @@ async def diarize_sentences(
                             if chapter_positions[sentence.id] + 1 < len(chapter_sentences)
                             else None
                         ),
+                        "previous_speaker_id": (
+                            chapter_sentences[chapter_positions[sentence.id] - 1].character_id
+                            if chapter_positions[sentence.id] > 0
+                            and chapter_sentences[chapter_positions[sentence.id] - 1].status != "pending_diarization"
+                            else None
+                        ),
+                        "quote_group": chapter_quote_group_ids.get(sentence.id),
                     }
                     for sentence in batch
                 ],
@@ -1336,8 +1541,16 @@ async def diarize_sentences(
                 char_id = result.get("character_id")
                 if char_id not in character_ids:
                     char_id = narrator_id
-                expression = result.get("expression")
-                if expression in _ALLOWED_EXPRESSION_TAGS:
+                position = chapter_positions[sentence.id]
+                previous_text = chapter_sentences[position - 1].original_text if position > 0 else ""
+                next_text = chapter_sentences[position + 1].original_text if position + 1 < len(chapter_sentences) else ""
+                expression = _grounded_expression(
+                    result.get("expression"),
+                    text=sentence.original_text,
+                    previous_text=previous_text,
+                    next_text=next_text,
+                )
+                if expression:
                     tagged = f"[{expression}] {sentence.original_text}"
                 else:
                     tagged = _sanitize_tagged_text(sentence.original_text, result.get("tagged_text"))
@@ -1348,8 +1561,6 @@ async def diarize_sentences(
                     confidence = 0.0
                 raw_reason = str(result.get("reason") or "Model speaker assignment")
                 reason = _DIARIZATION_REASON_LABELS.get(raw_reason, raw_reason)[:500]
-                position = chapter_positions[sentence.id]
-                next_text = chapter_sentences[position + 1].original_text if position + 1 < len(chapter_sentences) else ""
                 if not result.get("_fallback"):
                     char_id, reason, guardrail_confidence = _apply_speaker_guardrails(
                         text=sentence.original_text,
@@ -1359,6 +1570,7 @@ async def diarize_sentences(
                         minor_female_id=minor_female_id,
                         minor_male_id=minor_male_id,
                         reason=reason,
+                        character_genders=character_genders,
                     )
                     if guardrail_confidence is not None:
                         confidence = guardrail_confidence
@@ -1370,13 +1582,18 @@ async def diarize_sentences(
                     speaker_confidence=confidence,
                     speaker_reason=reason,
                 )
-                context_window.append(sentence.original_text)
+                context_window.append(f"[{character_names.get(char_id, 'Unassigned')}] {sentence.original_text}")
                 completed_count += 1
                 ready_sentence_ids.append(sentence.id)
 
-            if on_sentences_ready and ready_sentence_ids:
-                ready_sentence_ids.sort(key=sentence_lengths.get)
-                await on_sentences_ready(ready_sentence_ids)
+            delayed_ready_ids = [sentence_id for sentence_id in ready_sentence_ids if sentence_id in multi_sentence_quote_ids]
+            immediate_ready_ids = [
+                sentence_id for sentence_id in ready_sentence_ids if sentence_id not in multi_sentence_quote_ids
+            ]
+            chapter_dialogue_ready_ids.extend(delayed_ready_ids)
+            if on_sentences_ready and immediate_ready_ids:
+                immediate_ready_ids.sort(key=sentence_lengths.get)
+                await on_sentences_ready(immediate_ready_ids)
 
             chapter_summary = str(batch_result.get("chapter_summary") or chapter.summary or "")[:4000]
             await crud.audiobook.update_chapter_summary(db, chapter.id, chapter_summary or None)
@@ -1392,6 +1609,31 @@ async def diarize_sentences(
             if await crud.audiobook.consume_book_batch_limit(db, book_id):
                 logger.info("Book %s paused after one diarization batch.", book_id)
                 return
+
+        refreshed_sentences = await crud.audiobook.get_sentences_for_chapter(db, chapter.id)
+        speaker_overrides = _quote_speaker_overrides(
+            refreshed_sentences,
+            narrator_id=narrator_id,
+            minor_female_id=minor_female_id,
+            minor_male_id=minor_male_id,
+            character_aliases=character_aliases,
+        )
+        for sentence in refreshed_sentences:
+            corrected_character_id = speaker_overrides.get(sentence.id)
+            if corrected_character_id is None or corrected_character_id == sentence.character_id:
+                continue
+            await crud.audiobook.update_sentence_diarization(
+                db,
+                sentence.id,
+                corrected_character_id,
+                sentence.tagged_text or sentence.original_text,
+                speaker_confidence=0.96,
+                speaker_reason="Deterministic continuation of uninterrupted quoted dialogue",
+            )
+
+        if on_sentences_ready and chapter_dialogue_ready_ids:
+            ready_ids = sorted(set(chapter_dialogue_ready_ids), key=sentence_lengths.get)
+            await on_sentences_ready(ready_ids)
 
         if provider != STUB_PROVIDER and chapter.summary is None:
             await _generate_chapter_summary(

--- a/backend/app/services/audiobook_text.py
+++ b/backend/app/services/audiobook_text.py
@@ -1,0 +1,131 @@
+"""Quote-aware text helpers shared by diarization and speech generation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Any
+
+_SPEAKABLE_RE = re.compile(r"[\w\d]", re.UNICODE)
+
+
+@dataclass(frozen=True)
+class SpeechSegment:
+    """A contiguous span spoken by either a character or the narrator."""
+
+    text: str
+    is_dialogue: bool
+    starts_quote: bool = False
+    ends_quote: bool = False
+
+    @property
+    def has_speech(self) -> bool:
+        return bool(_SPEAKABLE_RE.search(self.text))
+
+
+def split_speech_segments(
+    text: str,
+    quote_state: str | None = None,
+) -> tuple[list[SpeechSegment], str | None]:
+    """Split dialogue from attribution/action prose without losing punctuation.
+
+    ``quote_state`` is ``"curly"`` or ``"straight"`` when a quotation began in
+    an earlier sentence or paragraph. Some sentence tokenizers attach an opening
+    curly quote to the preceding sentence; an unmatched closing quote therefore
+    also implies that the current sentence began inside dialogue.
+    """
+
+    if quote_state is None:
+        first_open = text.find("“")
+        first_close = text.find("”")
+        if first_close >= 0 and (first_open < 0 or first_close < first_open):
+            quote_state = "curly"
+
+    segments: list[SpeechSegment] = []
+    buffer: list[str] = []
+    buffer_dialogue = quote_state is not None
+    buffer_starts_quote = False
+
+    def flush(*, ends_quote: bool = False) -> None:
+        nonlocal buffer, buffer_starts_quote
+        value = "".join(buffer).strip()
+        if value:
+            segments.append(
+                SpeechSegment(
+                    text=value,
+                    is_dialogue=buffer_dialogue,
+                    starts_quote=buffer_starts_quote,
+                    ends_quote=ends_quote,
+                )
+            )
+        buffer = []
+        buffer_starts_quote = False
+
+    for character in text:
+        if character == "“":
+            if quote_state is None:
+                flush()
+                quote_state = "curly"
+                buffer_dialogue = True
+                buffer_starts_quote = True
+            buffer.append(character)
+            continue
+
+        if character == "”" and quote_state == "curly":
+            buffer.append(character)
+            flush(ends_quote=True)
+            quote_state = None
+            buffer_dialogue = False
+            continue
+
+        if character == '"' and quote_state != "curly":
+            if quote_state == "straight":
+                buffer.append(character)
+                flush(ends_quote=True)
+                quote_state = None
+                buffer_dialogue = False
+            else:
+                flush()
+                quote_state = "straight"
+                buffer_dialogue = True
+                buffer_starts_quote = True
+                buffer.append(character)
+            continue
+
+        buffer.append(character)
+
+    flush()
+    return segments, quote_state
+
+
+def quote_groups(sentences: list[Any]) -> list[list[int]]:
+    """Return sentence-id groups that belong to uninterrupted quotations."""
+
+    groups: list[list[int]] = []
+    current_group: list[int] | None = None
+    quote_state: str | None = None
+
+    for sentence in sentences:
+        segments, quote_state = split_speech_segments(sentence.original_text, quote_state)
+        for segment in segments:
+            if not segment.is_dialogue:
+                continue
+            if segment.starts_quote or current_group is None:
+                current_group = []
+                groups.append(current_group)
+            if segment.has_speech and sentence.id not in current_group:
+                current_group.append(sentence.id)
+            if segment.ends_quote:
+                current_group = None
+
+    return [group for group in groups if group]
+
+
+def quote_group_ids(sentences: list[Any]) -> dict[int, int]:
+    """Map unambiguous sentence ids to a stable chapter-local quote group."""
+
+    memberships: dict[int, list[int]] = {}
+    for group_id, sentence_ids in enumerate(quote_groups(sentences), start=1):
+        for sentence_id in sentence_ids:
+            memberships.setdefault(sentence_id, []).append(group_id)
+    return {sentence_id: group_ids[0] for sentence_id, group_ids in memberships.items() if len(group_ids) == 1}

--- a/backend/app/services/audiobook_tts.py
+++ b/backend/app/services/audiobook_tts.py
@@ -6,6 +6,9 @@ import asyncio
 import logging
 import os
 from pathlib import Path
+import re
+import shutil
+import tempfile
 
 import httpx
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -13,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from .. import crud
 from ..config import LIBRARY_PATH
 from ..models import AudiobookChapter, AudiobookCharacter, AudiobookSentence, AudiobookSettings
+from .audiobook_text import split_speech_segments
 from .tts_providers import (
     DEFAULT_VOICE_PROMPT,
     TTSRequest,
@@ -24,6 +28,10 @@ from .tts_providers import (
 
 logger = logging.getLogger(__name__)
 TTS_BATCH_SIZE = max(1, int(os.getenv("AUDIOBOOK_TTS_BATCH_SIZE", "4")))
+_LEADING_EXPRESSION_RE = re.compile(
+    r"^((?:\[(?:laughter|sigh|whisper|surprise-oh|dissatisfaction-hnn|confirmation-en)\]\s*)+)",
+    re.IGNORECASE,
+)
 
 
 def _snippet_path(book_id: int, sentence_id: int) -> Path:
@@ -55,9 +63,11 @@ async def _generate_sentence_clip(
     book_id: int,
     sentence: AudiobookSentence,
     db: AsyncSession,
+    requests: list[TTSRequest] | None = None,
 ) -> None:
-    request = await _build_sentence_request(settings, sentence, db)
-    audio_bytes = await _synthesize_with_retries(settings, sentence.id, request)
+    requests = requests or await _build_sentence_requests(settings, sentence, db)
+    audio_parts = [await _synthesize_with_retries(settings, sentence.id, request) for request in requests]
+    audio_bytes = await _concatenate_mp3_parts(audio_parts, sentence.id)
     await _persist_sentence_audio(
         book_id,
         sentence,
@@ -71,19 +81,112 @@ async def _build_sentence_request(
     sentence: AudiobookSentence,
     db: AsyncSession,
 ) -> TTSRequest:
-    voice_prompt = DEFAULT_VOICE_PROMPT
-    voice_id = None
-    if sentence.character_id is not None:
-        char = await db.get(AudiobookCharacter, sentence.character_id)
-        if char:
-            voice_prompt = char.voice_prompt or voice_prompt
-            voice_id = _voice_id_for_provider(settings, char)
+    """Compatibility helper for callers that require a single request."""
+    requests = await _build_sentence_requests(settings, sentence, db)
+    return requests[0]
 
-    return TTSRequest(
-        text=sentence.tagged_text or sentence.original_text,
-        voice_prompt=voice_prompt,
-        voice_id=voice_id,
-    )
+
+def _request_for_character(
+    settings: AudiobookSettings | None,
+    character: AudiobookCharacter | None,
+    text: str,
+) -> TTSRequest:
+    voice_prompt = character.voice_prompt if character and character.voice_prompt else DEFAULT_VOICE_PROMPT
+    voice_id = _voice_id_for_provider(settings, character) if character else None
+    return TTSRequest(text=text, voice_prompt=voice_prompt, voice_id=voice_id)
+
+
+async def _build_sentence_requests(
+    settings: AudiobookSettings | None,
+    sentence: AudiobookSentence,
+    db: AsyncSession,
+) -> list[TTSRequest]:
+    """Render dialogue with its character and attribution prose with Narrator."""
+
+    character = await db.get(AudiobookCharacter, sentence.character_id) if sentence.character_id is not None else None
+    full_text = sentence.tagged_text or sentence.original_text
+    if character is None or character.is_narrator:
+        return [_request_for_character(settings, character, full_text)]
+
+    segments, _quote_state = split_speech_segments(sentence.original_text)
+    spoken_segments = [segment for segment in segments if segment.has_speech]
+    roles = {segment.is_dialogue for segment in spoken_segments}
+    if len(spoken_segments) < 2 or roles != {False, True}:
+        return [_request_for_character(settings, character, full_text)]
+
+    chapter = await db.get(AudiobookChapter, sentence.chapter_id)
+    narrator = None
+    if chapter is not None:
+        narrator = next(
+            (
+                candidate
+                for candidate in await crud.audiobook.get_characters_for_book(db, chapter.book_id)
+                if candidate.is_narrator
+            ),
+            None,
+        )
+
+    expression_match = _LEADING_EXPRESSION_RE.match(full_text)
+    expression_prefix = expression_match.group(1).strip() if expression_match else ""
+    expression_applied = False
+    requests: list[TTSRequest] = []
+    for segment in spoken_segments:
+        text = segment.text
+        if segment.is_dialogue and expression_prefix and not expression_applied:
+            text = f"{expression_prefix} {text}"
+            expression_applied = True
+        requests.append(
+            _request_for_character(
+                settings,
+                character if segment.is_dialogue else narrator,
+                text,
+            )
+        )
+    return requests
+
+
+async def _concatenate_mp3_parts(parts: list[bytes], sentence_id: int) -> bytes:
+    if len(parts) == 1:
+        return parts[0]
+    ffmpeg = shutil.which("ffmpeg")
+    if not ffmpeg:
+        raise RuntimeError("ffmpeg is required to combine dialogue and narrator audio.")
+
+    with tempfile.TemporaryDirectory(prefix=f"story-manager-sentence-{sentence_id}-") as directory:
+        root = Path(directory)
+        manifest_path = root / "parts.txt"
+        output_path = root / "combined.mp3"
+        input_paths = []
+        for index, part in enumerate(parts):
+            input_path = root / f"part-{index}.mp3"
+            input_path.write_bytes(part)
+            input_paths.append(input_path)
+        manifest_path.write_text(
+            "".join(f"file '{path}'\n" for path in input_paths),
+            encoding="utf-8",
+        )
+        process = await asyncio.create_subprocess_exec(
+            ffmpeg,
+            "-v",
+            "error",
+            "-f",
+            "concat",
+            "-safe",
+            "0",
+            "-i",
+            str(manifest_path),
+            "-codec:a",
+            "copy",
+            "-y",
+            str(output_path),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        _, stderr = await process.communicate()
+        if process.returncode:
+            message = stderr.decode("utf-8", errors="replace")[:500]
+            raise RuntimeError(f"Unable to combine sentence {sentence_id} voice segments: {message}")
+        return output_path.read_bytes()
 
 
 async def _synthesize_with_retries(
@@ -158,16 +261,21 @@ async def _generate_sentence_clips(
     """Generate a provider-native batch and isolate any batch failure by sentence."""
     if not sentences:
         return {}
-    if len(sentences) == 1 or tts_provider_name(settings) != "omnivoice":
+    request_groups = [await _build_sentence_requests(settings, sentence, db) for sentence in sentences]
+    if (
+        len(sentences) == 1
+        or tts_provider_name(settings) != "omnivoice"
+        or any(len(requests) > 1 for requests in request_groups)
+    ):
         failures = {}
-        for sentence in sentences:
+        for sentence, requests in zip(sentences, request_groups, strict=True):
             try:
-                await _generate_sentence_clip(settings, book_id, sentence, db)
+                await _generate_sentence_clip(settings, book_id, sentence, db, requests)
             except Exception as exc:
                 failures[sentence.id] = exc
         return failures
 
-    requests = [await _build_sentence_request(settings, sentence, db) for sentence in sentences]
+    requests = [group[0] for group in request_groups]
     results = None
     for attempt in range(1, 4):
         try:

--- a/backend/app/services/tts_providers.py
+++ b/backend/app/services/tts_providers.py
@@ -24,7 +24,7 @@ SUPPORTED_TTS_PROVIDERS = {
 
 _PROFILE_TOKEN_RE = re.compile(r"\[([a-z]+)-([^\]]+)\]", re.IGNORECASE)
 _EXPRESSION_TAG_RE = re.compile(
-    r"\[(?:laughter|laugh|sigh|whisper|shout)\]",
+    r"\[(?:laughter|laugh|sigh|whisper|shout|surprise-oh|dissatisfaction-hnn|confirmation-en)\]",
     re.IGNORECASE,
 )
 

--- a/backend/tests/test_audiobook_pipeline.py
+++ b/backend/tests/test_audiobook_pipeline.py
@@ -18,6 +18,7 @@ from backend.app.services import (
     audiobook_ingestion,
     audiobook_llm,
     audiobook_publication,
+    audiobook_text,
     audiobook_tts,
     web_novel,
 )
@@ -121,7 +122,15 @@ def test_diarization_schema_keeps_model_output_compact():
     assert "tagged_text" not in properties
     assert "confidence" not in properties
     assert "reason" not in properties
-    assert properties["e"]["enum"] == [None, "laughter", "sigh", "whisper", "shout"]
+    assert properties["e"]["enum"] == [
+        None,
+        "laughter",
+        "sigh",
+        "whisper",
+        "surprise-oh",
+        "dissatisfaction-hnn",
+        "confirmation-en",
+    ]
     assert "chapter_summary" not in audiobook_llm.DIARIZATION_SCHEMA["properties"]
 
 
@@ -150,6 +159,110 @@ def test_only_quoted_spans_require_model_diarization():
     }
 
 
+def test_quote_aware_segments_separate_dialogue_from_attribution_prose():
+    segments, quote_state = audiobook_text.split_speech_segments(
+        "“Be right with you,” she muttered, by way of a Pavlovian response."
+    )
+
+    assert [(segment.text, segment.is_dialogue) for segment in segments] == [
+        ("“Be right with you,”", True),
+        ("she muttered, by way of a Pavlovian response.", False),
+    ]
+    assert quote_state is None
+
+
+def test_quote_groups_and_speaker_overrides_keep_long_quote_on_one_voice():
+    sentences = [
+        SimpleNamespace(
+            id=188,
+            original_text="“Paragraph two: I understand the agreement.",
+            character_id=30,
+        ),
+        SimpleNamespace(
+            id=189,
+            original_text="I may not refuse service.”",
+            character_id=20,
+        ),
+    ]
+
+    assert audiobook_text.quote_groups(sentences) == [[188, 189]]
+    assert audiobook_llm._quote_speaker_overrides(
+        sentences,
+        narrator_id=10,
+        minor_female_id=30,
+        minor_male_id=40,
+    ) == {188: 20, 189: 20}
+
+
+def test_quote_speaker_override_uses_attribution_before_continued_quote():
+    sentences = [
+        SimpleNamespace(
+            id=1518,
+            original_text="“Fah,” Thomas said. “",
+            character_id=207,
+        ),
+        SimpleNamespace(id=1519, original_text="I played golf with most of them.", character_id=203),
+        SimpleNamespace(id=1520, original_text="They would have been all for it.", character_id=207),
+        SimpleNamespace(id=1521, original_text="Did anyone else have anything surprising?”", character_id=203),
+    ]
+
+    assert audiobook_llm._quote_speaker_overrides(
+        sentences,
+        narrator_id=202,
+        minor_female_id=220,
+        minor_male_id=221,
+        character_aliases={203: ["John Perry", "John"], 207: ["Thomas Jane", "Thomas"]},
+    ) == {1519: 207, 1520: 207, 1521: 207}
+
+
+def test_quote_speaker_override_prefers_resolved_opening_boundary_over_next_turn():
+    sentences = [
+        SimpleNamespace(
+            id=1171,
+            original_text="“Don’t listen to him,” said the woman. “",
+            character_id=210,
+        ),
+        SimpleNamespace(id=1172, original_text="Tom is trying to take your food.", character_id=203),
+        SimpleNamespace(id=1173, original_text="That’s how I lost my sausage.”", character_id=210),
+        SimpleNamespace(
+            id=1174,
+            original_text="“That accusation is true,” Thomas said. “",
+            character_id=207,
+        ),
+    ]
+
+    assert audiobook_llm._quote_speaker_overrides(
+        sentences,
+        narrator_id=202,
+        minor_female_id=220,
+        minor_male_id=221,
+        character_aliases={207: ["Thomas Jane", "Thomas"], 210: ["Susan Reardon", "Susan"]},
+    ) == {1172: 210, 1173: 210}
+
+
+def test_quote_speaker_override_does_not_overwrite_two_quote_bridge_sentence():
+    sentences = [
+        SimpleNamespace(id=1, original_text="This is Earth.", character_id=203),
+        SimpleNamespace(
+            id=2,
+            original_text="And this”\u2014he pointed\u2014“is Colonial Station.",
+            character_id=203,
+        ),
+        SimpleNamespace(id=3, original_text="It is very far away.", character_id=221),
+        SimpleNamespace(id=4, original_text="Farther than the moon.”", character_id=203),
+    ]
+
+    overrides = audiobook_llm._quote_speaker_overrides(
+        sentences,
+        narrator_id=202,
+        minor_female_id=220,
+        minor_male_id=221,
+    )
+
+    assert 2 not in overrides
+    assert overrides == {3: 203, 4: 203}
+
+
 def test_tagged_text_sanitizer_only_accepts_supported_insertions():
     original = "Take your time, I said."
 
@@ -158,6 +271,36 @@ def test_tagged_text_sanitizer_only_accepts_supported_insertions():
     )
     assert audiobook_llm._sanitize_tagged_text(original, "[fade in] Take your time, I said.") == original
     assert audiobook_llm._sanitize_tagged_text(original, "I completely rewrote this sentence.") == original
+
+
+def test_expression_tags_require_explicit_nearby_evidence():
+    assert (
+        audiobook_llm._grounded_expression(
+            "whisper",
+            text="“Be right with you.”",
+            previous_text="",
+            next_text="she muttered without looking up.",
+        )
+        == "whisper"
+    )
+    assert (
+        audiobook_llm._grounded_expression(
+            None,
+            text="“Be right with you,” she muttered.",
+            previous_text="",
+            next_text="The door opened.",
+        )
+        == "whisper"
+    )
+    assert (
+        audiobook_llm._grounded_expression(
+            "dissatisfaction-hnn",
+            text="I agree to the terms of service.",
+            previous_text="Paragraph two.",
+            next_text="I signed.",
+        )
+        is None
+    )
 
 
 def test_diarization_parser_deduplicates_repeated_sentence_ids():
@@ -241,10 +384,32 @@ def test_speaker_guardrails_keep_prose_on_narrator_and_route_unnamed_dialogue():
         minor_male_id=40,
         reason="Narration setting up dialogue.",
     )
+    wrong_gender = audiobook_llm._apply_speaker_guardrails(
+        text="Be right with you,” she muttered.",
+        next_text="",
+        character_id=20,
+        narrator_id=10,
+        minor_female_id=30,
+        minor_male_id=40,
+        reason="Turn taking",
+        character_genders={20: "male", 30: "female"},
+    )
+    first_person_before_new_turn = audiobook_llm._apply_speaker_guardrails(
+        text="“I’m gratified to hear that,” I said.",
+        next_text="“We can continue,” she said.",
+        character_id=20,
+        narrator_id=10,
+        minor_female_id=30,
+        minor_male_id=40,
+        reason="Explicit first-person attribution",
+        character_genders={20: "male", 30: "female"},
+    )
 
     assert prose == (10, "Deterministic prose/narration guardrail", 0.98)
     assert dialogue == (30, "Deterministic she dialogue attribution to minor voice", 0.98)
     assert setup == (10, "Narration setting up dialogue.", None)
+    assert wrong_gender == (30, "Deterministic she dialogue attribution to minor voice", 0.98)
+    assert first_person_before_new_turn == (20, "Explicit first-person attribution", None)
 
 
 @pytest.mark.asyncio
@@ -1121,6 +1286,51 @@ async def test_character_voice_id_is_tagged_and_used_only_for_its_provider(db):
 
 
 @pytest.mark.asyncio
+async def test_mixed_dialogue_tts_uses_character_then_narrator_voice(db):
+    book = await _make_book(db, audiobook_enabled=True)
+    narrator, speaker = await crud.audiobook.create_characters_bulk(
+        db,
+        book.id,
+        [
+            {
+                "name": "Narrator",
+                "voice_prompt": "narrator voice",
+                "is_narrator": True,
+            },
+            {
+                "name": "Recruiter",
+                "voice_prompt": "recruiter voice",
+                "is_narrator": False,
+            },
+        ],
+    )
+    chapter = await crud.audiobook.create_chapter(db, book.id, 1, "chapter.xhtml")
+    await crud.audiobook.create_sentences_bulk(
+        db,
+        chapter.id,
+        [
+            {
+                "html_element_id": "mixed-1",
+                "sequence_order": 0,
+                "original_text": "Be right with you,” she muttered by the door.",
+                "tagged_text": "[whisper] Be right with you,” she muttered by the door.",
+                "character_id": speaker.id,
+                "status": "ready_for_audio",
+            }
+        ],
+    )
+    sentence = (await crud.audiobook.get_sentences_for_chapter(db, chapter.id))[0]
+
+    requests = await audiobook_tts._build_sentence_requests(None, sentence, db)
+
+    assert [(request.text, request.voice_prompt) for request in requests] == [
+        ("[whisper] Be right with you,”", "recruiter voice"),
+        ("she muttered by the door.", "narrator voice"),
+    ]
+    assert narrator.is_narrator is True
+
+
+@pytest.mark.asyncio
 async def test_tts_settings_invalidate_only_unfinished_books_below_eighty_percent(db, tmp_path, monkeypatch):
     library_path = tmp_path / "library"
     library_path.mkdir()
@@ -1307,6 +1517,7 @@ async def test_ingestion_preserves_nested_markup_and_records_spine_file(db, tmp_
         "Text/chapter_1.xhtml",
         "Text/chapter_2.xhtml",
     ]
+    assert [chapter.title for chapter in chapters] == ["One", "Two"]
 
     working_epub = library_path / "audiobooks" / str(book.id) / "working.epub"
     parsed = epub.read_epub(str(working_epub))

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1562,16 +1562,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -1764,9 +1764,9 @@
       "peer": true
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -2740,9 +2740,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -2929,9 +2929,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.24",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
+      "integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
       "dev": true,
       "funding": [
         {
@@ -2949,7 +2949,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/frontend/src/components/AudiobookPipeline.test.jsx
+++ b/frontend/src/components/AudiobookPipeline.test.jsx
@@ -159,6 +159,7 @@ describe("AudiobookPipeline", () => {
     const chapter = {
       id: 9,
       chapter_number: 1,
+      title: "Opening Night",
       sentence_count: 2,
       processed_sentence_count: 2,
       audio_generated_count: 0,
@@ -238,6 +239,7 @@ describe("AudiobookPipeline", () => {
     fireEvent.click(
       await screen.findByRole("button", { name: "Chapter Assembly" }),
     );
+    expect(screen.getByText("Opening Night")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Rebuild Preview" }));
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
@@ -247,6 +249,9 @@ describe("AudiobookPipeline", () => {
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Listen & Read" }));
+    expect(
+      (await screen.findAllByText("Opening Night")).length,
+    ).toBeGreaterThan(0);
     expect(
       await screen.findByText("Avery opened the door."),
     ).toBeInTheDocument();

--- a/frontend/src/components/audiobook/AnalysisOverview.jsx
+++ b/frontend/src/components/audiobook/AnalysisOverview.jsx
@@ -1,3 +1,5 @@
+import { chapterLabel } from "../../lib/audiobook";
+
 function AnalysisOverview({ status, chapters = [] }) {
   const analyzed = chapters.filter((chapter) => chapter.summary);
 
@@ -19,7 +21,8 @@ function AnalysisOverview({ status, chapters = [] }) {
         </p>
         {status?.summary && (
           <small className="analysis-review-note">
-            Model-generated working analysis — verify names and plot details before production.
+            Model-generated working analysis — verify names and plot details
+            before production.
           </small>
         )}
       </section>
@@ -35,7 +38,7 @@ function AnalysisOverview({ status, chapters = [] }) {
           return (
             <article className="chapter-analysis-card" key={chapter.id}>
               <div className="chapter-analysis-header">
-                <strong>Chapter {chapter.chapter_number}</strong>
+                <strong>{chapterLabel(chapter)}</strong>
                 <span>{percent}% attributed</span>
               </div>
               <div className="chapter-analysis-counts">

--- a/frontend/src/components/audiobook/AudiobookReader.jsx
+++ b/frontend/src/components/audiobook/AudiobookReader.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { getChapterAudioUrl, getSentences } from "../../api/audiobook";
+import { chapterLabel } from "../../lib/audiobook";
 
 function AudiobookReader({ chapters = [], characters = [], bookId }) {
   const playable = useMemo(
@@ -56,7 +57,7 @@ function AudiobookReader({ chapters = [], characters = [], bookId }) {
             className={chapter.id === chapterId ? "active" : ""}
             onClick={() => setChapterId(chapter.id)}
           >
-            Chapter {chapter.chapter_number}
+            {chapterLabel(chapter)}
             <small>{chapter.sentence_count} sentences</small>
           </button>
         ))}
@@ -65,7 +66,7 @@ function AudiobookReader({ chapters = [], characters = [], bookId }) {
         <div className="audiobook-reader-heading">
           <div>
             <span className="metric-label">Listen & read</span>
-            <h3>Chapter {selected?.chapter_number}</h3>
+            <h3>{chapterLabel(selected)}</h3>
           </div>
           <div className="audiobook-reader-nav">
             <button

--- a/frontend/src/components/audiobook/ChapterAssembly.jsx
+++ b/frontend/src/components/audiobook/ChapterAssembly.jsx
@@ -3,6 +3,7 @@ import {
   generateChapterPreview,
   getChapterAudioUrl,
 } from "../../api/audiobook";
+import { chapterLabel } from "../../lib/audiobook";
 
 function ChapterAssembly({ chapters, bookId, pipelineActive = false }) {
   const queryClient = useQueryClient();
@@ -47,7 +48,7 @@ function ChapterAssembly({ chapters, bookId, pipelineActive = false }) {
               chapter.audio_file_path && !chapter.needs_reassembly;
             return (
               <tr key={chapter.id}>
-                <td>Chapter {chapter.chapter_number}</td>
+                <td>{chapterLabel(chapter)}</td>
                 <td>
                   {previewBusy ? (
                     <span className="badge badge--warning">

--- a/frontend/src/components/audiobook/ProgressDashboard.jsx
+++ b/frontend/src/components/audiobook/ProgressDashboard.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { chapterLabel } from "../../lib/audiobook";
 
 const ACTIVE_STATUSES = new Set([
   "ingesting",
@@ -194,7 +195,7 @@ function ProgressDashboard({ status, chapters = [] }) {
         <div className="progress-chapter-list">
           {chapters.map((chapter) => (
             <article className="progress-chapter-row" key={chapter.id}>
-              <strong>Chapter {chapter.chapter_number}</strong>
+              <strong>{chapterLabel(chapter)}</strong>
               <div>
                 <span>
                   Analysis{" "}

--- a/frontend/src/components/audiobook/ScriptEditor.jsx
+++ b/frontend/src/components/audiobook/ScriptEditor.jsx
@@ -6,6 +6,7 @@ import {
   updateSentence,
   getSentenceAudioUrl,
 } from "../../api/audiobook";
+import { chapterLabel } from "../../lib/audiobook";
 
 const STATUS_ICONS = {
   pending_diarization: { icon: "⏳", label: "Pending diarization" },
@@ -249,7 +250,7 @@ function ScriptEditor({
             <option value="">All</option>
             {chapters.map((chapter) => (
               <option key={chapter.id} value={chapter.id}>
-                {chapter.chapter_number} · {chapter.processed_sentence_count}/
+                {chapterLabel(chapter)} · {chapter.processed_sentence_count}/
                 {chapter.sentence_count}
               </option>
             ))}

--- a/frontend/src/lib/audiobook.js
+++ b/frontend/src/lib/audiobook.js
@@ -1,0 +1,4 @@
+export function chapterLabel(chapter) {
+  const title = chapter?.title?.trim();
+  return title || `Chapter ${chapter?.chapter_number ?? ""}`.trim();
+}

--- a/scripts/start-services.sh
+++ b/scripts/start-services.sh
@@ -1,0 +1,375 @@
+#!/usr/bin/env bash
+
+set -u
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+RUNTIME_DIR="${STORY_MANAGER_RUNTIME_DIR:-$PROJECT_DIR/.run}"
+LOG_DIR="$RUNTIME_DIR/logs"
+PID_DIR="$RUNTIME_DIR/pids"
+LAUNCHER_DIR="$RUNTIME_DIR/launchers"
+OLLAMA_MODEL="${OLLAMA_MODEL:-qwen3.5:9b}"
+
+mkdir -p "$LOG_DIR" "$PID_DIR" "$LAUNCHER_DIR"
+
+info() {
+    printf '%s\n' "$*"
+}
+
+error() {
+    printf 'ERROR: %s\n' "$*" >&2
+}
+
+url_ready() {
+    curl --silent --show-error --fail --max-time 3 "$1" >/dev/null 2>&1
+}
+
+port_in_use() {
+    local port="$1"
+
+    if command -v lsof >/dev/null 2>&1; then
+        lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1
+        return
+    fi
+
+    if command -v nc >/dev/null 2>&1; then
+        nc -z localhost "$port" >/dev/null 2>&1
+        return
+    fi
+
+    return 1
+}
+
+database_ready() {
+    command -v docker >/dev/null 2>&1 \
+        && docker ps --format '{{.Names}}' 2>/dev/null | grep -qx 'story-manager-db' \
+        && docker exec story-manager-db pg_isready -U storyuser -d story_manager >/dev/null 2>&1
+}
+
+start_detached() {
+    local service_slug="$1"
+    local log_file
+    local pid_file
+    local launcher_file
+    local session_name
+    local argument
+    shift
+
+    log_file="$LOG_DIR/$service_slug.log"
+    pid_file="$PID_DIR/$service_slug.pid"
+
+    if command -v setsid >/dev/null 2>&1; then
+        (
+            cd "$PROJECT_DIR" || exit 1
+            nohup setsid "$@" >"$log_file" 2>&1 < /dev/null &
+            printf '%s\n' "$!" >"$pid_file"
+        )
+        return
+    fi
+
+    if command -v screen >/dev/null 2>&1; then
+        launcher_file="$LAUNCHER_DIR/$service_slug.sh"
+        session_name="story-manager-$service_slug-$$"
+
+        {
+            printf '#!/usr/bin/env bash\n'
+            printf 'cd %q || exit 1\n' "$PROJECT_DIR"
+            printf 'exec'
+            for argument in "$@"; do
+                printf ' %q' "$argument"
+            done
+            printf ' >> %q 2>&1\n' "$log_file"
+        } >"$launcher_file"
+        chmod 700 "$launcher_file"
+        rm -f "$pid_file"
+
+        screen -dmS "$session_name" "$launcher_file"
+        return
+    fi
+
+    (
+        cd "$PROJECT_DIR" || exit 1
+        nohup "$@" >"$log_file" 2>&1 < /dev/null &
+        printf '%s\n' "$!" >"$pid_file"
+    )
+}
+
+show_failure_log() {
+    local service_slug="$1"
+    local log_file="$LOG_DIR/$service_slug.log"
+
+    if [ -s "$log_file" ]; then
+        error "Last output from $log_file:"
+        tail -n 20 "$log_file" >&2
+    fi
+}
+
+wait_for_url() {
+    local service_name="$1"
+    local service_slug="$2"
+    local url="$3"
+    local timeout_seconds="$4"
+    local elapsed=0
+
+    while ! url_ready "$url"; do
+        if [ "$elapsed" -ge "$timeout_seconds" ]; then
+            error "$service_name did not become ready at $url within ${timeout_seconds}s."
+            show_failure_log "$service_slug"
+            return 1
+        fi
+
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+
+    info "READY   $service_name ($url)"
+}
+
+ensure_http_service() {
+    local service_name="$1"
+    local service_slug="$2"
+    local url="$3"
+    local port="$4"
+    local timeout_seconds="$5"
+    shift 5
+
+    if url_ready "$url"; then
+        info "READY   $service_name ($url) — already running"
+        return 0
+    fi
+
+    if port_in_use "$port"; then
+        error "$service_name is not healthy, but port $port is already occupied. Nothing was started."
+        return 1
+    fi
+
+    info "START   $service_name"
+    start_detached "$service_slug" "$@"
+    wait_for_url "$service_name" "$service_slug" "$url" "$timeout_seconds"
+}
+
+ensure_database() {
+    if database_ready; then
+        info "READY   PostgreSQL (localhost:5432) — already running"
+        return 0
+    fi
+
+    if ! command -v docker >/dev/null 2>&1; then
+        error "Docker is required to start PostgreSQL."
+        return 1
+    fi
+
+    if ! docker info >/dev/null 2>&1; then
+        error "Docker is installed but its daemon is not running."
+        return 1
+    fi
+
+    info "START   PostgreSQL"
+    if ! make -C "$PROJECT_DIR" ensure-db; then
+        error "PostgreSQL failed to start."
+        return 1
+    fi
+
+    if ! database_ready; then
+        error "PostgreSQL started but did not pass its readiness check."
+        return 1
+    fi
+
+    info "READY   PostgreSQL (localhost:5432)"
+}
+
+ensure_ollama() {
+    if url_ready "http://127.0.0.1:11434/api/tags"; then
+        info "READY   Ollama (http://127.0.0.1:11434/api/tags) — already running"
+        return 0
+    fi
+
+    if ! command -v ollama >/dev/null 2>&1; then
+        error "Ollama is not installed. Install it with: brew install ollama"
+        return 1
+    fi
+
+    ensure_http_service \
+        "Ollama" \
+        "ollama" \
+        "http://127.0.0.1:11434/api/tags" \
+        "11434" \
+        "60" \
+        ollama serve
+}
+
+check_ollama_model() {
+    if ! url_ready "http://127.0.0.1:11434/api/tags"; then
+        return 1
+    fi
+
+    if ollama list 2>/dev/null | awk -v model="$OLLAMA_MODEL" 'NR > 1 && $1 == model { found = 1 } END { exit !found }'; then
+        info "READY   Ollama model ($OLLAMA_MODEL)"
+        return 0
+    fi
+
+    error "Ollama is running, but $OLLAMA_MODEL is missing. Install it with: make pull-ollama-model"
+    return 1
+}
+
+ensure_api() {
+    if url_ready "http://127.0.0.1:8000/health"; then
+        info "READY   API (http://127.0.0.1:8000/health) — already running"
+        return 0
+    fi
+
+    if [ ! -x "$PROJECT_DIR/.venv/bin/uvicorn" ] || [ ! -x "$PROJECT_DIR/.venv/bin/alembic" ]; then
+        error "Backend dependencies are missing. Run: make setup"
+        return 1
+    fi
+
+    ensure_http_service \
+        "API" \
+        "api" \
+        "http://127.0.0.1:8000/health" \
+        "8000" \
+        "180" \
+        make run-api
+}
+
+ensure_ui() {
+    if url_ready "http://localhost:5173/"; then
+        info "READY   UI (http://localhost:5173/) — already running"
+        return 0
+    fi
+
+    if [ ! -x "$PROJECT_DIR/frontend/node_modules/.bin/vite" ]; then
+        error "Frontend dependencies are missing. Run: make setup"
+        return 1
+    fi
+
+    ensure_http_service \
+        "UI" \
+        "ui" \
+        "http://localhost:5173/" \
+        "5173" \
+        "120" \
+        make run-ui
+}
+
+ensure_omnivoice() {
+    local omnivoice_uvicorn="$PROJECT_DIR/services/omnivoice/.venv/bin/uvicorn"
+
+    if url_ready "http://127.0.0.1:8001/health"; then
+        info "READY   OmniVoice (http://127.0.0.1:8001/health) — already running"
+        return 0
+    fi
+
+    if [ ! -x "$omnivoice_uvicorn" ]; then
+        if ! command -v uv >/dev/null 2>&1; then
+            error "uv is required to install OmniVoice."
+            return 1
+        fi
+
+        info "SETUP   OmniVoice (first setup may take several minutes)"
+        if ! make -C "$PROJECT_DIR" setup-omnivoice; then
+            error "OmniVoice setup failed."
+            return 1
+        fi
+    fi
+
+    ensure_http_service \
+        "OmniVoice" \
+        "omnivoice" \
+        "http://127.0.0.1:8001/health" \
+        "8001" \
+        "900" \
+        env PYTORCH_ENABLE_MPS_FALLBACK=1 \
+        "$omnivoice_uvicorn" \
+        services.omnivoice.server:app \
+        --host 127.0.0.1 \
+        --port 8001
+}
+
+print_status() {
+    local missing=0
+
+    if database_ready; then
+        info "READY   PostgreSQL (localhost:5432)"
+    else
+        info "MISSING PostgreSQL (localhost:5432)"
+        missing=$((missing + 1))
+    fi
+
+    if url_ready "http://127.0.0.1:11434/api/tags"; then
+        info "READY   Ollama (http://127.0.0.1:11434)"
+    else
+        info "MISSING Ollama (http://127.0.0.1:11434)"
+        missing=$((missing + 1))
+    fi
+
+    if url_ready "http://127.0.0.1:8000/health"; then
+        info "READY   API (http://localhost:8000)"
+    else
+        info "MISSING API (http://localhost:8000)"
+        missing=$((missing + 1))
+    fi
+
+    if url_ready "http://localhost:5173/"; then
+        info "READY   UI (http://localhost:5173)"
+    else
+        info "MISSING UI (http://localhost:5173)"
+        missing=$((missing + 1))
+    fi
+
+    if url_ready "http://127.0.0.1:8001/health"; then
+        info "READY   OmniVoice (http://127.0.0.1:8001)"
+    else
+        info "MISSING OmniVoice (http://127.0.0.1:8001)"
+        missing=$((missing + 1))
+    fi
+
+    [ "$missing" -eq 0 ]
+}
+
+usage() {
+    printf 'Usage: %s [start|status]\n' "$0"
+}
+
+if ! command -v curl >/dev/null 2>&1; then
+    error "curl is required for service health checks."
+    exit 127
+fi
+
+case "${1:-start}" in
+    start)
+        failures=0
+
+        ensure_database || failures=$((failures + 1))
+        ensure_ollama || failures=$((failures + 1))
+
+        if database_ready; then
+            ensure_api || failures=$((failures + 1))
+        else
+            error "Skipping API startup because PostgreSQL is unavailable."
+            failures=$((failures + 1))
+        fi
+
+        ensure_ui || failures=$((failures + 1))
+        ensure_omnivoice || failures=$((failures + 1))
+        check_ollama_model || failures=$((failures + 1))
+
+        printf '\n'
+        if [ "$failures" -eq 0 ]; then
+            info "All Story Manager services are ready."
+            info "Logs for services started by this script: $LOG_DIR"
+            exit 0
+        fi
+
+        error "$failures startup check(s) failed. Healthy services were left running."
+        exit 1
+        ;;
+    status)
+        print_status
+        ;;
+    *)
+        usage >&2
+        exit 2
+        ;;
+esac


### PR DESCRIPTION
## Summary

- propagate EPUB chapter titles through the audiobook API and use them throughout the UI, with a numeric fallback
- add quote-aware sentence context and speaker reconciliation so uninterrupted long quotations keep one speaker
- split dialogue from attribution/action prose at TTS time so phrases such as “she said” use the narrator voice
- constrain expression tags to supported, text-grounded cues and improve gender/alias guardrails
- add `make start` and `make services-status` to launch only missing PostgreSQL, Ollama, API, UI, and OmniVoice services

## Why

Audiobook chapter controls showed internal chapter numbers instead of source titles. Historical sentence rows could also combine dialogue and narration or lose speaker continuity across tokenized quote paragraphs, producing incorrect voices and unsupported emotional delivery. Local development additionally required several separate foreground commands to bring up the full stack.

The root causes were missing title data in the chapter response/UI, sentence-level processing without persistent quote state, and no orchestration layer around the existing service commands.

## Impact

New ingestion uses EPUB TOC titles and quote-aware speech units. Existing mixed rows are rendered with separate character/narrator requests, while long quote groups are reconciled without overwriting sentences that bridge two distinct quoted spans. Developers can now run one idempotent command that leaves healthy services untouched, waits for readiness, prevents port collisions, and writes detached-service logs to `.run/logs/`.

## Validation

- `make test` — 301 backend tests passed (1 deselected), 39 frontend tests passed
- `make lint` — backend flake8 and frontend ESLint passed
- `bash -n scripts/start-services.sh`
- `git diff --check`
- validated representative problem clips and reassembled CHAPTER ONE for book 839
- book-wide dry-run reduced 498 unambiguous quote-group speaker conflicts to 0 while preserving 65 bridge sentences
- validated `make start` from a partial service state, checked health from a separate shell, and confirmed a second run creates no duplicates