### PR TITLE
Deduplicate imported audiobook downloads

### DIFF
--- a/backend/app/routers/audiobook.py
+++ b/backend/app/routers/audiobook.py
@@ -295,6 +295,7 @@ class ImportedAudiobookResponse(BaseModel):
     alignment_method: Optional[str]
     original_filenames: list[str]
     duration_ms: Optional[int]
+    audio_size_bytes: int
     progress_current: int
     progress_total: int
     progress_detail: Optional[str]
@@ -334,6 +335,26 @@ def _resolve_path(relative_path: Optional[str]) -> Optional[Path]:
     return path if path.is_relative_to(LIBRARY_PATH.resolve()) else None
 
 
+def _canonical_audio_track_ids(tracks: list[ImportedAudiobookTrack]) -> dict[str, int]:
+    canonical_ids: dict[str, int] = {}
+    for track in tracks:
+        canonical_ids.setdefault(track.audio_file_path, track.id)
+    return canonical_ids
+
+
+async def _canonical_audio_track_id(track: ImportedAudiobookTrack, db: AsyncSession) -> int:
+    result = await db.execute(
+        select(ImportedAudiobookTrack.id)
+        .where(
+            ImportedAudiobookTrack.imported_audiobook_id == track.imported_audiobook_id,
+            ImportedAudiobookTrack.audio_file_path == track.audio_file_path,
+        )
+        .order_by(ImportedAudiobookTrack.sequence_order)
+        .limit(1)
+    )
+    return result.scalar_one()
+
+
 async def _imported_audiobook_response(
     edition: ImportedAudiobook,
     db: AsyncSession,
@@ -344,6 +365,8 @@ async def _imported_audiobook_response(
         .order_by(ImportedAudiobookTrack.sequence_order)
     )
     tracks = list(result.scalars().all())
+    canonical_audio_track_ids = _canonical_audio_track_ids(tracks)
+    audio_paths = {path for track in tracks if (path := _resolve_path(track.audio_file_path)) is not None and path.is_file()}
     chapter_ids = {track.matched_chapter_id for track in tracks if track.matched_chapter_id is not None}
     chapters = {}
     if chapter_ids:
@@ -367,6 +390,7 @@ async def _imported_audiobook_response(
         alignment_method=edition.alignment_method,
         original_filenames=edition.original_filenames or [],
         duration_ms=edition.duration_ms,
+        audio_size_bytes=sum(path.stat().st_size for path in audio_paths),
         progress_current=edition.progress_current or 0,
         progress_total=edition.progress_total or 0,
         progress_detail=edition.progress_detail,
@@ -390,7 +414,10 @@ async def _imported_audiobook_response(
                 media_type=track.media_type,
                 cue_count=cue_counts.get(track.id, 0),
                 alignment_score=track.alignment_score,
-                audio_url=f"/api/imported-audiobooks/{edition.id}/tracks/{track.id}/audio",
+                audio_url=(
+                    f"/api/imported-audiobooks/{edition.id}/tracks/"
+                    f"{canonical_audio_track_ids[track.audio_file_path]}/audio"
+                ),
                 cues_url=f"/api/imported-audiobooks/{edition.id}/tracks/{track.id}/cues",
                 smil_url=f"/api/imported-audiobooks/{edition.id}/tracks/{track.id}/smil",
             )
@@ -657,6 +684,7 @@ async def get_imported_track_smil(
     if track.matched_chapter_id is None:
         raise HTTPException(status_code=404, detail="Track is not matched to book text")
     chapter = await db.get(AudiobookChapter, track.matched_chapter_id)
+    canonical_audio_track_id = await _canonical_audio_track_id(track, db)
     result = await db.execute(
         select(ImportedAudiobookCue, AudiobookSentence)
         .join(AudiobookSentence, AudiobookSentence.id == ImportedAudiobookCue.sentence_id)
@@ -677,7 +705,7 @@ async def get_imported_track_smil(
             par,
             "audio",
             {
-                "src": f"/api/imported-audiobooks/{edition.id}/tracks/{track.id}/audio",
+                "src": f"/api/imported-audiobooks/{edition.id}/tracks/{canonical_audio_track_id}/audio",
                 "clipBegin": f"{cue.clip_begin_ms / 1000:.3f}s",
                 "clipEnd": f"{cue.clip_end_ms / 1000:.3f}s",
             },

--- a/backend/app/routers/reader.py
+++ b/backend/app/routers/reader.py
@@ -434,7 +434,11 @@ async def get_reader_human_audiobooks(
                 "tracks": [
                     track.model_copy(
                         update={
-                            "audio_url": (f"/reader/human-audiobooks/{edition.id}/tracks/{track.id}/audio"),
+                            "audio_url": track.audio_url.replace(
+                                "/api/imported-audiobooks/",
+                                "/reader/human-audiobooks/",
+                                1,
+                            ),
                             "smil_url": (f"/reader/human-audiobooks/{edition.id}/tracks/{track.id}/smil"),
                         }
                     )
@@ -472,9 +476,9 @@ async def get_reader_human_audiobook_smil(
 ) -> Response:
     response = await audiobook_router.get_imported_track_smil(edition_id, track_id, db)
     text = response.body.decode("utf-8")
-    admin_audio = f"/api/imported-audiobooks/{edition_id}/tracks/{track_id}/audio"
-    reader_audio = f"/reader/human-audiobooks/{edition_id}/tracks/{track_id}/audio"
-    return Response(text.replace(admin_audio, reader_audio), media_type="application/smil+xml")
+    admin_audio_prefix = f"/api/imported-audiobooks/{edition_id}/tracks/"
+    reader_audio_prefix = f"/reader/human-audiobooks/{edition_id}/tracks/"
+    return Response(text.replace(admin_audio_prefix, reader_audio_prefix), media_type="application/smil+xml")
 
 
 def _etag(value: str) -> str:

--- a/backend/tests/test_reader_audiobook.py
+++ b/backend/tests/test_reader_audiobook.py
@@ -42,6 +42,7 @@ async def test_reader_audiobook_capability_and_assets(
     reader_smil = audiobook_publication.reader_smil_bytes(smil_content, "Text/chapter.xhtml")
 
     monkeypatch.setattr(reader, "LIBRARY_PATH", library)
+    monkeypatch.setattr(reader.audiobook_router, "LIBRARY_PATH", library)
     monkeypatch.setattr(audiobook_publication, "LIBRARY_PATH", library)
 
     async with sqlite_sessionmaker() as db:
@@ -67,6 +68,7 @@ async def test_reader_audiobook_capability_and_assets(
         db.add(book)
         db.add(
             models.AudiobookChapter(
+                id=701,
                 book_id=839,
                 chapter_number=1,
                 stable_chapter_key="src-chapter-one",
@@ -87,12 +89,79 @@ async def test_reader_audiobook_capability_and_assets(
                 duration_ms=1250,
             )
         )
+        db.add_all(
+            [
+                models.AudiobookSentence(
+                    id=702,
+                    chapter_id=701,
+                    html_element_id="sentence-1",
+                    sequence_order=0,
+                    original_text="Chapter one.",
+                ),
+                models.AudiobookSentence(
+                    id=703,
+                    chapter_id=701,
+                    html_element_id="sentence-2",
+                    sequence_order=1,
+                    original_text="Chapter two.",
+                ),
+            ]
+        )
         db.add(
             models.ImportedAudiobook(
+                id=70,
                 book_id=839,
                 name="Human narration",
                 status="ready",
             )
+        )
+        db.add(
+            models.ImportedAudiobookTrack(
+                id=71,
+                imported_audiobook_id=70,
+                matched_chapter_id=701,
+                sequence_order=0,
+                title="Chapter One",
+                audio_file_path=_relative(library, audio_path),
+                media_type="audio/mpeg",
+                source_start_ms=0,
+                source_end_ms=1250,
+                duration_ms=1250,
+            )
+        )
+        db.add(
+            models.ImportedAudiobookTrack(
+                id=72,
+                imported_audiobook_id=70,
+                matched_chapter_id=701,
+                sequence_order=1,
+                title="Chapter Two",
+                audio_file_path=_relative(library, audio_path),
+                media_type="audio/mpeg",
+                source_start_ms=1250,
+                source_end_ms=2500,
+                duration_ms=1250,
+            )
+        )
+        db.add_all(
+            [
+                models.ImportedAudiobookCue(
+                    track_id=71,
+                    sentence_id=702,
+                    sequence_order=0,
+                    clip_begin_ms=0,
+                    clip_end_ms=1250,
+                    method="estimated",
+                ),
+                models.ImportedAudiobookCue(
+                    track_id=72,
+                    sentence_id=703,
+                    sequence_order=0,
+                    clip_begin_ms=1250,
+                    clip_end_ms=2500,
+                    method="estimated",
+                ),
+            ]
         )
         db.add(
             models.Book(
@@ -166,6 +235,20 @@ async def test_reader_audiobook_capability_and_assets(
     single = app_client.get("/reader/books/839", auth=auth).json()
     assert single["audiobook"]["status"] == "complete"
     assert single["audiobook_types"] == ["ai_generated", "human_narrated"]
+    human = app_client.get("/reader/books/839/human-audiobooks", auth=auth).json()
+    assert len(human[0]["tracks"]) == 2
+    assert human[0]["audio_size_bytes"] == len(audio_content)
+    canonical_audio_url = "/reader/human-audiobooks/70/tracks/71/audio"
+    assert {track["audio_url"] for track in human[0]["tracks"]} == {canonical_audio_url}
+    for track in human[0]["tracks"]:
+        imported_smil = app_client.get(track["smil_url"], auth=auth)
+        assert imported_smil.status_code == 200
+        assert f'src="{canonical_audio_url}"'.encode() in imported_smil.content
+    assert b'clipBegin="0.000s" clipEnd="1.250s"' in app_client.get(human[0]["tracks"][0]["smil_url"], auth=auth).content
+    assert b'clipBegin="1.250s" clipEnd="2.500s"' in app_client.get(human[0]["tracks"][1]["smil_url"], auth=auth).content
+    imported_audio = app_client.get(canonical_audio_url, auth=auth)
+    assert imported_audio.content == audio_content
+    assert imported_audio.headers["accept-ranges"] == "bytes"
 
     manifest_response = app_client.get(protected_urls[0], auth=auth)
     assert manifest_response.status_code == 200


### PR DESCRIPTION
## Summary

- report imported audiobook size once at the edition level by summing distinct physical audio files
- canonicalize tracks sharing an audio file to one audio URL
- make every generated SMIL reference that canonical URL while retaining chapter-specific absolute clip windows
- add reader contract coverage for shared-file imports, SMIL timing, and byte-range serving

## Why

Chapter tracks extracted from an M4B all reference the same physical source file. Reporting and linking the full file independently for every track multiplied the displayed download size and could cause offline clients to download the same audiobook once per chapter. For Dungeon Crawler Carl, a roughly 738 MiB M4B could be presented as tens of gigabytes.

After this change, clients see the actual edition size and can deduplicate the shared audio resource by URL. Streaming and SMIL playback continue to seek using absolute timestamps into the source file.

## Validation

- `PYTHONPATH=. uv run pytest backend/tests/test_reader_audiobook.py backend/tests/test_audiobook_pipeline.py -q` — 64 passed
- Black formatting check passed
- Flake8 passed