### PR TITLE
Add prioritized AI endpoint pools

### DIFF
--- a/backend/alembic/versions/0027_ai_endpoint_pools.py
+++ b/backend/alembic/versions/0027_ai_endpoint_pools.py
@@ -1,0 +1,109 @@
+"""add ordered AI endpoint pools
+
+Revision ID: 0027
+Revises: 0026
+Create Date: 2026-08-01 00:00:00
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0027"
+down_revision = "0026"
+branch_labels = None
+depends_on = None
+
+_CREATED_COLUMN_COMMENT = "story-manager:alembic:0027"
+
+
+def _columns(conn, table_name: str) -> dict[str, dict]:
+    inspector = sa.inspect(conn)
+    if not inspector.has_table(table_name):
+        return {}
+    return {column["name"]: column for column in inspector.get_columns(table_name)}
+
+
+def upgrade():
+    conn = op.get_bind()
+    columns = _columns(conn, "audiobook_settings")
+    if not columns:
+        return
+
+    for name in ("llm_endpoints", "tts_endpoints", "transcription_endpoints"):
+        if name not in columns:
+            op.add_column(
+                "audiobook_settings",
+                sa.Column(name, sa.JSON(), nullable=True, comment=_CREATED_COLUMN_COMMENT),
+            )
+
+    settings = sa.table(
+        "audiobook_settings",
+        sa.column("id", sa.Integer),
+        sa.column("llm_provider", sa.String),
+        sa.column("llm_api_key", sa.String),
+        sa.column("llm_base_url", sa.String),
+        sa.column("llm_model", sa.String),
+        sa.column("tts_provider", sa.String),
+        sa.column("tts_api_key", sa.String),
+        sa.column("tts_base_url", sa.String),
+        sa.column("tts_model", sa.String),
+        sa.column("tts_default_voice", sa.String),
+        sa.column("transcription_provider", sa.String),
+        sa.column("transcription_api_key", sa.String),
+        sa.column("transcription_base_url", sa.String),
+        sa.column("transcription_model", sa.String),
+        sa.column("transcription_language", sa.String),
+        sa.column("llm_endpoints", sa.JSON),
+        sa.column("tts_endpoints", sa.JSON),
+        sa.column("transcription_endpoints", sa.JSON),
+    )
+
+    for row in conn.execute(sa.select(settings)).mappings():
+        values = {}
+        if row["llm_endpoints"] is None:
+            values["llm_endpoints"] = [
+                {
+                    "id": "legacy-llm",
+                    "name": "Primary",
+                    "provider": row["llm_provider"] or "stub",
+                    "api_key": row["llm_api_key"],
+                    "base_url": row["llm_base_url"],
+                    "model": row["llm_model"],
+                }
+            ]
+        if row["tts_endpoints"] is None:
+            values["tts_endpoints"] = [
+                {
+                    "id": "legacy-tts",
+                    "name": "Primary",
+                    "provider": row["tts_provider"] or "stub",
+                    "api_key": row["tts_api_key"],
+                    "base_url": row["tts_base_url"],
+                    "model": row["tts_model"],
+                    "default_voice": row["tts_default_voice"],
+                }
+            ]
+        if row["transcription_endpoints"] is None:
+            values["transcription_endpoints"] = [
+                {
+                    "id": "legacy-transcription",
+                    "name": "Primary",
+                    "provider": row["transcription_provider"] or "none",
+                    "api_key": row["transcription_api_key"],
+                    "base_url": row["transcription_base_url"],
+                    "model": row["transcription_model"],
+                    "language": row["transcription_language"],
+                }
+            ]
+        if values:
+            conn.execute(settings.update().where(settings.c.id == row["id"]).values(**values))
+
+
+def downgrade():
+    conn = op.get_bind()
+    columns = _columns(conn, "audiobook_settings")
+    for name in ("transcription_endpoints", "tts_endpoints", "llm_endpoints"):
+        if columns.get(name, {}).get("comment") == _CREATED_COLUMN_COMMENT:
+            op.drop_column("audiobook_settings", name)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -252,6 +252,9 @@ class AudiobookSettings(Base):
     transcription_base_url = Column(String, nullable=True)
     transcription_model = Column(String, nullable=True)
     transcription_language = Column(String, nullable=True)
+    llm_endpoints = Column(JSON, nullable=True)
+    tts_endpoints = Column(JSON, nullable=True)
+    transcription_endpoints = Column(JSON, nullable=True)
     roster_prompt_template = Column(Text, nullable=True)
     diarization_prompt_template = Column(Text, nullable=True)
 

--- a/backend/app/routers/audiobook.py
+++ b/backend/app/routers/audiobook.py
@@ -11,7 +11,7 @@ from xml.etree import ElementTree as ET
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile
 from fastapi.responses import FileResponse, Response
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -43,7 +43,8 @@ from ..services.transcription_providers import (
     transcription_provider_name,
     transcription_service_health,
 )
-from ..services.tts_providers import TTSRequest, synthesize_speech, tts_provider_name
+from ..services.endpoint_pool import configured_endpoints, primary_provider
+from ..services.tts_providers import TTSRequest, synthesize_speech_routed, tts_provider_name
 
 logger = logging.getLogger(__name__)
 
@@ -183,6 +184,17 @@ class ChapterResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class EndpointResponse(BaseModel):
+    id: str
+    name: str
+    provider: str
+    api_key_set: bool = False
+    base_url: Optional[str] = None
+    model: Optional[str] = None
+    default_voice: Optional[str] = None
+    language: Optional[str] = None
+
+
 class SettingsResponse(BaseModel):
     id: Optional[int]
     llm_provider: Optional[str]
@@ -199,8 +211,22 @@ class SettingsResponse(BaseModel):
     transcription_base_url: Optional[str]
     transcription_model: Optional[str]
     transcription_language: Optional[str]
+    llm_endpoints: list[EndpointResponse]
+    tts_endpoints: list[EndpointResponse]
+    transcription_endpoints: list[EndpointResponse]
     roster_prompt_template: Optional[str]
     diarization_prompt_template: Optional[str]
+
+
+class EndpointUpdate(BaseModel):
+    id: str
+    name: str
+    provider: str
+    api_key: Optional[str] = None
+    base_url: Optional[str] = None
+    model: Optional[str] = None
+    default_voice: Optional[str] = None
+    language: Optional[str] = None
 
 
 class SettingsUpdate(BaseModel):
@@ -218,6 +244,9 @@ class SettingsUpdate(BaseModel):
     transcription_base_url: Optional[str] = None
     transcription_model: Optional[str] = None
     transcription_language: Optional[str] = None
+    llm_endpoints: Optional[list[EndpointUpdate]] = Field(default=None, min_length=1)
+    tts_endpoints: Optional[list[EndpointUpdate]] = Field(default=None, min_length=1)
+    transcription_endpoints: Optional[list[EndpointUpdate]] = Field(default=None, min_length=1)
     roster_prompt_template: Optional[str] = None
     diarization_prompt_template: Optional[str] = None
 
@@ -1169,13 +1198,36 @@ async def download_audiobook(book_id: int, db: AsyncSession = Depends(get_db)) -
 # ---------------------------------------------------------------------------
 
 
-@router.get("/api/audiobook/settings", response_model=SettingsResponse)
-async def get_settings(db: AsyncSession = Depends(get_db)) -> SettingsResponse:
-    settings = await crud.audiobook.get_audiobook_settings(db)
+def _default_endpoint(capability: str) -> dict[str, Any]:
+    return {
+        "id": f"default-{capability}",
+        "name": "Primary",
+        "provider": {"llm": "stub", "tts": "stub", "transcription": "none"}[capability],
+    }
+
+
+def _public_endpoints(settings, capability: str) -> list[EndpointResponse]:
+    endpoints = configured_endpoints(settings, capability) if settings is not None else [_default_endpoint(capability)]
+    return [
+        EndpointResponse(
+            id=str(endpoint.get("id") or f"{capability}-{index + 1}"),
+            name=str(endpoint.get("name") or f"Endpoint {index + 1}"),
+            provider=str(endpoint.get("provider") or _default_endpoint(capability)["provider"]),
+            api_key_set=bool(endpoint.get("api_key")),
+            base_url=endpoint.get("base_url"),
+            model=endpoint.get("model"),
+            default_voice=endpoint.get("default_voice"),
+            language=endpoint.get("language"),
+        )
+        for index, endpoint in enumerate(endpoints)
+    ]
+
+
+def _settings_response(settings) -> SettingsResponse:
     if settings is None:
         return SettingsResponse(
             id=None,
-            llm_provider=None,
+            llm_provider="stub",
             llm_api_key_set=False,
             llm_base_url=None,
             llm_model=None,
@@ -1189,6 +1241,9 @@ async def get_settings(db: AsyncSession = Depends(get_db)) -> SettingsResponse:
             transcription_base_url=None,
             transcription_model=None,
             transcription_language=None,
+            llm_endpoints=_public_endpoints(None, "llm"),
+            tts_endpoints=_public_endpoints(None, "tts"),
+            transcription_endpoints=_public_endpoints(None, "transcription"),
             roster_prompt_template=None,
             diarization_prompt_template=None,
         )
@@ -1208,22 +1263,96 @@ async def get_settings(db: AsyncSession = Depends(get_db)) -> SettingsResponse:
         transcription_base_url=settings.transcription_base_url,
         transcription_model=settings.transcription_model,
         transcription_language=settings.transcription_language,
+        llm_endpoints=_public_endpoints(settings, "llm"),
+        tts_endpoints=_public_endpoints(settings, "tts"),
+        transcription_endpoints=_public_endpoints(settings, "transcription"),
         roster_prompt_template=settings.roster_prompt_template,
         diarization_prompt_template=settings.diarization_prompt_template,
     )
+
+
+def _merge_endpoint_secrets(
+    incoming: list[dict[str, Any]],
+    existing: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    existing_by_id = {str(endpoint.get("id")): endpoint for endpoint in existing}
+    merged = []
+    for index, endpoint in enumerate(incoming):
+        endpoint = dict(endpoint)
+        endpoint_id = str(endpoint.get("id") or f"endpoint-{index + 1}")
+        previous = existing_by_id.get(endpoint_id, {})
+        if "api_key" not in endpoint:
+            if previous.get("provider") == endpoint.get("provider"):
+                endpoint["api_key"] = previous.get("api_key")
+        elif not endpoint["api_key"]:
+            endpoint["api_key"] = None
+        endpoint["id"] = endpoint_id
+        endpoint["name"] = str(endpoint.get("name") or f"Endpoint {index + 1}").strip()
+        endpoint["provider"] = str(endpoint.get("provider") or "").strip().lower()
+        merged.append(endpoint)
+    return merged
+
+
+def _sync_primary_columns(data: dict[str, Any], capability: str, endpoints: list[dict[str, Any]]) -> None:
+    primary = endpoints[0]
+    prefix = "transcription" if capability == "transcription" else capability
+    for endpoint_field, column_field in (
+        ("provider", f"{prefix}_provider"),
+        ("api_key", f"{prefix}_api_key"),
+        ("base_url", f"{prefix}_base_url"),
+        ("model", f"{prefix}_model"),
+    ):
+        data[column_field] = primary.get(endpoint_field)
+    if capability == "tts":
+        data["tts_default_voice"] = primary.get("default_voice")
+    elif capability == "transcription":
+        data["transcription_language"] = primary.get("language")
+
+
+def _tts_signature(endpoints: list[dict[str, Any]]) -> list[tuple[Any, ...]]:
+    return [
+        (
+            endpoint.get("provider"),
+            endpoint.get("base_url"),
+            endpoint.get("model"),
+            endpoint.get("default_voice"),
+        )
+        for endpoint in endpoints
+    ]
+
+
+@router.get("/api/audiobook/settings", response_model=SettingsResponse)
+async def get_settings(db: AsyncSession = Depends(get_db)) -> SettingsResponse:
+    settings = await crud.audiobook.get_audiobook_settings(db)
+    return _settings_response(settings)
 
 
 @router.put("/api/audiobook/settings", response_model=SettingsResponse)
 async def update_settings(body: SettingsUpdate, db: AsyncSession = Depends(get_db)) -> SettingsResponse:
     data = body.model_dump(exclude_unset=True)
     previous = await crud.audiobook.get_audiobook_settings(db)
+    previous_tts_endpoints = configured_endpoints(previous, "tts") if previous else []
+
+    for capability in ("llm", "tts", "transcription"):
+        field = f"{capability}_endpoints"
+        if field not in data:
+            continue
+        existing = configured_endpoints(previous, capability) if previous else []
+        endpoints = _merge_endpoint_secrets(data[field], existing)
+        data[field] = endpoints
+        _sync_primary_columns(data, capability, endpoints)
+
     previous_provider = tts_provider_name(previous)
     next_provider = str(data.get("tts_provider") or previous_provider).strip().lower()
-    if next_provider != previous_provider and "tts_api_key" not in data:
+    if "tts_endpoints" not in data and next_provider != previous_provider and "tts_api_key" not in data:
         data["tts_api_key"] = None
     previous_transcription_provider = transcription_provider_name(previous)
     next_transcription_provider = str(data.get("transcription_provider") or previous_transcription_provider).strip().lower()
-    if next_transcription_provider != previous_transcription_provider and "transcription_api_key" not in data:
+    if (
+        "transcription_endpoints" not in data
+        and next_transcription_provider != previous_transcription_provider
+        and "transcription_api_key" not in data
+    ):
         data["transcription_api_key"] = None
 
     previous_tts = {
@@ -1234,51 +1363,38 @@ async def update_settings(body: SettingsUpdate, db: AsyncSession = Depends(get_d
     }
     next_tts = {name: data.get(name, value) for name, value in previous_tts.items()}
     next_tts["tts_provider"] = next_provider
-    tts_changed = next_tts != previous_tts
+    if "tts_endpoints" in data:
+        tts_changed = _tts_signature(previous_tts_endpoints) != _tts_signature(data["tts_endpoints"])
+    else:
+        tts_changed = next_tts != previous_tts
     settings = await crud.audiobook.upsert_audiobook_settings(db, data)
     if tts_changed:
         await crud.audiobook.invalidate_generated_audio_for_tts_change(db)
-    return SettingsResponse(
-        id=settings.id,
-        llm_provider=settings.llm_provider,
-        llm_api_key_set=bool(settings.llm_api_key),
-        llm_base_url=settings.llm_base_url,
-        llm_model=settings.llm_model,
-        tts_provider=settings.tts_provider or "stub",
-        tts_api_key_set=bool(settings.tts_api_key),
-        tts_base_url=settings.tts_base_url,
-        tts_model=settings.tts_model,
-        tts_default_voice=settings.tts_default_voice,
-        transcription_provider=settings.transcription_provider or "none",
-        transcription_api_key_set=bool(settings.transcription_api_key),
-        transcription_base_url=settings.transcription_base_url,
-        transcription_model=settings.transcription_model,
-        transcription_language=settings.transcription_language,
-        roster_prompt_template=settings.roster_prompt_template,
-        diarization_prompt_template=settings.diarization_prompt_template,
-    )
+    return _settings_response(settings)
 
 
 @router.post("/api/audiobook/settings/test-llm")
 async def test_llm_settings(db: AsyncSession = Depends(get_db)) -> dict[str, Any]:
     settings = await crud.audiobook.get_audiobook_settings(db)
-    if settings is None or (settings.llm_provider or "stub").lower() == "stub":
+    if settings is None or primary_provider(settings, "llm", "stub") == "stub":
         return {"status": "ready", "provider": "stub", "model": None, "response": "local harness"}
     schema = {
         "type": "object",
         "properties": {"status": {"type": "string"}},
         "required": ["status"],
     }
-    raw = await audiobook_llm._call_llm(
+    routed = await audiobook_llm._call_llm_routed(
         settings,
         [{"role": "user", "content": "Return JSON with status set to ready."}],
         response_schema=schema,
     )
+    raw = routed.value
     parsed = audiobook_llm._extract_json(raw)
     return {
         "status": parsed.get("status", "unknown") if isinstance(parsed, dict) else "unknown",
-        "provider": settings.llm_provider,
-        "model": settings.llm_model,
+        "endpoint": routed.endpoint.get("name"),
+        "provider": routed.endpoint.get("provider"),
+        "model": routed.endpoint.get("model"),
         "response": parsed,
     }
 
@@ -1286,20 +1402,22 @@ async def test_llm_settings(db: AsyncSession = Depends(get_db)) -> dict[str, Any
 @router.post("/api/audiobook/settings/test-tts")
 async def test_tts_settings(db: AsyncSession = Depends(get_db)) -> dict[str, Any]:
     settings = await crud.audiobook.get_audiobook_settings(db)
-    provider = (settings.tts_provider or "stub") if settings else "stub"
-    audio = await synthesize_speech(
+    if settings is None:
+        return {"status": "ready", "provider": "stub", "model": None, "audio_bytes": 0}
+    routed = await synthesize_speech_routed(
         settings,
         TTSRequest(
             text="Story Manager text to speech is ready.",
-            voice_id=settings.tts_default_voice if settings else None,
         ),
     )
+    audio = routed.value
     if not audio:
         raise HTTPException(status_code=502, detail="The TTS provider returned an empty response.")
     return {
         "status": "ready",
-        "provider": provider,
-        "model": settings.tts_model if settings else None,
+        "endpoint": routed.endpoint.get("name"),
+        "provider": routed.endpoint.get("provider"),
+        "model": routed.endpoint.get("model"),
         "audio_bytes": len(audio),
     }
 
@@ -1315,7 +1433,8 @@ async def test_transcription_settings(db: AsyncSession = Depends(get_db)) -> dic
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     return {
         "status": payload.get("status"),
-        "provider": settings.transcription_provider,
+        "endpoint": payload.get("endpoint", {}).get("name"),
+        "provider": payload.get("endpoint", {}).get("provider"),
         "model": payload.get("model"),
         "device": payload.get("device"),
     }

--- a/backend/app/services/audiobook_alignment.py
+++ b/backend/app/services/audiobook_alignment.py
@@ -25,6 +25,7 @@ from ..models import (
     ImportedAudiobookTrack,
 )
 from .audiobook_import import imported_audiobook_dir, relative_library_path
+from .endpoint_pool import configured_endpoints
 from .transcription_providers import (
     TranscriptResult,
     TranscriptWord,
@@ -431,6 +432,31 @@ def _write_transcript_cache(
         json.dump(payload, handle, ensure_ascii=False)
 
 
+def _transcription_cache_config(settings) -> tuple[str, str | None, str | None, str | None]:
+    """Fingerprint the whole ordered pool because any endpoint may do the work."""
+    if settings.transcription_endpoints is None:
+        return (
+            transcription_provider_name(settings),
+            settings.transcription_model,
+            settings.transcription_language,
+            settings.transcription_base_url,
+        )
+    signature = json.dumps(
+        [
+            {
+                "provider": endpoint.get("provider"),
+                "base_url": endpoint.get("base_url"),
+                "model": endpoint.get("model"),
+                "language": endpoint.get("language"),
+            }
+            for endpoint in configured_endpoints(settings, "transcription")
+        ],
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return "endpoint-pool", signature, None, None
+
+
 async def _sentences_for_track(track: ImportedAudiobookTrack, db: AsyncSession) -> list[AudiobookSentence]:
     result = await db.execute(
         select(AudiobookSentence)
@@ -473,6 +499,7 @@ async def process_alignment(edition_id: int, db: AsyncSession) -> None:
     try:
         scores = []
         edition_dir = imported_audiobook_dir(edition.book_id, edition.id)
+        cache_provider, cache_model, cache_language, cache_root = _transcription_cache_config(settings)
         for index, track in enumerate(tracks, start=1):
             edition.progress_detail = f"Transcribing {track.title} ({index} of {len(tracks)})"
             await db.commit()
@@ -480,10 +507,10 @@ async def process_alignment(edition_id: int, db: AsyncSession) -> None:
             cache_path = edition_dir / "alignment" / "transcripts" / f"track-{track.id}.json.gz"
             transcript = _read_transcript_cache(
                 cache_path,
-                provider,
-                settings.transcription_model,
-                settings.transcription_language,
-                settings.transcription_base_url,
+                cache_provider,
+                cache_model,
+                cache_language,
+                cache_root,
             )
             if transcript is None:
                 clip_path = edition_dir / "alignment" / "clips" / f"track-{track.id}.flac"
@@ -495,10 +522,10 @@ async def process_alignment(edition_id: int, db: AsyncSession) -> None:
                 _write_transcript_cache(
                     cache_path,
                     transcript,
-                    provider,
-                    settings.transcription_model,
-                    settings.transcription_language,
-                    settings.transcription_base_url,
+                    cache_provider,
+                    cache_model,
+                    cache_language,
+                    cache_root,
                 )
             track.transcript_file_path = relative_library_path(cache_path)
 

--- a/backend/app/services/audiobook_llm.py
+++ b/backend/app/services/audiobook_llm.py
@@ -17,6 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from .. import crud
 from ..models import AudiobookSettings, Book
 from .audiobook_text import quote_group_ids, quote_groups
+from .endpoint_pool import RoutedResult, route_request
 
 logger = logging.getLogger(__name__)
 
@@ -349,7 +350,7 @@ CHAPTER_SUMMARY_SCHEMA = {
 }
 
 
-async def _call_llm(
+async def _call_llm_endpoint(
     settings: AudiobookSettings,
     messages: list[dict[str, Any]],
     *,
@@ -448,6 +449,42 @@ async def _call_llm(
             resp.raise_for_status()
             data = resp.json()
         return data["choices"][0]["message"]["content"]
+
+
+async def _call_llm_routed(
+    settings: AudiobookSettings,
+    messages: list[dict[str, Any]],
+    *,
+    response_schema: dict[str, Any] | None = None,
+    progress_callback: Callable[[int], Awaitable[None]] | None = None,
+) -> RoutedResult[str]:
+    return await route_request(
+        settings,
+        "llm",
+        lambda endpoint_settings: _call_llm_endpoint(
+            endpoint_settings,
+            messages,
+            response_schema=response_schema,
+            progress_callback=progress_callback,
+        ),
+    )
+
+
+async def _call_llm(
+    settings: AudiobookSettings,
+    messages: list[dict[str, Any]],
+    *,
+    response_schema: dict[str, Any] | None = None,
+    progress_callback: Callable[[int], Awaitable[None]] | None = None,
+) -> str:
+    """Try configured LLM endpoints in priority order."""
+    routed = await _call_llm_routed(
+        settings,
+        messages,
+        response_schema=response_schema,
+        progress_callback=progress_callback,
+    )
+    return routed.value
 
 
 def _extract_json(raw: str) -> Any:

--- a/backend/app/services/audiobook_tts.py
+++ b/backend/app/services/audiobook_tts.py
@@ -93,7 +93,12 @@ def _request_for_character(
 ) -> TTSRequest:
     voice_prompt = character.voice_prompt if character and character.voice_prompt else DEFAULT_VOICE_PROMPT
     voice_id = _voice_id_for_provider(settings, character) if character else None
-    return TTSRequest(text=text, voice_prompt=voice_prompt, voice_id=voice_id)
+    return TTSRequest(
+        text=text,
+        voice_prompt=voice_prompt,
+        voice_id=voice_id,
+        voice_provider=character.tts_voice_provider if character else None,
+    )
 
 
 async def _build_sentence_requests(

--- a/backend/app/services/endpoint_pool.py
+++ b/backend/app/services/endpoint_pool.py
@@ -1,0 +1,135 @@
+"""Ordered AI endpoint pools with lightweight failure cooldowns."""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any, Awaitable, Callable, Generic, TypeVar
+
+from ..models import AudiobookSettings
+
+COOLDOWN_SECONDS = 60.0
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class RoutedResult(Generic[T]):
+    value: T
+    endpoint: dict[str, Any]
+
+
+_cooldowns: dict[tuple[str, str], float] = {}
+
+
+def _legacy_endpoint(settings: AudiobookSettings, capability: str) -> dict[str, Any]:
+    prefix = "transcription" if capability == "transcription" else capability
+    provider_default = {"llm": "stub", "tts": "stub", "transcription": "none"}[capability]
+    endpoint: dict[str, Any] = {
+        "id": f"legacy-{capability}",
+        "name": "Primary",
+        "provider": getattr(settings, f"{prefix}_provider", None) or provider_default,
+        "api_key": getattr(settings, f"{prefix}_api_key", None),
+        "base_url": getattr(settings, f"{prefix}_base_url", None),
+        "model": getattr(settings, f"{prefix}_model", None),
+    }
+    if capability == "tts":
+        endpoint["default_voice"] = settings.tts_default_voice
+    if capability == "transcription":
+        endpoint["language"] = settings.transcription_language
+    return endpoint
+
+
+def configured_endpoints(settings: AudiobookSettings | None, capability: str) -> list[dict[str, Any]]:
+    """Return endpoints in priority order, falling back to legacy columns."""
+    if settings is None:
+        return []
+    field = f"{capability}_endpoints"
+    stored = getattr(settings, field, None)
+    if stored is None:
+        return [_legacy_endpoint(settings, capability)]
+    return [dict(endpoint) for endpoint in stored if isinstance(endpoint, dict)]
+
+
+def primary_provider(settings: AudiobookSettings | None, capability: str, default: str) -> str:
+    endpoints = configured_endpoints(settings, capability)
+    provider = endpoints[0].get("provider") if endpoints else default
+    return str(provider or default).strip().lower()
+
+
+def _endpoint_key(capability: str, endpoint: dict[str, Any]) -> tuple[str, str]:
+    identity = endpoint.get("id") or "|".join(
+        str(endpoint.get(field) or "") for field in ("name", "provider", "base_url", "model")
+    )
+    return capability, str(identity)
+
+
+def _endpoint_settings(
+    settings: AudiobookSettings,
+    capability: str,
+    endpoint: dict[str, Any],
+) -> SimpleNamespace:
+    """Expose one generic endpoint through the legacy provider field names."""
+    values = {column.name: getattr(settings, column.name) for column in settings.__table__.columns}
+    prefix = "transcription" if capability == "transcription" else capability
+    for field in ("provider", "api_key", "base_url", "model"):
+        values[f"{prefix}_{field}"] = endpoint.get(field)
+    if capability == "tts":
+        values["tts_default_voice"] = endpoint.get("default_voice")
+    elif capability == "transcription":
+        values["transcription_language"] = endpoint.get("language")
+    return SimpleNamespace(**values)
+
+
+def cooldown_remaining(capability: str, endpoint: dict[str, Any]) -> float:
+    remaining = _cooldowns.get(_endpoint_key(capability, endpoint), 0.0) - time.monotonic()
+    return max(0.0, remaining)
+
+
+async def route_request(
+    settings: AudiobookSettings,
+    capability: str,
+    attempt: Callable[[Any], Awaitable[T]],
+) -> RoutedResult[T]:
+    """Try available endpoints in priority order and cool failed hosts down."""
+    endpoints = configured_endpoints(settings, capability)
+    if not endpoints:
+        raise RuntimeError(f"No {capability} endpoints are configured in Audio & AI Configuration.")
+
+    available = [endpoint for endpoint in endpoints if cooldown_remaining(capability, endpoint) <= 0]
+    if not available:
+        wait_seconds = min(cooldown_remaining(capability, endpoint) for endpoint in endpoints)
+        raise RuntimeError(
+            f"All {capability} endpoints are cooling down after failures; retry in {max(1, round(wait_seconds))} seconds."
+        )
+
+    last_error: Exception | None = None
+    for endpoint in available:
+        key = _endpoint_key(capability, endpoint)
+        try:
+            value = await attempt(_endpoint_settings(settings, capability, endpoint))
+        except Exception as exc:
+            _cooldowns[key] = time.monotonic() + COOLDOWN_SECONDS
+            logger.warning(
+                "%s endpoint %r failed and will cool down for %.0f seconds: %s",
+                capability.upper(),
+                endpoint.get("name") or endpoint.get("base_url") or endpoint.get("id"),
+                COOLDOWN_SECONDS,
+                exc,
+            )
+            last_error = exc
+            continue
+        _cooldowns.pop(key, None)
+        return RoutedResult(value=value, endpoint=endpoint)
+
+    assert last_error is not None
+    raise last_error
+
+
+def reset_cooldowns() -> None:
+    """Clear process-local cooldown state (primarily useful for tests)."""
+    _cooldowns.clear()

--- a/backend/app/services/transcription_providers.py
+++ b/backend/app/services/transcription_providers.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import httpx
 
 from ..models import AudiobookSettings
+from .endpoint_pool import primary_provider, route_request
 
 SUPPORTED_TRANSCRIPTION_PROVIDERS = {"none", "whisperx"}
 
@@ -28,8 +29,7 @@ class TranscriptResult:
 
 
 def transcription_provider_name(settings: AudiobookSettings | None) -> str:
-    provider = (settings.transcription_provider if settings else None) or "none"
-    provider = provider.strip().lower()
+    provider = primary_provider(settings, "transcription", "none")
     if provider not in SUPPORTED_TRANSCRIPTION_PROVIDERS:
         choices = ", ".join(sorted(SUPPORTED_TRANSCRIPTION_PROVIDERS))
         raise RuntimeError(f"Unsupported transcription provider {provider!r}. Choose one of: {choices}.")
@@ -52,7 +52,7 @@ def _headers(settings: AudiobookSettings) -> dict[str, str]:
     return headers
 
 
-async def transcription_service_health(settings: AudiobookSettings) -> dict:
+async def _transcription_service_health_endpoint(settings: AudiobookSettings) -> dict:
     if transcription_provider_name(settings) == "none":
         raise RuntimeError("Configure a transcription provider first.")
     timeout = httpx.Timeout(30.0, connect=10.0)
@@ -65,7 +65,19 @@ async def transcription_service_health(settings: AudiobookSettings) -> dict:
     return payload
 
 
-async def transcribe_file(settings: AudiobookSettings, audio_path: Path) -> TranscriptResult:
+async def transcription_service_health(settings: AudiobookSettings) -> dict:
+    routed = await route_request(settings, "transcription", _transcription_service_health_endpoint)
+    payload = dict(routed.value)
+    payload["endpoint"] = {
+        "id": routed.endpoint.get("id"),
+        "name": routed.endpoint.get("name"),
+        "provider": routed.endpoint.get("provider"),
+        "model": routed.endpoint.get("model"),
+    }
+    return payload
+
+
+async def _transcribe_file_endpoint(settings: AudiobookSettings, audio_path: Path) -> TranscriptResult:
     """Send one chapter clip to the configured timestamped ASR service."""
     provider = transcription_provider_name(settings)
     if provider == "none":
@@ -118,3 +130,13 @@ async def transcribe_file(settings: AudiobookSettings, audio_path: Path) -> Tran
         duration_ms=max(duration_ms, words[-1].end_ms),
         words=words,
     )
+
+
+async def transcribe_file(settings: AudiobookSettings, audio_path: Path) -> TranscriptResult:
+    """Transcribe through the first available endpoint."""
+    routed = await route_request(
+        settings,
+        "transcription",
+        lambda endpoint_settings: _transcribe_file_endpoint(endpoint_settings, audio_path),
+    )
+    return routed.value

--- a/backend/app/services/tts_providers.py
+++ b/backend/app/services/tts_providers.py
@@ -12,6 +12,7 @@ import shutil
 import httpx
 
 from ..models import AudiobookSettings
+from .endpoint_pool import RoutedResult, primary_provider, route_request
 
 DEFAULT_VOICE_PROMPT = "[gender-neutral][pitch-medium][speed-normal]"
 SUPPORTED_TTS_PROVIDERS = {
@@ -34,6 +35,7 @@ class TTSRequest:
     text: str
     voice_prompt: str = DEFAULT_VOICE_PROMPT
     voice_id: str | None = None
+    voice_provider: str | None = None
 
 
 @dataclass(frozen=True)
@@ -119,15 +121,14 @@ async def _stub_speech(text: str) -> bytes:
 
 
 def tts_provider_name(settings: AudiobookSettings | None) -> str:
-    provider = (settings.tts_provider if settings else None) or "stub"
-    provider = provider.strip().lower()
+    provider = primary_provider(settings, "tts", "stub")
     if provider not in SUPPORTED_TTS_PROVIDERS:
         choices = ", ".join(sorted(SUPPORTED_TTS_PROVIDERS))
         raise RuntimeError(f"Unsupported TTS provider {provider!r}. Choose one of: {choices}.")
     return provider
 
 
-async def synthesize_speech(
+async def _synthesize_speech_endpoint(
     settings: AudiobookSettings | None,
     request: TTSRequest,
 ) -> bytes:
@@ -154,7 +155,10 @@ async def synthesize_speech(
             response.raise_for_status()
             return response.content
 
-    voice_id = request.voice_id or settings.tts_default_voice
+    endpoint_voice_id = request.voice_id
+    if request.voice_provider and request.voice_provider != provider:
+        endpoint_voice_id = None
+    voice_id = endpoint_voice_id or settings.tts_default_voice
     if not voice_id:
         raise RuntimeError(
             f"A voice ID is required for the {provider} TTS provider. "
@@ -226,6 +230,28 @@ async def synthesize_speech(
         return response.content
 
 
+async def synthesize_speech_routed(
+    settings: AudiobookSettings,
+    request: TTSRequest,
+) -> RoutedResult[bytes]:
+    return await route_request(
+        settings,
+        "tts",
+        lambda endpoint_settings: _synthesize_speech_endpoint(endpoint_settings, request),
+    )
+
+
+async def synthesize_speech(
+    settings: AudiobookSettings | None,
+    request: TTSRequest,
+) -> bytes:
+    """Generate an MP3 using the first available endpoint."""
+    if settings is None:
+        return await _stub_speech(request.text)
+    routed = await synthesize_speech_routed(settings, request)
+    return routed.value
+
+
 async def synthesize_speech_batch(
     settings: AudiobookSettings | None,
     requests: list[TTSRequest],
@@ -233,9 +259,24 @@ async def synthesize_speech_batch(
     """Generate a true model batch when supported, with a sequential fallback."""
     if not requests:
         return []
+    if settings is None:
+        return [TTSResult(await _stub_speech(request.text)) for request in requests]
+    routed = await route_request(
+        settings,
+        "tts",
+        lambda endpoint_settings: _synthesize_speech_batch_endpoint(endpoint_settings, requests),
+    )
+    return routed.value
+
+
+async def _synthesize_speech_batch_endpoint(
+    settings: AudiobookSettings,
+    requests: list[TTSRequest],
+) -> list[TTSResult]:
+    """Generate one batch against a specific endpoint."""
     if tts_provider_name(settings) != "omnivoice":
-        return [TTSResult(await synthesize_speech(settings, request)) for request in requests]
-    if settings is None or not settings.tts_base_url:
+        return [TTSResult(await _synthesize_speech_endpoint(settings, request)) for request in requests]
+    if not settings.tts_base_url:
         raise RuntimeError("OmniVoice base URL is required in Audio Settings.")
 
     root = settings.tts_base_url.rstrip("/")

--- a/backend/tests/test_audiobook_pipeline.py
+++ b/backend/tests/test_audiobook_pipeline.py
@@ -1247,6 +1247,66 @@ async def test_provider_change_clears_stored_tts_api_key(db):
 
 
 @pytest.mark.asyncio
+async def test_endpoint_reorder_preserves_secrets_and_syncs_primary_columns(db):
+    settings = models.AudiobookSettings(
+        llm_provider="ollama",
+        llm_api_key="mini-secret",
+        llm_base_url="http://mini:11434",
+        llm_model="qwen3.5:9b",
+        llm_endpoints=[
+            {
+                "id": "mini",
+                "name": "Always-on mini PC",
+                "provider": "ollama",
+                "api_key": "mini-secret",
+                "base_url": "http://mini:11434",
+                "model": "qwen3.5:9b",
+            },
+            {
+                "id": "gaming",
+                "name": "Gaming PC",
+                "provider": "ollama",
+                "api_key": "gaming-secret",
+                "base_url": "http://gaming:11434",
+                "model": "qwen3.5:27b",
+            },
+        ],
+    )
+    db.add(settings)
+    await db.commit()
+
+    response = await audiobook_router.update_settings(
+        audiobook_router.SettingsUpdate(
+            llm_endpoints=[
+                audiobook_router.EndpointUpdate(
+                    id="gaming",
+                    name="Gaming PC",
+                    provider="ollama",
+                    base_url="http://gaming:11434",
+                    model="qwen3.5:27b",
+                ),
+                audiobook_router.EndpointUpdate(
+                    id="mini",
+                    name="Always-on mini PC",
+                    provider="ollama",
+                    base_url="http://mini:11434",
+                    model="qwen3.5:9b",
+                ),
+            ]
+        ),
+        db,
+    )
+    await db.refresh(settings)
+
+    assert [endpoint["id"] for endpoint in settings.llm_endpoints] == ["gaming", "mini"]
+    assert [endpoint["api_key"] for endpoint in settings.llm_endpoints] == ["gaming-secret", "mini-secret"]
+    assert settings.llm_base_url == "http://gaming:11434"
+    assert settings.llm_model == "qwen3.5:27b"
+    assert response.llm_endpoints[0].api_key_set is True
+    assert "api_key" not in response.llm_endpoints[0].model_dump()
+
+
+@pytest.mark.asyncio
 async def test_character_voice_id_is_tagged_and_used_only_for_its_provider(db):
     book = await _make_book(db, audiobook_enabled=True)
     character = (

--- a/backend/tests/test_endpoint_pool.py
+++ b/backend/tests/test_endpoint_pool.py
@@ -1,0 +1,83 @@
+import httpx
+import pytest
+
+from backend.app import models
+from backend.app.services import endpoint_pool
+
+
+@pytest.fixture(autouse=True)
+def clear_endpoint_cooldowns():
+    endpoint_pool.reset_cooldowns()
+    yield
+    endpoint_pool.reset_cooldowns()
+
+
+@pytest.mark.asyncio
+async def test_priority_endpoint_falls_back_and_is_skipped_during_cooldown(monkeypatch):
+    now = 1000.0
+    monkeypatch.setattr(endpoint_pool.time, "monotonic", lambda: now)
+    settings = models.AudiobookSettings(
+        llm_endpoints=[
+            {
+                "id": "gaming-pc",
+                "name": "Gaming PC",
+                "provider": "ollama",
+                "base_url": "http://gaming:11434",
+                "model": "qwen3.5:27b",
+            },
+            {
+                "id": "mini-pc",
+                "name": "Always-on mini PC",
+                "provider": "ollama",
+                "base_url": "http://mini:11434",
+                "model": "qwen3.5:9b",
+            },
+        ]
+    )
+    gaming_online = False
+    calls = []
+
+    async def attempt(endpoint_settings):
+        calls.append(endpoint_settings.llm_base_url)
+        if endpoint_settings.llm_base_url == "http://gaming:11434" and not gaming_online:
+            request = httpx.Request("POST", "http://gaming:11434/api/chat")
+            raise httpx.ConnectError("offline", request=request)
+        return endpoint_settings.llm_model
+
+    first = await endpoint_pool.route_request(settings, "llm", attempt)
+    assert first.value == "qwen3.5:9b"
+    assert first.endpoint["id"] == "mini-pc"
+    assert calls == ["http://gaming:11434", "http://mini:11434"]
+
+    gaming_online = True
+    calls.clear()
+    second = await endpoint_pool.route_request(settings, "llm", attempt)
+    assert second.endpoint["id"] == "mini-pc"
+    assert calls == ["http://mini:11434"]
+
+    now += 61
+    calls.clear()
+    third = await endpoint_pool.route_request(settings, "llm", attempt)
+    assert third.value == "qwen3.5:27b"
+    assert third.endpoint["id"] == "gaming-pc"
+    assert calls == ["http://gaming:11434"]
+
+
+@pytest.mark.asyncio
+async def test_all_cooling_endpoints_fail_fast(monkeypatch):
+    now = 2000.0
+    monkeypatch.setattr(endpoint_pool.time, "monotonic", lambda: now)
+    settings = models.AudiobookSettings(
+        tts_endpoints=[
+            {"id": "one", "name": "One", "provider": "omnivoice", "base_url": "http://one"},
+            {"id": "two", "name": "Two", "provider": "omnivoice", "base_url": "http://two"},
+        ]
+    )
+
+    async def fail(_endpoint_settings):
+        raise RuntimeError("offline")
+
+    with pytest.raises(RuntimeError, match="offline"):
+        await endpoint_pool.route_request(settings, "tts", fail)
+    with pytest.raises(RuntimeError, match="All tts endpoints are cooling down"):
+        await endpoint_pool.route_request(settings, "tts", fail)

--- a/backend/tests/test_tts_providers.py
+++ b/backend/tests/test_tts_providers.py
@@ -136,6 +136,28 @@ async def test_openai_compatible_uses_voice_id_and_compatible_payload():
 
 
 @pytest.mark.asyncio
+async def test_fallback_provider_uses_its_own_default_voice():
+    settings = models.AudiobookSettings(
+        tts_provider="openai-compatible",
+        tts_base_url="http://kokoro:8880",
+        tts_model="kokoro",
+        tts_default_voice="af_heart",
+    )
+
+    await tts_providers.synthesize_speech(
+        settings,
+        TTSRequest(
+            text="Hello.",
+            voice_id="elevenlabs-character-id",
+            voice_provider="elevenlabs",
+        ),
+    )
+
+    _url, request = _Client.calls[0]
+    assert request["json"]["voice"] == "af_heart"
+
+
+@pytest.mark.asyncio
 async def test_openai_instruction_capable_model_receives_voice_profile():
     settings = models.AudiobookSettings(
         tts_provider="openai",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1393,6 +1393,112 @@
   gap: 0.6rem;
 }
 
+.endpoint-routing-hint {
+  max-width: 62rem;
+  margin-bottom: 1.5rem;
+}
+
+.endpoint-pool-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.endpoint-pool-heading h3 {
+  margin-bottom: 0.35rem;
+}
+
+.endpoint-pool-heading .settings-hint {
+  margin: 0;
+}
+
+.endpoint-pool {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.endpoint-card {
+  border: 1px solid var(--border);
+  background: var(--surface);
+  padding: 1rem;
+}
+
+.endpoint-card:first-child {
+  border-color: var(--border-strong);
+  box-shadow: inset 3px 0 0 var(--accent);
+}
+
+.endpoint-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.9rem;
+}
+
+.endpoint-priority {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.endpoint-card:first-child .endpoint-priority {
+  color: var(--accent);
+}
+
+.endpoint-order-actions,
+.endpoint-test-status {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.endpoint-order-button,
+.endpoint-remove-button {
+  min-height: 2rem;
+  padding: 0.25rem 0.65rem;
+}
+
+.endpoint-fields {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0 0.9rem;
+}
+
+.endpoint-fields label:first-child,
+.endpoint-fields label:nth-child(4) {
+  grid-column: 1 / -1;
+}
+
+.endpoint-test-status {
+  margin-top: 0.9rem;
+}
+
+.endpoint-test-status p {
+  margin: 0;
+}
+
+@media (max-width: 700px) {
+  .endpoint-pool-heading,
+  .endpoint-card-header {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .endpoint-fields {
+    grid-template-columns: 1fr;
+  }
+
+  .endpoint-fields label {
+    grid-column: 1;
+  }
+}
+
 /* ─── Audiobook pipeline ────────────────────────────────── */
 .audiobook-pipeline {
   display: grid;

--- a/frontend/src/components/AudiobookSettings.jsx
+++ b/frontend/src/components/AudiobookSettings.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   getAudiobookSettings,
   testAudiobookLlm,
@@ -13,501 +13,464 @@ const DEFAULT_ROSTER_PROMPT_HINT =
 const DEFAULT_DIARIZATION_PROMPT_HINT =
   "Leave blank to use the built-in diarization prompt.";
 
+let endpointSequence = 0;
+
+function endpointId(capability) {
+  endpointSequence += 1;
+  return `${capability}-${Date.now()}-${endpointSequence}`;
+}
+
+const CAPABILITIES = {
+  llm: {
+    title: "LLM Endpoints",
+    description:
+      "Used for character extraction and speaker assignment. Endpoints are tried from top to bottom.",
+    providers: [
+      ["openai", "OpenAI"],
+      ["anthropic", "Anthropic"],
+      ["ollama", "Ollama (local)"],
+      ["custom", "Custom / Local"],
+      ["stub", "Deterministic local harness"],
+    ],
+    defaultProvider: "ollama",
+    modelPlaceholder: "e.g. qwen3.5:9b or gpt-4o",
+    baseUrlPlaceholder: "http://model-host:11434",
+  },
+  tts: {
+    title: "Text-to-Speech Endpoints",
+    description:
+      "Used to render narration. Put a fast, sometimes-available host above an always-on fallback.",
+    providers: [
+      ["omnivoice", "OmniVoice"],
+      ["openai-compatible", "OpenAI-compatible (Kokoro / local)"],
+      ["openai", "OpenAI"],
+      ["elevenlabs", "ElevenLabs"],
+      ["stub", "Deterministic local harness"],
+    ],
+    defaultProvider: "omnivoice",
+    modelPlaceholder: "e.g. kokoro or tts-1",
+    baseUrlPlaceholder: "http://speech-host:8001",
+  },
+  transcription: {
+    title: "Speech-to-Text Endpoints",
+    description:
+      "Used to align imported human narration with EPUB text and word timestamps.",
+    providers: [
+      ["whisperx", "WhisperX service"],
+      ["none", "Not configured"],
+    ],
+    defaultProvider: "whisperx",
+    modelPlaceholder: "e.g. large-v3",
+    baseUrlPlaceholder: "http://whisper-host:8002",
+  },
+};
+
+function legacyEndpoint(settings, capability) {
+  const prefix = capability === "transcription" ? "transcription" : capability;
+  const defaults = { llm: "stub", tts: "stub", transcription: "none" };
+  return {
+    id: `legacy-${capability}`,
+    name: "Primary",
+    provider: settings?.[`${prefix}_provider`] || defaults[capability],
+    api_key_set: Boolean(settings?.[`${prefix}_api_key_set`]),
+    base_url: settings?.[`${prefix}_base_url`] || "",
+    model: settings?.[`${prefix}_model`] || "",
+    default_voice: settings?.tts_default_voice || "",
+    language: settings?.transcription_language || "auto",
+  };
+}
+
+function initialiseEndpoints(settings, capability) {
+  const stored = settings?.[`${capability}_endpoints`];
+  const endpoints = stored?.length ? stored : [legacyEndpoint(settings, capability)];
+  return endpoints.map((endpoint) => ({
+    ...endpoint,
+    base_url: endpoint.base_url || "",
+    model: endpoint.model || "",
+    default_voice: endpoint.default_voice || "",
+    language: endpoint.language || "auto",
+    api_key: "",
+    api_key_dirty: false,
+  }));
+}
+
+function newEndpoint(capability, values = {}) {
+  return {
+    id: endpointId(capability),
+    name: values.name || `New ${capability.toUpperCase()} host`,
+    provider: values.provider || CAPABILITIES[capability].defaultProvider,
+    api_key: "",
+    api_key_set: false,
+    api_key_dirty: false,
+    base_url: values.base_url || "",
+    model: values.model || "",
+    default_voice: values.default_voice || "",
+    language: values.language || "auto",
+  };
+}
+
+function EndpointPoolEditor({ capability, endpoints, setEndpoints }) {
+  const config = CAPABILITIES[capability];
+
+  const update = (index, field, value) => {
+    setEndpoints((current) =>
+      current.map((endpoint, endpointIndex) => {
+        if (endpointIndex !== index) return endpoint;
+        if (field === "provider") {
+          return {
+            ...endpoint,
+            provider: value,
+            api_key: "",
+            api_key_set: false,
+            api_key_dirty: true,
+          };
+        }
+        if (field === "api_key") {
+          return { ...endpoint, api_key: value, api_key_dirty: true };
+        }
+        return { ...endpoint, [field]: value };
+      }),
+    );
+  };
+
+  const move = (index, direction) => {
+    setEndpoints((current) => {
+      const target = index + direction;
+      if (target < 0 || target >= current.length) return current;
+      const reordered = [...current];
+      [reordered[index], reordered[target]] = [
+        reordered[target],
+        reordered[index],
+      ];
+      return reordered;
+    });
+  };
+
+  const addPreset = () => {
+    const presets = {
+      llm: {
+        name: "Local Ollama",
+        provider: "ollama",
+        base_url: "http://127.0.0.1:11434",
+        model: "qwen3.5:9b",
+      },
+      tts: {
+        name: "Local OmniVoice",
+        provider: "omnivoice",
+        base_url: "http://127.0.0.1:8001",
+      },
+      transcription: {
+        name: "Local WhisperX",
+        provider: "whisperx",
+        base_url: "http://127.0.0.1:8002",
+        model: "large-v3",
+        language: "en",
+      },
+    };
+    setEndpoints((current) => [...current, newEndpoint(capability, presets[capability])]);
+  };
+
+  return (
+    <>
+      <div className="endpoint-pool-heading">
+        <div>
+          <h3>{config.title}</h3>
+          <p className="settings-hint">{config.description}</p>
+        </div>
+        <button type="button" className="btn-secondary" onClick={addPreset}>
+          + Add endpoint
+        </button>
+      </div>
+      <div className="endpoint-pool">
+        {endpoints.map((endpoint, index) => {
+          const disabled = ["stub", "none"].includes(endpoint.provider);
+          return (
+            <article className="endpoint-card" key={endpoint.id}>
+              <header className="endpoint-card-header">
+                <span className="endpoint-priority">Priority {index + 1}</span>
+                <div className="endpoint-order-actions">
+                  <button
+                    type="button"
+                    className="btn-secondary endpoint-order-button"
+                    aria-label={`Move ${endpoint.name} up`}
+                    disabled={index === 0}
+                    onClick={() => move(index, -1)}
+                  >
+                    ↑
+                  </button>
+                  <button
+                    type="button"
+                    className="btn-secondary endpoint-order-button"
+                    aria-label={`Move ${endpoint.name} down`}
+                    disabled={index === endpoints.length - 1}
+                    onClick={() => move(index, 1)}
+                  >
+                    ↓
+                  </button>
+                  <button
+                    type="button"
+                    className="btn-secondary endpoint-remove-button"
+                    disabled={endpoints.length === 1}
+                    onClick={() =>
+                      setEndpoints((current) =>
+                        current.filter((_, endpointIndex) => endpointIndex !== index),
+                      )
+                    }
+                  >
+                    Remove
+                  </button>
+                </div>
+              </header>
+              <div className="endpoint-fields">
+                <label>
+                  Name
+                  <input
+                    value={endpoint.name}
+                    onChange={(event) => update(index, "name", event.target.value)}
+                    placeholder="Gaming PC"
+                  />
+                </label>
+                <label>
+                  Provider
+                  <select
+                    value={endpoint.provider}
+                    onChange={(event) => update(index, "provider", event.target.value)}
+                  >
+                    {config.providers.map(([value, label]) => (
+                      <option value={value} key={value}>
+                        {label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                {!disabled && (
+                  <label>
+                    API Key
+                    <input
+                      type="password"
+                      value={endpoint.api_key}
+                      onChange={(event) => update(index, "api_key", event.target.value)}
+                      placeholder={
+                        endpoint.api_key_set
+                          ? "••••••••  (set — enter a new key to change)"
+                          : "Optional for trusted local hosts"
+                      }
+                    />
+                  </label>
+                )}
+                {!disabled && (
+                  <label>
+                    Base URL
+                    <input
+                      type="url"
+                      value={endpoint.base_url}
+                      onChange={(event) => update(index, "base_url", event.target.value)}
+                      placeholder={config.baseUrlPlaceholder}
+                    />
+                  </label>
+                )}
+                {!disabled && (
+                  <label>
+                    Model
+                    <input
+                      value={endpoint.model}
+                      onChange={(event) => update(index, "model", event.target.value)}
+                      placeholder={config.modelPlaceholder}
+                    />
+                  </label>
+                )}
+                {capability === "tts" &&
+                  !disabled &&
+                  endpoint.provider !== "omnivoice" && (
+                    <label>
+                      Default Voice ID
+                      <input
+                        value={endpoint.default_voice}
+                        onChange={(event) =>
+                          update(index, "default_voice", event.target.value)
+                        }
+                        placeholder="e.g. af_heart or alloy"
+                      />
+                    </label>
+                  )}
+                {capability === "transcription" && !disabled && (
+                  <label>
+                    Language
+                    <input
+                      value={endpoint.language}
+                      onChange={(event) => update(index, "language", event.target.value)}
+                      placeholder="auto or en"
+                    />
+                  </label>
+                )}
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </>
+  );
+}
+
+function serialiseEndpoints(endpoints) {
+  return endpoints.map((endpoint) => {
+    const payload = {
+      id: endpoint.id,
+      name: endpoint.name,
+      provider: endpoint.provider,
+      base_url: endpoint.base_url || null,
+      model: endpoint.model || null,
+      default_voice: endpoint.default_voice || null,
+      language: endpoint.language || null,
+    };
+    if (endpoint.api_key_dirty) payload.api_key = endpoint.api_key || null;
+    return payload;
+  });
+}
+
+function useEndpointTestMutation(testFunction, buildPayload, refreshSettings) {
+  return useMutation({
+    mutationFn: async () => {
+      await updateAudiobookSettings(buildPayload());
+      return testFunction();
+    },
+    onSuccess: refreshSettings,
+  });
+}
+
 function AudiobookSettings() {
   const queryClient = useQueryClient();
-
   const { data: settings, isLoading } = useQuery({
     queryKey: ["audiobook-settings"],
     queryFn: getAudiobookSettings,
   });
 
-  const [llmProvider, setLlmProvider] = useState("");
-  const [llmApiKey, setLlmApiKey] = useState("");
-  const [llmBaseUrl, setLlmBaseUrl] = useState("");
-  const [llmModel, setLlmModel] = useState("");
-  const [ttsProvider, setTtsProvider] = useState("stub");
-  const [ttsApiKey, setTtsApiKey] = useState("");
-  const [ttsBaseUrl, setTtsBaseUrl] = useState("");
-  const [ttsModel, setTtsModel] = useState("");
-  const [ttsDefaultVoice, setTtsDefaultVoice] = useState("");
-  const [transcriptionProvider, setTranscriptionProvider] = useState("none");
-  const [transcriptionApiKey, setTranscriptionApiKey] = useState("");
-  const [transcriptionBaseUrl, setTranscriptionBaseUrl] = useState("");
-  const [transcriptionModel, setTranscriptionModel] = useState("");
-  const [transcriptionLanguage, setTranscriptionLanguage] = useState("auto");
+  const [llmEndpoints, setLlmEndpoints] = useState([]);
+  const [ttsEndpoints, setTtsEndpoints] = useState([]);
+  const [transcriptionEndpoints, setTranscriptionEndpoints] = useState([]);
   const [rosterPrompt, setRosterPrompt] = useState("");
   const [diarizationPrompt, setDiarizationPrompt] = useState("");
   const [initialised, setInitialised] = useState(false);
 
   useEffect(() => {
     if (settings && !initialised) {
-      setLlmProvider(settings.llm_provider || "stub");
-      setLlmBaseUrl(settings.llm_base_url || "");
-      setLlmModel(settings.llm_model || "");
-      setTtsProvider(settings.tts_provider || "stub");
-      setTtsBaseUrl(settings.tts_base_url || "");
-      setTtsModel(settings.tts_model || "");
-      setTtsDefaultVoice(settings.tts_default_voice || "");
-      setTranscriptionProvider(settings.transcription_provider || "none");
-      setTranscriptionBaseUrl(settings.transcription_base_url || "");
-      setTranscriptionModel(settings.transcription_model || "");
-      setTranscriptionLanguage(settings.transcription_language || "auto");
+      setLlmEndpoints(initialiseEndpoints(settings, "llm"));
+      setTtsEndpoints(initialiseEndpoints(settings, "tts"));
+      setTranscriptionEndpoints(initialiseEndpoints(settings, "transcription"));
       setRosterPrompt(settings.roster_prompt_template || "");
       setDiarizationPrompt(settings.diarization_prompt_template || "");
       setInitialised(true);
     }
   }, [initialised, settings]);
 
+  const buildPayload = () => ({
+    llm_endpoints: serialiseEndpoints(llmEndpoints),
+    tts_endpoints: serialiseEndpoints(ttsEndpoints),
+    transcription_endpoints: serialiseEndpoints(transcriptionEndpoints),
+    roster_prompt_template: rosterPrompt || null,
+    diarization_prompt_template: diarizationPrompt || null,
+  });
+
+  const refreshSettings = () => {
+    const clearTypedSecrets = (current) =>
+      current.map((endpoint) => ({
+        ...endpoint,
+        api_key_set: endpoint.api_key_dirty
+          ? Boolean(endpoint.api_key)
+          : endpoint.api_key_set,
+        api_key: "",
+        api_key_dirty: false,
+      }));
+    setLlmEndpoints(clearTypedSecrets);
+    setTtsEndpoints(clearTypedSecrets);
+    setTranscriptionEndpoints(clearTypedSecrets);
+    queryClient.invalidateQueries({ queryKey: ["audiobook-settings"] });
+  };
+
   const saveMutation = useMutation({
-    mutationFn: (data) => updateAudiobookSettings(data),
-    onSuccess: () => {
-      setTtsApiKey("");
-      setTranscriptionApiKey("");
-      queryClient.invalidateQueries({ queryKey: ["audiobook-settings"] });
-    },
+    mutationFn: () => updateAudiobookSettings(buildPayload()),
+    onSuccess: refreshSettings,
   });
 
-  const buildPayload = () => {
-    const payload = {
-      llm_provider: llmProvider || null,
-      llm_base_url: llmBaseUrl || null,
-      llm_model: llmModel || null,
-      tts_provider: ttsProvider || "stub",
-      tts_base_url: ttsBaseUrl || null,
-      tts_model: ttsModel || null,
-      tts_default_voice: ttsDefaultVoice || null,
-      transcription_provider: transcriptionProvider || "none",
-      transcription_base_url: transcriptionBaseUrl || null,
-      transcription_model: transcriptionModel || null,
-      transcription_language: transcriptionLanguage || null,
-      roster_prompt_template: rosterPrompt || null,
-      diarization_prompt_template: diarizationPrompt || null,
-    };
-    if (llmApiKey) {
-      payload.llm_api_key = llmApiKey;
-    }
-    if (ttsApiKey) {
-      payload.tts_api_key = ttsApiKey;
-    }
-    if (transcriptionApiKey) {
-      payload.transcription_api_key = transcriptionApiKey;
-    }
-    return payload;
+  const llmTest = useEndpointTestMutation(
+    testAudiobookLlm,
+    buildPayload,
+    refreshSettings,
+  );
+  const ttsTest = useEndpointTestMutation(
+    testAudiobookTts,
+    buildPayload,
+    refreshSettings,
+  );
+  const transcriptionTest = useEndpointTestMutation(
+    testAudiobookTranscription,
+    buildPayload,
+    refreshSettings,
+  );
+
+  const handleSave = (event) => {
+    event.preventDefault();
+    saveMutation.mutate();
   };
 
-  const testMutation = useMutation({
-    mutationFn: async () => {
-      await updateAudiobookSettings(buildPayload());
-      return testAudiobookLlm();
-    },
-    onSuccess: () => {
-      setTtsApiKey("");
-      setTranscriptionApiKey("");
-      queryClient.invalidateQueries({ queryKey: ["audiobook-settings"] });
-    },
-  });
+  if (isLoading || !initialised) return <p>Loading settings…</p>;
 
-  const testTtsMutation = useMutation({
-    mutationFn: async () => {
-      await updateAudiobookSettings(buildPayload());
-      return testAudiobookTts();
-    },
-    onSuccess: () => {
-      setTtsApiKey("");
-      setTranscriptionApiKey("");
-      queryClient.invalidateQueries({ queryKey: ["audiobook-settings"] });
-    },
-  });
-
-  const testTranscriptionMutation = useMutation({
-    mutationFn: async () => {
-      await updateAudiobookSettings(buildPayload());
-      return testAudiobookTranscription();
-    },
-    onSuccess: () => {
-      setTranscriptionApiKey("");
-      queryClient.invalidateQueries({ queryKey: ["audiobook-settings"] });
-    },
-  });
-
-  const handleSave = (e) => {
-    e.preventDefault();
-    saveMutation.mutate(buildPayload());
-  };
-
-  if (isLoading) return <p>Loading settings…</p>;
+  const testStatus = (mutation, label) => (
+    <div className="endpoint-test-status">
+      <button
+        type="button"
+        onClick={() => mutation.mutate()}
+        disabled={mutation.isPending}
+      >
+        {mutation.isPending ? "Testing pool…" : `Save & Test ${label}`}
+      </button>
+      {mutation.isSuccess && (
+        <p className="success">
+          Connected{mutation.data.endpoint ? ` via ${mutation.data.endpoint}` : ""} to{" "}
+          {mutation.data.provider}
+          {mutation.data.model ? ` / ${mutation.data.model}` : ""}.
+        </p>
+      )}
+      {mutation.isError && (
+        <p className="error">{mutation.error?.message || `${label} test failed`}</p>
+      )}
+    </div>
+  );
 
   return (
     <div className="settings-page">
       <h2>Audio &amp; AI Configuration</h2>
+      <p className="settings-hint endpoint-routing-hint">
+        Requests use the highest-priority available endpoint. Connection or model
+        failures put that endpoint on a 60-second cooldown, then the next request
+        tries it again. No background polling runs when there is no work.
+      </p>
       <form onSubmit={handleSave}>
         <section className="settings-section">
-          <h3>LLM Provider</h3>
-          <label>
-            Provider
-            <select
-              value={llmProvider}
-              onChange={(e) => setLlmProvider(e.target.value)}
-            >
-              <option value="openai">OpenAI</option>
-              <option value="anthropic">Anthropic</option>
-              <option value="ollama">Ollama (local)</option>
-              <option value="custom">Custom / Local</option>
-              <option value="stub">Deterministic local harness</option>
-            </select>
-          </label>
-          <label>
-            API Key
-            <input
-              type="password"
-              value={llmApiKey}
-              onChange={(e) => setLlmApiKey(e.target.value)}
-              placeholder={
-                settings?.llm_api_key_set
-                  ? "••••••••  (set — enter new key to change)"
-                  : "Enter API key"
-              }
-            />
-          </label>
-          <label>
-            Base URL
-            <input
-              type="url"
-              value={llmBaseUrl}
-              onChange={(e) => setLlmBaseUrl(e.target.value)}
-              placeholder="https://api.openai.com  (leave blank for provider default)"
-            />
-          </label>
-          <label>
-            Model
-            <input
-              type="text"
-              value={llmModel}
-              onChange={(e) => setLlmModel(e.target.value)}
-              placeholder="e.g. gpt-4o or claude-opus-4-7"
-            />
-          </label>
-          <div className="settings-actions-inline">
-            <button
-              type="button"
-              className="btn-secondary"
-              onClick={() => {
-                setLlmProvider("ollama");
-                setLlmBaseUrl("http://127.0.0.1:11434");
-                setLlmModel("qwen3.5:9b");
-              }}
-            >
-              Use Recommended Local Ollama
-            </button>
-            <button
-              type="button"
-              onClick={() => testMutation.mutate()}
-              disabled={testMutation.isPending}
-            >
-              {testMutation.isPending ? "Testing…" : "Save & Test LLM"}
-            </button>
-          </div>
-          <p className="settings-hint">
-            Recommended local default: <code>qwen3.5:9b</code> (6.6 GB). Run{" "}
-            <code>ollama pull qwen3.5:9b</code> first. Story Manager uses
-            Ollama&apos;s schema-constrained JSON output and disables thinking
-            for predictable extraction latency.
-          </p>
-          {testMutation.isSuccess && (
-            <p className="success">
-              Connected to {testMutation.data.provider} /{" "}
-              {testMutation.data.model || "local harness"}.
-            </p>
-          )}
-          {testMutation.isError && (
-            <p className="error">
-              {testMutation.error?.message || "LLM test failed"}
-            </p>
-          )}
+          <EndpointPoolEditor
+            capability="llm"
+            endpoints={llmEndpoints}
+            setEndpoints={setLlmEndpoints}
+          />
+          {testStatus(llmTest, "LLM")}
         </section>
 
         <section className="settings-section">
-          <h3>Text-to-Speech Provider</h3>
-          <label>
-            Provider
-            <select
-              value={ttsProvider}
-              onChange={(e) => {
-                setTtsProvider(e.target.value);
-                setTtsApiKey("");
-              }}
-            >
-              <option value="omnivoice">OmniVoice</option>
-              <option value="openai-compatible">
-                OpenAI-compatible (Kokoro / local)
-              </option>
-              <option value="openai">OpenAI</option>
-              <option value="elevenlabs">ElevenLabs</option>
-              <option value="stub">Deterministic local harness</option>
-            </select>
-          </label>
-          {ttsProvider !== "stub" && (
-            <label>
-              API Key
-              <input
-                type="password"
-                value={ttsApiKey}
-                onChange={(e) => setTtsApiKey(e.target.value)}
-                placeholder={
-                  settings?.tts_api_key_set
-                    ? "••••••••  (set — enter new key to change)"
-                    : ttsProvider === "omnivoice" ||
-                        ttsProvider === "openai-compatible"
-                      ? "Optional for local servers"
-                      : "Enter API key"
-                }
-              />
-            </label>
-          )}
-          {ttsProvider !== "stub" && (
-            <label>
-              Base URL
-              <input
-                type="url"
-                value={ttsBaseUrl}
-                onChange={(e) => setTtsBaseUrl(e.target.value)}
-                placeholder={
-                  ttsProvider === "omnivoice"
-                    ? "http://your-omnivoice-server:8001"
-                    : ttsProvider === "openai-compatible"
-                      ? "http://your-tts-server:8880"
-                      : "Leave blank for the provider default"
-                }
-              />
-            </label>
-          )}
-          {["openai", "openai-compatible", "elevenlabs"].includes(
-            ttsProvider,
-          ) && (
-            <label>
-              Model
-              <input
-                type="text"
-                value={ttsModel}
-                onChange={(e) => setTtsModel(e.target.value)}
-                placeholder={
-                  ttsProvider === "openai-compatible"
-                    ? "e.g. kokoro"
-                    : ttsProvider === "openai"
-                      ? "tts-1"
-                      : "eleven_multilingual_v2"
-                }
-              />
-            </label>
-          )}
-          {["openai", "openai-compatible", "elevenlabs"].includes(
-            ttsProvider,
-          ) && (
-            <label>
-              Default Voice ID
-              <input
-                type="text"
-                value={ttsDefaultVoice}
-                onChange={(e) => setTtsDefaultVoice(e.target.value)}
-                placeholder={
-                  ttsProvider === "openai-compatible"
-                    ? "e.g. af_heart"
-                    : ttsProvider === "openai"
-                      ? "e.g. alloy"
-                      : "ElevenLabs voice ID"
-                }
-              />
-            </label>
-          )}
-          <div className="settings-actions-inline">
-            <button
-              type="button"
-              className="btn-secondary"
-              onClick={() => {
-                setTtsProvider("omnivoice");
-                setTtsApiKey("");
-                setTtsBaseUrl("http://127.0.0.1:8001");
-                setTtsModel("");
-                setTtsDefaultVoice("");
-              }}
-            >
-              Use Local OmniVoice
-            </button>
-            <button
-              type="button"
-              className="btn-secondary"
-              onClick={() => {
-                setTtsProvider("openai-compatible");
-                setTtsApiKey("");
-                setTtsBaseUrl("http://127.0.0.1:8880");
-                setTtsModel("kokoro");
-                setTtsDefaultVoice("af_heart");
-              }}
-            >
-              Use Local Kokoro
-            </button>
-            <button
-              type="button"
-              onClick={() => testTtsMutation.mutate()}
-              disabled={testTtsMutation.isPending}
-            >
-              {testTtsMutation.isPending ? "Testing…" : "Save & Test TTS"}
-            </button>
-          </div>
-          {testTtsMutation.isSuccess && (
-            <p className="success">
-              Connected to {testTtsMutation.data.provider}
-              {testTtsMutation.data.model
-                ? ` / ${testTtsMutation.data.model}`
-                : ""}
-              .
-            </p>
-          )}
-          {testTtsMutation.isError && (
-            <p className="error">
-              {testTtsMutation.error?.message || "TTS test failed"}
-            </p>
-          )}
-          <p className="settings-hint">
-            OmniVoice uses descriptive voice profiles and expression tags.
-            OpenAI-compatible and hosted APIs use voice IDs; set a default here
-            and optionally override it on individual characters.
-          </p>
-          {ttsProvider === "omnivoice" && (
-            <p className="settings-hint">
-              Run <code>make run-omnivoice</code> for the bundled local adapter.
-              It receives <code>POST /generate</code> and returns MP3 audio.
-            </p>
-          )}
-          {ttsProvider === "openai-compatible" && (
-            <p className="settings-hint">
-              Compatible servers must implement{" "}
-              <code>POST /v1/audio/speech</code>. Kokoro FastAPI is supported by
-              the local preset.
-            </p>
-          )}
-          {ttsProvider === "stub" && (
-            <p className="settings-hint">
-              The deterministic harness generates silent placeholder MP3s with
-              realistic timing for offline validation.
-            </p>
-          )}
+          <EndpointPoolEditor
+            capability="tts"
+            endpoints={ttsEndpoints}
+            setEndpoints={setTtsEndpoints}
+          />
+          {testStatus(ttsTest, "TTS")}
         </section>
 
         <section className="settings-section">
-          <h3>Speech-to-Text Alignment</h3>
-          <p className="settings-hint">
-            Transcribe imported human narration into forced-aligned word
-            timestamps, then fuzzy-match those words to EPUB sentences for
-            accurate highlighting and SMIL timing.
-          </p>
-          <label>
-            Provider
-            <select
-              value={transcriptionProvider}
-              onChange={(e) => {
-                setTranscriptionProvider(e.target.value);
-                setTranscriptionApiKey("");
-              }}
-            >
-              <option value="whisperx">WhisperX service</option>
-              <option value="none">Not configured</option>
-            </select>
-          </label>
-          {transcriptionProvider !== "none" && (
-            <>
-              <label>
-                API Key
-                <input
-                  type="password"
-                  value={transcriptionApiKey}
-                  onChange={(e) => setTranscriptionApiKey(e.target.value)}
-                  placeholder={
-                    settings?.transcription_api_key_set
-                      ? "••••••••  (set — enter new key to change)"
-                      : "Optional for a trusted local service"
-                  }
-                />
-              </label>
-              <label>
-                Base URL
-                <input
-                  type="url"
-                  value={transcriptionBaseUrl}
-                  onChange={(e) => setTranscriptionBaseUrl(e.target.value)}
-                  placeholder="http://your-whisper-server:8002"
-                />
-              </label>
-              <label>
-                Model
-                <input
-                  type="text"
-                  value={transcriptionModel}
-                  onChange={(e) => setTranscriptionModel(e.target.value)}
-                  placeholder="large-v3"
-                />
-              </label>
-              <label>
-                Language
-                <input
-                  type="text"
-                  value={transcriptionLanguage}
-                  onChange={(e) => setTranscriptionLanguage(e.target.value)}
-                  placeholder="auto or en"
-                />
-              </label>
-            </>
-          )}
-          <div className="settings-actions-inline">
-            <button
-              type="button"
-              className="btn-secondary"
-              onClick={() => {
-                setTranscriptionProvider("whisperx");
-                setTranscriptionApiKey("");
-                setTranscriptionBaseUrl("http://127.0.0.1:8002");
-                setTranscriptionModel("large-v3");
-                setTranscriptionLanguage("en");
-              }}
-            >
-              Use Local WhisperX
-            </button>
-            <button
-              type="button"
-              onClick={() => testTranscriptionMutation.mutate()}
-              disabled={
-                transcriptionProvider === "none" ||
-                testTranscriptionMutation.isPending
-              }
-            >
-              {testTranscriptionMutation.isPending
-                ? "Testing…"
-                : "Save & Test Transcription"}
-            </button>
-          </div>
-          {testTranscriptionMutation.isSuccess && (
-            <p className="success">
-              Connected to {testTranscriptionMutation.data.provider} /{" "}
-              {testTranscriptionMutation.data.model}
-              {testTranscriptionMutation.data.device
-                ? ` on ${testTranscriptionMutation.data.device}`
-                : ""}
-              .
-            </p>
-          )}
-          {testTranscriptionMutation.isError && (
-            <p className="error">
-              {testTranscriptionMutation.error?.message ||
-                "Transcription service test failed"}
-            </p>
-          )}
-          {transcriptionProvider === "whisperx" && (
-            <p className="settings-hint">
-              Run <code>make run-transcription</code> locally or use the
-              published <code>story-manager-transcription</code> container. The
-              bundled image includes FFmpeg.
-            </p>
-          )}
+          <EndpointPoolEditor
+            capability="transcription"
+            endpoints={transcriptionEndpoints}
+            setEndpoints={setTranscriptionEndpoints}
+          />
+          {testStatus(transcriptionTest, "Transcription")}
         </section>
 
         <section className="settings-section">
@@ -517,7 +480,7 @@ function AudiobookSettings() {
             <textarea
               rows={6}
               value={rosterPrompt}
-              onChange={(e) => setRosterPrompt(e.target.value)}
+              onChange={(event) => setRosterPrompt(event.target.value)}
               placeholder={DEFAULT_ROSTER_PROMPT_HINT}
             />
           </label>
@@ -526,19 +489,16 @@ function AudiobookSettings() {
             <textarea
               rows={6}
               value={diarizationPrompt}
-              onChange={(e) => setDiarizationPrompt(e.target.value)}
+              onChange={(event) => setDiarizationPrompt(event.target.value)}
               placeholder={DEFAULT_DIARIZATION_PROMPT_HINT}
             />
           </label>
         </section>
 
         {saveMutation.isError && (
-          <p className="error">
-            {saveMutation.error?.message || "Save failed"}
-          </p>
+          <p className="error">{saveMutation.error?.message || "Save failed"}</p>
         )}
         {saveMutation.isSuccess && <p className="success">Settings saved.</p>}
-
         <button type="submit" disabled={saveMutation.isPending}>
           {saveMutation.isPending ? "Saving…" : "Save Settings"}
         </button>

--- a/frontend/src/components/AudiobookSettings.test.jsx
+++ b/frontend/src/components/AudiobookSettings.test.jsx
@@ -63,7 +63,7 @@ describe("AudiobookSettings", () => {
     renderWithClient(<AudiobookSettings />);
 
     const providerSelect = (await screen.findAllByRole("combobox"))[1];
-    const ttsApiKeyInput = screen.getAllByLabelText("API Key")[1];
+    const ttsApiKeyInput = screen.getByLabelText("API Key");
     fireEvent.change(ttsApiKeyInput, { target: { value: "openai-secret" } });
     fireEvent.change(providerSelect, {
       target: { value: "openai-compatible" },
@@ -71,7 +71,57 @@ describe("AudiobookSettings", () => {
     fireEvent.click(screen.getByRole("button", { name: "Save & Test TTS" }));
 
     await waitFor(() => expect(updates).toHaveLength(1));
-    expect(updates[0].tts_provider).toBe("openai-compatible");
-    expect(updates[0]).not.toHaveProperty("tts_api_key");
+    expect(updates[0].tts_endpoints[0].provider).toBe("openai-compatible");
+    expect(updates[0].tts_endpoints[0].api_key).toBeNull();
+  });
+
+  it("reorders endpoint priority before saving", async () => {
+    const updates = [];
+    globalThis.fetch = vi.fn((url, options) => {
+      if (url === "/api/audiobook/settings" && !options) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              llm_endpoints: [
+                {
+                  id: "always-on",
+                  name: "Always-on mini PC",
+                  provider: "ollama",
+                  base_url: "http://mini:11434",
+                  model: "qwen3.5:9b",
+                },
+                {
+                  id: "gaming-pc",
+                  name: "Gaming PC",
+                  provider: "ollama",
+                  base_url: "http://gaming:11434",
+                  model: "qwen3.5:27b",
+                },
+              ],
+              tts_provider: "stub",
+              transcription_provider: "none",
+            }),
+        });
+      }
+      if (url === "/api/audiobook/settings" && options?.method === "PUT") {
+        updates.push(JSON.parse(options.body));
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+
+    renderWithClient(<AudiobookSettings />);
+
+    await screen.findByDisplayValue("Gaming PC");
+    fireEvent.click(
+      screen.getByRole("button", { name: "Move Gaming PC up" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Save Settings" }));
+
+    await waitFor(() => expect(updates).toHaveLength(1));
+    expect(updates[0].llm_endpoints.map((endpoint) => endpoint.id)).toEqual([
+      "gaming-pc",
+      "always-on",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- add ordered endpoint pools for LLM, text-to-speech, and speech-to-text configuration
- route requests through endpoints by priority with automatic fallback
- place failed endpoints on a 60-second cooldown and retry them only when new work arrives
- add priority-card controls for adding, removing, editing, and reordering hosts
- migrate existing single-endpoint settings into Priority 1 while preserving masked API keys
- fingerprint the transcription pool for cache correctness and use endpoint-specific TTS defaults during mixed-provider fallback

## Why

Local AI models may be distributed across several home computers with different availability and performance. A fast gaming PC can now be preferred when online while an always-on, slower host transparently handles requests during downtime.

## Impact

Existing installations retain their current provider as the first endpoint. There is no idle health polling. Failures are logged, cooled down for one minute, and retried on the first request after cooldown expiry.

## Validation

- `make test`: 326 backend tests passed, 1 integration test deselected; 46 frontend tests passed
- frontend ESLint passed
- frontend production build passed
- PostgreSQL migration tested from scratch, with existing settings data, and through downgrade
- Audio Settings tab verified interactively with add/remove/reorder behavior and no browser console errors