### PR TITLE
Add unified processing queue

### DIFF
--- a/backend/alembic/versions/0026_processing_jobs.py
+++ b/backend/alembic/versions/0026_processing_jobs.py
@@ -1,0 +1,263 @@
+"""add durable processing jobs and imported-audio content tracking
+
+Revision ID: 0026
+Revises: 0025
+Create Date: 2026-07-31 00:00:00
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0026"
+down_revision = "0025"
+branch_labels = None
+depends_on = None
+
+_CREATED_TABLE_COMMENT = "story-manager:alembic:0026:processing-jobs"
+_CREATED_COLUMN_COMMENT = "story-manager:alembic:0026"
+
+
+def _columns(conn, table_name: str) -> dict[str, dict]:
+    inspector = sa.inspect(conn)
+    if not inspector.has_table(table_name):
+        return {}
+    return {column["name"]: column for column in inspector.get_columns(table_name)}
+
+
+def _seed_legacy_jobs(conn) -> None:
+    """Preserve work that was queued through the pre-0026 status columns."""
+    jobs = sa.table(
+        "processing_jobs",
+        sa.column("job_type", sa.String),
+        sa.column("status", sa.String),
+        sa.column("book_id", sa.Integer),
+        sa.column("target_type", sa.String),
+        sa.column("target_id", sa.Integer),
+        sa.column("target_content_version", sa.Integer),
+        sa.column("payload", sa.JSON),
+        sa.column("dedupe_key", sa.String),
+        sa.column("progress_detail", sa.String),
+    )
+
+    if sa.inspect(conn).has_table("books"):
+        books = sa.table(
+            "books",
+            sa.column("id", sa.Integer),
+            sa.column("content_version", sa.Integer),
+            sa.column("refresh_status", sa.String),
+            sa.column("audiobook_pipeline_status", sa.String),
+        )
+        rows = conn.execute(
+            sa.select(
+                books.c.id,
+                books.c.content_version,
+                books.c.refresh_status,
+                books.c.audiobook_pipeline_status,
+            )
+        ).fetchall()
+        active_audio = {"ingesting", "roster_gen", "diarizing", "audio_gen", "assembling"}
+        for row in rows:
+            if row.refresh_status in {"queued", "processing"}:
+                conn.execute(
+                    jobs.insert().values(
+                        job_type="refresh_book",
+                        status="queued",
+                        book_id=row.id,
+                        target_type="book",
+                        target_id=row.id,
+                        target_content_version=row.content_version,
+                        payload={"legacy_resume": True},
+                        dedupe_key=f"refresh_book:book:{row.id}",
+                        progress_detail="Queued after processing-jobs migration",
+                    )
+                )
+            if row.audiobook_pipeline_status in active_audio:
+                conn.execute(
+                    jobs.insert().values(
+                        job_type="audiobook_pipeline",
+                        status="queued",
+                        book_id=row.id,
+                        target_type="book",
+                        target_id=row.id,
+                        target_content_version=row.content_version,
+                        payload={"mode": "resume", "legacy_resume": True},
+                        dedupe_key=f"audiobook_pipeline:book:{row.id}:v{row.content_version or 1}",
+                        progress_detail="Queued after processing-jobs migration",
+                    )
+                )
+
+    if sa.inspect(conn).has_table("imported_audiobooks"):
+        editions = sa.table(
+            "imported_audiobooks",
+            sa.column("id", sa.Integer),
+            sa.column("book_id", sa.Integer),
+            sa.column("status", sa.String),
+        )
+        for row in conn.execute(
+            sa.select(editions.c.id, editions.c.book_id, editions.c.status).where(
+                editions.c.status.in_(("queued", "importing", "aligning"))
+            )
+        ).fetchall():
+            job_type = "align_imported_audiobook" if row.status == "aligning" else "import_audiobook"
+            conn.execute(
+                jobs.insert().values(
+                    job_type=job_type,
+                    status="queued",
+                    book_id=row.book_id,
+                    target_type="imported_audiobook",
+                    target_id=row.id,
+                    payload={"legacy_resume": True},
+                    dedupe_key=f"{job_type}:imported_audiobook:{row.id}",
+                    progress_detail="Queued after processing-jobs migration",
+                )
+            )
+
+    if sa.inspect(conn).has_table("audiobook_chapters"):
+        chapters = sa.table(
+            "audiobook_chapters",
+            sa.column("id", sa.Integer),
+            sa.column("book_id", sa.Integer),
+            sa.column("preview_status", sa.String),
+        )
+        for row in conn.execute(
+            sa.select(chapters.c.id, chapters.c.book_id).where(chapters.c.preview_status.in_(("queued", "generating")))
+        ).fetchall():
+            conn.execute(
+                jobs.insert().values(
+                    job_type="generate_chapter_preview",
+                    status="queued",
+                    book_id=row.book_id,
+                    target_type="audiobook_chapter",
+                    target_id=row.id,
+                    payload={"legacy_resume": True},
+                    dedupe_key=f"generate_chapter_preview:audiobook_chapter:{row.id}",
+                    progress_detail="Queued after processing-jobs migration",
+                )
+            )
+
+        if sa.inspect(conn).has_table("audiobook_sentences"):
+            sentences = sa.table(
+                "audiobook_sentences",
+                sa.column("id", sa.Integer),
+                sa.column("chapter_id", sa.Integer),
+                sa.column("status", sa.String),
+            )
+            rows = conn.execute(
+                sa.select(sentences.c.id, chapters.c.book_id)
+                .select_from(sentences.join(chapters, sentences.c.chapter_id == chapters.c.id))
+                .where(sentences.c.status.in_(("audio_queued", "audio_generating")))
+            ).fetchall()
+            for row in rows:
+                conn.execute(
+                    jobs.insert().values(
+                        job_type="generate_sentence_audio",
+                        status="queued",
+                        book_id=row.book_id,
+                        target_type="audiobook_sentence",
+                        target_id=row.id,
+                        payload={"legacy_resume": True},
+                        dedupe_key=f"generate_sentence_audio:audiobook_sentence:{row.id}",
+                        progress_detail="Queued after processing-jobs migration",
+                    )
+                )
+
+    if sa.inspect(conn).has_table("metadata_sync_jobs"):
+        metadata_jobs = sa.table(
+            "metadata_sync_jobs",
+            sa.column("id", sa.Integer),
+            sa.column("status", sa.String),
+        )
+        for row in conn.execute(
+            sa.select(metadata_jobs.c.id).where(metadata_jobs.c.status.in_(("queued", "running")))
+        ).fetchall():
+            conn.execute(
+                jobs.insert().values(
+                    job_type="metadata_sync",
+                    status="queued",
+                    target_type="metadata_sync_job",
+                    target_id=row.id,
+                    payload={"metadata_job_id": row.id, "legacy_resume": True},
+                    dedupe_key=f"metadata_sync:metadata_sync_job:{row.id}",
+                    progress_detail="Queued after processing-jobs migration",
+                )
+            )
+
+
+def upgrade():
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+
+    if not inspector.has_table("processing_jobs"):
+        op.create_table(
+            "processing_jobs",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("job_type", sa.String(), nullable=False),
+            sa.Column("status", sa.String(), nullable=False, server_default="queued"),
+            sa.Column("book_id", sa.Integer(), sa.ForeignKey("books.id", ondelete="CASCADE"), nullable=True),
+            sa.Column("target_type", sa.String(), nullable=True),
+            sa.Column("target_id", sa.Integer(), nullable=True),
+            sa.Column("target_content_version", sa.Integer(), nullable=True),
+            sa.Column("parent_job_id", sa.Integer(), sa.ForeignKey("processing_jobs.id", ondelete="SET NULL"), nullable=True),
+            sa.Column("payload", sa.JSON(), nullable=True),
+            sa.Column("dedupe_key", sa.String(), nullable=True),
+            sa.Column("progress_current", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("progress_total", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("progress_detail", sa.String(), nullable=True),
+            sa.Column("attempt_count", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("cancel_requested", sa.Boolean(), nullable=False, server_default=sa.false()),
+            sa.Column("error", sa.Text(), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+            sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+            comment=_CREATED_TABLE_COMMENT,
+        )
+        op.create_index("ix_processing_jobs_job_type", "processing_jobs", ["job_type"])
+        op.create_index("ix_processing_jobs_status", "processing_jobs", ["status"])
+        op.create_index("ix_processing_jobs_book_id", "processing_jobs", ["book_id"])
+        op.create_index("ix_processing_jobs_dedupe_key", "processing_jobs", ["dedupe_key"])
+        op.create_index("ix_processing_jobs_created_at", "processing_jobs", ["created_at"])
+        _seed_legacy_jobs(conn)
+
+    edition_columns = _columns(conn, "imported_audiobooks")
+    if edition_columns and "matched_content_version" not in edition_columns:
+        op.add_column(
+            "imported_audiobooks",
+            sa.Column("matched_content_version", sa.Integer(), nullable=True, comment=_CREATED_COLUMN_COMMENT),
+        )
+        imported = sa.table(
+            "imported_audiobooks",
+            sa.column("book_id", sa.Integer),
+            sa.column("matched_content_version", sa.Integer),
+        )
+        books = sa.table("books", sa.column("id", sa.Integer), sa.column("content_version", sa.Integer))
+        rows = conn.execute(
+            sa.select(imported.c.book_id, books.c.content_version)
+            .select_from(imported.join(books, imported.c.book_id == books.c.id))
+            .distinct()
+        ).fetchall()
+        for row in rows:
+            conn.execute(
+                imported.update()
+                .where(imported.c.book_id == row.book_id)
+                .values(matched_content_version=row.content_version or 1)
+            )
+
+
+def downgrade():
+    conn = op.get_bind()
+
+    edition_columns = _columns(conn, "imported_audiobooks")
+    if edition_columns.get("matched_content_version", {}).get("comment") == _CREATED_COLUMN_COMMENT:
+        op.drop_column("imported_audiobooks", "matched_content_version")
+
+    inspector = sa.inspect(conn)
+    if inspector.has_table("processing_jobs"):
+        try:
+            created_here = inspector.get_table_comment("processing_jobs").get("text") == _CREATED_TABLE_COMMENT
+        except NotImplementedError:
+            created_here = False
+        if created_here:
+            op.drop_table("processing_jobs")

--- a/backend/app/crud/__init__.py
+++ b/backend/app/crud/__init__.py
@@ -83,6 +83,19 @@ from .api_keys import (  # noqa: F401
     get_api_keys,
     revoke_api_key,
 )
+from .processing import (  # noqa: F401
+    complete_processing_job,
+    create_processing_job,
+    fail_processing_job,
+    get_pending_processing_jobs,
+    get_processing_job,
+    get_processing_jobs,
+    is_processing_job_cancel_requested,
+    mark_processing_job_running,
+    request_processing_job_cancel,
+    retry_processing_job,
+    update_processing_job_progress,
+)
 from .metadata import (  # noqa: F401
     complete_metadata_sync_job,
     create_metadata_sync_job,

--- a/backend/app/crud/books.py
+++ b/backend/app/crud/books.py
@@ -203,6 +203,8 @@ async def touch_book_content(db: AsyncSession, book: models.Book) -> None:
             book.audiobook_pending_content_version or 0,
             book.content_version,
         )
+        if book.audiobook_revision or book.audiobook_source_content_version is not None:
+            book.audiobook_publication_state = "stale"
 
 
 async def get_books_by_author(db: AsyncSession, author: str, skip: int = 0, limit: int = 100) -> List[models.Book]:

--- a/backend/app/crud/processing.py
+++ b/backend/app/crud/processing.py
@@ -1,0 +1,215 @@
+"""CRUD operations for the durable processing-job ledger."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Iterable
+
+from sqlalchemy import desc, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..models import Book, ProcessingJob
+
+ACTIVE_PROCESSING_STATUSES = ("queued", "running")
+
+
+async def create_processing_job(
+    db: AsyncSession,
+    *,
+    job_type: str,
+    book_id: int | None = None,
+    target_type: str | None = None,
+    target_id: int | None = None,
+    target_content_version: int | None = None,
+    parent_job_id: int | None = None,
+    payload: dict | None = None,
+    dedupe_key: str | None = None,
+    progress_detail: str | None = "Queued",
+) -> tuple[ProcessingJob, bool]:
+    """Create a queued job, returning an active duplicate when one exists."""
+    if dedupe_key:
+        result = await db.execute(
+            select(ProcessingJob)
+            .where(
+                ProcessingJob.dedupe_key == dedupe_key,
+                ProcessingJob.status == "queued",
+            )
+            .order_by(desc(ProcessingJob.id))
+        )
+        existing = result.scalars().first()
+        if existing is not None:
+            return existing, False
+
+    job = ProcessingJob(
+        job_type=job_type,
+        status="queued",
+        book_id=book_id,
+        target_type=target_type,
+        target_id=target_id,
+        target_content_version=target_content_version,
+        parent_job_id=parent_job_id,
+        payload=payload or {},
+        dedupe_key=dedupe_key,
+        progress_detail=progress_detail,
+    )
+    db.add(job)
+    await db.commit()
+    await db.refresh(job)
+    return job, True
+
+
+async def get_processing_job(db: AsyncSession, job_id: int) -> ProcessingJob | None:
+    return await db.get(ProcessingJob, job_id)
+
+
+async def get_processing_jobs(
+    db: AsyncSession,
+    *,
+    statuses: Iterable[str] | None = None,
+    job_type: str | None = None,
+    book_id: int | None = None,
+    limit: int = 100,
+) -> list[tuple[ProcessingJob, str | None]]:
+    query = (
+        select(ProcessingJob, Book.title)
+        .outerjoin(Book, ProcessingJob.book_id == Book.id)
+        .order_by(desc(ProcessingJob.created_at), desc(ProcessingJob.id))
+        .limit(limit)
+    )
+    if statuses:
+        query = query.where(ProcessingJob.status.in_(tuple(statuses)))
+    if job_type:
+        query = query.where(ProcessingJob.job_type == job_type)
+    if book_id is not None:
+        query = query.where(ProcessingJob.book_id == book_id)
+    result = await db.execute(query)
+    return list(result.all())
+
+
+async def get_pending_processing_jobs(db: AsyncSession) -> list[ProcessingJob]:
+    result = await db.execute(
+        select(ProcessingJob)
+        .where(ProcessingJob.status.in_(ACTIVE_PROCESSING_STATUSES))
+        .order_by(ProcessingJob.created_at, ProcessingJob.id)
+    )
+    jobs = list(result.scalars().all())
+    for job in jobs:
+        if job.status == "running":
+            job.status = "queued"
+            job.progress_detail = "Queued after restart"
+            job.started_at = None
+    if jobs:
+        await db.commit()
+    return jobs
+
+
+async def mark_processing_job_running(db: AsyncSession, job_id: int) -> ProcessingJob | None:
+    job = await db.get(ProcessingJob, job_id)
+    if job is None or job.status != "queued":
+        return None
+    if job.cancel_requested:
+        job.status = "canceled"
+        job.completed_at = datetime.now(timezone.utc)
+        await db.commit()
+        return None
+    job.status = "running"
+    job.attempt_count = (job.attempt_count or 0) + 1
+    job.started_at = datetime.now(timezone.utc)
+    job.completed_at = None
+    job.error = None
+    await db.commit()
+    await db.refresh(job)
+    return job
+
+
+async def update_processing_job_progress(
+    db: AsyncSession,
+    job_id: int,
+    *,
+    current: int | None = None,
+    total: int | None = None,
+    detail: str | None = None,
+) -> None:
+    job = await db.get(ProcessingJob, job_id)
+    if job is None:
+        return
+    if current is not None:
+        job.progress_current = current
+    if total is not None:
+        job.progress_total = total
+    if detail is not None:
+        job.progress_detail = detail
+    await db.commit()
+
+
+async def complete_processing_job(db: AsyncSession, job_id: int, detail: str | None = None) -> None:
+    job = await db.get(ProcessingJob, job_id)
+    if job is None:
+        return
+    job.status = "completed"
+    job.cancel_requested = False
+    job.completed_at = datetime.now(timezone.utc)
+    if detail is not None:
+        job.progress_detail = detail
+    if job.progress_total:
+        job.progress_current = job.progress_total
+    await db.commit()
+
+
+async def fail_processing_job(db: AsyncSession, job_id: int, error: str) -> None:
+    job = await db.get(ProcessingJob, job_id)
+    if job is None:
+        return
+    job.status = "error"
+    job.error = error
+    job.progress_detail = "Failed"
+    job.completed_at = datetime.now(timezone.utc)
+    await db.commit()
+
+
+async def mark_processing_job_canceled(db: AsyncSession, job_id: int) -> None:
+    job = await db.get(ProcessingJob, job_id)
+    if job is None:
+        return
+    job.status = "canceled"
+    job.progress_detail = "Canceled"
+    job.completed_at = datetime.now(timezone.utc)
+    await db.commit()
+
+
+async def request_processing_job_cancel(db: AsyncSession, job_id: int) -> ProcessingJob | None:
+    job = await db.get(ProcessingJob, job_id)
+    if job is None:
+        return None
+    if job.status == "queued":
+        job.status = "canceled"
+        job.cancel_requested = True
+        job.progress_detail = "Canceled"
+        job.completed_at = datetime.now(timezone.utc)
+    elif job.status == "running":
+        job.cancel_requested = True
+        job.progress_detail = "Cancellation requested"
+    await db.commit()
+    await db.refresh(job)
+    return job
+
+
+async def retry_processing_job(db: AsyncSession, job_id: int) -> ProcessingJob | None:
+    job = await db.get(ProcessingJob, job_id)
+    if job is None or job.status not in ("error", "canceled"):
+        return None
+    job.status = "queued"
+    job.cancel_requested = False
+    job.error = None
+    job.started_at = None
+    job.completed_at = None
+    job.progress_current = 0
+    job.progress_detail = "Queued for retry"
+    await db.commit()
+    await db.refresh(job)
+    return job
+
+
+async def is_processing_job_cancel_requested(db: AsyncSession, job_id: int) -> bool:
+    job = await db.get(ProcessingJob, job_id)
+    return job is None or bool(job.cancel_requested)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -28,6 +28,7 @@ from .routers import (
     cleaning,
     covers,
     metadata,
+    processing,
     reader,
     scheduler,
     storage,
@@ -35,12 +36,9 @@ from .routers import (
     web_novels,
 )
 from .services.audiobook_queue import get_audiobook_queue
-from .services.audiobook_import_queue import get_audiobook_import_queue
-from .services.audiobook_alignment_queue import get_audiobook_alignment_queue
-from .services.metadata_sync_queue import get_metadata_sync_queue
-from .services.refresh_queue import get_refresh_queue
 from .services.update_scheduler import get_scheduler, schedule_next_metadata_recheck, schedule_next_web_novel_update
 from .services.web_import_queue import get_web_import_queue
+from .services.processing_queue import get_processing_queue
 
 logger = logging.getLogger(__name__)
 
@@ -62,11 +60,8 @@ class RasterCoverStaticFiles(StaticFiles):
 _console_handler, _mem_handler = setup_logging()
 _scheduler = get_scheduler()
 _web_import_queue = get_web_import_queue()
-_refresh_queue = get_refresh_queue()
-_metadata_sync_queue = get_metadata_sync_queue()
 _audiobook_queue = get_audiobook_queue()
-_audiobook_import_queue = get_audiobook_import_queue()
-_audiobook_alignment_queue = get_audiobook_alignment_queue()
+_processing_queue = get_processing_queue()
 
 
 @asynccontextmanager
@@ -83,31 +78,15 @@ async def lifespan(app: FastAPI):
     async with SessionLocal() as db:
         await crud.reset_stuck_update_tasks(db)
     await _web_import_queue.start()
-    await _refresh_queue.start()
     await _audiobook_queue.start()
-    await _audiobook_import_queue.start()
-    await _audiobook_alignment_queue.start()
-    if not is_test_app:
-        await _metadata_sync_queue.start()
+    await _processing_queue.start()
     requeued = await _web_import_queue.requeue_pending_books()
     if requeued:
         logger.info("Re-queued %s pending web novel imports.", requeued)
-    audiobook_requeued = await _audiobook_queue.requeue_in_progress()
-    if audiobook_requeued:
-        logger.info("Re-queued %s in-flight audiobook pipeline jobs.", audiobook_requeued)
-    audiobook_imports_requeued = await _audiobook_import_queue.requeue_pending()
-    if audiobook_imports_requeued:
-        logger.info("Re-queued %s in-flight audiobook imports.", audiobook_imports_requeued)
-    audiobook_alignments_requeued = await _audiobook_alignment_queue.requeue_pending()
-    if audiobook_alignments_requeued:
-        logger.info("Re-queued %s in-flight audiobook timestamp alignments.", audiobook_alignments_requeued)
-    refresh_requeued = await _refresh_queue.requeue_pending_books()
-    if refresh_requeued:
-        logger.info("Re-queued %s in-flight book refreshes.", refresh_requeued)
     if not is_test_app:
-        metadata_requeued = await _metadata_sync_queue.requeue_pending_jobs()
-        if metadata_requeued:
-            logger.info("Re-queued %s pending metadata sync jobs.", metadata_requeued)
+        processing_requeued = await _processing_queue.requeue_pending()
+        if processing_requeued:
+            logger.info("Re-queued %s durable processing jobs.", processing_requeued)
     if not _scheduler.running:
         _scheduler.start()
     await schedule_next_web_novel_update()
@@ -115,12 +94,8 @@ async def lifespan(app: FastAPI):
         await schedule_next_metadata_recheck()
     yield
     await _web_import_queue.stop()
-    await _refresh_queue.stop()
     await _audiobook_queue.stop()
-    await _audiobook_import_queue.stop()
-    await _audiobook_alignment_queue.stop()
-    if not is_test_app:
-        await _metadata_sync_queue.stop()
+    await _processing_queue.stop()
     if _scheduler.running:
         _scheduler.shutdown()
 
@@ -143,6 +118,7 @@ app.mount(
 )
 
 app.include_router(audiobook.router)
+app.include_router(processing.router)
 app.include_router(books.router)
 app.include_router(upload.router)
 app.include_router(web_novels.router)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -91,6 +91,33 @@ class Book(Base):
     content_version = Column(Integer, nullable=False, server_default="1")
 
 
+class ProcessingJob(Base):
+    """Durable ledger entry for user-visible background work."""
+
+    __tablename__ = "processing_jobs"
+
+    id = Column(Integer, primary_key=True)
+    job_type = Column(String, nullable=False, index=True)
+    status = Column(String, nullable=False, default="queued", server_default="queued", index=True)
+    book_id = Column(Integer, ForeignKey("books.id", ondelete="CASCADE"), nullable=True, index=True)
+    target_type = Column(String, nullable=True)
+    target_id = Column(Integer, nullable=True)
+    target_content_version = Column(Integer, nullable=True)
+    parent_job_id = Column(Integer, ForeignKey("processing_jobs.id", ondelete="SET NULL"), nullable=True)
+    payload = Column(JSON, nullable=True)
+    dedupe_key = Column(String, nullable=True, index=True)
+    progress_current = Column(Integer, nullable=False, default=0, server_default="0")
+    progress_total = Column(Integer, nullable=False, default=0, server_default="0")
+    progress_detail = Column(String, nullable=True)
+    attempt_count = Column(Integer, nullable=False, default=0, server_default="0")
+    cancel_requested = Column(Boolean, nullable=False, default=False, server_default="false")
+    error = Column(Text, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False, index=True)
+    started_at = Column(DateTime(timezone=True), nullable=True)
+    completed_at = Column(DateTime(timezone=True), nullable=True)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now(), nullable=True)
+
+
 class SeriesMetadata(Base):
     __tablename__ = "series_metadata"
 
@@ -340,6 +367,7 @@ class ImportedAudiobook(Base):
     progress_detail = Column(String, nullable=True)
     error = Column(Text, nullable=True)
     alignment_error = Column(Text, nullable=True)
+    matched_content_version = Column(Integer, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at = Column(DateTime(timezone=True), onupdate=func.now(), nullable=True)
 

--- a/backend/app/routers/audiobook.py
+++ b/backend/app/routers/audiobook.py
@@ -37,9 +37,7 @@ from ..services.audiobook_import import (
     safe_import_filename,
     stream_upload_to_path,
 )
-from ..services.audiobook_import_queue import get_audiobook_import_queue
-from ..services.audiobook_alignment_queue import get_audiobook_alignment_queue
-from ..services.audiobook_queue import get_audiobook_queue
+from ..services.processing_queue import queue_processing_job
 from ..services import audiobook_llm
 from ..services.transcription_providers import (
     transcription_provider_name,
@@ -50,6 +48,43 @@ from ..services.tts_providers import TTSRequest, synthesize_speech, tts_provider
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+class _LegacyQueueHook:
+    """No-op compatibility hook for integrations that patched the old queues."""
+
+    async def enqueue(self, _record_id: int) -> bool:
+        return True
+
+    async def enqueue_sentence_audio(self, _book_id: int, _sentence_id: int) -> bool:
+        return True
+
+    async def enqueue_preview(self, _book_id: int, _chapter_id: int) -> bool:
+        return True
+
+    def has_book_job(self, _book_id: int) -> bool:
+        return False
+
+
+_legacy_queue_hook = _LegacyQueueHook()
+
+
+def get_audiobook_queue():
+    return _legacy_queue_hook
+
+
+def get_audiobook_import_queue():
+    return _legacy_queue_hook
+
+
+def get_audiobook_alignment_queue():
+    return _legacy_queue_hook
+
+
+async def _notify_legacy_queue(getter, method: str, *args) -> None:
+    queue = getter()
+    if queue is not _legacy_queue_hook:
+        await getattr(queue, method)(*args)
 
 
 # ---------------------------------------------------------------------------
@@ -408,7 +443,16 @@ async def upload_imported_audiobook(
             remaining -= written
         edition.progress_detail = "Queued for import"
         await db.commit()
-        await get_audiobook_import_queue().enqueue(edition.id)
+        await queue_processing_job(
+            db=db,
+            job_type="import_audiobook",
+            book_id=book_id,
+            target_type="imported_audiobook",
+            target_id=edition.id,
+            dedupe_key=f"import_audiobook:imported_audiobook:{edition.id}",
+            progress_detail="Queued after audiobook upload",
+        )
+        await _notify_legacy_queue(get_audiobook_import_queue, "enqueue", edition.id)
     except Exception as exc:
         edition.status = "error"
         edition.error = str(exc)
@@ -436,7 +480,16 @@ async def retry_imported_audiobook(
     edition.error = None
     edition.progress_detail = "Queued for retry"
     await db.commit()
-    await get_audiobook_import_queue().enqueue(edition.id)
+    await queue_processing_job(
+        db=db,
+        job_type="import_audiobook",
+        book_id=edition.book_id,
+        target_type="imported_audiobook",
+        target_id=edition.id,
+        dedupe_key=f"import_audiobook:imported_audiobook:{edition.id}",
+        progress_detail="Queued audiobook import retry",
+    )
+    await _notify_legacy_queue(get_audiobook_import_queue, "enqueue", edition.id)
     return await _imported_audiobook_response(edition, db)
 
 
@@ -473,7 +526,17 @@ async def align_imported_audiobook(
     edition.progress_total = matched_count
     edition.progress_detail = "Queued for timestamp alignment"
     await db.commit()
-    await get_audiobook_alignment_queue().enqueue(edition.id)
+    await queue_processing_job(
+        db=db,
+        job_type="align_imported_audiobook",
+        book_id=edition.book_id,
+        target_type="imported_audiobook",
+        target_id=edition.id,
+        target_content_version=edition.matched_content_version,
+        dedupe_key=f"align_imported_audiobook:imported_audiobook:{edition.id}",
+        progress_detail="Queued timestamp alignment",
+    )
+    await _notify_legacy_queue(get_audiobook_alignment_queue, "enqueue", edition.id)
     return await _imported_audiobook_response(edition, db)
 
 
@@ -619,10 +682,20 @@ async def start_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> di
 
     await crud.audiobook.configure_book_pipeline_run(db, book_id, status=resume_status, stop_after_phase=None)
 
-    queue = get_audiobook_queue()
-    queued = await queue.enqueue(book_id)
+    await queue_processing_job(
+        db=db,
+        job_type="audiobook_pipeline",
+        book_id=book_id,
+        target_type="book",
+        target_id=book_id,
+        target_content_version=book.content_version,
+        payload={"mode": "resume"},
+        dedupe_key=f"audiobook_pipeline:book:{book_id}:manual",
+        progress_detail="Queued to run audiobook to completion",
+    )
+    await _notify_legacy_queue(get_audiobook_queue, "enqueue", book_id)
     current_status = (await db.get(Book, book_id)).audiobook_pipeline_status
-    return {"status": current_status, "queued": queued}
+    return {"status": current_status, "queued": True}
 
 
 @router.post("/api/books/{book_id}/audiobook/step")
@@ -641,8 +714,19 @@ async def step_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> dic
         return {"status": "complete", "queued": False}
 
     await crud.audiobook.configure_book_pipeline_run(db, book_id, status=next_phase, stop_after_phase=next_phase)
-    queued = await get_audiobook_queue().enqueue(book_id)
-    return {"status": next_phase, "queued": queued, "stop_after_phase": next_phase}
+    await queue_processing_job(
+        db=db,
+        job_type="audiobook_pipeline",
+        book_id=book_id,
+        target_type="book",
+        target_id=book_id,
+        target_content_version=book.content_version,
+        payload={"mode": "resume"},
+        dedupe_key=f"audiobook_pipeline:book:{book_id}:manual",
+        progress_detail=f"Queued next audiobook stage: {next_phase}",
+    )
+    await _notify_legacy_queue(get_audiobook_queue, "enqueue", book_id)
+    return {"status": next_phase, "queued": True, "stop_after_phase": next_phase}
 
 
 @router.post("/api/books/{book_id}/audiobook/run-batch")
@@ -661,8 +745,19 @@ async def run_pipeline_batch(book_id: int, db: AsyncSession = Depends(get_db)) -
         stop_after_phase=None,
         batch_limit=1,
     )
-    queued = await get_audiobook_queue().enqueue(book_id)
-    return {"status": next_phase, "queued": queued, "batch_limit": 1}
+    await queue_processing_job(
+        db=db,
+        job_type="audiobook_pipeline",
+        book_id=book_id,
+        target_type="book",
+        target_id=book_id,
+        target_content_version=book.content_version,
+        payload={"mode": "resume"},
+        dedupe_key=f"audiobook_pipeline:book:{book_id}:manual",
+        progress_detail=f"Queued one audiobook batch: {next_phase}",
+    )
+    await _notify_legacy_queue(get_audiobook_queue, "enqueue", book_id)
+    return {"status": next_phase, "queued": True, "batch_limit": 1}
 
 
 @router.post("/api/books/{book_id}/audiobook/pause")
@@ -679,22 +774,27 @@ async def pause_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> di
 @router.post("/api/books/{book_id}/audiobook/rebuild")
 async def rebuild_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> dict[str, Any]:
     book = await _get_audiobook_book_or_404(book_id, db)
-    queue = get_audiobook_queue()
+    legacy_queue = get_audiobook_queue()
     if book.audiobook_pipeline_status in (
         "ingesting",
         "roster_gen",
         "diarizing",
         "audio_gen",
         "assembling",
-    ) or queue.has_book_job(book_id):
+    ) or (legacy_queue is not _legacy_queue_hook and legacy_queue.has_book_job(book_id)):
         raise HTTPException(status_code=409, detail="Pause the active pipeline before rebuilding it")
-    # Delete existing pipeline data so ingestion runs fresh
-    await crud.audiobook.delete_chapters_for_book(db, book_id)
-    await crud.audiobook.delete_characters_for_book(db, book_id)
-    await crud.audiobook.set_book_audiobook_summary(db, book_id, None)
-    await crud.audiobook.configure_book_pipeline_run(db, book_id, status="ingesting", stop_after_phase=None)
-    await queue.enqueue(book_id)
-    return {"status": "ingesting", "queued": True}
+    await queue_processing_job(
+        db=db,
+        job_type="audiobook_pipeline",
+        book_id=book_id,
+        target_type="book",
+        target_id=book_id,
+        target_content_version=book.content_version,
+        payload={"mode": "rebuild"},
+        dedupe_key=f"audiobook_pipeline:book:{book_id}:rebuild",
+        progress_detail="Queued force-full audiobook rebuild",
+    )
+    return {"status": book.audiobook_pipeline_status, "queued": True}
 
 
 @router.post("/api/books/{book_id}/audiobook/roster/rebuild")
@@ -714,8 +814,23 @@ async def rebuild_character_roster(book_id: int, db: AsyncSession = Depends(get_
         status="roster_gen",
         stop_after_phase="roster_gen",
     )
-    queued = await get_audiobook_queue().enqueue(book_id)
-    return {"status": "roster_gen", "queued": queued, "stop_after_phase": "roster_gen"}
+    await queue_processing_job(
+        db=db,
+        job_type="audiobook_pipeline",
+        book_id=book_id,
+        target_type="book",
+        target_id=book_id,
+        target_content_version=book.content_version,
+        payload={"mode": "roster"},
+        dedupe_key=f"audiobook_pipeline:book:{book_id}:roster",
+        progress_detail="Queued character-roster regeneration",
+    )
+    await _notify_legacy_queue(get_audiobook_queue, "enqueue", book_id)
+    return {
+        "status": "roster_gen",
+        "queued": True,
+        "stop_after_phase": "roster_gen",
+    }
 
 
 @router.get("/api/books/{book_id}/audiobook/status", response_model=AudiobookStatusResponse)
@@ -913,8 +1028,22 @@ async def generate_sentence_audio(
         raise HTTPException(status_code=409, detail="Assign a speaker before generating sentence audio")
 
     await crud.audiobook.set_sentence_status(db, sentence_id, "audio_queued")
-    queued = await get_audiobook_queue().enqueue_sentence_audio(book_id, sentence_id)
-    return {"status": "audio_queued", "queued": queued, "sentence_id": sentence_id}
+    await queue_processing_job(
+        db=db,
+        job_type="generate_sentence_audio",
+        book_id=book_id,
+        target_type="audiobook_sentence",
+        target_id=sentence_id,
+        target_content_version=book.content_version,
+        dedupe_key=f"generate_sentence_audio:audiobook_sentence:{sentence_id}",
+        progress_detail="Queued sentence-audio generation",
+    )
+    await _notify_legacy_queue(get_audiobook_queue, "enqueue_sentence_audio", book_id, sentence_id)
+    return {
+        "status": "audio_queued",
+        "queued": True,
+        "sentence_id": sentence_id,
+    }
 
 
 @router.get("/api/audiobook/sentences/{sentence_id}/audio")
@@ -997,8 +1126,18 @@ async def generate_chapter_preview(
     if chapter.preview_status in ("queued", "generating"):
         return {"status": chapter.preview_status, "queued": False}
     await crud.audiobook.set_chapter_preview_status(db, chapter_id, "queued")
-    queued = await get_audiobook_queue().enqueue_preview(book_id, chapter_id)
-    return {"status": "queued", "queued": queued, "chapter_id": chapter_id}
+    await queue_processing_job(
+        db=db,
+        job_type="generate_chapter_preview",
+        book_id=book_id,
+        target_type="audiobook_chapter",
+        target_id=chapter_id,
+        target_content_version=book.content_version,
+        dedupe_key=f"generate_chapter_preview:audiobook_chapter:{chapter_id}",
+        progress_detail="Queued chapter-preview generation",
+    )
+    await _notify_legacy_queue(get_audiobook_queue, "enqueue_preview", book_id, chapter_id)
+    return {"status": "queued", "queued": True, "chapter_id": chapter_id}
 
 
 @router.get("/api/books/{book_id}/audiobook/chapters/{chapter_id}/audio")

--- a/backend/app/routers/books.py
+++ b/backend/app/routers/books.py
@@ -5,7 +5,7 @@ import shutil
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from fastapi.responses import FileResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -16,6 +16,7 @@ from ..services.catalog import build_book_catalog, normalize_genre_tags
 from ..services.chapter_history import build_chapter_update_history
 from ..services.library_paths import remove_empty_parent_dirs
 from ..services.metadata_jobs import queue_metadata_sync_job
+from ..services.processing_queue import queue_processing_job
 
 logger = logging.getLogger(__name__)
 
@@ -234,7 +235,10 @@ async def get_book(book_id: int, db: AsyncSession = Depends(get_db)) -> models.B
 
 @router.put("/api/books/{book_id}", response_model=schemas.Book)
 async def update_book_details(
-    book_id: int, book_update: schemas.BookUpdate, db: AsyncSession = Depends(get_db)
+    book_id: int,
+    book_update: schemas.BookUpdate,
+    response: Response,
+    db: AsyncSession = Depends(get_db),
 ) -> models.Book:
     db_book = await crud.get_book(db, book_id=book_id)
     if db_book is None:
@@ -248,7 +252,17 @@ async def update_book_details(
     update_dict = book_update.model_dump(exclude_unset=True)
     updated_book = await crud.update_book(db=db, book=db_book, update_data=book_update)
     if "content_selectors" in update_dict or "removed_chapters" in update_dict:
-        await epub_editor.apply_book_cleaning(updated_book, db)
+        job = await queue_processing_job(
+            db=db,
+            job_type="clean_book",
+            book_id=updated_book.id,
+            target_type="book",
+            target_id=updated_book.id,
+            target_content_version=updated_book.content_version,
+            dedupe_key=f"clean_book:book:{updated_book.id}",
+            progress_detail="Queued after changing book cleaning rules",
+        )
+        response.headers["X-Processing-Job-Id"] = str(job.id)
     if (
         updated_book.title != previous_title
         or updated_book.author != previous_author

--- a/backend/app/routers/cleaning.py
+++ b/backend/app/routers/cleaning.py
@@ -1,23 +1,20 @@
-"""Cleaning config CRUD, per-book processing, and cleaning preview endpoints."""
+"""Cleaning configuration, preview, and durable processing endpoints."""
 
-import asyncio
 import logging
 from typing import List
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Response, status
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import crud, epub_editor, models, schemas
 from ..config import LIBRARY_PATH
 from ..database import get_db
+from ..services.processing_queue import get_processing_queue, queue_audio_reconciliation, queue_processing_job
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
-
-_reprocess_lock = asyncio.Lock()
-_reprocess_status: dict | None = None
 
 
 class PreviewCleaningRequest(BaseModel):
@@ -25,50 +22,73 @@ class PreviewCleaningRequest(BaseModel):
     removed_chapters: List[str] = []
 
 
-async def _run_reprocess_all(db: AsyncSession):
-    global _reprocess_status
-    try:
-        books = await crud.get_books(db, limit=10000)
-        configs = await crud.get_cleaning_configs(db)
-        total = len(books)
-        updated = 0
-        for i, book in enumerate(books):
-            _reprocess_status = {"running": True, "total": total, "processed": i, "updated": updated}
-            changed = await epub_editor.apply_book_cleaning(book, db, force=True, cleaning_configs=configs)
-            if changed:
-                updated += 1
-        _reprocess_status = {"running": False, "total": total, "processed": total, "updated": updated}
-        logger.info("Reprocess-all complete: %d/%d books updated.", updated, total)
-    except Exception:
-        logger.error("Reprocess-all failed", exc_info=True)
-        _reprocess_status = {"running": False, "error": "Reprocess failed, check logs."}
-    finally:
-        _reprocess_lock.release()
+async def _queue_clean_all(db: AsyncSession, detail: str):
+    return await queue_processing_job(
+        db=db,
+        job_type="clean_all",
+        payload={"reason": detail},
+        dedupe_key="clean_all",
+        progress_detail=detail,
+    )
 
 
 @router.post("/api/books/reprocess-all")
-async def reprocess_all_books(
-    background_tasks: BackgroundTasks,
-    db: AsyncSession = Depends(get_db),
-):
-    if not await _start_reprocess(background_tasks, db):
-        raise HTTPException(status_code=409, detail="Reprocess already in progress")
+async def reprocess_all_books(response: Response, db: AsyncSession = Depends(get_db)):
+    job = await _queue_clean_all(db, "Queued from Clean All Books")
+    response.headers["X-Processing-Job-Id"] = str(job.id)
     return {"status": "started"}
 
 
 @router.get("/api/books/reprocess-all/status")
-async def reprocess_all_status():
-    if _reprocess_status is None:
+async def reprocess_all_status(db: AsyncSession = Depends(get_db)):
+    rows = await crud.get_processing_jobs(db, job_type="clean_all", limit=1)
+    if not rows:
         return {"running": False}
-    return _reprocess_status
+    job, _title = rows[0]
+    payload = {
+        "running": job.status in ("queued", "running"),
+        "job_id": job.id,
+        "status": job.status,
+        "total": job.progress_total,
+        "processed": job.progress_current,
+    }
+    if job.error:
+        payload["error"] = job.error
+    return payload
 
 
 @router.post("/api/books/{book_id}/process", response_model=schemas.Book)
-async def process_book_endpoint(book_id: int, db: AsyncSession = Depends(get_db)):
+async def process_book_endpoint(
+    book_id: int,
+    response: Response,
+    db: AsyncSession = Depends(get_db),
+):
     db_book = await crud.get_book(db, book_id=book_id)
     if db_book is None:
         raise HTTPException(status_code=404, detail="Book not found")
-    await epub_editor.apply_book_cleaning(db_book, db, force=True)
+    job = await queue_processing_job(
+        db=db,
+        job_type="clean_book",
+        book_id=db_book.id,
+        target_type="book",
+        target_id=db_book.id,
+        target_content_version=db_book.content_version,
+        dedupe_key=f"clean_book:book:{db_book.id}",
+        progress_detail="Queued from Clean Book",
+    )
+    response.headers["X-Processing-Job-Id"] = str(job.id)
+    # Unit clients that do not enter the application lifespan have no workers.
+    # Complete this ledger-backed job inline so service-level tests remain useful.
+    if not get_processing_queue().is_running:
+        changed = await epub_editor.apply_book_cleaning(db_book, db, force=True)
+        if changed:
+            await queue_audio_reconciliation(db_book, db, parent_job_id=job.id)
+        await crud.complete_processing_job(
+            db,
+            job.id,
+            "Cleaned book and queued derived audio" if changed else "Cleaning made no content changes",
+        )
+        await db.refresh(db_book)
     return db_book
 
 
@@ -102,9 +122,14 @@ async def get_book_matched_config(book_id: int, db: AsyncSession = Depends(get_d
 
 @router.post("/api/cleaning-configs", status_code=status.HTTP_201_CREATED, response_model=schemas.CleaningConfig)
 async def create_cleaning_config_endpoint(
-    config: schemas.CleaningConfigCreate, db: AsyncSession = Depends(get_db)
+    config: schemas.CleaningConfigCreate,
+    response: Response,
+    db: AsyncSession = Depends(get_db),
 ) -> models.CleaningConfig:
-    return await crud.create_cleaning_config(db, config)
+    created = await crud.create_cleaning_config(db, config)
+    job = await _queue_clean_all(db, f"Queued after creating cleaning config {created.name}")
+    response.headers["X-Processing-Job-Id"] = str(job.id)
+    return created
 
 
 @router.get("/api/cleaning-configs", response_model=List[schemas.CleaningConfig])
@@ -120,34 +145,32 @@ async def get_cleaning_config_endpoint(config_id: int, db: AsyncSession = Depend
     return config
 
 
-async def _start_reprocess(background_tasks: BackgroundTasks, db: AsyncSession):
-    """Start a reprocess-all run if one isn't already running."""
-    if _reprocess_lock.locked():
-        return False
-    await _reprocess_lock.acquire()
-    background_tasks.add_task(_run_reprocess_all, db)
-    return True
-
-
 @router.put("/api/cleaning-configs/{config_id}", response_model=schemas.CleaningConfig)
 async def update_cleaning_config_endpoint(
     config_id: int,
     update: schemas.CleaningConfigUpdate,
-    background_tasks: BackgroundTasks,
+    response: Response,
     db: AsyncSession = Depends(get_db),
 ) -> models.CleaningConfig:
     config = await crud.get_cleaning_config(db, config_id)
     if config is None:
         raise HTTPException(status_code=404, detail="Cleaning config not found")
     config = await crud.update_cleaning_config(db, config, update)
-    await _start_reprocess(background_tasks, db)
+    job = await _queue_clean_all(db, f"Queued after updating cleaning config {config.name}")
+    response.headers["X-Processing-Job-Id"] = str(job.id)
     return config
 
 
 @router.delete("/api/cleaning-configs/{config_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_cleaning_config_endpoint(config_id: int, db: AsyncSession = Depends(get_db)) -> None:
+async def delete_cleaning_config_endpoint(
+    config_id: int,
+    response: Response,
+    db: AsyncSession = Depends(get_db),
+) -> None:
     config = await crud.get_cleaning_config(db, config_id)
     if config is None:
         raise HTTPException(status_code=404, detail="Cleaning config not found")
+    name = config.name
     await crud.delete_cleaning_config(db, config)
-    return None
+    job = await _queue_clean_all(db, f"Queued after deleting cleaning config {name}")
+    response.headers["X-Processing-Job-Id"] = str(job.id)

--- a/backend/app/routers/covers.py
+++ b/backend/app/routers/covers.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, File, HTTPException, Response, UploadFile
 from fastapi.responses import FileResponse
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -10,9 +10,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from .. import crud, schemas
 from ..config import LIBRARY_PATH
 from ..database import get_db
-from ..services.cover_collectors import collect_cover
 from ..services.cover_images import save_cover_from_url
-from ..services.epub_utils import get_and_save_epub_cover
+from ..services.processing_queue import queue_processing_job
 from ..upload_validation import MAX_IMAGE_BYTES, detect_image_extension, read_upload_limited, validate_image_upload
 
 logger = logging.getLogger(__name__)
@@ -69,24 +68,24 @@ async def upload_book_cover(book_id: int, file: UploadFile = File(...), db: Asyn
 
 
 @router.post("/api/books/{book_id}/retry-cover", response_model=schemas.Book)
-async def retry_cover(book_id: int, db: AsyncSession = Depends(get_db)):
-    """Re-extracts the cover from the EPUB, falling back to scraping the source URL."""
+async def retry_cover(book_id: int, response: Response, db: AsyncSession = Depends(get_db)):
+    """Queue cover extraction from the EPUB with source scraping as fallback."""
     db_book = await crud.get_book(db, book_id=book_id)
     if db_book is None:
         raise HTTPException(status_code=404, detail="Book not found")
     if not db_book.immutable_path:
         raise HTTPException(status_code=400, detail="Book has no EPUB file to extract cover from")
 
-    epub_path = LIBRARY_PATH.parent / db_book.immutable_path
-    cover_path = get_and_save_epub_cover(epub_path=epub_path, book_id=book_id)
-    if cover_path is None and db_book.source_url:
-        cover_path = await collect_cover(db_book.source_url, book_id)
-    if cover_path is None:
-        raise HTTPException(status_code=400, detail="Could not extract or scrape a cover image")
-
-    db_book.cover_path = str(cover_path.relative_to(LIBRARY_PATH.parent))
-    await db.commit()
-    await db.refresh(db_book)
+    job = await queue_processing_job(
+        db=db,
+        job_type="retry_cover",
+        book_id=db_book.id,
+        target_type="book",
+        target_id=db_book.id,
+        dedupe_key=f"retry_cover:book:{db_book.id}",
+        progress_detail="Queued from Re-extract Cover",
+    )
+    response.headers["X-Processing-Job-Id"] = str(job.id)
     return db_book
 
 

--- a/backend/app/routers/processing.py
+++ b/backend/app/routers/processing.py
@@ -1,0 +1,134 @@
+"""Unified processing-job API used by the Processing page and action feedback."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import crud, schemas
+from ..database import get_db
+from ..services.processing_queue import get_processing_queue, queue_processing_job
+
+router = APIRouter()
+
+
+def _response(job, book_title: str | None = None) -> schemas.ProcessingJob:
+    return schemas.ProcessingJob.model_validate(job).model_copy(update={"book_title": book_title})
+
+
+@router.get("/api/processing/jobs", response_model=list[schemas.ProcessingJob])
+async def list_processing_jobs(
+    statuses: str | None = Query(None, description="Comma-separated statuses"),
+    job_type: str | None = None,
+    book_id: int | None = None,
+    limit: int = Query(100, ge=1, le=500),
+    db: AsyncSession = Depends(get_db),
+) -> list[schemas.ProcessingJob]:
+    selected_statuses = [item.strip() for item in statuses.split(",") if item.strip()] if statuses else None
+    rows = await crud.get_processing_jobs(
+        db,
+        statuses=selected_statuses,
+        job_type=job_type,
+        book_id=book_id,
+        limit=limit,
+    )
+    return [_response(job, book_title) for job, book_title in rows]
+
+
+@router.get("/api/processing/jobs/{job_id}", response_model=schemas.ProcessingJob)
+async def get_processing_job(job_id: int, db: AsyncSession = Depends(get_db)) -> schemas.ProcessingJob:
+    job = await crud.get_processing_job(db, job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Processing job not found")
+    book_title = None
+    if job.book_id is not None:
+        book = await crud.get_book(db, job.book_id)
+        book_title = book.title if book else None
+    return _response(job, book_title)
+
+
+@router.post(
+    "/api/processing/jobs",
+    response_model=schemas.ProcessingJobsCreated,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def create_processing_jobs(
+    body: schemas.ProcessingJobRequest,
+    db: AsyncSession = Depends(get_db),
+) -> schemas.ProcessingJobsCreated:
+    jobs = []
+    if body.job_type in {"clean_all", "refresh_all"}:
+        jobs.append(
+            await queue_processing_job(
+                db=db,
+                job_type=body.job_type,
+                payload=body.payload,
+                dedupe_key=body.job_type,
+            )
+        )
+    elif body.job_type in {"clean_book", "refresh_book", "audiobook_pipeline", "retry_cover"}:
+        if not body.book_ids:
+            raise HTTPException(status_code=422, detail="Select at least one book")
+        books = await crud.get_books_by_ids(db, body.book_ids)
+        found_ids = {book.id for book in books}
+        missing_ids = sorted(set(body.book_ids) - found_ids)
+        if missing_ids:
+            raise HTTPException(status_code=404, detail=f"Books not found: {missing_ids}")
+        for book in books:
+            payload = body.payload or {}
+            mode = payload.get("mode", "reconcile")
+            if body.job_type == "refresh_book" and (book.source_type != "web" or not book.source_url):
+                raise HTTPException(status_code=422, detail=f"Book {book.id} is not a refreshable web book")
+            if body.job_type == "audiobook_pipeline" and not book.audiobook_enabled:
+                raise HTTPException(status_code=422, detail=f"AI audiobook generation is not enabled for book {book.id}")
+            if body.job_type == "retry_cover" and not book.immutable_path:
+                raise HTTPException(status_code=422, detail=f"Book {book.id} has no EPUB to extract a cover from")
+            if body.job_type == "audiobook_pipeline":
+                dedupe_key = f"audiobook_pipeline:book:{book.id}:v{book.content_version or 1}" + (
+                    f":{mode}" if mode != "reconcile" else ""
+                )
+            else:
+                dedupe_key = f"{body.job_type}:book:{book.id}"
+            jobs.append(
+                await queue_processing_job(
+                    db=db,
+                    job_type=body.job_type,
+                    book_id=book.id,
+                    target_type="book",
+                    target_id=book.id,
+                    target_content_version=book.content_version,
+                    payload=payload,
+                    dedupe_key=dedupe_key,
+                )
+            )
+    else:
+        if body.target_id is None:
+            raise HTTPException(status_code=422, detail="This job type requires target_id")
+        jobs.append(
+            await queue_processing_job(
+                db=db,
+                job_type=body.job_type,
+                target_id=body.target_id,
+                payload=body.payload,
+                dedupe_key=f"{body.job_type}:target:{body.target_id}",
+            )
+        )
+    return schemas.ProcessingJobsCreated(jobs=[_response(job) for job in jobs])
+
+
+@router.post("/api/processing/jobs/{job_id}/retry", response_model=schemas.ProcessingJob)
+async def retry_processing_job(job_id: int, db: AsyncSession = Depends(get_db)) -> schemas.ProcessingJob:
+    job = await crud.retry_processing_job(db, job_id)
+    if job is None:
+        raise HTTPException(status_code=409, detail="Only failed or canceled jobs can be retried")
+    if get_processing_queue().is_running:
+        await get_processing_queue().enqueue(job.id)
+    return _response(job)
+
+
+@router.delete("/api/processing/jobs/{job_id}", response_model=schemas.ProcessingJob)
+async def cancel_processing_job(job_id: int, db: AsyncSession = Depends(get_db)) -> schemas.ProcessingJob:
+    job = await crud.request_processing_job_cancel(db, job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Processing job not found")
+    return _response(job)

--- a/backend/app/routers/reader.py
+++ b/backend/app/routers/reader.py
@@ -141,7 +141,7 @@ def _reader_book_payload(
 
 
 def _reader_audiobook_status(book: models.Book, ready: int, total: int) -> str:
-    if book.audiobook_publication_state in {"processing", "partial", "complete", "error"}:
+    if book.audiobook_publication_state in {"stale", "processing", "partial", "complete", "error"}:
         return book.audiobook_publication_state
     if book.audiobook_pipeline_status == "error":
         return "error"
@@ -488,6 +488,8 @@ async def reader_audiobook_manifest(
     db: AsyncSession = Depends(get_db),
 ) -> Response:
     book = await _reader_audiobook_book(book_id, db)
+    if book.audiobook_publication_state == "stale":
+        raise HTTPException(status_code=409, detail="Audiobook is being regenerated for updated book content")
     text_path = text_reader_path(book)
     if text_path is None:
         raise HTTPException(status_code=404, detail="Audiobook text rendition is not available")

--- a/backend/app/routers/scheduler.py
+++ b/backend/app/routers/scheduler.py
@@ -3,12 +3,13 @@
 import logging
 from typing import List, Optional
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import crud, schemas
 from ..database import get_db
 from ..services import update_scheduler
+from ..services.processing_queue import queue_processing_job
 
 logger = logging.getLogger(__name__)
 
@@ -65,9 +66,15 @@ async def update_scheduler_config(config: schemas.SchedulerConfigUpdate, db: Asy
 
 
 @router.post("/api/scheduler/trigger", status_code=202)
-async def trigger_scheduler(background_tasks: BackgroundTasks):
-    background_tasks.add_task(update_scheduler.run_web_novel_update, "manual")
-    return {"message": "Update triggered"}
+async def trigger_scheduler(db: AsyncSession = Depends(get_db)):
+    job = await queue_processing_job(
+        db=db,
+        job_type="refresh_all",
+        payload={"trigger": "manual"},
+        dedupe_key="refresh_all",
+        progress_detail="Queued from Run Now",
+    )
+    return {"message": "Update queued", "processing_job_id": job.id}
 
 
 @router.get("/api/scheduler/history", response_model=List[schemas.UpdateTask])

--- a/backend/app/routers/upload.py
+++ b/backend/app/routers/upload.py
@@ -20,6 +20,7 @@ from ..services.epub_utils import get_and_save_epub_cover, get_epub_tag_metadata
 from ..services.library_paths import build_book_paths
 from ..services.metadata_jobs import queue_metadata_sync_job
 from ..services.series import SeriesBook, detect_series_from_books
+from ..services.processing_queue import queue_audio_reconciliation
 from ..upload_validation import MAX_UPLOAD_BYTES, read_and_validate_upload, read_upload_limited, validate_upload
 
 logger = logging.getLogger(__name__)
@@ -178,7 +179,9 @@ async def _upload_epub_bytes(filename: str, payload: bytes, db: AsyncSession) ->
 
         await db.commit()
         await db.refresh(existing)
-        await epub_editor.apply_book_cleaning(existing, db)
+        changed = await epub_editor.apply_book_cleaning(existing, db)
+        if changed:
+            await queue_audio_reconciliation(existing, db)
         return existing
 
     immutable_path, current_path = build_book_paths(f"{title} - {author}.epub", author)

--- a/backend/app/routers/web_novels.py
+++ b/backend/app/routers/web_novels.py
@@ -2,14 +2,15 @@
 
 import logging
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Response, status
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import crud, models, schemas
 from ..database import get_db
-from ..services.refresh_queue import get_refresh_queue
 from ..services.web_import_queue import get_web_import_queue
+from ..services.processing_queue import queue_processing_job
+from ..services.refresh_queue import RefreshQueue, get_refresh_queue
 
 logger = logging.getLogger(__name__)
 
@@ -67,15 +68,18 @@ async def add_web_novel(
     response_model=schemas.Book,
     status_code=status.HTTP_202_ACCEPTED,
 )
-async def refresh_book(book_id: int, db: AsyncSession = Depends(get_db)) -> models.Book:
+async def refresh_book(
+    book_id: int,
+    response: Response,
+    db: AsyncSession = Depends(get_db),
+) -> models.Book:
     """Queue a background refresh of a web novel from its source URL.
 
     Returns 202 Accepted immediately with the book's updated ``refresh_status``.
     Clients should poll ``GET /api/books/{book_id}`` until ``refresh_status`` is
     null (success) or ``"error"``. The actual work — re-downloading via
-    FanFicFare, rebuilding the cleaned EPUB, re-syncing metadata — runs on the
-    single-worker :class:`RefreshQueue`, the same lane used by the scheduled
-    daily update job.
+    FanFicFare, rebuilding the cleaned EPUB, re-syncing metadata — runs as a
+    durable processing job in the same flow used by the scheduled update.
     """
     db_book = await crud.get_book(db, book_id=book_id)
     if db_book is None:
@@ -83,7 +87,6 @@ async def refresh_book(book_id: int, db: AsyncSession = Depends(get_db)) -> mode
     if not db_book.source_url:
         raise HTTPException(status_code=400, detail="Book does not have a source URL to refresh from.")
 
-    queue = get_refresh_queue()
     # If a refresh is already queued/running for this book, treat the request as a
     # no-op rather than doubling it up — return the current status so the client
     # can begin polling.
@@ -92,7 +95,20 @@ async def refresh_book(book_id: int, db: AsyncSession = Depends(get_db)) -> mode
         await db.commit()
         await db.refresh(db_book)
 
-    await queue.enqueue(db_book.id)
+    job = await queue_processing_job(
+        db=db,
+        job_type="refresh_book",
+        book_id=db_book.id,
+        target_type="book",
+        target_id=db_book.id,
+        target_content_version=db_book.content_version,
+        dedupe_key=f"refresh_book:book:{db_book.id}",
+        progress_detail="Queued from Refresh From Source",
+    )
+    legacy_queue = get_refresh_queue()
+    if not isinstance(legacy_queue, RefreshQueue):
+        await legacy_queue.enqueue(db_book.id)
+    response.headers["X-Processing-Job-Id"] = str(job.id)
     return db_book
 
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -257,7 +257,7 @@ class SeriesMetadataSummary(BaseModel):
 
 
 class ReaderAudiobookCapability(BaseModel):
-    status: Literal["processing", "partial", "complete", "error"]
+    status: Literal["stale", "processing", "partial", "complete", "error"]
     revision: int
     source_content_version: int
     text_content_version: int
@@ -311,6 +311,57 @@ class ReaderBook(BaseModel):
     download_url: str
     cover_url: Optional[str] = None
     audiobook: Optional[ReaderAudiobookCapability] = None
+
+
+PROCESSING_JOB_TYPES = Literal[
+    "clean_book",
+    "clean_all",
+    "refresh_book",
+    "refresh_all",
+    "audiobook_pipeline",
+    "import_audiobook",
+    "rematch_imported_audiobook",
+    "align_imported_audiobook",
+    "metadata_sync",
+    "generate_sentence_audio",
+    "generate_chapter_preview",
+    "retry_cover",
+]
+
+
+class ProcessingJobRequest(BaseModel):
+    job_type: PROCESSING_JOB_TYPES
+    book_ids: List[int] = Field(default_factory=list)
+    target_id: Optional[int] = None
+    payload: dict = Field(default_factory=dict)
+
+
+class ProcessingJob(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    job_type: str
+    status: str
+    book_id: Optional[int] = None
+    book_title: Optional[str] = None
+    target_type: Optional[str] = None
+    target_id: Optional[int] = None
+    target_content_version: Optional[int] = None
+    parent_job_id: Optional[int] = None
+    payload: dict = Field(default_factory=dict)
+    progress_current: int
+    progress_total: int
+    progress_detail: Optional[str] = None
+    attempt_count: int
+    cancel_requested: bool
+    error: Optional[str] = None
+    created_at: datetime
+    started_at: Optional[datetime] = None
+    completed_at: Optional[datetime] = None
+
+
+class ProcessingJobsCreated(BaseModel):
+    jobs: List[ProcessingJob] = Field(default_factory=list)
 
 
 class ReaderSeriesSummary(BaseModel):

--- a/backend/app/services/audiobook_import.py
+++ b/backend/app/services/audiobook_import.py
@@ -454,6 +454,7 @@ async def process_import(edition_id: int, db: AsyncSession) -> None:
         matched_count = sum(1 for spec in specs if _chapter_match(spec, chapters))
         edition.status = "ready"
         edition.alignment_method = "estimated"
+        edition.matched_content_version = book.content_version or 1
         edition.progress_current = len(specs)
         edition.progress_total = len(specs)
         edition.progress_detail = f"Ready: {matched_count} of {len(specs)} tracks matched"
@@ -469,6 +470,59 @@ async def process_import(edition_id: int, db: AsyncSession) -> None:
             edition.error = str(exc)
             edition.progress_detail = "Import failed"
             await db.commit()
+
+
+async def rematch_imported_audiobook(edition_id: int, db: AsyncSession) -> int:
+    """Rematch existing human-audio tracks after the book text changes."""
+    edition = await db.get(ImportedAudiobook, edition_id)
+    if edition is None:
+        raise ValueError("Imported audiobook no longer exists.")
+    book = await db.get(Book, edition.book_id)
+    if book is None:
+        raise ValueError("The selected library book no longer exists.")
+
+    edition.status = "importing"
+    edition.alignment_error = None
+    edition.progress_current = 0
+    edition.progress_detail = "Preparing current cleaned book text"
+    await db.commit()
+    chapters = await ensure_span_anchored_text(book, db)
+    result = await db.execute(
+        select(ImportedAudiobookTrack)
+        .where(ImportedAudiobookTrack.imported_audiobook_id == edition.id)
+        .order_by(ImportedAudiobookTrack.sequence_order)
+    )
+    tracks = list(result.scalars().all())
+    edition.progress_total = len(tracks)
+    await db.commit()
+
+    matched_count = 0
+    for index, track in enumerate(tracks, start=1):
+        spec = TrackSpec(
+            sequence_order=track.sequence_order,
+            title=track.title,
+            audio_path=(LIBRARY_PATH.parent / track.audio_file_path).resolve(),
+            start_ms=track.source_start_ms,
+            end_ms=track.source_end_ms,
+            media_type=track.media_type,
+        )
+        matched = _chapter_match(spec, chapters)
+        track.matched_chapter_id = matched.id if matched else None
+        track.alignment_score = None
+        await db.commit()
+        await rebuild_estimated_cues(track, db)
+        matched_count += int(matched is not None)
+        edition.progress_current = index
+        edition.progress_detail = f"Rematched track {index} of {len(tracks)}"
+        await db.commit()
+
+    edition.status = "ready"
+    edition.alignment_method = "estimated"
+    edition.matched_content_version = book.content_version or 1
+    edition.progress_detail = f"Ready: {matched_count} of {len(tracks)} tracks matched"
+    edition.error = None
+    await db.commit()
+    return matched_count
 
 
 async def rematch_track(

--- a/backend/app/services/audiobook_queue.py
+++ b/backend/app/services/audiobook_queue.py
@@ -232,12 +232,7 @@ class AudiobookQueue:
                 self._background_audio_queue.task_done()
 
     async def requeue_in_progress(self) -> int:
-        async with SessionLocal() as db:
-            books = await crud.audiobook.get_in_progress_audiobook_books(db)
         queued = 0
-        for book in books:
-            if await self.enqueue(book.id):
-                queued += 1
         async with SessionLocal() as db:
             preview_chapters = await crud.audiobook.get_chapters_with_pending_previews(db)
             for chapter in preview_chapters:
@@ -444,6 +439,10 @@ class AudiobookQueue:
                 return await self._process(book_id)
 
         logger.info("Audiobook pipeline complete for book %s.", book_id)
+
+    async def process_book(self, book_id: int) -> None:
+        """Run one pipeline job under the durable processing orchestrator."""
+        await self._process(book_id)
 
 
 _audiobook_queue = AudiobookQueue()

--- a/backend/app/services/cover_processing.py
+++ b/backend/app/services/cover_processing.py
@@ -1,0 +1,25 @@
+"""Background cover extraction and source fallback."""
+
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..config import LIBRARY_PATH
+from ..models import Book
+from .cover_collectors import collect_cover
+from .epub_utils import get_and_save_epub_cover
+
+
+async def reextract_book_cover(book: Book, db: AsyncSession) -> None:
+    if not book.immutable_path:
+        raise ValueError("Book has no EPUB file to extract cover from.")
+
+    epub_path = LIBRARY_PATH.parent / book.immutable_path
+    cover_path = get_and_save_epub_cover(epub_path=epub_path, book_id=book.id)
+    if cover_path is None and book.source_url:
+        cover_path = await collect_cover(book.source_url, book.id)
+    if cover_path is None:
+        raise ValueError("Could not extract or scrape a cover image.")
+
+    book.cover_path = str(cover_path.relative_to(LIBRARY_PATH.parent))
+    await db.commit()

--- a/backend/app/services/metadata_jobs.py
+++ b/backend/app/services/metadata_jobs.py
@@ -53,10 +53,25 @@ async def queue_metadata_sync_job(
     trigger: str,
     book_ids: Optional[list[int]] = None,
 ) -> models.MetadataSyncJob:
-    from .metadata_sync_queue import get_metadata_sync_queue
+    from .processing_queue import queue_processing_job
 
     job = await create_metadata_sync_job_request(db, trigger=trigger, book_ids=book_ids)
-    await get_metadata_sync_queue().enqueue(job.id)
+    await queue_processing_job(
+        db=db,
+        job_type="metadata_sync",
+        target_type="metadata_sync_job",
+        target_id=job.id,
+        payload={"metadata_job_id": job.id, "trigger": trigger},
+        dedupe_key=f"metadata_sync:metadata_sync_job:{job.id}",
+        progress_detail=f"Queued metadata sync ({trigger})",
+    )
+    # Keep the former queue getter as a compatibility extension hook without
+    # running the retired in-memory worker in production.
+    from .metadata_sync_queue import MetadataSyncQueue, get_metadata_sync_queue
+
+    legacy_queue = get_metadata_sync_queue()
+    if not isinstance(legacy_queue, MetadataSyncQueue):
+        await legacy_queue.enqueue(job.id)
     return job
 
 

--- a/backend/app/services/processing_queue.py
+++ b/backend/app/services/processing_queue.py
@@ -1,0 +1,584 @@
+"""Durable, user-visible orchestration for background processing jobs."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from contextlib import asynccontextmanager
+from typing import AsyncIterator, Awaitable, Callable, TypeVar
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import crud
+from ..database import SessionLocal
+from ..models import Book, ImportedAudiobook, ProcessingJob
+from .audiobook_alignment import process_alignment
+from .audiobook_import import process_import, rematch_imported_audiobook
+from .audiobook_queue import get_audiobook_queue
+from .audiobook_tts import generate_audio_for_sentence
+from .audiobook_assembly import assemble_chapter_preview
+from .audiobook_tts import generate_audio_for_chapter_preview
+from .cover_processing import reextract_book_cover
+from .metadata_jobs import process_metadata_sync_job
+from .update_scheduler import run_web_novel_update
+from .web_novel import run_book_refresh
+
+logger = logging.getLogger(__name__)
+
+_Result = TypeVar("_Result")
+
+
+class ProcessingQueue:
+    """A durable ledger backed by a small set of resource-aware workers."""
+
+    def __init__(self) -> None:
+        self._queue: asyncio.Queue[int | None] = asyncio.Queue()
+        self._queued_ids: set[int] = set()
+        self._worker_tasks: list[asyncio.Task[None]] = []
+        self._lanes = {
+            "audiobook": asyncio.Semaphore(1),
+            "maintenance": asyncio.Semaphore(1),
+        }
+
+    async def start(self) -> None:
+        if self._worker_tasks:
+            return
+        worker_count = max(1, int(os.getenv("PROCESSING_WORKERS", "3")))
+        self._worker_tasks = [
+            asyncio.create_task(self._run(), name=f"processing-worker-{index + 1}") for index in range(worker_count)
+        ]
+
+    @property
+    def is_running(self) -> bool:
+        return bool(self._worker_tasks)
+
+    async def stop(self) -> None:
+        if not self._worker_tasks:
+            return
+        for task in self._worker_tasks:
+            task.cancel()
+        await asyncio.gather(*self._worker_tasks, return_exceptions=True)
+        self._worker_tasks.clear()
+        self._queued_ids.clear()
+        self._queue = asyncio.Queue()
+
+    async def enqueue(self, job_id: int) -> bool:
+        if job_id in self._queued_ids:
+            return False
+        self._queued_ids.add(job_id)
+        await self._queue.put(job_id)
+        return True
+
+    async def requeue_pending(self) -> int:
+        async with SessionLocal() as db:
+            jobs = await crud.get_pending_processing_jobs(db)
+        return sum([await self.enqueue(job.id) for job in jobs])
+
+    @asynccontextmanager
+    async def _lane(self, job_type: str) -> AsyncIterator[None]:
+        if job_type in {
+            "audiobook_pipeline",
+            "import_audiobook",
+            "rematch_imported_audiobook",
+            "align_imported_audiobook",
+            "generate_sentence_audio",
+            "generate_chapter_preview",
+        }:
+            semaphore = self._lanes["audiobook"]
+        elif job_type in {"clean_all", "refresh_all"}:
+            semaphore = self._lanes["maintenance"]
+        else:
+            semaphore = None
+        if semaphore is None:
+            yield
+        else:
+            async with semaphore:
+                yield
+
+    async def _run(self) -> None:
+        while True:
+            job_id = await self._queue.get()
+            try:
+                if job_id is None:
+                    return
+                async with SessionLocal() as db:
+                    job = await crud.mark_processing_job_running(db, job_id)
+                if job is None:
+                    continue
+                try:
+                    async with self._lane(job.job_type):
+                        async with SessionLocal() as db:
+                            if await crud.is_processing_job_cancel_requested(db, job.id):
+                                await crud.mark_processing_job_canceled(db, job.id)
+                                continue
+                        detail = await self._execute(job)
+                    async with SessionLocal() as db:
+                        if await crud.is_processing_job_cancel_requested(db, job.id):
+                            await crud.mark_processing_job_canceled(db, job.id)
+                        else:
+                            await crud.complete_processing_job(db, job.id, detail)
+                except Exception as exc:
+                    logger.exception("Processing job %s (%s) failed.", job.id, job.job_type)
+                    async with SessionLocal() as db:
+                        await crud.fail_processing_job(db, job.id, str(exc))
+            finally:
+                if job_id is not None:
+                    self._queued_ids.discard(job_id)
+                self._queue.task_done()
+
+    async def _execute(self, job: ProcessingJob) -> str:
+        payload = job.payload or {}
+        if job.job_type == "clean_book":
+            return await self._clean_book(job.id, job.book_id)
+        if job.job_type == "clean_all":
+            return await self._clean_all(job.id)
+        if job.job_type == "refresh_book":
+            if job.book_id is None:
+                raise ValueError("Refresh job has no book.")
+            await self._update_progress(job.id, 0, 1, "Downloading and rebuilding the web book")
+            await run_book_refresh(job.book_id)
+            async with SessionLocal() as db:
+                book = await db.get(Book, job.book_id)
+                if book is not None and book.refresh_status == "error":
+                    raise RuntimeError("Book refresh failed; check the application logs.")
+                await crud.update_processing_job_progress(db, job.id, current=1, total=1, detail="Web book refreshed")
+            return "Book refresh completed"
+        if job.job_type == "refresh_all":
+
+            async def refresh_all() -> bool:
+                return await run_web_novel_update(payload.get("trigger", "manual"))
+
+            await self._run_with_progress_mirror(
+                job.id,
+                refresh_all,
+                self._library_refresh_progress,
+            )
+            async with SessionLocal() as db:
+                refresh_task = await crud.get_latest_update_task(db)
+                if refresh_task is not None and refresh_task.status == "failed":
+                    raise RuntimeError("One or more web books failed to refresh; check the job history.")
+            return "Library refresh completed"
+        if job.job_type == "audiobook_pipeline":
+            return await self._run_audiobook_pipeline(job)
+        if job.job_type == "import_audiobook":
+            target_id = _required_target(job)
+
+            async def import_audio() -> None:
+                async with SessionLocal() as db:
+                    await process_import(target_id, db)
+
+            await self._run_with_progress_mirror(
+                job.id,
+                import_audio,
+                lambda: self._imported_audio_progress(target_id),
+            )
+            async with SessionLocal() as db:
+                edition = await db.get(ImportedAudiobook, target_id)
+                if edition is not None and edition.status == "error":
+                    raise RuntimeError(edition.error or "Human audiobook import failed.")
+            return "Human audiobook import completed"
+        if job.job_type == "rematch_imported_audiobook":
+            target_id = _required_target(job)
+
+            async def rematch_audio() -> int:
+                async with SessionLocal() as db:
+                    return await rematch_imported_audiobook(target_id, db)
+
+            matched = await self._run_with_progress_mirror(
+                job.id,
+                rematch_audio,
+                lambda: self._imported_audio_progress(target_id),
+            )
+            if payload.get("realign"):
+                child = await queue_processing_job(
+                    job_type="align_imported_audiobook",
+                    book_id=job.book_id,
+                    target_type="imported_audiobook",
+                    target_id=job.target_id,
+                    parent_job_id=job.id,
+                    dedupe_key=f"align_imported_audiobook:imported_audiobook:{job.target_id}",
+                    progress_detail="Queued after human-audio rematch",
+                )
+                await self.enqueue(child.id)
+            return f"Human audiobook rematched ({matched} tracks)"
+        if job.job_type == "align_imported_audiobook":
+            target_id = _required_target(job)
+
+            async def align_audio() -> None:
+                async with SessionLocal() as db:
+                    await process_alignment(target_id, db)
+
+            await self._run_with_progress_mirror(
+                job.id,
+                align_audio,
+                lambda: self._imported_audio_progress(target_id),
+            )
+            async with SessionLocal() as db:
+                edition = await db.get(ImportedAudiobook, target_id)
+                if edition is not None and edition.alignment_error:
+                    raise RuntimeError(edition.alignment_error)
+            return "Human audiobook timing alignment completed"
+        if job.job_type == "metadata_sync":
+            metadata_job_id = payload.get("metadata_job_id") or job.target_id
+            if metadata_job_id is None:
+                raise ValueError("Metadata processing job has no metadata job.")
+            metadata_job_id = int(metadata_job_id)
+
+            async def sync_metadata() -> None:
+                async with SessionLocal() as db:
+                    await process_metadata_sync_job(db, metadata_job_id)
+
+            await self._run_with_progress_mirror(
+                job.id,
+                sync_metadata,
+                lambda: self._metadata_progress(metadata_job_id),
+            )
+            async with SessionLocal() as db:
+                metadata_job = await crud.get_metadata_sync_job(db, int(metadata_job_id))
+                if metadata_job is not None and metadata_job.status == "failed":
+                    raise RuntimeError(metadata_job.error or "Metadata sync failed.")
+            return "Metadata sync completed"
+        if job.job_type == "generate_sentence_audio":
+            sentence_id = _required_target(job)
+            async with SessionLocal() as db:
+                await crud.update_processing_job_progress(db, job.id, current=0, total=1, detail="Generating sentence audio")
+                await crud.audiobook.set_sentence_status(db, sentence_id, "audio_generating")
+                await generate_audio_for_sentence(job.book_id, sentence_id, db)
+                await crud.update_processing_job_progress(db, job.id, current=1, total=1, detail="Sentence audio generated")
+            return "Sentence audio generated"
+        if job.job_type == "generate_chapter_preview":
+            chapter_id = _required_target(job)
+            async with SessionLocal() as db:
+                await crud.update_processing_job_progress(db, job.id, current=0, total=2, detail="Generating preview audio")
+                await crud.audiobook.set_chapter_preview_status(db, chapter_id, "generating")
+                await generate_audio_for_chapter_preview(job.book_id, chapter_id, db)
+                await crud.update_processing_job_progress(db, job.id, current=1, total=2, detail="Assembling chapter preview")
+                await assemble_chapter_preview(job.book_id, chapter_id, db)
+                await crud.audiobook.set_chapter_preview_status(db, chapter_id, "ready")
+                await crud.update_processing_job_progress(db, job.id, current=2, total=2, detail="Chapter preview ready")
+            return "Chapter preview generated"
+        if job.job_type == "retry_cover":
+            async with SessionLocal() as db:
+                book = await db.get(Book, job.book_id)
+                if book is None:
+                    raise ValueError("Book no longer exists.")
+                await crud.update_processing_job_progress(
+                    db, job.id, current=0, total=1, detail="Extracting or finding a book cover"
+                )
+                await reextract_book_cover(book, db)
+                await crud.update_processing_job_progress(db, job.id, current=1, total=1, detail="Book cover updated")
+            return "Book cover re-extracted"
+        raise ValueError(f"Unsupported processing job type: {job.job_type}")
+
+    async def _clean_book(self, job_id: int, book_id: int | None) -> str:
+        if book_id is None:
+            raise ValueError("Cleaning job has no book.")
+        from .. import epub_editor
+
+        async with SessionLocal() as db:
+            book = await db.get(Book, book_id)
+            if book is None:
+                raise ValueError("Book no longer exists.")
+            await crud.update_processing_job_progress(db, job_id, current=0, total=1, detail="Applying cleaning rules")
+            changed = await epub_editor.apply_book_cleaning(book, db, force=True)
+            if changed:
+                await queue_audio_reconciliation(book, db, parent_job_id=job_id)
+            await crud.update_processing_job_progress(
+                db,
+                job_id,
+                current=1,
+                total=1,
+                detail="Cleaning changed the book" if changed else "Cleaning made no content changes",
+            )
+        return "Cleaned book and queued derived audio" if changed else "Cleaning made no content changes"
+
+    async def _clean_all(self, job_id: int) -> str:
+        from .. import epub_editor
+
+        async with SessionLocal() as db:
+            books = await crud.get_books(db, limit=100000)
+            configs = await crud.get_cleaning_configs(db)
+            total = len(books)
+            await crud.update_processing_job_progress(db, job_id, current=0, total=total, detail="Starting library cleaning")
+            updated = 0
+            for index, book in enumerate(books, start=1):
+                if await crud.is_processing_job_cancel_requested(db, job_id):
+                    return f"Stopped after {index - 1} of {total} books"
+                changed = await epub_editor.apply_book_cleaning(book, db, force=True, cleaning_configs=configs)
+                if changed:
+                    updated += 1
+                    await queue_audio_reconciliation(book, db, parent_job_id=job_id)
+                await crud.update_processing_job_progress(
+                    db,
+                    job_id,
+                    current=index,
+                    total=total,
+                    detail=f"Cleaned {index} of {total} books; {updated} changed",
+                )
+        return f"Cleaned {total} books; {updated} changed"
+
+    async def _run_audiobook_pipeline(self, job: ProcessingJob) -> str:
+        mode = (job.payload or {}).get("mode", "resume")
+        async with SessionLocal() as db:
+            book = await db.get(Book, job.book_id)
+            if book is None:
+                raise ValueError("Book no longer exists.")
+            if not book.audiobook_enabled:
+                raise ValueError("AI audiobook generation is not enabled for this book.")
+
+            if mode == "rebuild":
+                await crud.audiobook.delete_chapters_for_book(db, book.id)
+                await crud.audiobook.delete_characters_for_book(db, book.id)
+                await crud.audiobook.set_book_audiobook_summary(db, book.id, None)
+                next_phase = "ingesting"
+                stop_after = None
+                batch_limit = None
+            elif mode == "roster":
+                chapters = await crud.audiobook.get_chapters_for_book(db, book.id)
+                if not chapters:
+                    raise ValueError("Run ingestion before regenerating the roster.")
+                await crud.audiobook.reset_roster_and_diarization_for_book(db, book.id)
+                await crud.audiobook.set_book_audiobook_summary(db, book.id, None)
+                next_phase = "roster_gen"
+                stop_after = "roster_gen"
+                batch_limit = None
+            elif mode == "reconcile":
+                next_phase = "ingesting"
+                stop_after = None
+                batch_limit = None
+            elif mode == "resume" and book.audiobook_pipeline_status in {
+                "ingesting",
+                "roster_gen",
+                "diarizing",
+                "audio_gen",
+                "assembling",
+            }:
+                next_phase = book.audiobook_pipeline_status
+                stop_after = book.audiobook_stop_after_phase
+                batch_limit = book.audiobook_batch_limit
+            else:
+                if book.audiobook_pipeline_status == "error" and await crud.audiobook.has_sentence_status(
+                    db, book.id, "error"
+                ):
+                    await crud.audiobook.reset_error_sentences_for_book(db, book.id)
+                next_phase = await crud.audiobook.infer_audiobook_resume_status(db, book.id)
+                if next_phase == "complete":
+                    return "Audiobook was already complete"
+                stop_after = next_phase if mode == "step" else None
+                batch_limit = 1 if mode == "batch" else None
+
+            await crud.audiobook.configure_book_pipeline_run(
+                db,
+                book.id,
+                status=next_phase,
+                stop_after_phase=stop_after,
+                batch_limit=batch_limit,
+            )
+        pipeline_task = asyncio.create_task(
+            get_audiobook_queue().process_book(job.book_id),
+            name=f"audiobook-processing-job-{job.id}",
+        )
+        try:
+            while not pipeline_task.done():
+                try:
+                    await asyncio.wait_for(asyncio.shield(pipeline_task), timeout=1)
+                except asyncio.TimeoutError:
+                    async with SessionLocal() as db:
+                        book = await db.get(Book, job.book_id)
+                        if book is not None:
+                            await crud.update_processing_job_progress(
+                                db,
+                                job.id,
+                                current=book.audiobook_progress_current or 0,
+                                total=book.audiobook_progress_total or 0,
+                                detail=book.audiobook_progress_detail or f"Audiobook phase: {book.audiobook_pipeline_status}",
+                            )
+                        if await crud.is_processing_job_cancel_requested(db, job.id):
+                            await crud.audiobook.request_book_pipeline_pause(db, job.book_id)
+            await pipeline_task
+        except asyncio.CancelledError:
+            pipeline_task.cancel()
+            await asyncio.gather(pipeline_task, return_exceptions=True)
+            raise
+        async with SessionLocal() as db:
+            book = await db.get(Book, job.book_id)
+            if book is not None and book.audiobook_pipeline_status == "error":
+                raise RuntimeError(book.audiobook_last_error or "Audiobook processing failed.")
+        return "Audiobook processing reached its requested checkpoint"
+
+    async def _run_with_progress_mirror(
+        self,
+        job_id: int,
+        operation: Callable[[], Awaitable[_Result]],
+        snapshot: Callable[[], Awaitable[tuple[int, int, str | None]]],
+    ) -> _Result:
+        task = asyncio.create_task(operation(), name=f"processing-operation-{job_id}")
+        try:
+            while not task.done():
+                try:
+                    await asyncio.wait_for(asyncio.shield(task), timeout=0.5)
+                except asyncio.TimeoutError:
+                    current, total, detail = await snapshot()
+                    await self._update_progress(job_id, current, total, detail)
+            result = await task
+            current, total, detail = await snapshot()
+            await self._update_progress(job_id, current, total, detail)
+            return result
+        except asyncio.CancelledError:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+            raise
+
+    async def _update_progress(
+        self,
+        job_id: int,
+        current: int,
+        total: int,
+        detail: str | None,
+    ) -> None:
+        async with SessionLocal() as db:
+            await crud.update_processing_job_progress(
+                db,
+                job_id,
+                current=current,
+                total=total,
+                detail=detail,
+            )
+
+    async def _imported_audio_progress(self, edition_id: int) -> tuple[int, int, str | None]:
+        async with SessionLocal() as db:
+            edition = await db.get(ImportedAudiobook, edition_id)
+            if edition is None:
+                return 0, 0, "Audiobook edition no longer exists"
+            return (
+                edition.progress_current or 0,
+                edition.progress_total or 0,
+                edition.progress_detail,
+            )
+
+    async def _metadata_progress(self, metadata_job_id: int) -> tuple[int, int, str | None]:
+        async with SessionLocal() as db:
+            metadata_job = await crud.get_metadata_sync_job(db, metadata_job_id)
+            if metadata_job is None:
+                return 0, 0, "Metadata job no longer exists"
+            return (
+                metadata_job.processed_books or 0,
+                metadata_job.total_books or 0,
+                (
+                    f"Checked {metadata_job.processed_books or 0} of {metadata_job.total_books or 0} books"
+                    f" · {metadata_job.matched_books or 0} matched"
+                    f" · {metadata_job.proposed_books or 0} proposed"
+                ),
+            )
+
+    async def _library_refresh_progress(self) -> tuple[int, int, str | None]:
+        async with SessionLocal() as db:
+            task = await crud.get_latest_update_task(db)
+            if task is None:
+                return 0, 0, "Preparing the web library refresh"
+            return (
+                task.completed_books or 0,
+                task.total_books or 0,
+                f"Refreshed {task.completed_books or 0} of {task.total_books or 0} web books",
+            )
+
+
+def _required_target(job: ProcessingJob) -> int:
+    if job.target_id is None:
+        raise ValueError(f"{job.job_type} job has no target.")
+    return job.target_id
+
+
+_processing_queue = ProcessingQueue()
+
+
+def get_processing_queue() -> ProcessingQueue:
+    return _processing_queue
+
+
+async def queue_processing_job(
+    *,
+    job_type: str,
+    db: AsyncSession | None = None,
+    book_id: int | None = None,
+    target_type: str | None = None,
+    target_id: int | None = None,
+    target_content_version: int | None = None,
+    parent_job_id: int | None = None,
+    payload: dict | None = None,
+    dedupe_key: str | None = None,
+    progress_detail: str | None = "Queued",
+) -> ProcessingJob:
+    owns_session = db is None
+    session = db or SessionLocal()
+    try:
+        job, created = await crud.create_processing_job(
+            session,
+            job_type=job_type,
+            book_id=book_id,
+            target_type=target_type,
+            target_id=target_id,
+            target_content_version=target_content_version,
+            parent_job_id=parent_job_id,
+            payload=payload,
+            dedupe_key=dedupe_key,
+            progress_detail=progress_detail,
+        )
+        if created and get_processing_queue().is_running:
+            await get_processing_queue().enqueue(job.id)
+        return job
+    finally:
+        if owns_session:
+            await session.close()
+
+
+async def queue_audio_reconciliation(book: Book, db: AsyncSession, parent_job_id: int | None = None) -> list[ProcessingJob]:
+    """Invalidate and queue every audio derivative of the current cleaned text."""
+    await db.refresh(book)
+    content_version = book.content_version or 1
+    queued: list[ProcessingJob] = []
+    if book.audiobook_enabled:
+        book.audiobook_publication_state = "stale"
+        await db.commit()
+
+    result = await db.execute(select(ImportedAudiobook).where(ImportedAudiobook.book_id == book.id))
+    for edition in result.scalars().all():
+        if edition.matched_content_version == content_version and edition.status != "stale":
+            continue
+        realign = edition.alignment_method in {"transcribed", "hybrid"}
+        edition.status = "stale"
+        edition.progress_detail = "Book content changed; rematch queued"
+        edition.alignment_error = None
+        await db.commit()
+        queued.append(
+            await queue_processing_job(
+                db=db,
+                job_type="rematch_imported_audiobook",
+                book_id=book.id,
+                target_type="imported_audiobook",
+                target_id=edition.id,
+                target_content_version=content_version,
+                parent_job_id=parent_job_id,
+                payload={"realign": realign},
+                dedupe_key=f"rematch_imported_audiobook:imported_audiobook:{edition.id}:v{content_version}",
+                progress_detail=f"Queued to rematch against cleaned content v{content_version}",
+            )
+        )
+    if book.audiobook_enabled:
+        queued.append(
+            await queue_processing_job(
+                db=db,
+                job_type="audiobook_pipeline",
+                book_id=book.id,
+                target_type="book",
+                target_id=book.id,
+                target_content_version=content_version,
+                parent_job_id=parent_job_id,
+                payload={"mode": "reconcile"},
+                dedupe_key=f"audiobook_pipeline:book:{book.id}:v{content_version}",
+                progress_detail=f"Queued for cleaned content v{content_version}",
+            )
+        )
+    return queued

--- a/backend/app/services/update_scheduler.py
+++ b/backend/app/services/update_scheduler.py
@@ -167,6 +167,18 @@ def get_next_run_time_for_task(
     return calculate_next_run_time(get_last_run_anchor(task), now=now_utc)
 
 
+async def queue_scheduled_web_novel_update() -> None:
+    """Record scheduled refresh work in the durable processing ledger."""
+    from .processing_queue import queue_processing_job
+
+    await queue_processing_job(
+        job_type="refresh_all",
+        payload={"trigger": "scheduled"},
+        dedupe_key="refresh_all",
+        progress_detail="Queued by the web novel schedule",
+    )
+
+
 async def schedule_next_web_novel_update() -> datetime:
     async with SessionLocal() as db:
         latest_task = await crud.get_latest_update_task(db)
@@ -174,7 +186,7 @@ async def schedule_next_web_novel_update() -> datetime:
 
     next_run_at = get_next_run_time_for_task(latest_task, schedule_settings=schedule_settings)
     _scheduler.add_job(
-        run_web_novel_update,
+        queue_scheduled_web_novel_update,
         "date",
         id=WEB_NOVEL_UPDATE_JOB_ID,
         replace_existing=True,

--- a/backend/app/services/web_novel.py
+++ b/backend/app/services/web_novel.py
@@ -320,25 +320,27 @@ def _run_fff_lossless_update(
 
 
 async def _enqueue_audiobook_refresh(book: models.Book, db) -> None:
-    """Persist and enqueue refreshed content without losing an active build."""
-    if not book.audiobook_enabled:
-        return
+    """Queue every audio derivative affected by refreshed or cleaned content."""
     await db.refresh(book)
-    content_version = book.content_version or 1
-    book.audiobook_pending_content_version = max(
-        book.audiobook_pending_content_version or 0,
-        content_version,
-    )
-    active_statuses = {"ingesting", "roster_gen", "diarizing", "audio_gen", "assembling"}
-    if book.audiobook_pipeline_status not in active_statuses:
-        book.audiobook_pipeline_status = "ingesting"
-    await db.commit()
+    if book.audiobook_enabled:
+        content_version = book.content_version or 1
+        book.audiobook_pending_content_version = max(
+            book.audiobook_pending_content_version or 0,
+            content_version,
+        )
+        active_statuses = {"ingesting", "roster_gen", "diarizing", "audio_gen", "assembling"}
+        if book.audiobook_pipeline_status not in active_statuses:
+            book.audiobook_pipeline_status = "ingesting"
+        await db.commit()
 
-    from .audiobook_queue import get_audiobook_queue
+        from .audiobook_queue import AudiobookQueue, get_audiobook_queue
 
-    queue = get_audiobook_queue()
-    if not queue.has_book_job(book.id):
-        await queue.enqueue(book.id)
+        legacy_queue = get_audiobook_queue()
+        if not isinstance(legacy_queue, AudiobookQueue) and not legacy_queue.has_book_job(book.id):
+            await legacy_queue.enqueue(book.id)
+    from .processing_queue import queue_audio_reconciliation
+
+    await queue_audio_reconciliation(book, db)
 
 
 def _run_fff_main(args: List[str]) -> int:

--- a/backend/tests/test_processing_jobs.py
+++ b/backend/tests/test_processing_jobs.py
@@ -1,0 +1,148 @@
+"""Tests for the durable processing ledger and audio invalidation graph."""
+
+import asyncio
+
+import pytest
+from sqlalchemy import select
+
+from backend.app import crud
+from backend.app.models import Book, ImportedAudiobook, ProcessingJob, SourceType
+from backend.app.services import processing_queue as processing_queue_module
+from backend.app.services.processing_queue import ProcessingQueue, queue_audio_reconciliation
+
+
+@pytest.mark.asyncio
+async def test_processing_api_queues_lists_cancels_and_retries(app_client, sqlite_sessionmaker):
+    async with sqlite_sessionmaker() as db:
+        book = Book(
+            title="Queue Me",
+            author="Worker",
+            source_type=SourceType.epub,
+            immutable_path="library/queue-me-immutable.epub",
+            current_path="library/queue-me.epub",
+        )
+        db.add(book)
+        await db.commit()
+        await db.refresh(book)
+        book_id = book.id
+
+    response = app_client.post(
+        "/api/processing/jobs",
+        json={"job_type": "clean_book", "book_ids": [book_id]},
+    )
+    assert response.status_code == 202
+    job = response.json()["jobs"][0]
+    assert job["status"] == "queued"
+    assert job["book_id"] == book_id
+
+    response = app_client.get("/api/processing/jobs?statuses=queued")
+    assert response.status_code == 200
+    assert response.json()[0]["book_title"] == "Queue Me"
+
+    response = app_client.delete(f"/api/processing/jobs/{job['id']}")
+    assert response.status_code == 200
+    assert response.json()["status"] == "canceled"
+
+    response = app_client.post(f"/api/processing/jobs/{job['id']}/retry")
+    assert response.status_code == 200
+    assert response.json()["status"] == "queued"
+
+    response = app_client.post(f"/api/books/{book_id}/retry-cover")
+    assert response.status_code == 200
+    assert response.headers["x-processing-job-id"]
+    async with sqlite_sessionmaker() as db:
+        cover_job = await db.get(ProcessingJob, int(response.headers["x-processing-job-id"]))
+        assert cover_job is not None
+        assert cover_job.job_type == "retry_cover"
+
+
+@pytest.mark.asyncio
+async def test_audio_reconciliation_invalidates_generated_and_human_derivatives(db):
+    book = Book(
+        title="Changed Text",
+        author="Cleaner",
+        source_type=SourceType.epub,
+        immutable_path="library/changed-immutable.epub",
+        current_path="library/changed.epub",
+        audiobook_enabled=True,
+        audiobook_revision=3,
+        audiobook_source_content_version=1,
+        audiobook_publication_state="complete",
+        content_version=2,
+    )
+    db.add(book)
+    await db.flush()
+    edition = ImportedAudiobook(
+        book_id=book.id,
+        name="Human edition",
+        status="ready",
+        alignment_method="transcribed",
+        matched_content_version=1,
+    )
+    db.add(edition)
+    await db.commit()
+
+    jobs = await queue_audio_reconciliation(book, db, parent_job_id=None)
+    await db.refresh(book)
+    await db.refresh(edition)
+
+    assert book.audiobook_publication_state == "stale"
+    assert edition.status == "stale"
+    assert [job.job_type for job in jobs] == [
+        "rematch_imported_audiobook",
+        "audiobook_pipeline",
+    ]
+    assert jobs[0].payload["realign"] is True
+    assert all(job.target_content_version == 2 for job in jobs)
+
+
+@pytest.mark.asyncio
+async def test_touching_content_marks_published_audiobook_stale(db):
+    book = Book(
+        title="Published",
+        author="Versioned",
+        source_type=SourceType.epub,
+        immutable_path="library/published-immutable.epub",
+        current_path="library/published.epub",
+        audiobook_enabled=True,
+        audiobook_revision=1,
+        audiobook_source_content_version=1,
+        audiobook_publication_state="complete",
+        content_version=1,
+    )
+    db.add(book)
+    await db.commit()
+
+    await crud.touch_book_content(db, book)
+    await db.commit()
+    result = await db.execute(select(ProcessingJob))
+
+    assert book.content_version == 2
+    assert book.audiobook_pending_content_version == 2
+    assert book.audiobook_publication_state == "stale"
+    assert result.scalars().all() == []
+
+
+@pytest.mark.asyncio
+async def test_progress_mirror_updates_the_durable_job(monkeypatch, sqlite_sessionmaker):
+    monkeypatch.setattr(processing_queue_module, "SessionLocal", sqlite_sessionmaker)
+    async with sqlite_sessionmaker() as db:
+        job, _created = await crud.create_processing_job(db, job_type="metadata_sync")
+        job_id = job.id
+
+    async def operation():
+        await asyncio.sleep(0.55)
+        return "done"
+
+    async def snapshot():
+        return 2, 5, "Checked 2 of 5 books"
+
+    result = await ProcessingQueue()._run_with_progress_mirror(job_id, operation, snapshot)
+
+    async with sqlite_sessionmaker() as db:
+        job = await db.get(ProcessingJob, job_id)
+        assert job is not None
+        assert result == "done"
+        assert job.progress_current == 2
+        assert job.progress_total == 5
+        assert job.progress_detail == "Checked 2 of 5 books"

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2735,6 +2735,216 @@
   padding: 0 1.25rem 3rem;
 }
 
+.nav-job-count {
+  display: inline-flex;
+  min-width: 1.25rem;
+  height: 1.25rem;
+  margin-left: 0.4rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  background: #2563eb;
+  color: white;
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+
+.processing-page {
+  display: grid;
+  gap: 1rem;
+}
+
+.processing-queue-panel,
+.processing-book-picker {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.processing-quick-actions,
+.processing-picker-actions,
+.processing-job-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.processing-book-picker {
+  grid-template-columns: minmax(12rem, 1fr) minmax(12rem, 2fr);
+  align-items: end;
+}
+
+.processing-book-picker > label,
+.processing-list-header > label {
+  display: grid;
+  gap: 0.3rem;
+  color: var(--text-muted, #94a3b8);
+  font-size: 0.8rem;
+}
+
+.processing-book-options {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(15rem, 1fr));
+  max-height: 17rem;
+  overflow: auto;
+  gap: 0.35rem;
+  padding: 0.6rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 8px;
+}
+
+.processing-book-options > label {
+  display: flex;
+  gap: 0.5rem;
+  align-items: flex-start;
+  padding: 0.4rem;
+  border-radius: 5px;
+}
+
+.processing-book-options > label:hover {
+  background: rgba(148, 163, 184, 0.08);
+}
+
+.processing-book-options span,
+.processing-book-options small {
+  display: block;
+}
+
+.processing-book-options small {
+  margin-top: 0.1rem;
+  color: var(--text-muted, #94a3b8);
+}
+
+.job-queued-notice {
+  color: #4ade80;
+  font-size: 0.875rem;
+}
+
+.processing-list-header,
+.processing-job-main {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.processing-job-list {
+  display: grid;
+  gap: 0.65rem;
+  margin-top: 1rem;
+}
+
+.processing-job {
+  padding: 0.85rem 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-left-width: 4px;
+  border-radius: 8px;
+  background: rgba(15, 23, 42, 0.28);
+}
+
+.processing-job--running {
+  border-left-color: #3b82f6;
+}
+
+.processing-job--queued {
+  border-left-color: #f59e0b;
+}
+
+.processing-job--completed {
+  border-left-color: #22c55e;
+}
+
+.processing-job--error {
+  border-left-color: #ef4444;
+}
+
+.processing-job-main > div {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.55rem;
+}
+
+.processing-job-main a {
+  color: #60a5fa;
+}
+
+.processing-job-main small,
+.processing-job > p {
+  color: var(--text-muted, #94a3b8);
+}
+
+.processing-job > p {
+  margin: 0.55rem 0;
+  font-size: 0.85rem;
+}
+
+.processing-status {
+  text-transform: capitalize;
+}
+
+.processing-status--running {
+  background: rgba(59, 130, 246, 0.18);
+  color: #93c5fd;
+}
+
+.processing-status--queued {
+  background: rgba(245, 158, 11, 0.18);
+  color: #fcd34d;
+}
+
+.processing-status--completed {
+  background: rgba(34, 197, 94, 0.18);
+  color: #86efac;
+}
+
+.processing-status--error {
+  background: rgba(239, 68, 68, 0.18);
+  color: #fca5a5;
+}
+
+.processing-job-progress {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.65rem;
+  align-items: center;
+  margin-bottom: 0.55rem;
+  color: var(--text-muted, #94a3b8);
+  font-size: 0.8rem;
+}
+
+.processing-job-progress progress {
+  width: 100%;
+  accent-color: #3b82f6;
+}
+
+.processing-job-progress--indeterminate progress {
+  opacity: 0.8;
+}
+
+.processing-job-error {
+  max-height: 8rem;
+  overflow: auto;
+  white-space: pre-wrap;
+  color: #fca5a5;
+  font-size: 0.78rem;
+}
+
+@media (max-width: 700px) {
+  .processing-book-picker {
+    grid-template-columns: 1fr;
+  }
+
+  .processing-book-options {
+    grid-column: 1;
+  }
+
+  .processing-list-header,
+  .processing-job-main {
+    flex-direction: column;
+  }
+}
+
 .config-list {
   display: flex;
   flex-direction: column;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import "./App.css";
 import { getAuthStatus, logout } from "./api/auth";
 import { getBook } from "./api/books";
@@ -11,6 +12,8 @@ import CleaningConfigs from "./components/CleaningConfigs.jsx";
 import SchedulerStatus from "./components/SchedulerStatus.jsx";
 import Logs from "./components/Logs.jsx";
 import Utilities from "./components/Utilities.jsx";
+import ProcessingJobs from "./components/ProcessingJobs.jsx";
+import { getProcessingJobs } from "./api/processing";
 import useDebouncedValue from "./hooks/useDebouncedValue";
 import useLibraryCatalog from "./hooks/useLibraryCatalog";
 import {
@@ -133,6 +136,13 @@ function App() {
     enabled: Boolean(authStatus?.authenticated),
   });
 
+  const { data: activeProcessingJobs = [] } = useQuery({
+    queryKey: ["active-processing-jobs"],
+    queryFn: () => getProcessingJobs({ statuses: "queued,running", limit: 100 }),
+    enabled: Boolean(authStatus?.authenticated),
+    refetchInterval: 3000,
+  });
+
   const handleClearSearch = () => {
     setQ("");
   };
@@ -227,6 +237,8 @@ function App() {
         return <CleaningConfigs />;
       case "scheduler":
         return <SchedulerStatus />;
+      case "processing":
+        return <ProcessingJobs />;
       case "logs":
         return <Logs />;
       case "utilities":
@@ -334,6 +346,9 @@ function App() {
             aria-current={activeTab === tab.key ? "page" : undefined}
           >
             {tab.label}
+            {tab.key === "processing" && activeProcessingJobs.length > 0 && (
+              <span className="nav-job-count">{activeProcessingJobs.length}</span>
+            )}
           </button>
         ))}
       </nav>

--- a/frontend/src/api/processing.js
+++ b/frontend/src/api/processing.js
@@ -1,0 +1,29 @@
+import { getJson, sendJson, sendWithoutBody } from "./client";
+
+export function getProcessingJobs({ statuses = "", jobType = "", bookId = "", limit = 100 } = {}) {
+  const params = new URLSearchParams({ limit: String(limit) });
+  if (statuses) params.set("statuses", statuses);
+  if (jobType) params.set("job_type", jobType);
+  if (bookId) params.set("book_id", String(bookId));
+  return getJson(`/api/processing/jobs?${params}`, "Failed to fetch processing jobs");
+}
+
+export function queueProcessingJobs(jobType, bookIds = [], payload = {}) {
+  return sendJson("/api/processing/jobs", {
+    body: { job_type: jobType, book_ids: bookIds, payload },
+    fallbackMessage: "Failed to queue processing",
+  });
+}
+
+export function retryProcessingJob(jobId) {
+  return sendWithoutBody(`/api/processing/jobs/${jobId}/retry`, {
+    fallbackMessage: "Failed to retry processing job",
+  });
+}
+
+export function cancelProcessingJob(jobId) {
+  return sendWithoutBody(`/api/processing/jobs/${jobId}`, {
+    method: "DELETE",
+    fallbackMessage: "Failed to cancel processing job",
+  });
+}

--- a/frontend/src/components/AudiobookPipeline.jsx
+++ b/frontend/src/components/AudiobookPipeline.jsx
@@ -129,6 +129,7 @@ function AudiobookPipeline({ book, onEnableAi }) {
     book.audiobook_enabled === undefined ? "Progress" : "Sources",
   );
   const [confirmRebuild, setConfirmRebuild] = useState(false);
+  const [lastQueuedJob, setLastQueuedJob] = useState(null);
 
   const isActive = (status) => ACTIVE_STATUSES.has(status);
 
@@ -156,7 +157,7 @@ function AudiobookPipeline({ book, onEnableAi }) {
     refetchInterval: ({ state }) =>
       Array.isArray(state.data) &&
       state.data.some((edition) =>
-        ["queued", "importing", "aligning"].includes(edition.status),
+        ["stale", "queued", "importing", "aligning"].includes(edition.status),
       )
         ? 1000
         : false,
@@ -189,17 +190,26 @@ function AudiobookPipeline({ book, onEnableAi }) {
 
   const startMutation = useMutation({
     mutationFn: () => startPipeline(bookId),
-    onSuccess: invalidateAll,
+    onSuccess: (data) => {
+      setLastQueuedJob(data.processing_job_id || true);
+      invalidateAll();
+    },
   });
 
   const stepMutation = useMutation({
     mutationFn: () => stepPipeline(bookId),
-    onSuccess: invalidateAll,
+    onSuccess: (data) => {
+      setLastQueuedJob(data.processing_job_id || true);
+      invalidateAll();
+    },
   });
 
   const batchMutation = useMutation({
     mutationFn: () => runPipelineBatch(bookId),
-    onSuccess: invalidateAll,
+    onSuccess: (data) => {
+      setLastQueuedJob(data.processing_job_id || true);
+      invalidateAll();
+    },
   });
 
   const pauseMutation = useMutation({
@@ -209,7 +219,8 @@ function AudiobookPipeline({ book, onEnableAi }) {
 
   const rebuildMutation = useMutation({
     mutationFn: () => rebuildPipeline(bookId),
-    onSuccess: () => {
+    onSuccess: (data) => {
+      setLastQueuedJob(data.processing_job_id || true);
       setConfirmRebuild(false);
       invalidateAll();
     },
@@ -362,7 +373,7 @@ function AudiobookPipeline({ book, onEnableAi }) {
                   onClick={() => rebuildMutation.mutate()}
                   disabled={rebuildMutation.isPending}
                 >
-                  {rebuildMutation.isPending ? "Rebuilding…" : "Yes, rebuild"}
+                  {rebuildMutation.isPending ? "Queueing…" : "Yes, queue rebuild"}
                 </button>{" "}
                 <button
                   className="btn-text"
@@ -373,6 +384,13 @@ function AudiobookPipeline({ book, onEnableAi }) {
               </span>
             ))}
         </div>
+
+        {lastQueuedJob && (
+          <p className="job-queued-notice" role="status">
+            Processing job{typeof lastQueuedJob === "number" ? ` #${lastQueuedJob}` : ""} queued.{" "}
+            <a href="/processing">View processing</a>
+          </p>
+        )}
 
         {(startMutation.isError ||
           stepMutation.isError ||

--- a/frontend/src/components/BookSettings.jsx
+++ b/frontend/src/components/BookSettings.jsx
@@ -137,6 +137,7 @@ function BookSettings({ book: initialBook, onBack }) {
   } = useBookSettingsForm(initialBook);
   const [previewedChapter, setPreviewedChapter] = useState(null);
   const [bookTab, setBookTab] = useState("details");
+  const [jobNotice, setJobNotice] = useState("");
 
   const { data: chapters = [], isLoading: chaptersLoading } = useQuery({
     queryKey: ["chapters", book.id],
@@ -195,6 +196,7 @@ function BookSettings({ book: initialBook, onBack }) {
   const processMutation = useMutation({
     mutationFn: () => processBook(book.id),
     onSuccess: () => {
+      setJobNotice("EPUB cleaning job queued.");
       queryClient.invalidateQueries({ queryKey: ["book-catalog"] });
       queryClient.invalidateQueries({
         queryKey: ["cleaned-chapters", book.id],
@@ -209,6 +211,7 @@ function BookSettings({ book: initialBook, onBack }) {
   const refreshMutation = useMutation({
     mutationFn: () => refreshBook(book.id),
     onSuccess: (updatedBook) => {
+      setJobNotice("Source refresh job queued.");
       queryClient.setQueryData(["book", book.id], updatedBook);
       queryClient.invalidateQueries({ queryKey: ["book-catalog"] });
       queryClient.invalidateQueries({
@@ -262,9 +265,8 @@ function BookSettings({ book: initialBook, onBack }) {
   const retryCoverMutation = useMutation({
     mutationFn: () => retryBookCover(book.id),
     onSuccess: () => {
-      bumpCoverVersion();
-      queryClient.invalidateQueries({ queryKey: ["book-catalog"] });
-      queryClient.invalidateQueries({ queryKey: ["book", book.id] });
+      setJobNotice("Cover re-extraction job queued.");
+      queryClient.invalidateQueries({ queryKey: ["active-processing-jobs"] });
     },
   });
 
@@ -523,7 +525,7 @@ function BookSettings({ book: initialBook, onBack }) {
                   coverUrlMutation.isPending
                 }
               >
-                {retryCoverMutation.isPending ? "Retrying…" : "Re-extract"}
+                {retryCoverMutation.isPending ? "Queueing…" : "Queue re-extract"}
               </button>
             )}
             <div className="cover-url-row">
@@ -789,8 +791,8 @@ function BookSettings({ book: initialBook, onBack }) {
             title="Save changes and rebuild the EPUB file with current cleaning rules"
           >
             {processMutation.isPending
-              ? "Rebuilding..."
-              : "Rebuild EPUB from saved edits"}
+              ? "Queueing..."
+              : "Queue EPUB rebuild from saved edits"}
           </button>
           {book.source_type === "web" && (
             <button onClick={() => refreshMutation.mutate()} disabled={isBusy}>
@@ -804,6 +806,11 @@ function BookSettings({ book: initialBook, onBack }) {
             </button>
           )}
         </div>
+        {jobNotice && (
+          <p className="job-queued-notice" role="status">
+            {jobNotice} <a href="/processing">View processing</a>
+          </p>
+        )}
         <p className="hint actions-hint">
           <strong>Save Metadata</strong> updates the database only.{" "}
           <strong>Rebuild EPUB</strong> saves edits and regenerates the file

--- a/frontend/src/components/CleaningConfigs.jsx
+++ b/frontend/src/components/CleaningConfigs.jsx
@@ -84,6 +84,7 @@ function CleaningConfigs({ onBack }) {
   const queryClient = useQueryClient();
   const [creating, setCreating] = useState(false);
   const [editingId, setEditingId] = useState(null);
+  const [jobNotice, setJobNotice] = useState("");
 
   const [reprocessStatus, setReprocessStatus] = useState(null);
   const [polling, setPolling] = useState(false);
@@ -121,6 +122,7 @@ function CleaningConfigs({ onBack }) {
       return res.json();
     },
     onSuccess: () => {
+      setJobNotice("Library cleaning job queued.");
       setReprocessStatus({ running: true, total: 0, processed: 0, updated: 0 });
       setPolling(true);
     },
@@ -151,6 +153,7 @@ function CleaningConfigs({ onBack }) {
       return res.json();
     },
     onSuccess: () => {
+      setJobNotice("Cleaning config saved; affected book cleaning is queued.");
       queryClient.invalidateQueries({ queryKey: ["cleaning-configs"] });
       setCreating(false);
     },
@@ -170,6 +173,7 @@ function CleaningConfigs({ onBack }) {
       return res.json();
     },
     onSuccess: () => {
+      setJobNotice("Cleaning config updated; affected book cleaning is queued.");
       queryClient.invalidateQueries({ queryKey: ["cleaning-configs"] });
       setEditingId(null);
       setPolling(true);
@@ -186,8 +190,11 @@ function CleaningConfigs({ onBack }) {
         throw new Error(err.detail || "Delete failed");
       }
     },
-    onSuccess: () =>
-      queryClient.invalidateQueries({ queryKey: ["cleaning-configs"] }),
+    onSuccess: () => {
+      setJobNotice("Cleaning config deleted; restoring affected books is queued.");
+      queryClient.invalidateQueries({ queryKey: ["cleaning-configs"] });
+      queryClient.invalidateQueries({ queryKey: ["active-processing-jobs"] });
+    },
   });
 
   return (
@@ -234,9 +241,14 @@ function CleaningConfigs({ onBack }) {
             {isReprocessing ? "Cleaning..." : "Clean All Books"}
           </button>
         </div>
+        {jobNotice && (
+          <p className="job-queued-notice" role="status">
+            {jobNotice} <a href="/processing">View processing</a>
+          </p>
+        )}
         {isReprocessing && reprocessStatus?.total > 0 && (
           <p className="hint" style={{ marginTop: "0.5rem" }}>
-            {reprocessStatus.processed} / {reprocessStatus.total} books processed ({reprocessStatus.updated} updated)
+            {reprocessStatus.processed} / {reprocessStatus.total} books processed
           </p>
         )}
         {reprocessMutation.isError && (
@@ -246,7 +258,7 @@ function CleaningConfigs({ onBack }) {
         )}
         {!isReprocessing && reprocessStatus && !reprocessStatus.running && reprocessStatus.total > 0 && (
           <p className="hint" style={{ marginTop: "0.5rem" }}>
-            Done. {reprocessStatus.updated} / {reprocessStatus.total} books updated.
+            Cleaning job {reprocessStatus.status || "completed"}.
           </p>
         )}
         {reprocessStatus?.error && (

--- a/frontend/src/components/EpubEditor.jsx
+++ b/frontend/src/components/EpubEditor.jsx
@@ -141,10 +141,10 @@ function EpubEditor({ book, onBack }) {
         disabled={saveMutation.isPending || processMutation.isPending}
       >
         {processMutation.isPending
-          ? "Processing..."
+          ? "Queueing..."
           : saveMutation.isPending
             ? "Saving..."
-            : "Process Book"}
+            : "Queue Book Processing"}
       </button>
 
       {saveMutation.isError && (

--- a/frontend/src/components/ProcessingJobs.jsx
+++ b/frontend/src/components/ProcessingJobs.jsx
@@ -1,0 +1,271 @@
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { getBookCatalog } from "../api/books";
+import {
+  cancelProcessingJob,
+  getProcessingJobs,
+  queueProcessingJobs,
+  retryProcessingJob,
+} from "../api/processing";
+
+const ACTIVE = new Set(["queued", "running"]);
+
+const JOB_LABELS = {
+  clean_book: "Clean book",
+  clean_all: "Clean library",
+  refresh_book: "Refresh book",
+  refresh_all: "Refresh web library",
+  audiobook_pipeline: "Generate AI audiobook",
+  import_audiobook: "Import human audiobook",
+  rematch_imported_audiobook: "Rematch human audiobook",
+  align_imported_audiobook: "Align human audiobook",
+  metadata_sync: "Sync metadata",
+  generate_sentence_audio: "Generate sentence audio",
+  generate_chapter_preview: "Generate chapter preview",
+  retry_cover: "Re-extract book cover",
+};
+
+const QUEUE_OPERATIONS = [
+  { value: "clean_book", label: "Clean selected books" },
+  { value: "audiobook_pipeline", label: "Regenerate selected AI audiobooks" },
+  { value: "refresh_book", label: "Refresh selected web books" },
+];
+
+function formatDate(value) {
+  return value ? new Date(value).toLocaleString() : "—";
+}
+
+function JobProgress({ job }) {
+  const measured = job.progress_total > 0;
+  if (!measured && job.status !== "running") return null;
+
+  const percent = measured
+    ? Math.min(100, Math.round((job.progress_current * 100) / job.progress_total))
+    : null;
+
+  return (
+    <div className={`processing-job-progress${measured ? "" : " processing-job-progress--indeterminate"}`}>
+      <progress
+        aria-label={`${JOB_LABELS[job.job_type] || job.job_type} progress`}
+        {...(measured ? { value: job.progress_current, max: job.progress_total } : {})}
+      />
+      <span>
+        {measured
+          ? `${percent}% · ${job.progress_current} / ${job.progress_total}`
+          : "In progress"}
+      </span>
+    </div>
+  );
+}
+
+function ProcessingJobs() {
+  const queryClient = useQueryClient();
+  const [statusFilter, setStatusFilter] = useState("active");
+  const [operation, setOperation] = useState("clean_book");
+  const [bookSearch, setBookSearch] = useState("");
+  const [selectedIds, setSelectedIds] = useState([]);
+  const [queueNotice, setQueueNotice] = useState("");
+  const statuses =
+    statusFilter === "active" ? "queued,running" : statusFilter === "all" ? "" : statusFilter;
+
+  const { data: jobs = [], isLoading, error } = useQuery({
+    queryKey: ["processing-jobs", statuses],
+    queryFn: () => getProcessingJobs({ statuses, limit: 200 }),
+    refetchInterval: ({ state }) =>
+      state.data?.some((job) => ACTIVE.has(job.status)) ? 1500 : 5000,
+  });
+  const { data: catalog = [] } = useQuery({
+    queryKey: ["processing-book-catalog"],
+    queryFn: () => getBookCatalog({ q: "", sortBy: "title", sortOrder: "asc" }),
+    staleTime: 30_000,
+  });
+
+  const eligibleBooks = useMemo(() => {
+    const query = bookSearch.trim().toLocaleLowerCase();
+    return catalog.filter((book) => {
+      if (operation === "refresh_book" && book.source_type !== "web") return false;
+      if (operation === "audiobook_pipeline" && !book.audiobook_enabled) return false;
+      return !query || `${book.title} ${book.author}`.toLocaleLowerCase().includes(query);
+    });
+  }, [bookSearch, catalog, operation]);
+
+  const refresh = () => {
+    queryClient.invalidateQueries({ queryKey: ["processing-jobs"] });
+    queryClient.invalidateQueries({ queryKey: ["active-processing-jobs"] });
+  };
+  const queueMutation = useMutation({
+    mutationFn: ({ jobType, bookIds, payload }) => queueProcessingJobs(jobType, bookIds, payload),
+    onSuccess: (data) => {
+      const count = data.jobs?.length || 0;
+      setQueueNotice(`${count} processing job${count === 1 ? "" : "s"} queued.`);
+      setSelectedIds([]);
+      refresh();
+    },
+  });
+  const retryMutation = useMutation({ mutationFn: retryProcessingJob, onSuccess: refresh });
+  const cancelMutation = useMutation({ mutationFn: cancelProcessingJob, onSuccess: refresh });
+
+  const toggleBook = (bookId) => {
+    setSelectedIds((current) =>
+      current.includes(bookId) ? current.filter((id) => id !== bookId) : [...current, bookId],
+    );
+  };
+  const queueSelected = () => {
+    const payload = operation === "audiobook_pipeline" ? { mode: "reconcile" } : {};
+    queueMutation.mutate({ jobType: operation, bookIds: selectedIds, payload });
+  };
+
+  return (
+    <div className="processing-page">
+      <section className="settings-section processing-queue-panel">
+        <div>
+          <h2>Queue processing</h2>
+          <p className="hint">
+            Queue cleaning, source refreshes, or audiobook regeneration for one or more books.
+          </p>
+        </div>
+        <div className="processing-quick-actions">
+          <button
+            onClick={() => queueMutation.mutate({ jobType: "clean_all", bookIds: [], payload: {} })}
+            disabled={queueMutation.isPending}
+          >
+            Clean entire library
+          </button>
+          <button
+            onClick={() =>
+              queueMutation.mutate({
+                jobType: "refresh_all",
+                bookIds: [],
+                payload: { trigger: "manual" },
+              })
+            }
+            disabled={queueMutation.isPending}
+          >
+            Refresh all web books
+          </button>
+        </div>
+        <div className="processing-book-picker">
+          <label>
+            Action
+            <select
+              value={operation}
+              onChange={(event) => {
+                setOperation(event.target.value);
+                setSelectedIds([]);
+              }}
+            >
+              {QUEUE_OPERATIONS.map((item) => (
+                <option key={item.value} value={item.value}>{item.label}</option>
+              ))}
+            </select>
+          </label>
+          <label>
+            Find books
+            <input
+              value={bookSearch}
+              onChange={(event) => setBookSearch(event.target.value)}
+              placeholder="Title or author"
+            />
+          </label>
+          <div className="processing-picker-actions">
+            <button
+              className="btn-text"
+              onClick={() => setSelectedIds(eligibleBooks.map((book) => book.id))}
+              disabled={!eligibleBooks.length}
+            >
+              Select visible
+            </button>
+            <button className="btn-text" onClick={() => setSelectedIds([])} disabled={!selectedIds.length}>
+              Clear
+            </button>
+          </div>
+          <div className="processing-book-options" role="group" aria-label="Books to process">
+            {eligibleBooks.slice(0, 100).map((book) => (
+              <label key={book.id}>
+                <input
+                  type="checkbox"
+                  checked={selectedIds.includes(book.id)}
+                  onChange={() => toggleBook(book.id)}
+                />
+                <span><strong>{book.title}</strong><small>{book.author}</small></span>
+              </label>
+            ))}
+            {!eligibleBooks.length && <p className="hint">No eligible books match.</p>}
+          </div>
+          <button
+            className="btn-primary"
+            onClick={queueSelected}
+            disabled={!selectedIds.length || queueMutation.isPending}
+          >
+            {queueMutation.isPending
+              ? "Queueing…"
+              : selectedIds.length
+                ? `Queue ${selectedIds.length} selected`
+                : "Queue selected"}
+          </button>
+        </div>
+        {queueNotice && <p className="job-queued-notice">{queueNotice}</p>}
+        {queueMutation.isError && <p className="error">{queueMutation.error.message}</p>}
+      </section>
+
+      <section className="settings-section">
+        <div className="processing-list-header">
+          <div>
+            <h2>Processing jobs</h2>
+            <p className="hint">Durable work survives application restarts and can be retried here.</p>
+          </div>
+          <label>
+            Status
+            <select value={statusFilter} onChange={(event) => setStatusFilter(event.target.value)}>
+              <option value="active">Active</option>
+              <option value="all">All</option>
+              <option value="error">Failed</option>
+              <option value="completed">Completed</option>
+              <option value="canceled">Canceled</option>
+            </select>
+          </label>
+        </div>
+        {isLoading && <p>Loading jobs…</p>}
+        {error && <p className="error">{error.message}</p>}
+        {!isLoading && !jobs.length && <p className="hint">No processing jobs in this view.</p>}
+        <div className="processing-job-list">
+          {jobs.map((job) => (
+            <article key={job.id} className={`processing-job processing-job--${job.status}`}>
+              <div className="processing-job-main">
+                <div>
+                  <span className={`badge processing-status processing-status--${job.status}`}>{job.status}</span>
+                  <strong>{JOB_LABELS[job.job_type] || job.job_type.replaceAll("_", " ")}</strong>
+                  {job.book_id && (
+                    <a href={`/books/${job.book_id}`}>{job.book_title || `Book ${job.book_id}`}</a>
+                  )}
+                </div>
+                <small>#{job.id} · {formatDate(job.created_at)}</small>
+              </div>
+              <p>{job.progress_detail || "Waiting"}</p>
+              <JobProgress job={job} />
+              {job.error && <pre className="processing-job-error">{job.error}</pre>}
+              <div className="processing-job-actions">
+                {ACTIVE.has(job.status) && (
+                  <button
+                    className="btn-text"
+                    onClick={() => cancelMutation.mutate(job.id)}
+                    disabled={cancelMutation.isPending || job.cancel_requested}
+                  >
+                    {job.cancel_requested ? "Cancellation requested" : "Cancel"}
+                  </button>
+                )}
+                {["error", "canceled"].includes(job.status) && (
+                  <button onClick={() => retryMutation.mutate(job.id)} disabled={retryMutation.isPending}>
+                    Retry
+                  </button>
+                )}
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+export default ProcessingJobs;

--- a/frontend/src/components/ProcessingJobs.test.jsx
+++ b/frontend/src/components/ProcessingJobs.test.jsx
@@ -1,0 +1,73 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ProcessingJobs from "./ProcessingJobs";
+
+function renderPage() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <ProcessingJobs />
+    </QueryClientProvider>,
+  );
+}
+
+describe("ProcessingJobs", () => {
+  beforeEach(() => {
+    globalThis.fetch = vi.fn(async (url) => {
+      if (String(url).startsWith("/api/books/catalog")) {
+        return {
+          ok: true,
+          json: async () => [
+            {
+              id: 7,
+              title: "Queued Story",
+              author: "Test Author",
+              source_type: "epub",
+              audiobook_enabled: true,
+            },
+          ],
+        };
+      }
+      return {
+        ok: true,
+        json: async () => [
+          {
+            id: 42,
+            job_type: "clean_book",
+            status: "running",
+            book_id: 7,
+            book_title: "Queued Story",
+            target_type: "book",
+            target_id: 7,
+            target_content_version: 2,
+            parent_job_id: null,
+            payload: {},
+            progress_current: 1,
+            progress_total: 3,
+            progress_detail: "Cleaning chapters",
+            attempt_count: 1,
+            cancel_requested: false,
+            error: null,
+            created_at: "2026-07-31T12:00:00Z",
+            started_at: "2026-07-31T12:00:01Z",
+            completed_at: null,
+          },
+        ],
+      };
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shows active durable jobs and their progress", async () => {
+    renderPage();
+    expect(await screen.findByRole("link", { name: "Queued Story" })).toBeInTheDocument();
+    expect(screen.getByText("Cleaning chapters")).toBeInTheDocument();
+    expect(screen.getByText("33% · 1 / 3")).toBeInTheDocument();
+    expect(screen.getByRole("progressbar")).toHaveValue(1);
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/SchedulerStatus.jsx
+++ b/frontend/src/components/SchedulerStatus.jsx
@@ -223,6 +223,8 @@ function SchedulerStatus({ onBack }) {
     mutationFn: () =>
       fetch("/api/scheduler/trigger", { method: "POST" }).then((r) => r.json()),
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["active-processing-jobs"] });
+      queryClient.invalidateQueries({ queryKey: ["processing-jobs"] });
       queryClient.invalidateQueries({ queryKey: ["scheduler-job"] });
       queryClient.invalidateQueries({ queryKey: ["scheduler-status"] });
       queryClient.invalidateQueries({ queryKey: ["scheduler-history"] });
@@ -372,13 +374,15 @@ function SchedulerStatus({ onBack }) {
           onClick={() => triggerMutation.mutate()}
           disabled={isRunning || triggerMutation.isPending}
         >
-          {triggerMutation.isPending ? "Triggering..." : "Run Now"}
+          {triggerMutation.isPending ? "Queueing..." : "Queue Run Now"}
         </button>
         {triggerMutation.isError && (
           <p className="error">Failed: {triggerMutation.error.message}</p>
         )}
         {triggerMutation.isSuccess && !isRunning && (
-          <p className="hint">Update triggered.</p>
+          <p className="job-queued-notice">
+            Library refresh queued. <a href="/processing">View processing</a>
+          </p>
         )}
       </section>
 

--- a/frontend/src/components/audiobook/AudiobookSources.jsx
+++ b/frontend/src/components/audiobook/AudiobookSources.jsx
@@ -29,6 +29,7 @@ function AudiobookSources({
   const inputRef = useRef(null);
   const [files, setFiles] = useState([]);
   const [name, setName] = useState("");
+  const [jobNotice, setJobNotice] = useState("");
 
   const invalidate = () => {
     queryClient.invalidateQueries({ queryKey: ["audiobook-imports", bookId] });
@@ -37,6 +38,7 @@ function AudiobookSources({
   const uploadMutation = useMutation({
     mutationFn: () => uploadImportedAudiobook(bookId, files, name),
     onSuccess: () => {
+      setJobNotice("Human audiobook import and matching queued.");
       setFiles([]);
       setName("");
       if (inputRef.current) inputRef.current.value = "";
@@ -45,7 +47,10 @@ function AudiobookSources({
   });
   const retryMutation = useMutation({
     mutationFn: retryImportedAudiobook,
-    onSuccess: invalidate,
+    onSuccess: () => {
+      setJobNotice("Human audiobook import retry queued.");
+      invalidate();
+    },
   });
   const deleteMutation = useMutation({
     mutationFn: deleteImportedAudiobook,
@@ -53,7 +58,10 @@ function AudiobookSources({
   });
   const alignMutation = useMutation({
     mutationFn: alignImportedAudiobook,
-    onSuccess: invalidate,
+    onSuccess: () => {
+      setJobNotice("Human audiobook timestamp alignment queued.");
+      invalidate();
+    },
   });
   const matchMutation = useMutation({
     mutationFn: ({ editionId, trackId, chapterId }) =>
@@ -137,7 +145,7 @@ function AudiobookSources({
         <p className="empty-state">No human-narrated editions imported yet.</p>
       ) : (
         imports.map((edition) => {
-          const active = ["queued", "importing", "aligning"].includes(
+          const active = ["stale", "queued", "importing", "aligning"].includes(
             edition.status,
           );
           const matched = edition.tracks.filter(
@@ -270,6 +278,11 @@ function AudiobookSources({
             </section>
           );
         })
+      )}
+      {jobNotice && (
+        <p className="job-queued-notice" role="status">
+          {jobNotice} <a href="/processing">View processing</a>
+        </p>
       )}
       {(retryMutation.isError ||
         alignMutation.isError ||

--- a/frontend/src/components/audiobook/CharacterRoster.jsx
+++ b/frontend/src/components/audiobook/CharacterRoster.jsx
@@ -149,6 +149,7 @@ function CharacterRoster({ characters, bookId, pipelineStatus, series }) {
       queryClient.invalidateQueries({
         queryKey: ["audiobook-characters", bookId],
       });
+      queryClient.invalidateQueries({ queryKey: ["active-processing-jobs"] });
       queryClient.invalidateQueries({
         queryKey: ["audiobook-chapters", bookId],
       });
@@ -218,6 +219,11 @@ function CharacterRoster({ characters, bookId, pipelineStatus, series }) {
         )}
         {regenerateMutation.isError && (
           <span className="error">{regenerateMutation.error?.message}</span>
+        )}
+        {regenerateMutation.isSuccess && (
+          <span className="success">
+            Roster regeneration queued. <a href="/processing">View processing</a>
+          </span>
         )}
         {shareMutation.isSuccess && (
           <span className="success">

--- a/frontend/src/lib/navigation.js
+++ b/frontend/src/lib/navigation.js
@@ -2,6 +2,7 @@ export const TABS = [
   { key: "library", label: "Library", path: "/" },
   { key: "configs", label: "Cleaning Configs", path: "/configs" },
   { key: "scheduler", label: "Scheduler", path: "/scheduler" },
+  { key: "processing", label: "Processing", path: "/processing" },
   { key: "logs", label: "Logs", path: "/logs" },
   { key: "utilities", label: "Utilities", path: "/utilities" },
   { key: "audio-settings", label: "Audio Settings", path: "/audio-settings" },

--- a/frontend/tests-e2e/EpubEditor.spec.js
+++ b/frontend/tests-e2e/EpubEditor.spec.js
@@ -90,16 +90,49 @@ test("EpubEditor interactions", async ({ page }) => {
   await page.getByPlaceholder("Add CSS selector, e.g. div.note").fill("p");
   await page.getByRole("button", { name: "Add" }).click();
 
-  // Save edits and rebuild the generated EPUB.
-  await page
-    .getByRole("button", { name: /rebuild epub from saved edits/i })
-    .click();
+  // Save edits and queue the generated EPUB rebuild.
+  const [processingResponse] = await Promise.all([
+    page.waitForResponse(
+      (response) =>
+        /\/api\/books\/\d+\/process$/.test(new URL(response.url()).pathname) &&
+        response.status() === 200,
+    ),
+    page
+      .getByRole("button", { name: /queue epub rebuild from saved edits/i })
+      .click(),
+  ]);
+  const processedBook = await processingResponse.json();
 
-  // Wait for rebuild to finish, then go back to the book list
-  await expect(
-    page.getByRole("button", { name: /rebuild epub from saved edits/i }),
-  ).toBeEnabled();
+  await expect(page.getByRole("status")).toContainText(
+    "EPUB cleaning job queued",
+  );
+
+  // The action returns when durable work is queued. Wait for every cleaning
+  // job for this book to finish before checking its regenerated word count.
+  await expect
+    .poll(
+      async () => {
+        const response = await page.request.get(
+          `/api/processing/jobs?job_type=clean_book&book_id=${processedBook.id}&limit=20`,
+        );
+        if (!response.ok()) return "request-failed";
+        const jobs = await response.json();
+        if (!jobs.length) return "missing";
+        if (jobs.some((job) => ["queued", "running"].includes(job.status))) {
+          return "active";
+        }
+        if (jobs.some((job) => job.status === "error")) return "error";
+        return jobs.every((job) => job.status === "completed")
+          ? "completed"
+          : "terminal";
+      },
+      { timeout: 30000 },
+    )
+    .toBe("completed");
+
+  // Go back to the book list and reload the catalog after processing.
   await page.getByRole("button", { name: /back/i }).click();
+  await page.reload();
   await expect(page.getByText("Story Manager")).toBeVisible();
   await page.getByPlaceholder("Search by title, author, series, or tag").fill("Test Book");
   await page.getByRole("tab", { name: /standalone/i }).click();


### PR DESCRIPTION
## What changed

- add a durable `processing_jobs` ledger, API, and resource-aware background orchestrator
- route cleaning, web refreshes, metadata sync, generated narration, human-audio import/rematching/alignment, sentence and preview generation, roster rebuilds, and cover re-extraction through processing jobs
- invalidate generated and human audio derivatives when cleaned book content changes, then queue the appropriate regeneration, rematch, and optional realignment work
- add a Processing page with bulk book actions, active-job navigation count, status filters, live progress, errors, cancellation, and retry controls
- update existing UI actions to clearly indicate that work was queued and link to the Processing page
- migrate in-flight legacy work and track the book content version used by imported human narration

## Why

Book cleaning can change the text that generated or human narration is associated with. The previous independent in-memory queues did not provide one durable place to invalidate, recover, inspect, retry, or monitor that derived work.

## Impact

Processing work now survives restarts and is visible from one UI. When cleaning materially changes a book, stale generated narration is no longer served as current, generated audio is reconciled, and imported human narration is rematched against the new text and realigned when its prior timing used transcription.

Progress is shown where measurable, including book counts, track counts, metadata counts, audiobook phases, and preview assembly steps. Unmeasurable running work uses an indeterminate progress indicator.

## Validation

- `make test`: 320 passed, 1 deselected; 40 frontend tests passed
- `make lint`
- frontend production build
- clean PostgreSQL migration upgrade/downgrade
- populated PostgreSQL legacy-data migration, including active audiobook, chapter-preview, and sentence-audio work