### PR TITLE
Expose audiobook types and preserve book navigation

### DIFF
--- a/backend/app/crud/audiobook.py
+++ b/backend/app/crud/audiobook.py
@@ -16,7 +16,16 @@ from ..models import (
     AudiobookSeriesCharacter,
     AudiobookSentence,
     Book,
+    ImportedAudiobook,
 )
+
+
+async def get_human_audiobook_book_ids(db: AsyncSession, book_ids: list[int]) -> set[int]:
+    """Return books that have at least one attached human-narrated edition."""
+    if not book_ids:
+        return set()
+    result = await db.execute(select(ImportedAudiobook.book_id).where(ImportedAudiobook.book_id.in_(book_ids)).distinct())
+    return set(result.scalars().all())
 
 
 async def invalidate_packaged_audiobook(db: AsyncSession, book_id: int) -> None:

--- a/backend/app/routers/reader.py
+++ b/backend/app/routers/reader.py
@@ -120,8 +120,10 @@ def _reader_book_payload(
     *,
     series_user_genre_tags: list[str] | None = None,
     audiobook_chapters: list[models.AudiobookChapter] | None = None,
+    has_human_audiobook: bool = False,
 ) -> dict:
     base_url = str(request.base_url).rstrip("/")
+    generated_audiobook = _reader_audiobook_capability(book, audiobook_chapters or [])
     return {
         "id": book.id,
         "title": book.title,
@@ -136,7 +138,11 @@ def _reader_book_payload(
         "effective_genre_tags": _effective_genre_tags(book, series_user_genre_tags),
         "download_url": f"{base_url}/reader/books/{book.id}/download",
         "cover_url": f"{base_url}/reader/covers/{book.id}" if book.cover_path else None,
-        "audiobook": _reader_audiobook_capability(book, audiobook_chapters or []),
+        "audiobook": generated_audiobook,
+        "audiobook_types": [
+            *(["ai_generated"] if generated_audiobook is not None else []),
+            *(["human_narrated"] if has_human_audiobook else []),
+        ],
     }
 
 
@@ -353,6 +359,7 @@ async def _series_metadata_map(db: AsyncSession, books: list[models.Book]) -> di
 async def _reader_books_response(books: list[models.Book], request: Request, db: AsyncSession) -> list[schemas.ReaderBook]:
     metadata_map = await _series_metadata_map(db, books)
     chapters_by_book = await crud.audiobook.get_chapters_for_books(db, [book.id for book in books])
+    human_audiobook_book_ids = await crud.audiobook.get_human_audiobook_book_ids(db, [book.id for book in books])
     return [
         schemas.ReaderBook.model_validate(
             _reader_book_payload(
@@ -362,6 +369,7 @@ async def _reader_books_response(books: list[models.Book], request: Request, db:
                     metadata_map[book.series].user_genre_tags if book.series and book.series in metadata_map else None
                 ),
                 audiobook_chapters=chapters_by_book.get(book.id, []),
+                has_human_audiobook=book.id in human_audiobook_book_ids,
             )
         )
         for book in books

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -4,6 +4,8 @@ from typing import Literal, Optional, List
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from .models import SourceType
 
+AudiobookType = Literal["ai_generated", "human_narrated"]
+
 
 # Base Pydantic model for a book, defining common attributes.
 class BookBase(BaseModel):
@@ -86,6 +88,7 @@ class BookCatalogEntry(BaseModel):
     refresh_status: Optional[str] = None
     audiobook_enabled: bool = False
     audiobook_pipeline_status: Optional[str] = None
+    audiobook_types: List[AudiobookType] = Field(default_factory=list)
 
 
 # Pydantic model for creating a new book log.
@@ -311,6 +314,7 @@ class ReaderBook(BaseModel):
     download_url: str
     cover_url: Optional[str] = None
     audiobook: Optional[ReaderAudiobookCapability] = None
+    audiobook_types: List[AudiobookType] = Field(default_factory=list)
 
 
 PROCESSING_JOB_TYPES = Literal[

--- a/backend/app/services/catalog.py
+++ b/backend/app/services/catalog.py
@@ -41,10 +41,12 @@ async def _series_metadata_map(
 def serialize_catalog_book(
     book: models.Book,
     *,
+    audiobook_types: list[schemas.AudiobookType] | None = None,
     series_user_genre_tags: list[str] | None = None,
     effective_series_genre_tags: list[str] | None = None,
 ) -> schemas.BookCatalogEntry:
     payload = schemas.BookCatalogEntry.model_validate(book).model_dump()
+    payload["audiobook_types"] = audiobook_types or []
     payload["series_user_genre_tags"] = series_user_genre_tags or []
     payload["effective_genre_tags"] = effective_genre_tags(book, series_user_genre_tags)
     payload["effective_series_genre_tags"] = effective_series_genre_tags or []
@@ -60,6 +62,7 @@ async def build_book_catalog(
 ) -> list[schemas.BookCatalogEntry]:
     books = await crud.get_book_catalog(db, q=q, sort_by=sort_by, sort_order=sort_order)
     metadata_map = await _series_metadata_map(db, books)
+    human_audiobook_book_ids = await crud.audiobook.get_human_audiobook_book_ids(db, [book.id for book in books])
 
     series_books: dict[str, list[models.Book]] = {}
     for book in books:
@@ -74,6 +77,10 @@ async def build_book_catalog(
     return [
         serialize_catalog_book(
             book,
+            audiobook_types=[
+                *(["ai_generated"] if book.audiobook_enabled else []),
+                *(["human_narrated"] if book.id in human_audiobook_book_ids else []),
+            ],
             series_user_genre_tags=(metadata_map.get(book.series).user_genre_tags if book.series in metadata_map else []),
             effective_series_genre_tags=effective_series_tags.get(book.series, []) if book.series else [],
         )

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -97,6 +97,38 @@ async def test_get_book_catalog_returns_minimal_entries(db_session):
 
 
 @pytest.mark.asyncio
+async def test_book_catalog_includes_generated_and_human_audiobook_types(db_session):
+    async with AsyncTestingSessionLocal() as session:
+        book = await crud.create_book(
+            session,
+            schemas.BookCreate(
+                title="Two Audio Editions",
+                author="Catalog Author",
+                immutable_path="two-audio-source.epub",
+                current_path="two-audio.epub",
+                source_type=models.SourceType.epub,
+                audiobook_enabled=True,
+            ),
+        )
+        session.add(
+            models.ImportedAudiobook(
+                book_id=book.id,
+                name="Human edition",
+                status="ready",
+            )
+        )
+        await session.commit()
+
+    response = client.get("/api/books/catalog")
+
+    assert response.status_code == 200
+    assert response.json()[0]["audiobook_types"] == [
+        "ai_generated",
+        "human_narrated",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_book_catalog_sorts_audiobook_enabled_first(db_session):
     async with AsyncTestingSessionLocal() as session:
         enabled = await crud.create_book(

--- a/backend/tests/test_reader_audiobook.py
+++ b/backend/tests/test_reader_audiobook.py
@@ -88,6 +88,13 @@ async def test_reader_audiobook_capability_and_assets(
             )
         )
         db.add(
+            models.ImportedAudiobook(
+                book_id=839,
+                name="Human narration",
+                status="ready",
+            )
+        )
+        db.add(
             models.Book(
                 id=840,
                 title="Complete Standalone Audio",
@@ -141,7 +148,8 @@ async def test_reader_audiobook_capability_and_assets(
     }
     for url, expected_book_id in listing_urls.items():
         payload = app_client.get(url, auth=auth).json()
-        audiobook = next(item for item in payload if item["id"] == expected_book_id)["audiobook"]
+        listed_book = next(item for item in payload if item["id"] == expected_book_id)
+        audiobook = listed_book["audiobook"]
         assert audiobook == {
             "status": "complete",
             "revision": 7,
@@ -152,8 +160,12 @@ async def test_reader_audiobook_capability_and_assets(
             "ready_audio_bytes": len(audio_content),
             "manifest_url": f"/reader/books/{expected_book_id}/audiobook/manifest",
         }
+        assert listed_book["audiobook_types"] == (
+            ["ai_generated", "human_narrated"] if expected_book_id == 839 else ["ai_generated"]
+        )
     single = app_client.get("/reader/books/839", auth=auth).json()
     assert single["audiobook"]["status"] == "complete"
+    assert single["audiobook_types"] == ["ai_generated", "human_narrated"]
 
     manifest_response = app_client.get(protected_urls[0], auth=auth)
     assert manifest_response.status_code == 200
@@ -246,7 +258,40 @@ async def test_reader_book_omits_audiobook_for_legacy_book(app_client, sqlite_se
     auth = ("reader", key_response.json()["token"])
     book = app_client.get("/reader/books/all", auth=auth).json()[0]
     assert book["audiobook"] is None
+    assert book["audiobook_types"] == []
     assert app_client.get(f"/reader/books/{book['id']}/audiobook/manifest", auth=auth).status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_reader_book_exposes_a_human_only_audiobook_type(app_client, sqlite_sessionmaker):
+    async with sqlite_sessionmaker() as db:
+        book = models.Book(
+            title="Human Audio Book",
+            author="Reader",
+            source_type=models.SourceType.epub,
+            immutable_path="library/human-source.epub",
+            current_path="library/human.epub",
+            content_version=1,
+            audiobook_enabled=False,
+        )
+        db.add(book)
+        await db.flush()
+        db.add(
+            models.ImportedAudiobook(
+                book_id=book.id,
+                name="Human narration",
+                status="ready",
+            )
+        )
+        await db.commit()
+        book_id = book.id
+
+    key_response = app_client.post("/api/reader-keys", json={"label": "Human Audio Reader"})
+    auth = ("reader", key_response.json()["token"])
+    payload = app_client.get(f"/reader/books/{book_id}", auth=auth).json()
+
+    assert payload["audiobook"] is None
+    assert payload["audiobook_types"] == ["human_narrated"]
 
 
 def test_reader_audiobook_capability_supports_all_publication_states():

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -750,6 +750,9 @@
   border-radius: 999px;
   white-space: nowrap;
 }
+.badge-audiobook + .badge-audiobook {
+  margin-left: 0.35rem;
+}
 .badge-config {
   display: inline-block;
   padding: 0.15em 0.55em;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -28,6 +28,8 @@ function App() {
   const [sortBy, setSortBy] = useState("title");
   const [sortOrder, setSortOrder] = useState("asc");
   const [editingBook, setEditingBook] = useState(null);
+  const [bookSection, setBookSection] = useState("details");
+  const [audiobookTab, setAudiobookTab] = useState("sources");
   const [activeTab, setActiveTab] = useState("library");
   const [libraryView, setLibraryView] = useState("series");
   const [addBookOpen, setAddBookOpen] = useState(false);
@@ -49,9 +51,18 @@ function App() {
   }, []);
 
   const applyLocation = useCallback(
-    async (pathname, hash, stateData = null) => {
-      const parsed = parseLocation(pathname, hash);
+    async (pathname, hash, search, stateData = null) => {
+      const parsed = parseLocation(pathname, hash, search);
       if (parsed.view === "book") {
+        if (parsed.legacyBookPath) {
+          window.history.replaceState(
+            window.history.state,
+            "",
+            buildBookPath(parsed.bookId, "details"),
+          );
+        }
+        setBookSection(parsed.bookSection);
+        setAudiobookTab(parsed.audiobookTab);
         if (stateData?.id === parsed.bookId) {
           setEditingBook(stateData);
           return;
@@ -83,8 +94,14 @@ function App() {
 
   const navigate = (view, data = null) => {
     if (view === "book" && data?.id) {
-      window.history.pushState({ view, data }, "", buildBookPath(data.id));
+      window.history.pushState(
+        { view, data },
+        "",
+        buildBookPath(data.id, "details"),
+      );
       setEditingBook(data);
+      setBookSection("details");
+      setAudiobookTab("sources");
     } else {
       const nextPath = buildTabPath(view, libraryView);
       const tab = TABS.find((item) => item.key === view) || TABS[0];
@@ -107,7 +124,11 @@ function App() {
     if (!authStatus?.authenticated) {
       return;
     }
-    void applyLocation(window.location.pathname, window.location.hash);
+    void applyLocation(
+      window.location.pathname,
+      window.location.hash,
+      window.location.search,
+    );
   }, [applyLocation, authStatus?.authenticated]);
 
   useEffect(() => {
@@ -118,6 +139,7 @@ function App() {
       void applyLocation(
         window.location.pathname,
         window.location.hash,
+        window.location.search,
         e.state?.data ?? null,
       );
     };
@@ -161,6 +183,25 @@ function App() {
     if (fullBook) {
       navigate("book", fullBook);
     }
+  };
+
+  const handleBookNavigation = (nextSection, nextAudiobookTab = audiobookTab) => {
+    if (!editingBook) return;
+    const nextPath = buildBookPath(
+      editingBook.id,
+      nextSection,
+      nextAudiobookTab,
+    );
+    const currentPath = `${window.location.pathname}${window.location.search}`;
+    if (currentPath !== nextPath) {
+      window.history.pushState(
+        { view: "book", data: editingBook },
+        "",
+        nextPath,
+      );
+    }
+    setBookSection(nextSection);
+    setAudiobookTab(nextAudiobookTab);
   };
 
   const handleLogout = async () => {
@@ -227,7 +268,13 @@ function App() {
 
   if (editingBook) {
     return (
-      <BookSettings book={editingBook} onBack={() => window.history.back()} />
+      <BookSettings
+        book={editingBook}
+        onBack={() => navigate("library")}
+        bookSection={bookSection}
+        audiobookTab={audiobookTab}
+        onNavigationChange={handleBookNavigation}
+      />
     );
   }
 

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -424,7 +424,7 @@ describe("App", () => {
     });
   });
 
-  it("shows, filters, and sorts audiobook-enabled books", async () => {
+  it("shows and filters AI-generated and human audiobook badges", async () => {
     const mockBooks = [
       {
         id: 31,
@@ -438,6 +438,16 @@ describe("App", () => {
       },
       {
         id: 32,
+        title: "Human Audio",
+        author: "Narrator B",
+        current_word_count: 1000,
+        source_type: "epub",
+        series: null,
+        audiobook_enabled: false,
+        audiobook_types: ["human_narrated"],
+      },
+      {
+        id: 33,
         title: "Text Only",
         author: "Author B",
         current_word_count: 900,
@@ -470,13 +480,17 @@ describe("App", () => {
     fireEvent.click(await screen.findByRole("tab", { name: /standalone/i }));
 
     expect(await screen.findByTitle("Audiobook: paused")).toBeInTheDocument();
-    expect(screen.getByText("Showing 2 of 2 books")).toBeInTheDocument();
+    expect(
+      screen.getByTitle("Human-narrated audiobook"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Showing 3 of 3 books")).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText("Audiobook"), {
       target: { value: "enabled" },
     });
-    expect(screen.getByText("Showing 1 of 2 books")).toBeInTheDocument();
+    expect(screen.getByText("Showing 2 of 3 books")).toBeInTheDocument();
     expect(screen.getByText("Audio Ready")).toBeInTheDocument();
+    expect(screen.getByText("Human Audio")).toBeInTheDocument();
     expect(screen.queryByText("Text Only")).not.toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText("Sort library by"), {
@@ -487,5 +501,56 @@ describe("App", () => {
         "/api/books/catalog?sort_by=audiobook_enabled&sort_order=desc",
       );
     });
+  });
+
+  it("keeps the book section and audiobook tab in the URL", async () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/books/44/audiobooks?tab=characters",
+    );
+    const book = {
+      id: 44,
+      title: "Routed Audio",
+      author: "Author",
+      source_type: "epub",
+      immutable_path: "library/source.epub",
+      current_path: "library/current.epub",
+      removed_chapters: [],
+      content_selectors: [],
+      content_version: 1,
+      audiobook_enabled: true,
+    };
+    globalThis.fetch = vi.fn((url) => {
+      if (url === "/api/books/44") {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(book) });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+    });
+
+    renderWithClient(<App />);
+
+    const characters = await screen.findByRole("button", {
+      name: "Characters",
+    });
+    expect(characters).toHaveClass("sub-tab--active");
+    expect(window.location.pathname).toBe("/books/44/audiobooks");
+    expect(window.location.search).toBe("?tab=characters");
+
+    fireEvent.click(screen.getByRole("button", { name: "Analysis" }));
+    expect(window.location.search).toBe("?tab=analysis");
+
+    fireEvent.click(screen.getByRole("button", { name: "Details" }));
+    expect(window.location.pathname).toBe("/books/44/details");
+    expect(window.location.search).toBe("");
+
+    fireEvent.click(screen.getByRole("button", { name: "Audiobook Pipeline" }));
+    expect(window.location.pathname).toBe("/books/44/audiobooks");
+    expect(window.location.search).toBe("?tab=analysis");
+
+    fireEvent.click(screen.getByRole("button", { name: /back/i }));
+    expect(window.location.pathname).toBe("/");
+    expect(window.location.hash).toBe("#series");
+    expect(await screen.findByText("No books found.")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/AudiobookPipeline.jsx
+++ b/frontend/src/components/AudiobookPipeline.jsx
@@ -19,6 +19,7 @@ import AnalysisOverview from "./audiobook/AnalysisOverview";
 import AudiobookReader from "./audiobook/AudiobookReader";
 import ProgressDashboard from "./audiobook/ProgressDashboard";
 import AudiobookSources from "./audiobook/AudiobookSources";
+import { AUDIOBOOK_TABS } from "../lib/navigation";
 
 const PIPELINE_STEPS = [
   { status: "ingesting", label: "Ingesting" },
@@ -113,20 +114,25 @@ function JobInspector({ statusData, totalSentences, doneCount }) {
   );
 }
 
-const AI_SUB_TABS = [
-  "Progress",
-  "Analysis",
-  "Characters",
-  "Script Editor",
-  "Chapter Assembly",
-];
+const AI_SUB_TAB_KEYS = new Set([
+  "progress",
+  "analysis",
+  "characters",
+  "script-editor",
+  "chapter-assembly",
+]);
 
-function AudiobookPipeline({ book, onEnableAi }) {
+function AudiobookPipeline({
+  book,
+  onEnableAi,
+  audiobookTab,
+  onAudiobookTabChange,
+}) {
   const bookId = book.id;
   const aiEnabled = book.audiobook_enabled !== false;
   const queryClient = useQueryClient();
-  const [subTab, setSubTab] = useState(
-    book.audiobook_enabled === undefined ? "Progress" : "Sources",
+  const [internalSubTab, setInternalSubTab] = useState(
+    book.audiobook_enabled === undefined ? "progress" : "sources",
   );
   const [confirmRebuild, setConfirmRebuild] = useState(false);
   const [lastQueuedJob, setLastQueuedJob] = useState(null);
@@ -257,11 +263,17 @@ function AudiobookPipeline({ book, onEnableAi }) {
     }
   }, [aiEnabled, bookId, pipelineStatus, queryClient]);
 
-  const subTabs = [
-    "Sources",
-    "Listen & Read",
-    ...(aiEnabled ? AI_SUB_TABS : []),
-  ];
+  const subTabs = AUDIOBOOK_TABS.filter(
+    (tab) => !AI_SUB_TAB_KEYS.has(tab.key) || aiEnabled,
+  );
+  const requestedSubTab = audiobookTab || internalSubTab;
+  const subTab = subTabs.some((tab) => tab.key === requestedSubTab)
+    ? requestedSubTab
+    : "sources";
+  const selectSubTab = (tab) => {
+    setInternalSubTab(tab);
+    onAudiobookTabChange?.(tab);
+  };
 
   return (
     <div className="audiobook-pipeline">
@@ -411,19 +423,19 @@ function AudiobookPipeline({ book, onEnableAi }) {
       )}
 
       <nav className="sub-tabs">
-        {subTabs.map((t) => (
+        {subTabs.map((tab) => (
           <button
-            key={t}
-            className={`sub-tab${subTab === t ? " sub-tab--active" : ""}`}
-            onClick={() => setSubTab(t)}
+            key={tab.key}
+            className={`sub-tab${subTab === tab.key ? " sub-tab--active" : ""}`}
+            onClick={() => selectSubTab(tab.key)}
           >
-            {t}
+            {tab.label}
           </button>
         ))}
       </nav>
 
       <div className="sub-tab-content">
-        {subTab === "Sources" && (
+        {subTab === "sources" && (
           <AudiobookSources
             bookId={bookId}
             chapters={chapters}
@@ -432,13 +444,13 @@ function AudiobookPipeline({ book, onEnableAi }) {
             onEnableAi={onEnableAi}
           />
         )}
-        {subTab === "Progress" && (
+        {subTab === "progress" && (
           <ProgressDashboard status={statusData} chapters={chapters} />
         )}
-        {subTab === "Analysis" && (
+        {subTab === "analysis" && (
           <AnalysisOverview status={statusData} chapters={chapters} />
         )}
-        {subTab === "Characters" && (
+        {subTab === "characters" && (
           <CharacterRoster
             characters={characters}
             bookId={bookId}
@@ -446,7 +458,7 @@ function AudiobookPipeline({ book, onEnableAi }) {
             series={book.series}
           />
         )}
-        {subTab === "Script Editor" && (
+        {subTab === "script-editor" && (
           <ScriptEditor
             bookId={bookId}
             characters={characters}
@@ -454,14 +466,14 @@ function AudiobookPipeline({ book, onEnableAi }) {
             pipelineActive={isActive(pipelineStatus)}
           />
         )}
-        {subTab === "Chapter Assembly" && (
+        {subTab === "chapter-assembly" && (
           <ChapterAssembly
             chapters={chapters}
             bookId={bookId}
             pipelineActive={isActive(pipelineStatus)}
           />
         )}
-        {subTab === "Listen & Read" && (
+        {subTab === "listen-read" && (
           <AudiobookReader
             chapters={chapters}
             characters={characters}

--- a/frontend/src/components/BookList.jsx
+++ b/frontend/src/components/BookList.jsx
@@ -83,8 +83,8 @@ function LibraryFilters({
           onChange={(event) => onAudiobookFilterChange(event.target.value)}
         >
           <option value="">All books</option>
-          <option value="enabled">Enabled</option>
-          <option value="disabled">Not enabled</option>
+          <option value="enabled">Available</option>
+          <option value="disabled">No audiobook</option>
         </select>
       </label>
     </div>
@@ -189,10 +189,13 @@ function BookList({
   const filteredBooks = useMemo(
     () =>
       books.filter((book) => {
-        if (audiobookFilter === "enabled" && !book.audiobook_enabled) {
+        const hasAudiobook = Boolean(
+          book.audiobook_types?.length || book.audiobook_enabled,
+        );
+        if (audiobookFilter === "enabled" && !hasAudiobook) {
           return false;
         }
-        if (audiobookFilter === "disabled" && book.audiobook_enabled) {
+        if (audiobookFilter === "disabled" && hasAudiobook) {
           return false;
         }
         if (reviewFilter === "missing-series") {

--- a/frontend/src/components/BookSettings.jsx
+++ b/frontend/src/components/BookSettings.jsx
@@ -52,7 +52,13 @@ const fetchUpdateHistory = async ({ queryKey }) => {
   return getBookUpdateHistory(bookId);
 };
 
-function BookSettings({ book: initialBook, onBack }) {
+function BookSettings({
+  book: initialBook,
+  onBack,
+  bookSection,
+  audiobookTab,
+  onNavigationChange,
+}) {
   const queryClient = useQueryClient();
   const coverInputRef = useRef(null);
 
@@ -136,7 +142,19 @@ function BookSettings({ book: initialBook, onBack }) {
     getUpdatedFields,
   } = useBookSettingsForm(initialBook);
   const [previewedChapter, setPreviewedChapter] = useState(null);
-  const [bookTab, setBookTab] = useState("details");
+  const [internalBookTab, setInternalBookTab] = useState("details");
+  const bookTab = bookSection
+    ? bookSection === "audiobooks"
+      ? "audiobook"
+      : "details"
+    : internalBookTab;
+  const setBookTab = (tab) => {
+    if (onNavigationChange) {
+      onNavigationChange(tab === "audiobook" ? "audiobooks" : "details");
+    } else {
+      setInternalBookTab(tab);
+    }
+  };
   const [jobNotice, setJobNotice] = useState("");
 
   const { data: chapters = [], isLoading: chaptersLoading } = useQuery({
@@ -386,6 +404,10 @@ function BookSettings({ book: initialBook, onBack }) {
         <AudiobookPipeline
           book={book}
           onEnableAi={() => enableAudiobookMutation.mutate()}
+          audiobookTab={audiobookTab}
+          onAudiobookTabChange={(tab) =>
+            onNavigationChange?.("audiobooks", tab)
+          }
         />
       )}
 

--- a/frontend/src/components/book-list/BookCards.jsx
+++ b/frontend/src/components/book-list/BookCards.jsx
@@ -1,4 +1,5 @@
 import { getCoverUrl } from "./catalogDisplay";
+import { buildBookPath } from "../../lib/navigation";
 
 const NO_COVER_SVG =
   "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='250'%3E%3Crect width='200' height='250' fill='%23e0e0e0'/%3E%3Ctext x='100' y='125' dominant-baseline='middle' text-anchor='middle' font-family='sans-serif' font-size='14' fill='%23888'%3ENo Cover%3C/text%3E%3C/svg%3E";
@@ -24,16 +25,30 @@ export function GenreTagList({ tags, className = "" }) {
 }
 
 export function AudiobookBadge({ book }) {
-  if (!book.audiobook_enabled) return null;
+  const audiobookTypes = book.audiobook_types?.length
+    ? book.audiobook_types
+    : book.audiobook_enabled
+      ? ["ai_generated"]
+      : [];
+  if (!audiobookTypes.length) return null;
   const status = book.audiobook_pipeline_status;
   return (
-    <span
-      className="badge-audiobook"
-      title={status ? `Audiobook: ${status}` : "Audiobook enabled"}
-    >
-      <span aria-hidden="true">🎧</span>{" "}
-      {status === "complete" ? "Audiobook ready" : "Audiobook"}
-    </span>
+    <>
+      {audiobookTypes.includes("ai_generated") && (
+        <span
+          className="badge-audiobook"
+          title={status ? `Audiobook: ${status}` : "Audiobook enabled"}
+        >
+          <span aria-hidden="true">🎧</span>{" "}
+          {status === "complete" ? "Audiobook ready" : "Audiobook"}
+        </span>
+      )}
+      {audiobookTypes.includes("human_narrated") && (
+        <span className="badge-audiobook" title="Human-narrated audiobook">
+          <span aria-hidden="true">🎧</span> Human audiobook
+        </span>
+      )}
+    </>
   );
 }
 
@@ -96,7 +111,7 @@ export function BookCard({ book, onEdit }) {
 
   return (
     <a
-      href={isPending ? undefined : `/books/${book.id}`}
+      href={isPending ? undefined : buildBookPath(book.id, "details")}
       className={`book-card${isPending ? " book-card--pending" : ""}${isError ? " book-card--error" : ""}`}
       onClick={handleClick}
     >
@@ -160,7 +175,7 @@ export function BookRow({
   return (
     <div className="book-row">
       <a
-        href={`/books/${book.id}`}
+        href={buildBookPath(book.id, "details")}
         className="book-row-main"
         onClick={handleClick}
       >

--- a/frontend/src/components/book-list/SeriesSummaryRow.jsx
+++ b/frontend/src/components/book-list/SeriesSummaryRow.jsx
@@ -108,8 +108,9 @@ export default function SeriesSummaryRow({ series, books, onEdit, allSeries }) {
       authors,
       totalWords,
       hasWebNovel: orderedBooks.some((book) => book.source_type === "web"),
-      audiobookCount: orderedBooks.filter((book) => book.audiobook_enabled)
-        .length,
+      audiobookCount: orderedBooks.filter(
+        (book) => book.audiobook_types?.length || book.audiobook_enabled,
+      ).length,
       coverBook,
       coverBooks,
       latestUpdate: latestUpdate.getTime() > 0 ? latestUpdate : null,

--- a/frontend/src/lib/navigation.js
+++ b/frontend/src/lib/navigation.js
@@ -10,10 +10,32 @@ export const TABS = [
 
 export const LIBRARY_VIEWS = ["series", "standalone", "web"];
 
-export function parseLocation(pathname, hash) {
-  const match = pathname.match(/^\/books\/(\d+)$/);
+export const BOOK_SECTIONS = ["details", "audiobooks"];
+
+export const AUDIOBOOK_TABS = [
+  { key: "sources", label: "Sources" },
+  { key: "listen-read", label: "Listen & Read" },
+  { key: "progress", label: "Progress" },
+  { key: "analysis", label: "Analysis" },
+  { key: "characters", label: "Characters" },
+  { key: "script-editor", label: "Script Editor" },
+  { key: "chapter-assembly", label: "Chapter Assembly" },
+];
+
+export function parseLocation(pathname, hash, search = "") {
+  const match = pathname.match(/^\/books\/(\d+)(?:\/(details|audiobooks))?\/?$/);
   if (match) {
-    return { view: "book", bookId: Number.parseInt(match[1], 10) };
+    const requestedTab = new URLSearchParams(search).get("tab");
+    const audiobookTab = AUDIOBOOK_TABS.some((tab) => tab.key === requestedTab)
+      ? requestedTab
+      : "sources";
+    return {
+      view: "book",
+      bookId: Number.parseInt(match[1], 10),
+      bookSection: match[2] || "details",
+      audiobookTab,
+      ...(!match[2] ? { legacyBookPath: true } : {}),
+    };
   }
 
   const tab = TABS.find((item) => item.path === pathname);
@@ -21,8 +43,19 @@ export function parseLocation(pathname, hash) {
   return { view: "tab", tab: tab?.key || "library", libraryView };
 }
 
-export function buildBookPath(bookId) {
-  return `/books/${bookId}`;
+export function buildBookPath(
+  bookId,
+  bookSection = "details",
+  audiobookTab = "sources",
+) {
+  const section = BOOK_SECTIONS.includes(bookSection) ? bookSection : "details";
+  if (section === "audiobooks") {
+    const tab = AUDIOBOOK_TABS.some((item) => item.key === audiobookTab)
+      ? audiobookTab
+      : "sources";
+    return `/books/${bookId}/audiobooks?tab=${encodeURIComponent(tab)}`;
+  }
+  return `/books/${bookId}/details`;
 }
 
 export function buildTabPath(tabKey, libraryView) {

--- a/frontend/src/lib/navigation.test.js
+++ b/frontend/src/lib/navigation.test.js
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { buildBookPath, parseLocation } from "./navigation";
+
+describe("book navigation", () => {
+  it("parses canonical book sections and audiobook tabs", () => {
+    expect(
+      parseLocation(
+        "/books/12/audiobooks",
+        "",
+        "?tab=chapter-assembly",
+      ),
+    ).toEqual({
+      view: "book",
+      bookId: 12,
+      bookSection: "audiobooks",
+      audiobookTab: "chapter-assembly",
+    });
+  });
+
+  it("keeps legacy book URLs working as details URLs", () => {
+    expect(parseLocation("/books/12", "", "")).toMatchObject({
+      view: "book",
+      bookId: 12,
+      bookSection: "details",
+      legacyBookPath: true,
+    });
+  });
+
+  it("builds stable canonical URLs and rejects unknown tabs", () => {
+    expect(buildBookPath(12, "details")).toBe("/books/12/details");
+    expect(buildBookPath(12, "audiobooks", "listen-read")).toBe(
+      "/books/12/audiobooks?tab=listen-read",
+    );
+    expect(buildBookPath(12, "audiobooks", "unknown")).toBe(
+      "/books/12/audiobooks?tab=sources",
+    );
+  });
+});


### PR DESCRIPTION
## What changed

- Add matching library badges for imported human-narrated audiobook editions.
- Include `audiobook_types` (`ai_generated` and `human_narrated`) in catalog and Reader/mobile book responses.
- Treat human-only editions as audiobooks in library filters and series summaries.
- Persist book sections in `/books/:id/details` and `/books/:id/audiobooks`.
- Persist the selected audiobook sub-tab in the `tab` query parameter while retaining legacy `/books/:id` support.
- Make the page-level Back button return directly to the Library after tab navigation.

## Why

Human-narrated editions were stored separately from the generated-audiobook flag, so the library and mobile Reader API could not identify them. Book tabs were also local component state, which made refreshes and links lose the selected view.

The first URL-backed implementation used browser history for the page-level Back button. Once each tab selection had a URL, that button stepped through tab history instead of returning to the Library. It now performs an explicit Library navigation; the browser Back button remains available for history traversal.

## Impact

Library users can see and filter both generated and human audiobook editions. Mobile clients receive a stable type discriminator, and book/audiobook views can be refreshed, linked, and revisited without losing navigation state.

## Validation

- Backend: 321 passed, 1 integration test deselected
- Frontend: 44 passed
- ESLint and Flake8 passed
- Black formatting check passed
- Vite production build passed