### PR TITLE
Redesign manager UI and add reader audiobook endpoints

### DIFF
--- a/backend/app/routers/reader.py
+++ b/backend/app/routers/reader.py
@@ -27,6 +27,7 @@ from ..services.audiobook_publication import (
     stable_chapter_key,
     text_reader_path,
 )
+from . import audiobook as audiobook_router
 
 router = APIRouter(dependencies=[Depends(get_reader_api_key)])
 
@@ -418,6 +419,66 @@ async def _reader_audiobook_book(book_id: int, db: AsyncSession) -> models.Book:
     if not book.audiobook_enabled or (not book.audiobook_pipeline_status and not book.audiobook_revision):
         raise HTTPException(status_code=404, detail="Generated audiobook is not available")
     return book
+
+
+@router.get("/reader/books/{book_id}/human-audiobooks")
+async def get_reader_human_audiobooks(
+    book_id: int,
+    db: AsyncSession = Depends(get_db),
+) -> list[audiobook_router.ImportedAudiobookResponse]:
+    """Reader-key-safe metadata for ready human-narrated audiobook editions."""
+    editions = await audiobook_router.list_imported_audiobooks(book_id, db)
+    return [
+        edition.model_copy(
+            update={
+                "tracks": [
+                    track.model_copy(
+                        update={
+                            "audio_url": (
+                                f"/reader/human-audiobooks/{edition.id}/tracks/{track.id}/audio"
+                            ),
+                            "smil_url": (
+                                f"/reader/human-audiobooks/{edition.id}/tracks/{track.id}/smil"
+                            ),
+                        }
+                    )
+                    for track in edition.tracks
+                ]
+            }
+        )
+        for edition in editions
+    ]
+
+
+@router.get("/reader/books/{book_id}/human-audiobooks/chapters")
+async def get_reader_human_audiobook_chapters(
+    book_id: int,
+    db: AsyncSession = Depends(get_db),
+) -> list[audiobook_router.ChapterResponse]:
+    """Chapter ids and hrefs used to match imported tracks to publication resources."""
+    return await audiobook_router.list_chapters(book_id, db)
+
+
+@router.get("/reader/human-audiobooks/{edition_id}/tracks/{track_id}/audio")
+async def get_reader_human_audiobook_audio(
+    edition_id: int,
+    track_id: int,
+    db: AsyncSession = Depends(get_db),
+) -> FileResponse:
+    return await audiobook_router.get_imported_track_audio(edition_id, track_id, db)
+
+
+@router.get("/reader/human-audiobooks/{edition_id}/tracks/{track_id}/smil")
+async def get_reader_human_audiobook_smil(
+    edition_id: int,
+    track_id: int,
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    response = await audiobook_router.get_imported_track_smil(edition_id, track_id, db)
+    text = response.body.decode("utf-8")
+    admin_audio = f"/api/imported-audiobooks/{edition_id}/tracks/{track_id}/audio"
+    reader_audio = f"/reader/human-audiobooks/{edition_id}/tracks/{track_id}/audio"
+    return Response(text.replace(admin_audio, reader_audio), media_type="application/smil+xml")
 
 
 def _etag(value: str) -> str:

--- a/backend/app/routers/reader.py
+++ b/backend/app/routers/reader.py
@@ -434,12 +434,8 @@ async def get_reader_human_audiobooks(
                 "tracks": [
                     track.model_copy(
                         update={
-                            "audio_url": (
-                                f"/reader/human-audiobooks/{edition.id}/tracks/{track.id}/audio"
-                            ),
-                            "smil_url": (
-                                f"/reader/human-audiobooks/{edition.id}/tracks/{track.id}/smil"
-                            ),
+                            "audio_url": (f"/reader/human-audiobooks/{edition.id}/tracks/{track.id}/audio"),
+                            "smil_url": (f"/reader/human-audiobooks/{edition.id}/tracks/{track.id}/smil"),
                         }
                     )
                     for track in edition.tracks

--- a/backend/tests/test_reader_audiobook.py
+++ b/backend/tests/test_reader_audiobook.py
@@ -292,6 +292,16 @@ async def test_reader_book_exposes_a_human_only_audiobook_type(app_client, sqlit
 
     assert payload["audiobook"] is None
     assert payload["audiobook_types"] == ["human_narrated"]
+    human_url = f"/reader/books/{book_id}/human-audiobooks"
+    assert app_client.get(human_url).status_code == 401
+    editions = app_client.get(human_url, auth=auth).json()
+    assert len(editions) == 1
+    assert editions[0]["name"] == "Human narration"
+    assert editions[0]["status"] == "ready"
+    assert app_client.get(
+        f"/reader/books/{book_id}/human-audiobooks/chapters",
+        auth=auth,
+    ).json() == []
 
 
 def test_reader_audiobook_capability_supports_all_publication_states():

--- a/backend/tests/test_reader_audiobook.py
+++ b/backend/tests/test_reader_audiobook.py
@@ -298,10 +298,13 @@ async def test_reader_book_exposes_a_human_only_audiobook_type(app_client, sqlit
     assert len(editions) == 1
     assert editions[0]["name"] == "Human narration"
     assert editions[0]["status"] == "ready"
-    assert app_client.get(
-        f"/reader/books/{book_id}/human-audiobooks/chapters",
-        auth=auth,
-    ).json() == []
+    assert (
+        app_client.get(
+            f"/reader/books/{book_id}/human-audiobooks/chapters",
+            auth=auth,
+        ).json()
+        == []
+    )
 
 
 def test_reader_audiobook_capability_supports_all_publication_states():

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -13,7 +13,7 @@
   border-radius: var(--radius);
   pointer-events: none;
   z-index: 1000;
-  background: rgba(98, 114, 234, 0.03);
+  background: color-mix(in srgb, var(--accent) 3%, transparent);
 }
 
 .app-header {
@@ -90,7 +90,7 @@
 
   .main-tab--active {
     border-color: var(--accent);
-    background: rgba(98, 114, 234, 0.1);
+    background: color-mix(in srgb, var(--accent) 10%, transparent);
   }
 }
 
@@ -316,7 +316,7 @@
 .drop-zone:hover,
 .drop-zone.dragging {
   border-color: var(--accent);
-  background-color: rgba(98, 114, 234, 0.06);
+  background-color: color-mix(in srgb, var(--accent) 6%, transparent);
   color: var(--text);
 }
 .drop-zone--has-files {
@@ -541,7 +541,7 @@
 .library-view-tab--active {
   border-color: var(--accent);
   color: var(--text);
-  background: rgba(98, 114, 234, 0.1);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
 }
 
 .library-view-tab-count {
@@ -660,8 +660,8 @@
   align-items: center;
   padding: 0.2rem 0.55rem;
   border-radius: 999px;
-  background: rgba(98, 114, 234, 0.12);
-  border: 1px solid rgba(98, 114, 234, 0.18);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 18%, transparent);
   color: var(--accent);
   font-size: 0.7rem;
   font-weight: 500;
@@ -695,9 +695,9 @@
   align-items: center;
   padding: 0.2rem 0.55rem;
   border-radius: 999px;
-  background: rgba(40, 167, 69, 0.1);
-  border: 1px solid rgba(40, 167, 69, 0.18);
-  color: #2f7d49;
+  background: color-mix(in srgb, var(--success) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--success) 24%, transparent);
+  color: var(--success);
   font-size: 0.7rem;
   font-weight: 500;
   line-height: 1.2;
@@ -733,7 +733,7 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  background: rgba(98, 114, 234, 0.18);
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
   color: var(--accent);
   border-radius: 3px;
 }
@@ -744,9 +744,9 @@
   padding: 0.15em 0.55em;
   font-size: 0.68rem;
   font-weight: 650;
-  background: rgba(34, 197, 94, 0.14);
-  color: #79d99a;
-  border: 1px solid rgba(34, 197, 94, 0.22);
+  background: color-mix(in srgb, var(--success) 14%, transparent);
+  color: var(--success);
+  border: 1px solid color-mix(in srgb, var(--success) 28%, transparent);
   border-radius: 999px;
   white-space: nowrap;
 }
@@ -758,7 +758,7 @@
   padding: 0.15em 0.55em;
   font-size: 0.75rem;
   font-weight: 500;
-  background: rgba(98, 114, 234, 0.15);
+  background: color-mix(in srgb, var(--accent) 15%, transparent);
   color: var(--accent);
   border-radius: 3px;
   margin-left: 0.5rem;
@@ -1000,8 +1000,8 @@
 }
 .series-action-btn--active {
   color: var(--accent);
-  background: rgba(98, 114, 234, 0.1);
-  border-color: rgba(98, 114, 234, 0.25);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 25%, transparent);
 }
 
 /* Edit forms */
@@ -1203,7 +1203,7 @@
 }
 
 .book-rows--web .book-row {
-  background: linear-gradient(180deg, var(--surface), rgba(98, 114, 234, 0.06));
+  background: linear-gradient(180deg, var(--surface), color-mix(in srgb, var(--accent) 6%, transparent));
 }
 
 .library-filters {
@@ -1226,12 +1226,6 @@
   min-width: 11rem;
   min-height: 2.4rem;
 }
-.library-results-summary {
-  color: var(--text-muted);
-  font-size: 0.78rem;
-  margin-bottom: 0.75rem;
-}
-
 @media (max-width: 720px) {
   .series-header {
     gap: 0.75rem;
@@ -1524,6 +1518,15 @@
   min-width: 0;
 }
 
+.utilities-tabs {
+  margin-bottom: 1.5rem;
+}
+
+.utilities-tab-content > .settings-section:first-child {
+  padding-top: 0;
+  border-top: 0;
+}
+
 .pipeline-header,
 .pipeline-inspector,
 .analysis-book-summary,
@@ -1599,7 +1602,7 @@
 }
 
 .pipeline-step--active .pipeline-step-dot {
-  box-shadow: 0 0 0 4px rgba(98, 114, 234, 0.16);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 16%, transparent);
 }
 
 .pipeline-meta,
@@ -1749,16 +1752,16 @@
   height: 0.65rem;
   border-radius: 999px;
   background: var(--accent);
-  box-shadow: 0 0 0 0 rgba(98, 114, 234, 0.4);
+  box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 40%, transparent);
   animation: progress-pulse 1.6s infinite;
 }
 
 @keyframes progress-pulse {
   70% {
-    box-shadow: 0 0 0 0.5rem rgba(98, 114, 234, 0);
+    box-shadow: 0 0 0 0.5rem transparent;
   }
   100% {
-    box-shadow: 0 0 0 0 rgba(98, 114, 234, 0);
+    box-shadow: 0 0 0 0 transparent;
   }
 }
 
@@ -2044,7 +2047,7 @@
 }
 
 .audiobook-reader-text span:hover {
-  background: rgba(98, 114, 234, 0.08);
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
 }
 
 .audiobook-reader-text .audiobook-sentence--active {
@@ -2074,7 +2077,7 @@
 
 .audiobook-reader-chapters button.active {
   border-color: var(--accent);
-  background: rgba(98, 114, 234, 0.12);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
 }
 
 .audiobook-reader-chapters small {
@@ -2954,6 +2957,17 @@
   gap: 0.75rem;
 }
 
+.cleaning-config-actions-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.cleaning-config-actions-header h3 {
+  flex: 1;
+}
+
 .config-card {
   background: var(--surface);
   border: 1px solid var(--border);
@@ -3154,5 +3168,927 @@
   to {
     opacity: 1;
     transform: translateY(0);
+  }
+}
+
+/* ─── Editorial desk redesign ────────────────────────────── */
+body {
+  background:
+    linear-gradient(90deg, transparent 0, transparent calc(50% - 590px), rgba(226, 214, 192, 0.035) calc(50% - 590px), rgba(226, 214, 192, 0.035) calc(50% - 589px), transparent calc(50% - 589px)),
+    var(--bg);
+}
+
+.app-container {
+  max-width: 1180px;
+  padding: 2rem 2rem 4rem;
+  border-left: 1px solid var(--border);
+  border-right: 1px solid var(--border);
+}
+
+.app-header {
+  align-items: flex-end;
+  gap: 1.5rem;
+  margin: 0;
+  padding: 0 0 1.25rem;
+  border-bottom: 1px solid var(--text);
+}
+
+.app-header h1 {
+  font-style: italic;
+}
+
+.app-header > .btn-text {
+  padding: 0;
+  border: 0;
+  background: transparent;
+}
+
+.main-tabs {
+  gap: 0;
+  margin: 0 0 2rem;
+  padding: 0;
+  border-bottom: 1px solid var(--border-strong);
+}
+
+.main-tab {
+  min-height: 2.8rem;
+  padding: 0.65rem 1rem;
+  border: 0;
+  border-right: 1px solid var(--border);
+  border-bottom: 0;
+  border-radius: 0;
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  letter-spacing: 0.025em;
+}
+
+.main-tab:first-child {
+  border-left: 1px solid var(--border);
+}
+
+.main-tab:hover:not(:disabled) {
+  color: var(--text);
+  border-color: var(--border-strong);
+  background: var(--surface);
+}
+
+.main-tab--active,
+.main-tab--active:hover:not(:disabled) {
+  color: var(--bg);
+  border-color: var(--text);
+  background: var(--text);
+  font-weight: 500;
+}
+
+.nav-job-count {
+  min-width: 1.15rem;
+  height: 1.15rem;
+  border-radius: 50%;
+  background: var(--accent);
+  color: var(--bg);
+  font-weight: 600;
+}
+
+.library-page-heading {
+  padding-bottom: 1rem;
+}
+
+.search-controls {
+  gap: 0;
+  margin: 0 0 1.25rem;
+  padding: 0;
+  border-top: 1px solid var(--border-strong);
+  border-bottom: 1px solid var(--border-strong);
+}
+
+.search-input-wrap input,
+.sort-controls select,
+.sort-order-btn {
+  min-height: 3rem;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+.search-input-wrap input:focus,
+.sort-controls select:focus {
+  background: var(--surface);
+}
+
+.sort-controls {
+  gap: 0;
+  border-left: 1px solid var(--border-strong);
+}
+
+.sort-controls select {
+  min-width: 11rem;
+  border-right: 1px solid var(--border);
+}
+
+.sort-order-btn {
+  min-width: 3rem;
+  padding: 0;
+}
+
+.add-book-details {
+  margin: 0 0 1.5rem;
+}
+
+.add-book-summary {
+  border-color: var(--text);
+  border-radius: 0;
+  background: transparent;
+  color: var(--text);
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 0.74rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.add-book-summary:hover {
+  border-color: var(--accent);
+  background: transparent;
+  color: var(--accent-hover);
+}
+
+.add-book-container,
+.drop-zone,
+.config-card,
+.scheduler-stat,
+.task-history-row {
+  border-radius: 0;
+}
+
+.add-book-container {
+  border: 0;
+  border-top: 1px solid var(--border-strong);
+  border-bottom: 1px solid var(--border-strong);
+  background: transparent;
+}
+
+.library-filters {
+  padding: 0.75rem 0;
+  margin: 0;
+  border-top: 1px solid var(--border);
+}
+
+.library-filters label {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.library-filters select {
+  min-height: 2.2rem;
+  border: 0;
+  border-bottom: 1px solid var(--border-strong);
+  border-radius: 0;
+  background: transparent;
+  color: var(--text);
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.library-view-tabs {
+  gap: 0;
+  margin: 0 0 0.75rem;
+  padding: 0;
+  border-top: 1px solid var(--text);
+  border-bottom: 1px solid var(--text);
+}
+
+.library-view-tab {
+  min-width: 0;
+  padding: 0.75rem 1.1rem;
+  border: 0;
+  border-right: 1px solid var(--border-strong);
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font-family: Georgia, "Times New Roman", serif;
+}
+
+.library-view-tab:first-child {
+  border-left: 1px solid var(--border-strong);
+}
+
+.library-view-tab:hover:not(:disabled) {
+  border-color: var(--border-strong);
+  background: var(--surface);
+  color: var(--text);
+}
+
+.library-view-tab--active,
+.library-view-tab--active:hover:not(:disabled) {
+  border-color: var(--text);
+  background: var(--text);
+  color: var(--bg);
+}
+
+.library-view-tab-count {
+  border: 1px solid currentColor;
+  border-radius: 50%;
+  background: transparent;
+  color: inherit;
+}
+
+.series-group {
+  margin: 0;
+  border-bottom: 1px solid var(--border-strong);
+}
+
+.series-group:first-of-type {
+  border-top: 1px solid var(--border-strong);
+}
+
+.series-group--expanded {
+  margin: 0 0 1.5rem;
+  border-color: var(--text-muted);
+}
+
+.series-header {
+  min-height: 7rem;
+  gap: 1.25rem;
+  padding: 1rem 0.75rem;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  transition: background-color 0.15s;
+}
+
+.series-header:hover,
+.series-group--expanded .series-header {
+  border: 0;
+  background: color-mix(in srgb, var(--surface) 64%, transparent);
+  box-shadow: none;
+}
+
+.series-cover-stack,
+.series-cover-stack:has(.series-cover-stacked) {
+  width: 60px;
+  height: 78px;
+}
+
+.series-cover-image,
+.series-cover-placeholder {
+  width: 52px;
+  height: 74px;
+  border-radius: 0;
+  border-color: var(--border-strong);
+}
+
+.series-cover-stacked {
+  top: 0;
+  left: 0;
+  transform: translateX(calc(var(--stack-i) * 4px))
+    translateY(calc(var(--stack-i) * 2px));
+  box-shadow: none;
+}
+
+.series-name {
+  color: var(--text);
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 1.12rem;
+  font-weight: 500;
+}
+
+.series-meta-author {
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 0.88rem;
+}
+
+.series-stat-value {
+  font-weight: 500;
+}
+
+.series-toggle {
+  color: var(--accent);
+}
+
+.series-expanded {
+  border: 0;
+  border-top: 1px solid var(--border);
+  border-radius: 0;
+  background: var(--surface);
+  padding: 1rem;
+}
+
+.series-toolbar {
+  border-radius: 0;
+}
+
+.genre-tag,
+.badge-web,
+.badge-audiobook,
+.badge-config,
+.pill {
+  border-radius: 1px;
+}
+
+.btn-primary,
+.btn-primary:hover:not(:disabled) {
+  color: var(--bg);
+}
+
+.badge-web,
+.badge-config {
+  border: 1px solid color-mix(in srgb, var(--accent) 28%, transparent);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
+.genre-tag {
+  border-color: var(--border-strong);
+  background: transparent;
+  color: var(--text-muted);
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  text-transform: uppercase;
+  letter-spacing: 0.035em;
+}
+
+.book-row {
+  border: 0;
+  border-bottom: 1px solid var(--border-strong);
+  border-radius: 0;
+  background: transparent;
+}
+
+.book-rows--web .book-row {
+  background: transparent;
+}
+
+.book-row-main:hover {
+  background: var(--surface);
+}
+
+.book-cover,
+.book-row-cover,
+.book-row-cover-image,
+.settings-cover-img {
+  border-radius: 0;
+}
+
+.book-row-title {
+  font-family: Georgia, "Times New Roman", serif;
+  font-weight: 500;
+}
+
+/* The book desk keeps the editorial shell and uses rules instead of cards. */
+.book-settings {
+  max-width: 900px;
+  padding: 1.5rem 2rem 4rem;
+  border-left: 1px solid var(--border);
+  border-right: 1px solid var(--border);
+}
+
+.book-settings--wide {
+  max-width: 1440px;
+}
+
+.settings-header {
+  position: static;
+  align-items: flex-end;
+  gap: 1.25rem;
+  margin: 0;
+  padding: 0 0 1.25rem;
+  border-bottom-color: var(--text);
+  background: transparent;
+}
+
+.settings-header > .btn-text {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--accent-hover);
+}
+
+.settings-title-block {
+  min-width: 0;
+  display: grid;
+  gap: 0.2rem;
+}
+
+.settings-header .settings-title-block h2 {
+  font-size: 1.45rem;
+  font-style: italic;
+  font-weight: 500;
+}
+
+.settings-title-block > span {
+  color: var(--text-muted);
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 0.82rem;
+}
+
+.book-settings-tabs {
+  display: flex;
+  gap: 0;
+  margin: 0 0 1.5rem;
+  border-bottom: 1px solid var(--border-strong);
+}
+
+.book-settings-tab {
+  min-height: 2.75rem;
+  padding: 0.65rem 1rem;
+  border: 0;
+  border-left: 1px solid var(--border);
+  border-right: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-muted);
+}
+
+.book-settings-tab + .book-settings-tab {
+  border-left: 0;
+}
+
+.book-settings-tab--active,
+.book-settings-tab--active:hover:not(:disabled) {
+  border-color: var(--text);
+  background: var(--text);
+  color: var(--bg);
+}
+
+.settings-section {
+  padding: 1.25rem 0;
+  margin: 0 0 1.25rem;
+  border: 0;
+  border-top: 1px solid var(--border-strong);
+  border-radius: 0;
+  background: transparent;
+}
+
+.app-container > .main-tabs + div > .settings-section:first-child {
+  padding-top: 0;
+  border-top: 0;
+}
+
+.settings-section h3 {
+  font-size: 1.12rem;
+  margin-bottom: 1rem;
+  padding-bottom: 0.7rem;
+  border-bottom-color: var(--border);
+}
+
+.settings-section label {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  letter-spacing: 0.035em;
+  text-transform: uppercase;
+}
+
+.settings-section label input,
+.settings-section label textarea,
+.settings-section > textarea {
+  font-family: "Avenir Next", Avenir, sans-serif;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.settings-cover-aside {
+  padding-left: 1.25rem;
+  border-left: 1px solid var(--border);
+}
+
+.actions-bar {
+  padding: 1.25rem;
+  border: 1px solid var(--border-strong);
+  background: var(--surface);
+}
+
+.collapsible-header:hover h3 {
+  color: var(--accent-hover);
+}
+
+.chapter-list-scroll,
+.chapter-preview,
+.chapter-history-chart,
+.chapter-history-stat {
+  border-radius: 0;
+}
+
+.chapter-history-bar {
+  border-radius: 0;
+  background: var(--accent);
+  box-shadow: none;
+}
+
+/* Production pages switch to a denser console vocabulary. */
+.processing-page {
+  gap: 0;
+  margin: -2rem;
+  padding: 0 2rem 3rem;
+  background: var(--bg);
+  color: var(--text);
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  border-bottom: 1px solid var(--border-strong);
+}
+
+.processing-page h2,
+.processing-page h3 {
+  color: var(--text);
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  letter-spacing: -0.025em;
+}
+
+.processing-console-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 1rem;
+  padding: 1.25rem 0 1rem;
+  border-bottom: 1px solid var(--border-strong);
+}
+
+.processing-console-header > div {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.processing-console-header span,
+.processing-section-code {
+  color: var(--accent);
+  font-size: 0.68rem;
+  letter-spacing: 0.1em;
+}
+
+.processing-console-header p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+}
+
+.processing-health-strip {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  border-bottom: 1px solid var(--border-strong);
+  background: var(--surface-2);
+}
+
+.processing-health-strip > div {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 0.15rem 0.55rem;
+  padding: 0.75rem 0.9rem;
+  border-right: 1px solid var(--border-strong);
+}
+
+.processing-health-strip > div:last-child {
+  border-right: 0;
+}
+
+.processing-health-strip small {
+  grid-column: 2;
+  color: var(--text-muted);
+}
+
+.processing-health-dot {
+  grid-row: 1 / span 2;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 0.2rem color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.processing-page > .settings-section {
+  padding: 1.25rem;
+  margin: 1rem 0 0;
+  border: 1px solid var(--border-strong);
+  background: var(--surface);
+}
+
+.processing-queue-summary {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.35rem 2rem;
+  margin: -1.25rem;
+  padding: 1.25rem 3.25rem 1.25rem 1.25rem;
+  cursor: pointer;
+  list-style: none;
+}
+
+.processing-queue-summary::-webkit-details-marker {
+  display: none;
+}
+
+.processing-queue-summary::after {
+  content: "+";
+  position: absolute;
+  right: 1.25rem;
+  color: var(--accent);
+  font-size: 1.25rem;
+}
+
+.processing-queue-panel[open] > .processing-queue-summary {
+  margin-bottom: 0;
+  border-bottom: 1px solid var(--border-strong);
+}
+
+.processing-queue-panel[open] > .processing-queue-summary::after {
+  content: "−";
+}
+
+.processing-queue-summary-heading {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.processing-queue-title {
+  color: var(--text);
+  font-size: 1.45rem;
+  letter-spacing: -0.025em;
+}
+
+.processing-queue-summary > .hint {
+  margin: 0;
+}
+
+.processing-page .hint,
+.processing-page label,
+.processing-job-main small,
+.processing-job > p {
+  color: var(--text-muted);
+}
+
+.processing-page input,
+.processing-page select,
+.processing-page button:not(.btn-primary) {
+  border-color: var(--border-strong);
+  border-radius: 0;
+  background: var(--surface-2);
+  color: var(--text);
+}
+
+.processing-page .btn-primary {
+  border-color: var(--accent);
+  border-radius: 0;
+  background: var(--accent);
+  color: var(--bg);
+}
+
+.processing-quick-actions {
+  padding: 0.7rem 0;
+  border-top: 1px solid var(--border-strong);
+  border-bottom: 1px solid var(--border-strong);
+}
+
+.processing-book-options {
+  gap: 0;
+  padding: 0;
+  border-color: var(--border-strong);
+  border-radius: 0;
+  background: var(--bg);
+}
+
+.processing-book-options > label {
+  padding: 0.55rem;
+  margin: 0;
+  border-right: 1px solid var(--border-strong);
+  border-bottom: 1px solid var(--border-strong);
+  border-radius: 0;
+}
+
+.processing-book-options > label:hover {
+  background: var(--surface-2);
+}
+
+.processing-job-list {
+  gap: 0;
+  border-top: 1px solid var(--border-strong);
+}
+
+.processing-job {
+  padding: 0.9rem 1rem;
+  border: 0;
+  border-bottom: 1px solid var(--border-strong);
+  border-left: 3px solid var(--border-strong);
+  border-radius: 0;
+  background: var(--bg);
+}
+
+.processing-job--running { border-left-color: var(--accent); }
+.processing-job--queued { border-left-color: var(--warning); }
+.processing-job--completed { border-left-color: var(--success); }
+.processing-job--error { border-left-color: var(--danger); }
+
+.processing-job-main a {
+  color: var(--accent);
+}
+
+.processing-status {
+  border: 1px solid currentColor;
+  border-radius: 0;
+  background: transparent;
+}
+
+.processing-status--running { color: var(--accent); background: transparent; }
+.processing-status--queued { color: var(--warning); background: transparent; }
+.processing-status--completed { color: var(--success); background: transparent; }
+.processing-status--error { color: var(--danger); background: transparent; }
+
+.processing-job-progress progress {
+  accent-color: var(--accent);
+}
+
+/* The audiobook pipeline uses the console system within the editorial book desk. */
+.audiobook-pipeline {
+  padding: 1rem;
+  border: 1px solid var(--border-strong);
+  background: var(--bg);
+  color: var(--text);
+}
+
+.audiobook-pipeline h3,
+.audiobook-pipeline strong,
+.audiobook-pipeline p {
+  color: inherit;
+}
+
+.audiobook-pipeline h3 {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  letter-spacing: -0.02em;
+}
+
+.pipeline-header,
+.pipeline-inspector,
+.analysis-book-summary,
+.chapter-analysis-card,
+.character-card,
+.script-editor,
+.chapter-assembly,
+.audiobook-source-upload,
+.audiobook-ai-source,
+.imported-edition-card,
+.progress-live-card,
+.progress-metric,
+.progress-chapters,
+.progress-error-detail,
+.pipeline-error-summary {
+  border-radius: 0;
+}
+
+.pipeline-header {
+  border-left: 3px solid var(--accent);
+  background: var(--surface);
+}
+
+.pipeline-step {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+}
+
+.pipeline-step-dot {
+  border-radius: 50%;
+  background: var(--surface);
+}
+
+.pipeline-step--active .pipeline-step-dot {
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 18%, transparent);
+}
+
+.pipeline-inspector {
+  border: 1px solid var(--border-strong);
+  background: var(--surface-2);
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+}
+
+.pipeline-inspector-grid > div {
+  padding-right: 0.8rem;
+  border-right: 1px solid var(--border-strong);
+}
+
+.pipeline-inspector-grid > div:last-child {
+  border-right: 0;
+}
+
+.metric-label {
+  color: var(--accent);
+}
+
+.sub-tabs {
+  gap: 0;
+  border-color: var(--border-strong);
+}
+
+.sub-tab {
+  border: 0;
+  border-right: 1px solid var(--border-strong);
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+}
+
+.sub-tab--active,
+.sub-tab--active:hover:not(:disabled) {
+  border-color: var(--text);
+  background: var(--text);
+  color: var(--bg);
+}
+
+.audiobook-pipeline input,
+.audiobook-pipeline select,
+.audiobook-pipeline textarea,
+.audiobook-pipeline button:not(.btn-primary) {
+  border-radius: 0;
+}
+
+.audiobook-pipeline progress {
+  accent-color: var(--accent);
+}
+
+@media (max-width: 760px) {
+  body {
+    background: var(--bg);
+  }
+
+  .app-container,
+  .book-settings {
+    padding: 1.25rem 1rem 3rem;
+    border: 0;
+  }
+
+  .main-tabs {
+    margin-bottom: 1.25rem;
+  }
+
+  .main-tab {
+    min-height: 2.5rem;
+    padding: 0.55rem 0.75rem;
+  }
+
+  .library-page-heading,
+  .settings-header,
+  .processing-console-header {
+    align-items: flex-start;
+  }
+
+  .settings-header {
+    flex-direction: column;
+  }
+
+  .settings-cover-aside {
+    padding-left: 0;
+    border-left: 0;
+  }
+
+  .processing-page {
+    margin: -1.25rem -1rem;
+    padding: 0 1rem 3rem;
+  }
+
+  .processing-health-strip {
+    grid-template-columns: 1fr;
+  }
+
+  .processing-health-strip > div {
+    border-right: 0;
+    border-bottom: 1px solid var(--border-strong);
+  }
+
+  .pipeline-inspector-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .pipeline-inspector-grid > div:nth-child(2) {
+    border-right: 0;
+  }
+}
+
+@media (max-width: 480px) {
+  .main-tabs {
+    display: flex;
+    flex-wrap: nowrap;
+    gap: 0;
+    border-bottom: 1px solid var(--border-strong);
+  }
+
+  .main-tab,
+  .main-tab--active {
+    border-radius: 0;
+  }
+
+  .library-page-heading,
+  .processing-console-header {
+    flex-direction: column;
+  }
+
+  .library-view-tabs {
+    gap: 0;
+  }
+
+  .library-view-tab {
+    padding: 0.6rem 0.35rem;
+  }
+
+  .pipeline-inspector-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .pipeline-inspector-grid > div {
+    padding: 0 0 0.65rem;
+    border-right: 0;
+    border-bottom: 1px solid var(--border-strong);
   }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -295,6 +295,9 @@ function App() {
       default:
         return (
           <>
+            <div className="library-page-heading">
+              <h2>Library</h2>
+            </div>
             <div className="search-controls">
               <div className="search-input-wrap">
                 <svg

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -483,12 +483,11 @@ describe("App", () => {
     expect(
       screen.getByTitle("Human-narrated audiobook"),
     ).toBeInTheDocument();
-    expect(screen.getByText("Showing 3 of 3 books")).toBeInTheDocument();
+    expect(screen.getByText("Text Only")).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText("Audiobook"), {
       target: { value: "enabled" },
     });
-    expect(screen.getByText("Showing 2 of 3 books")).toBeInTheDocument();
     expect(screen.getByText("Audio Ready")).toBeInTheDocument();
     expect(screen.getByText("Human Audio")).toBeInTheDocument();
     expect(screen.queryByText("Text Only")).not.toBeInTheDocument();

--- a/frontend/src/components/BookList.jsx
+++ b/frontend/src/components/BookList.jsx
@@ -254,9 +254,6 @@ function BookList({
         audiobookFilter={audiobookFilter}
         onAudiobookFilterChange={setAudiobookFilter}
       />
-      <div className="library-results-summary" role="status">
-        Showing {filteredBooks.length} of {books.length} books
-      </div>
       <LibraryViewTabs
         view={libraryView}
         onChange={handleTabChange}

--- a/frontend/src/components/BookSettings.jsx
+++ b/frontend/src/components/BookSettings.jsx
@@ -380,9 +380,12 @@ function BookSettings({
           }
           style={{ flexShrink: 0 }}
         >
-          ← Back
+          ← Back to library
         </button>
-        <h2>{book.title}</h2>
+        <div className="settings-title-block">
+          <h2>{book.title}</h2>
+          <span>{book.author || "Unknown author"}</span>
+        </div>
       </div>
 
       <nav className="book-settings-tabs">

--- a/frontend/src/components/CleaningConfigs.jsx
+++ b/frontend/src/components/CleaningConfigs.jsx
@@ -205,31 +205,16 @@ function CleaningConfigs({ onBack }) {
           <h2>Cleaning Configs</h2>
         </div>
       )}
-      <div style={{ display: "flex", justifyContent: "flex-end", marginBottom: "0.75rem" }}>
-        <button onClick={() => setCreating(true)} disabled={creating}>
-          + New Config
-        </button>
-      </div>
-
       {isLoading && <p>Loading...</p>}
       {error && <p className="error">{error.message}</p>}
 
-      {creating && (
-        <div className="config-editor">
-          <h3>New Config</h3>
-          <ConfigForm
-            onSave={(data) => createMutation.mutate(data)}
-            onCancel={() => setCreating(false)}
-            isSaving={createMutation.isPending}
-          />
-          {createMutation.isError && (
-            <p className="error">{createMutation.error.message}</p>
-          )}
-        </div>
-      )}
-
       <section className="settings-section">
-        <h3>Clean All Books</h3>
+        <div className="cleaning-config-actions-header">
+          <h3>Clean All Books</h3>
+          <button onClick={() => setCreating(true)} disabled={creating}>
+            + New Config
+          </button>
+        </div>
         <p className="hint">
           Re-applies cleaning configs and selectors to every book in the library.
         </p>
@@ -267,6 +252,20 @@ function CleaningConfigs({ onBack }) {
           </p>
         )}
       </section>
+
+      {creating && (
+        <div className="config-editor">
+          <h3>New Config</h3>
+          <ConfigForm
+            onSave={(data) => createMutation.mutate(data)}
+            onCancel={() => setCreating(false)}
+            isSaving={createMutation.isPending}
+          />
+          {createMutation.isError && (
+            <p className="error">{createMutation.error.message}</p>
+          )}
+        </div>
+      )}
 
       <div className="config-list">
         {configs.map((config) => (

--- a/frontend/src/components/ProcessingJobs.jsx
+++ b/frontend/src/components/ProcessingJobs.jsx
@@ -115,15 +115,32 @@ function ProcessingJobs() {
     queueMutation.mutate({ jobType: operation, bookIds: selectedIds, payload });
   };
 
+  const runningCount = jobs.filter((job) => job.status === "running").length;
+  const queuedCount = jobs.filter((job) => job.status === "queued").length;
+
   return (
     <div className="processing-page">
-      <section className="settings-section processing-queue-panel">
+      <header className="processing-console-header">
         <div>
-          <h2>Queue processing</h2>
-          <p className="hint">
-            Queue cleaning, source refreshes, or audiobook regeneration for one or more books.
-          </p>
+          <span>PRODUCTION CONSOLE</span>
+          <h2>Processing control</h2>
         </div>
+        <p>Durable work queue · automatic recovery enabled</p>
+      </header>
+      <div className="processing-health-strip" aria-label="Processing system status">
+        <div><span className="processing-health-dot" /><strong>Queue online</strong><small>Workers available</small></div>
+        <div><strong>{runningCount} running</strong><small>{queuedCount} waiting</small></div>
+      </div>
+      <details className="settings-section processing-queue-panel">
+        <summary className="processing-queue-summary">
+          <span className="processing-queue-summary-heading">
+          <span className="processing-section-code">01 / DISPATCH</span>
+            <span className="processing-queue-title">Queue work</span>
+          </span>
+          <span className="hint">
+            Queue cleaning, source refreshes, or audiobook regeneration for one or more books.
+          </span>
+        </summary>
         <div className="processing-quick-actions">
           <button
             onClick={() => queueMutation.mutate({ jobType: "clean_all", bookIds: [], payload: {} })}
@@ -206,11 +223,12 @@ function ProcessingJobs() {
         </div>
         {queueNotice && <p className="job-queued-notice">{queueNotice}</p>}
         {queueMutation.isError && <p className="error">{queueMutation.error.message}</p>}
-      </section>
+      </details>
 
       <section className="settings-section">
         <div className="processing-list-header">
           <div>
+            <span className="processing-section-code">02 / JOB LEDGER</span>
             <h2>Processing jobs</h2>
             <p className="hint">Durable work survives application restarts and can be retried here.</p>
           </div>

--- a/frontend/src/components/ProcessingJobs.test.jsx
+++ b/frontend/src/components/ProcessingJobs.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import ProcessingJobs from "./ProcessingJobs";
@@ -69,5 +69,15 @@ describe("ProcessingJobs", () => {
     expect(screen.getByText("33% · 1 / 3")).toBeInTheDocument();
     expect(screen.getByRole("progressbar")).toHaveValue(1);
     expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+  });
+
+  it("keeps the dispatch controls collapsed until requested", async () => {
+    renderPage();
+    const summary = await screen.findByText("Queue work");
+    const panel = summary.closest("details");
+
+    expect(panel).not.toHaveAttribute("open");
+    fireEvent.click(summary.closest("summary"));
+    expect(panel).toHaveAttribute("open");
   });
 });

--- a/frontend/src/components/Utilities.jsx
+++ b/frontend/src/components/Utilities.jsx
@@ -10,6 +10,14 @@ import {
 } from "../api/metadata";
 import ReaderKeys from "./ReaderKeys.jsx";
 
+const utilityTabs = [
+  { key: "audit", label: "Audit" },
+  { key: "series", label: "Series Detection" },
+  { key: "metadata", label: "Metadata" },
+  { key: "storage", label: "Storage" },
+  { key: "reader-access", label: "Reader Access" },
+];
+
 function formatBytes(bytes) {
   if (bytes === 0) return "0 B";
   if (bytes < 1024) return `${bytes} B`;
@@ -85,6 +93,7 @@ function formatMetadataMatchOption(match) {
 
 function Utilities({ onBack }) {
   const queryClient = useQueryClient();
+  const [activeTab, setActiveTab] = useState("audit");
   const [preview, setPreview] = useState(null);
   const [detectState, setDetectState] = useState(null); // null | "pending" | { updated, series_detected, error? }
   const [selectedMatchIds, setSelectedMatchIds] = useState({});
@@ -169,7 +178,7 @@ function Utilities({ onBack }) {
   };
 
   return (
-    <div className={onBack ? "book-settings" : undefined}>
+    <div className={`${onBack ? "book-settings " : ""}utilities-page`}>
       {onBack && (
         <div className="settings-header">
           <button className="btn-text" onClick={onBack} style={{ flexShrink: 0 }}>
@@ -179,7 +188,24 @@ function Utilities({ onBack }) {
         </div>
       )}
 
-      <section className="settings-section">
+      <nav className="sub-tabs utilities-tabs" aria-label="Utility sections" role="tablist">
+        {utilityTabs.map((tab) => (
+          <button
+            key={tab.key}
+            className={`sub-tab${activeTab === tab.key ? " sub-tab--active" : ""}`}
+            type="button"
+            role="tab"
+            aria-selected={activeTab === tab.key}
+            onClick={() => setActiveTab(tab.key)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </nav>
+
+      <div className="sub-tab-content utilities-tab-content">
+        {activeTab === "audit" && (
+          <section className="settings-section">
         <h3>Library Audit</h3>
         <p className="hint">
           Checks every book record for missing or broken file paths (EPUB files, covers).
@@ -249,9 +275,11 @@ function Utilities({ onBack }) {
             )}
           </div>
         )}
-      </section>
+          </section>
+        )}
 
-      <section className="settings-section">
+        {activeTab === "series" && (
+          <section className="settings-section">
         <h3>Detect Series</h3>
         <p className="hint">
           Scans all books without a series and attempts to detect one from the title.
@@ -273,9 +301,11 @@ function Utilities({ onBack }) {
               : `Updated ${detectState.updated} book${detectState.updated > 1 ? "s" : ""}: ${detectState.series_detected.join(", ")}`}
           </p>
         )}
-      </section>
+          </section>
+        )}
 
-      <section className="settings-section">
+        {activeTab === "metadata" && (
+          <section className="settings-section">
         <h3>Sync Online Metadata</h3>
         <p className="hint">
           Runs in the background for new books and stale books, then puts uncertain matches into an inbox for approval.
@@ -414,9 +444,11 @@ function Utilities({ onBack }) {
             No metadata approvals are waiting right now.
           </p>
         )}
-      </section>
+          </section>
+        )}
 
-      <section className="settings-section">
+        {activeTab === "storage" && (
+          <section className="settings-section">
         <h3>Storage Cleanup</h3>
         <p className="hint">
           Scans the library directory for orphaned EPUB and cover files, and
@@ -552,9 +584,11 @@ function Utilities({ onBack }) {
             )}
           </div>
         )}
-      </section>
+          </section>
+        )}
 
-      <ReaderKeys />
+        {activeTab === "reader-access" && <ReaderKeys />}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/Utilities.test.jsx
+++ b/frontend/src/components/Utilities.test.jsx
@@ -10,7 +10,7 @@ describe("Utilities", () => {
     vi.stubGlobal("alert", vi.fn());
   });
 
-  it("renders all utility sections", () => {
+  it("organizes utilities into focused tabs and shows the audit by default", () => {
     globalThis.fetch = vi.fn((url) => {
       if (url === "/api/metadata/jobs/latest") {
         return Promise.resolve({ ok: true, json: () => Promise.resolve(null) });
@@ -23,10 +23,25 @@ describe("Utilities", () => {
 
     renderWithClient(<Utilities onBack={() => {}} />);
 
+    expect(screen.getByRole("tab", { name: "Audit" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tab", { name: "Series Detection" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Metadata" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Storage" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Reader Access" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Library Audit" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Series Detection" }));
     expect(screen.getByRole("heading", { name: "Detect Series" })).toBeInTheDocument();
+
+    expect(screen.queryByRole("heading", { name: "Sync Online Metadata" })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("tab", { name: "Metadata" }));
     expect(screen.getByRole("heading", { name: "Sync Online Metadata" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Storage" }));
     expect(screen.getByRole("heading", { name: "Storage Cleanup" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Reader Access" }));
+    expect(screen.getByRole("heading", { name: "Reader API Keys" })).toBeInTheDocument();
   });
 
   it("runs library audit and shows results", async () => {
@@ -281,6 +296,8 @@ describe("Utilities", () => {
 
     renderWithClient(<Utilities onBack={() => {}} />);
 
+    fireEvent.click(screen.getByRole("tab", { name: "Metadata" }));
+
     await waitFor(() => {
       expect(screen.getByText(/2\/10 processed, 1 matched, 1 proposed, 0 applied/)).toBeInTheDocument();
     });
@@ -328,6 +345,8 @@ describe("Utilities", () => {
 
     renderWithClient(<Utilities onBack={() => {}} />);
 
+    fireEvent.click(screen.getByRole("tab", { name: "Series Detection" }));
+
     fireEvent.click(
       screen.getByRole("button", { name: "Detect Series in Library" }),
     );
@@ -357,6 +376,8 @@ describe("Utilities", () => {
     });
 
     renderWithClient(<Utilities onBack={() => {}} />);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Series Detection" }));
 
     fireEvent.click(
       screen.getByRole("button", { name: "Detect Series in Library" }),
@@ -390,6 +411,8 @@ describe("Utilities", () => {
     });
 
     renderWithClient(<Utilities onBack={() => {}} />);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Storage" }));
 
     fireEvent.click(
       screen.getByRole("button", { name: "Scan for Orphaned Files" }),
@@ -432,6 +455,8 @@ describe("Utilities", () => {
     });
 
     renderWithClient(<Utilities onBack={() => {}} />);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Storage" }));
 
     fireEvent.click(
       screen.getByRole("button", { name: "Scan for Orphaned Files" }),

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,23 +1,23 @@
 :root {
-  --bg: #13141a;
-  --surface: #1e2028;
-  --surface-2: #262830;
-  --surface-3: #2e3040;
-  --border: rgba(255, 255, 255, 0.07);
-  --border-strong: rgba(255, 255, 255, 0.14);
-  --text: #dde1f0;
-  --text-muted: #7a7f9a;
-  --accent: #6272ea;
-  --accent-hover: #7b8ef5;
-  --danger: #d94f4f;
-  --danger-hover: #e96060;
-  --success: #4caf7d;
-  --warning: #d68f2c;
-  --radius: 8px;
-  --radius-sm: 5px;
-  --radius-lg: 12px;
+  --bg: #171510;
+  --surface: #1f1c17;
+  --surface-2: #29251e;
+  --surface-3: #332e25;
+  --border: rgba(226, 214, 192, 0.13);
+  --border-strong: rgba(226, 214, 192, 0.28);
+  --text: #eee7d9;
+  --text-muted: #a39989;
+  --accent: #d5836a;
+  --accent-hover: #e59a80;
+  --danger: #e06e67;
+  --danger-hover: #ec847d;
+  --success: #b79a68;
+  --warning: #d9a654;
+  --radius: 1px;
+  --radius-sm: 1px;
+  --radius-lg: 1px;
 
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  font-family: "Avenir Next", Avenir, -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
   line-height: 1.5;
   font-weight: 400;
   color: var(--text);
@@ -40,13 +40,14 @@ body {
 }
 
 h1, h2, h3 {
+  font-family: Georgia, "Times New Roman", serif;
   color: var(--text);
   margin: 0;
 }
 
-h1 { font-size: 1.6rem; font-weight: 700; }
-h2 { font-size: 1.25rem; font-weight: 600; }
-h3 { font-size: 1rem; font-weight: 600; }
+h1 { font-size: 1.85rem; font-weight: 500; letter-spacing: -0.025em; }
+h2 { font-size: 1.45rem; font-weight: 500; letter-spacing: -0.02em; }
+h3 { font-size: 1.05rem; font-weight: 500; }
 
 a {
   color: var(--accent);


### PR DESCRIPTION
## What changed

- replaces the generic dark blue interface with a consistent brown, cream, and terracotta editorial system
- standardizes navigation, controls, covers, series stacks, book settings, processing jobs, and audiobook pipeline styling
- removes hard-coded and decorative catalog counts and labels that were not connected to application data
- collapses the Processing dispatch panel by default and reorganizes Utilities into focused sub-tabs
- moves New Config beside Clean All Books and fixes duplicate divider and tab-spacing issues
- adds reader-key-safe routes for listing and streaming imported human-narrated audiobooks, including reader-safe SMIL URLs

## Why

The manager had inconsistent visual treatments, misleading hard-coded telemetry, and several pages that required excessive scrolling. The mobile reader also needed authenticated access to human-narrated audiobook metadata and assets without relying on admin API URLs.

## Impact

The management UI is denser, more distinctive, and consistent across pages. Mobile clients can discover imported audiobook editions, map tracks to chapters, and fetch audio/SMIL assets through reader-authenticated routes.

## Validation

- frontend: 12 test files, 45 tests passed
- frontend production build passed
- frontend lint passed
- backend reader audiobook and audiobook import suites: 10 tests passed
- staged diff whitespace check passed