### PR TITLE
Harden audiobook generation and rebuild recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ Run the Story Manager OmniVoice image as a second Unraid container:
 | Model cache | `/mnt/user/appdata/story-manager-omnivoice/models` -> `/models` (read/write) |
 | `OMNIVOICE_DEVICE` | `auto` |
 | `OMNIVOICE_NUM_STEPS` | `16` |
+| `OMNIVOICE_NATIVE_BATCHING` | `false` |
+| `OMNIVOICE_QUALITY_ATTEMPTS` | `3` |
 
 For an NVIDIA GPU, install Unraid's NVIDIA driver support and add `--gpus all` under **Extra Parameters**. The image
 can fall back to CPU when no supported GPU is available, but whole-book generation will be much slower. The first

--- a/backend/app/crud/audiobook.py
+++ b/backend/app/crud/audiobook.py
@@ -653,7 +653,7 @@ async def delete_characters_for_book(db: AsyncSession, book_id: int) -> None:
 
 
 async def reset_roster_and_diarization_for_book(db: AsyncSession, book_id: int) -> None:
-    """Clear derived speaker analysis while preserving the expensive EPUB ingestion."""
+    """Clear AI analysis/audio while preserving ingestion and human audiobook cues."""
     chapter_ids = select(AudiobookChapter.id).where(AudiobookChapter.book_id == book_id)
     await db.execute(
         update(AudiobookSentence)
@@ -677,10 +677,57 @@ async def reset_roster_and_diarization_for_book(db: AsyncSession, book_id: int) 
             needs_reassembly=True,
             preview_status=None,
             preview_error=None,
+            audio_file_path=None,
+            smil_file_path=None,
+            reader_audio_file_path=None,
+            reader_smil_file_path=None,
+            audio_size_bytes=None,
+            audio_sha256=None,
+            smil_size_bytes=None,
+            smil_sha256=None,
+            duration_ms=None,
+            generation_state="pending",
         )
     )
     await db.commit()
+    await invalidate_packaged_audiobook(db, book_id)
     await delete_characters_for_book(db, book_id)
+
+
+async def reset_audio_generation_for_book(db: AsyncSession, book_id: int) -> int:
+    """Clear only AI TTS/assembly output, preserving speakers and human cues."""
+    chapter_ids = select(AudiobookChapter.id).where(AudiobookChapter.book_id == book_id)
+    result = await db.execute(
+        update(AudiobookSentence)
+        .where(AudiobookSentence.chapter_id.in_(chapter_ids))
+        .values(
+            audio_file_path=None,
+            audio_duration_ms=None,
+            status="ready_for_audio",
+        )
+    )
+    await db.execute(
+        update(AudiobookChapter)
+        .where(AudiobookChapter.book_id == book_id)
+        .values(
+            needs_reassembly=True,
+            preview_status=None,
+            preview_error=None,
+            audio_file_path=None,
+            smil_file_path=None,
+            reader_audio_file_path=None,
+            reader_smil_file_path=None,
+            audio_size_bytes=None,
+            audio_sha256=None,
+            smil_size_bytes=None,
+            smil_sha256=None,
+            duration_ms=None,
+            generation_state="pending",
+        )
+    )
+    await db.commit()
+    await invalidate_packaged_audiobook(db, book_id)
+    return result.rowcount or 0
 
 
 # ---------------------------------------------------------------------------
@@ -871,6 +918,21 @@ async def reset_error_sentences_for_book(db: AsyncSession, book_id: int) -> int:
         .values(status="ready_for_audio", audio_file_path=None, audio_duration_ms=None)
     )
     await db.execute(update(AudiobookChapter).where(AudiobookChapter.book_id == book_id).values(needs_reassembly=True))
+    await db.commit()
+    return result.rowcount or 0
+
+
+async def reset_interrupted_sentences_for_book(db: AsyncSession, book_id: int) -> int:
+    """Reclaim speech clips whose in-memory worker disappeared during a restart."""
+    chapter_ids = select(AudiobookChapter.id).where(AudiobookChapter.book_id == book_id)
+    result = await db.execute(
+        update(AudiobookSentence)
+        .where(
+            AudiobookSentence.chapter_id.in_(chapter_ids),
+            AudiobookSentence.status.in_(("audio_queued", "audio_generating")),
+        )
+        .values(status="ready_for_audio", audio_file_path=None, audio_duration_ms=None)
+    )
     await db.commit()
     return result.rowcount or 0
 

--- a/backend/app/routers/audiobook.py
+++ b/backend/app/routers/audiobook.py
@@ -302,6 +302,7 @@ class ImportedAudiobookResponse(BaseModel):
     error: Optional[str]
     alignment_error: Optional[str]
     created_at: datetime
+    is_reader_default: bool = False
     tracks: list[ImportedTrackResponse]
 
 
@@ -358,6 +359,8 @@ async def _canonical_audio_track_id(track: ImportedAudiobookTrack, db: AsyncSess
 async def _imported_audiobook_response(
     edition: ImportedAudiobook,
     db: AsyncSession,
+    *,
+    is_reader_default: bool = False,
 ) -> ImportedAudiobookResponse:
     result = await db.execute(
         select(ImportedAudiobookTrack)
@@ -397,6 +400,7 @@ async def _imported_audiobook_response(
         error=edition.error,
         alignment_error=edition.alignment_error,
         created_at=edition.created_at,
+        is_reader_default=is_reader_default,
         tracks=[
             ImportedTrackResponse(
                 id=track.id,
@@ -458,7 +462,16 @@ async def list_imported_audiobooks(
         .where(ImportedAudiobook.book_id == book_id)
         .order_by(ImportedAudiobook.created_at.desc(), ImportedAudiobook.id.desc())
     )
-    return [await _imported_audiobook_response(edition, db) for edition in result.scalars().all()]
+    editions = list(result.scalars().all())
+    reader_default_id = next((edition.id for edition in editions if edition.status == "ready"), None)
+    return [
+        await _imported_audiobook_response(
+            edition,
+            db,
+            is_reader_default=edition.id == reader_default_id,
+        )
+        for edition in editions
+    ]
 
 
 @router.post(
@@ -596,6 +609,50 @@ async def align_imported_audiobook(
     return await _imported_audiobook_response(edition, db)
 
 
+@router.post(
+    "/api/imported-audiobooks/{edition_id}/rematch",
+    response_model=ImportedAudiobookResponse,
+)
+async def rematch_imported_audiobook(
+    edition_id: int,
+    db: AsyncSession = Depends(get_db),
+) -> ImportedAudiobookResponse:
+    """Rebuild human-audio chapter matches and text cues without reimporting audio."""
+    edition = await db.get(ImportedAudiobook, edition_id)
+    if edition is None:
+        raise HTTPException(status_code=404, detail="Imported audiobook not found")
+    book = await _get_book_or_404(edition.book_id, db)
+    if edition.status in ("queued", "importing", "aligning", "stale"):
+        raise HTTPException(status_code=409, detail=f"Audiobook is already {edition.status}")
+    track_count = await db.scalar(
+        select(func.count(ImportedAudiobookTrack.id)).where(
+            ImportedAudiobookTrack.imported_audiobook_id == edition.id,
+        )
+    )
+    if not track_count:
+        raise HTTPException(status_code=409, detail="This audiobook has no imported audio tracks")
+
+    realign = edition.alignment_method in {"transcribed", "hybrid"}
+    edition.status = "stale"
+    edition.alignment_error = None
+    edition.progress_current = 0
+    edition.progress_total = track_count
+    edition.progress_detail = "Chapter rematch queued"
+    await db.commit()
+    await queue_processing_job(
+        db=db,
+        job_type="rematch_imported_audiobook",
+        book_id=book.id,
+        target_type="imported_audiobook",
+        target_id=edition.id,
+        target_content_version=book.content_version,
+        payload={"realign": realign},
+        dedupe_key=f"rematch_imported_audiobook:imported_audiobook:{edition.id}:v{book.content_version or 1}",
+        progress_detail="Queued to restore human-audio chapter matches and text cues",
+    )
+    return await _imported_audiobook_response(edition, db)
+
+
 @router.delete("/api/imported-audiobooks/{edition_id}", status_code=204)
 async def delete_imported_audiobook(
     edition_id: int,
@@ -694,12 +751,13 @@ async def get_imported_track_smil(
     root = ET.Element("smil", {"xmlns": "http://www.w3.org/ns/SMIL", "version": "3.0"})
     body = ET.SubElement(root, "body")
     seq = ET.SubElement(body, "seq")
+    chapter_text_href = chapter.content_file_name.replace("\\", "/").rsplit("/", 1)[-1]
     for cue, sentence in result.all():
         par = ET.SubElement(seq, "par")
         ET.SubElement(
             par,
             "text",
-            {"src": f"{chapter.content_file_name}#{sentence.html_element_id}"},
+            {"src": f"{chapter_text_href}#{sentence.html_element_id}"},
         )
         ET.SubElement(
             par,
@@ -849,9 +907,45 @@ async def rebuild_pipeline(book_id: int, db: AsyncSession = Depends(get_db)) -> 
         target_content_version=book.content_version,
         payload={"mode": "rebuild"},
         dedupe_key=f"audiobook_pipeline:book:{book_id}:rebuild",
-        progress_detail="Queued force-full audiobook rebuild",
+        progress_detail="Queued AI audiobook rebuild; human editions preserved",
     )
     return {"status": book.audiobook_pipeline_status, "queued": True}
+
+
+@router.post("/api/books/{book_id}/audiobook/audio/rebuild")
+async def rebuild_audio_only(book_id: int, db: AsyncSession = Depends(get_db)) -> dict[str, Any]:
+    """Regenerate AI TTS and assembly without changing speaker analysis."""
+    book = await _get_audiobook_book_or_404(book_id, db)
+    if book.audiobook_pipeline_status in ("ingesting", "roster_gen", "diarizing", "audio_gen", "assembling"):
+        raise HTTPException(status_code=409, detail="Pause the active pipeline before regenerating AI audio")
+    chapters = await crud.audiobook.get_chapters_for_book(db, book_id)
+    characters = await crud.audiobook.get_characters_for_book(db, book_id)
+    review = await crud.audiobook.count_sentence_review_flags(db, book_id)
+    if not chapters or not characters:
+        raise HTTPException(status_code=409, detail="Run AI speaker analysis before regenerating TTS audio")
+    if review.get("unassigned", 0):
+        raise HTTPException(status_code=409, detail="Assign every sentence before regenerating TTS audio")
+
+    await crud.audiobook.reset_audio_generation_for_book(db, book_id)
+    await crud.audiobook.configure_book_pipeline_run(
+        db,
+        book_id,
+        status="audio_gen",
+        stop_after_phase=None,
+    )
+    await queue_processing_job(
+        db=db,
+        job_type="audiobook_pipeline",
+        book_id=book_id,
+        target_type="book",
+        target_id=book_id,
+        target_content_version=book.content_version,
+        payload={"mode": "audio"},
+        dedupe_key=f"audiobook_pipeline:book:{book_id}:audio-rebuild",
+        progress_detail="Queued AI TTS regeneration; speakers and human editions preserved",
+    )
+    await _notify_legacy_queue(get_audiobook_queue, "enqueue", book_id)
+    return {"status": "audio_gen", "queued": True}
 
 
 @router.post("/api/books/{book_id}/audiobook/roster/rebuild")

--- a/backend/app/services/audiobook_queue.py
+++ b/backend/app/services/audiobook_queue.py
@@ -388,6 +388,17 @@ class AudiobookQueue:
                     # A process restart can resume directly in this phase, after
                     # the in-memory TTS queue has been lost. Rebuild it from
                     # durable sentence state and preserve length bucketing.
+                    if not self._background_audio_ids.get(book_id):
+                        recovered = await crud.audiobook.reset_interrupted_sentences_for_book(
+                            db,
+                            book_id,
+                        )
+                        if recovered:
+                            logger.warning(
+                                "Book %s: reclaiming %d interrupted speech clips.",
+                                book_id,
+                                recovered,
+                            )
                     ready_sentences = await crud.audiobook.get_sentences_ready_for_audio(
                         db,
                         book_id,

--- a/backend/app/services/processing_queue.py
+++ b/backend/app/services/processing_queue.py
@@ -329,10 +329,23 @@ class ProcessingQueue:
                 raise ValueError("AI audiobook generation is not enabled for this book.")
 
             if mode == "rebuild":
-                await crud.audiobook.delete_chapters_for_book(db, book.id)
-                await crud.audiobook.delete_characters_for_book(db, book.id)
+                chapters = await crud.audiobook.get_chapters_for_book(db, book.id)
+                if chapters:
+                    await crud.audiobook.reset_roster_and_diarization_for_book(db, book.id)
                 await crud.audiobook.set_book_audiobook_summary(db, book.id, None)
-                next_phase = "ingesting"
+                next_phase = "roster_gen" if chapters else "ingesting"
+                stop_after = None
+                batch_limit = None
+            elif mode == "audio":
+                chapters = await crud.audiobook.get_chapters_for_book(db, book.id)
+                characters = await crud.audiobook.get_characters_for_book(db, book.id)
+                review = await crud.audiobook.count_sentence_review_flags(db, book.id)
+                if not chapters or not characters:
+                    raise ValueError("Run AI speaker analysis before regenerating TTS audio.")
+                if review.get("unassigned", 0):
+                    raise ValueError("Assign every sentence before regenerating TTS audio.")
+                await crud.audiobook.reset_audio_generation_for_book(db, book.id)
+                next_phase = "audio_gen"
                 stop_after = None
                 batch_limit = None
             elif mode == "roster":

--- a/backend/app/services/tts_providers.py
+++ b/backend/app/services/tts_providers.py
@@ -79,6 +79,11 @@ def _plain_text(text: str) -> str:
     return " ".join(_EXPRESSION_TAG_RE.sub("", text).split())
 
 
+def _has_spoken_content(text: str) -> bool:
+    """Return whether text contains something a speech model can pronounce."""
+    return any(character.isalnum() for character in _plain_text(text))
+
+
 def _openai_speech_url(base_url: str) -> str:
     root = base_url.rstrip("/")
     if root.endswith("/audio/speech"):
@@ -246,6 +251,8 @@ async def synthesize_speech(
     request: TTSRequest,
 ) -> bytes:
     """Generate an MP3 using the first available endpoint."""
+    if not _has_spoken_content(request.text):
+        return await _stub_speech("")
     if settings is None:
         return await _stub_speech(request.text)
     routed = await synthesize_speech_routed(settings, request)
@@ -259,14 +266,26 @@ async def synthesize_speech_batch(
     """Generate a true model batch when supported, with a sequential fallback."""
     if not requests:
         return []
+
+    spoken_requests = [request for request in requests if _has_spoken_content(request.text)]
     if settings is None:
-        return [TTSResult(await _stub_speech(request.text)) for request in requests]
-    routed = await route_request(
-        settings,
-        "tts",
-        lambda endpoint_settings: _synthesize_speech_batch_endpoint(endpoint_settings, requests),
-    )
-    return routed.value
+        spoken_results = [TTSResult(await _stub_speech(request.text)) for request in spoken_requests]
+    elif spoken_requests:
+        routed = await route_request(
+            settings,
+            "tts",
+            lambda endpoint_settings: _synthesize_speech_batch_endpoint(endpoint_settings, spoken_requests),
+        )
+        spoken_results = routed.value
+    else:
+        spoken_results = []
+
+    if len(spoken_requests) == len(requests):
+        return spoken_results
+
+    silence = TTSResult(await _stub_speech(""))
+    spoken = iter(spoken_results)
+    return [next(spoken) if _has_spoken_content(request.text) else silence for request in requests]
 
 
 async def _synthesize_speech_batch_endpoint(

--- a/backend/tests/test_audiobook_import.py
+++ b/backend/tests/test_audiobook_import.py
@@ -17,6 +17,7 @@ from backend.app.models import (
     ImportedAudiobook,
     ImportedAudiobookCue,
     ImportedAudiobookTrack,
+    ProcessingJob,
 )
 from backend.app.routers import audiobook as audiobook_router
 from backend.app.services import audiobook_import
@@ -317,3 +318,51 @@ async def test_alignment_endpoint_durably_queues_ready_edition(
     assert response.json()["status"] == "aligning"
     assert response.json()["progress_total"] == 1
     assert queue.queued == [edition_id]
+
+
+@pytest.mark.asyncio
+async def test_rematch_endpoint_queues_cue_recovery_without_reimporting_audio(
+    app_client,
+    sqlite_sessionmaker,
+):
+    async with sqlite_sessionmaker() as db:
+        book, _chapter = await _seed_book_text(db)
+        edition = ImportedAudiobook(
+            book_id=book.id,
+            name="Damaged alignment",
+            status="ready",
+            alignment_method="transcribed",
+        )
+        db.add(edition)
+        await db.flush()
+        db.add(
+            ImportedAudiobookTrack(
+                imported_audiobook_id=edition.id,
+                sequence_order=0,
+                title="Chapter 1",
+                audio_file_path="library/audio.m4b",
+                media_type="audio/mp4",
+                source_start_ms=0,
+                source_end_ms=10_000,
+                duration_ms=10_000,
+            )
+        )
+        await db.commit()
+        edition_id = edition.id
+
+    response = app_client.post(f"/api/imported-audiobooks/{edition_id}/rematch")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "stale"
+    async with sqlite_sessionmaker() as db:
+        edition = await db.get(ImportedAudiobook, edition_id)
+        job = (
+            await db.execute(
+                select(ProcessingJob).where(
+                    ProcessingJob.job_type == "rematch_imported_audiobook",
+                    ProcessingJob.target_id == edition_id,
+                )
+            )
+        ).scalar_one()
+        assert edition.status == "stale"
+        assert job.payload == {"realign": True}

--- a/backend/tests/test_audiobook_pipeline.py
+++ b/backend/tests/test_audiobook_pipeline.py
@@ -20,10 +20,12 @@ from backend.app.services import (
     audiobook_publication,
     audiobook_text,
     audiobook_tts,
+    processing_queue,
     web_novel,
 )
 from backend.app.services import audiobook_queue
 from backend.app.services.audiobook_queue import AudiobookQueue
+from backend.app.services.processing_queue import ProcessingQueue
 
 
 async def _make_book(db, **overrides):
@@ -1074,6 +1076,36 @@ async def test_roster_rebuild_preserves_ingestion_and_clears_derived_analysis(db
     chapter.summary = "Old summary"
     sentence.speaker_confidence = 0.9
     sentence.audio_file_path = "library/audiobooks/1/snippets/1.mp3"
+    edition = models.ImportedAudiobook(
+        book_id=book.id,
+        name="Human edition",
+        status="ready",
+    )
+    db.add(edition)
+    await db.flush()
+    track = models.ImportedAudiobookTrack(
+        imported_audiobook_id=edition.id,
+        matched_chapter_id=chapter.id,
+        sequence_order=0,
+        title="Chapter 1",
+        audio_file_path="library/audiobooks/1/imports/1/chapter.mp3",
+        media_type="audio/mpeg",
+        source_start_ms=0,
+        source_end_ms=10_000,
+        duration_ms=10_000,
+    )
+    db.add(track)
+    await db.flush()
+    cue = models.ImportedAudiobookCue(
+        track_id=track.id,
+        sentence_id=sentence.id,
+        sequence_order=0,
+        clip_begin_ms=0,
+        clip_end_ms=1_000,
+        confidence=0.9,
+        method="transcribed",
+    )
+    db.add(cue)
     await db.commit()
     queue = _FakeQueue()
     monkeypatch.setattr(audiobook_router, "get_audiobook_queue", lambda: queue)
@@ -1095,7 +1127,115 @@ async def test_roster_rebuild_preserves_ingestion_and_clears_derived_analysis(db
     assert sentence.audio_file_path is None
     assert chapter.summary is None
     assert await crud.audiobook.get_characters_for_book(db, book.id) == []
+    preserved_track = await db.get(models.ImportedAudiobookTrack, track.id)
+    preserved_cue = await db.get(models.ImportedAudiobookCue, cue.id)
+    assert preserved_track is not None
+    assert preserved_track.matched_chapter_id == chapter.id
+    assert preserved_cue is not None
+    assert preserved_cue.sentence_id == sentence.id
     assert queue.enqueued == [book.id]
+
+
+@pytest.mark.asyncio
+async def test_audio_only_rebuild_preserves_speakers_and_human_audiobook(db, monkeypatch):
+    book = await _make_book(db, audiobook_enabled=True, audiobook_pipeline_status="complete")
+    chapter, character, sentence = await _seed_audio_chapter(
+        db,
+        book.id,
+        sentence_status="audio_generated",
+    )
+    sentence.tagged_text = "[whisper] One sentence."
+    sentence.speaker_confidence = 0.91
+    sentence.speaker_reason = "Explicit attribution"
+    sentence.audio_file_path = "library/audiobooks/1/snippets/1.mp3"
+    sentence.audio_duration_ms = 1_000
+    edition = models.ImportedAudiobook(book_id=book.id, name="Human edition", status="ready")
+    db.add(edition)
+    await db.flush()
+    track = models.ImportedAudiobookTrack(
+        imported_audiobook_id=edition.id,
+        matched_chapter_id=chapter.id,
+        sequence_order=0,
+        title="Chapter 1",
+        audio_file_path="library/audiobooks/1/imports/1/chapter.mp3",
+        media_type="audio/mpeg",
+        source_start_ms=0,
+        source_end_ms=10_000,
+        duration_ms=10_000,
+    )
+    db.add(track)
+    await db.flush()
+    cue = models.ImportedAudiobookCue(
+        track_id=track.id,
+        sentence_id=sentence.id,
+        sequence_order=0,
+        clip_begin_ms=0,
+        clip_end_ms=1_000,
+        confidence=0.9,
+        method="transcribed",
+    )
+    db.add(cue)
+    await db.commit()
+    queue = _FakeQueue()
+    monkeypatch.setattr(audiobook_router, "get_audiobook_queue", lambda: queue)
+
+    response = await audiobook_router.rebuild_audio_only(book.id, db)
+
+    await db.refresh(book)
+    await db.refresh(chapter)
+    await db.refresh(sentence)
+    assert response == {"status": "audio_gen", "queued": True}
+    assert book.audiobook_pipeline_status == "audio_gen"
+    assert sentence.status == "ready_for_audio"
+    assert sentence.character_id == character.id
+    assert sentence.tagged_text == "[whisper] One sentence."
+    assert sentence.speaker_confidence == 0.91
+    assert sentence.speaker_reason == "Explicit attribution"
+    assert sentence.audio_file_path is None
+    assert chapter.audio_file_path is None
+    assert chapter.needs_reassembly is True
+    preserved_track = await db.get(models.ImportedAudiobookTrack, track.id)
+    preserved_cue = await db.get(models.ImportedAudiobookCue, cue.id)
+    assert preserved_track is not None
+    assert preserved_track.matched_chapter_id == chapter.id
+    assert preserved_cue is not None
+    assert preserved_cue.sentence_id == sentence.id
+    assert queue.enqueued == [book.id]
+
+
+@pytest.mark.asyncio
+async def test_force_rebuild_worker_preserves_ingested_ids(
+    db,
+    sqlite_sessionmaker,
+    monkeypatch,
+):
+    book = await _make_book(db, audiobook_enabled=True, audiobook_pipeline_status="complete")
+    chapter, _character, sentence = await _seed_audio_chapter(
+        db,
+        book.id,
+        sentence_status="audio_generated",
+    )
+    book_id = book.id
+    chapter_id = chapter.id
+    sentence_id = sentence.id
+
+    class FakeAudiobookQueue:
+        async def process_book(self, _book_id):
+            return None
+
+    monkeypatch.setattr(processing_queue, "SessionLocal", sqlite_sessionmaker)
+    monkeypatch.setattr(processing_queue, "get_audiobook_queue", lambda: FakeAudiobookQueue())
+
+    await ProcessingQueue()._run_audiobook_pipeline(SimpleNamespace(id=987, book_id=book_id, payload={"mode": "rebuild"}))
+
+    db.expire_all()
+    preserved_chapter = await db.get(models.AudiobookChapter, chapter_id)
+    preserved_sentence = await db.get(models.AudiobookSentence, sentence_id)
+    refreshed_book = await db.get(models.Book, book_id)
+    assert preserved_chapter is not None
+    assert preserved_sentence is not None
+    assert preserved_sentence.status == "pending_diarization"
+    assert refreshed_book.audiobook_pipeline_status == "roster_gen"
 
 
 @pytest.mark.asyncio
@@ -1163,6 +1303,47 @@ async def test_restarted_audio_phase_rebuilds_length_bucketed_background_queue(
 
     await queue._process(book.id)
 
+    assert enqueued == [(book.id, [sentence.id])]
+
+
+@pytest.mark.asyncio
+async def test_restarted_audio_phase_reclaims_interrupted_sentences(
+    db,
+    sqlite_sessionmaker,
+    monkeypatch,
+):
+    book = await _make_book(
+        db,
+        audiobook_enabled=True,
+        audiobook_pipeline_status="audio_gen",
+        audiobook_stop_after_phase="audio_gen",
+    )
+    _chapter, _character, sentence = await _seed_audio_chapter(
+        db,
+        book.id,
+        sentence_status="audio_generating",
+    )
+    queue = AudiobookQueue()
+    enqueued: list[tuple[int, list[int]]] = []
+
+    async def record_background_audio(book_id, sentence_ids):
+        enqueued.append((book_id, sentence_ids))
+
+    async def finish_audio(book_id, phase_db):
+        await crud.audiobook.set_book_pipeline_status(phase_db, book_id, "assembling")
+
+    async def wait_for_audio(_book_id):
+        return None
+
+    monkeypatch.setattr(audiobook_queue, "SessionLocal", sqlite_sessionmaker)
+    monkeypatch.setattr(queue, "enqueue_background_audio", record_background_audio)
+    monkeypatch.setattr(queue, "_wait_for_background_audio", wait_for_audio)
+    monkeypatch.setattr(audiobook_queue, "generate_audio_for_book", finish_audio)
+
+    await queue._process(book.id)
+
+    await db.refresh(sentence)
+    assert sentence.status == "ready_for_audio"
     assert enqueued == [(book.id, [sentence.id])]
 
 

--- a/backend/tests/test_omnivoice_adapter.py
+++ b/backend/tests/test_omnivoice_adapter.py
@@ -50,9 +50,7 @@ def test_accepts_speech_like_audio_with_natural_variation():
     time = np.arange(sampling_rate * 2) / sampling_rate
     envelope = np.maximum(0, np.sin(2 * np.pi * 1.3 * time)) ** 2
     samples = envelope * (
-        0.12 * np.sin(2 * np.pi * 130 * time)
-        + 0.06 * np.sin(2 * np.pi * 260 * time)
-        + 0.03 * np.sin(2 * np.pi * 390 * time)
+        0.12 * np.sin(2 * np.pi * 130 * time) + 0.06 * np.sin(2 * np.pi * 260 * time) + 0.03 * np.sin(2 * np.pi * 390 * time)
     )
 
     report = validate_generated_audio(samples.astype(np.float32), sampling_rate)

--- a/backend/tests/test_omnivoice_adapter.py
+++ b/backend/tests/test_omnivoice_adapter.py
@@ -1,3 +1,7 @@
+import numpy as np
+import pytest
+
+from services.omnivoice.audio_quality import AudioQualityError, validate_generated_audio
 from services.omnivoice.prompt import translate_generation_prompt
 
 
@@ -30,3 +34,27 @@ def test_accepts_native_omnivoice_instruction():
     )
 
     assert prompt.instruct == "male, elderly, low pitch, american accent"
+
+
+def test_rejects_stationary_mechanical_noise():
+    sampling_rate = 24000
+    rng = np.random.default_rng(42)
+    samples = rng.normal(0, 0.08, sampling_rate * 2).astype(np.float32)
+
+    with pytest.raises(AudioQualityError, match="stationary mechanical noise"):
+        validate_generated_audio(samples, sampling_rate)
+
+
+def test_accepts_speech_like_audio_with_natural_variation():
+    sampling_rate = 24000
+    time = np.arange(sampling_rate * 2) / sampling_rate
+    envelope = np.maximum(0, np.sin(2 * np.pi * 1.3 * time)) ** 2
+    samples = envelope * (
+        0.12 * np.sin(2 * np.pi * 130 * time)
+        + 0.06 * np.sin(2 * np.pi * 260 * time)
+        + 0.03 * np.sin(2 * np.pi * 390 * time)
+    )
+
+    report = validate_generated_audio(samples.astype(np.float32), sampling_rate)
+
+    assert report.has_stationary_mechanical_noise is False

--- a/backend/tests/test_reader_audiobook.py
+++ b/backend/tests/test_reader_audiobook.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -113,6 +114,16 @@ async def test_reader_audiobook_capability_and_assets(
                 book_id=839,
                 name="Human narration",
                 status="ready",
+                created_at=datetime(2026, 7, 2, 15, 30, tzinfo=timezone.utc),
+            )
+        )
+        db.add(
+            models.ImportedAudiobook(
+                id=69,
+                book_id=839,
+                name="Older human narration",
+                status="ready",
+                created_at=datetime(2026, 7, 1, 15, 30, tzinfo=timezone.utc),
             )
         )
         db.add(
@@ -236,6 +247,9 @@ async def test_reader_audiobook_capability_and_assets(
     assert single["audiobook"]["status"] == "complete"
     assert single["audiobook_types"] == ["ai_generated", "human_narrated"]
     human = app_client.get("/reader/books/839/human-audiobooks", auth=auth).json()
+    assert [edition["id"] for edition in human] == [70, 69]
+    assert [edition["is_reader_default"] for edition in human] == [True, False]
+    assert human[0]["created_at"].startswith("2026-07-02T15:30:00")
     assert len(human[0]["tracks"]) == 2
     assert human[0]["audio_size_bytes"] == len(audio_content)
     canonical_audio_url = "/reader/human-audiobooks/70/tracks/71/audio"
@@ -244,6 +258,7 @@ async def test_reader_audiobook_capability_and_assets(
         imported_smil = app_client.get(track["smil_url"], auth=auth)
         assert imported_smil.status_code == 200
         assert f'src="{canonical_audio_url}"'.encode() in imported_smil.content
+        assert b'src="chapter.xhtml#' in imported_smil.content
     assert b'clipBegin="0.000s" clipEnd="1.250s"' in app_client.get(human[0]["tracks"][0]["smil_url"], auth=auth).content
     assert b'clipBegin="1.250s" clipEnd="2.500s"' in app_client.get(human[0]["tracks"][1]["smil_url"], auth=auth).content
     imported_audio = app_client.get(canonical_audio_url, auth=auth)

--- a/backend/tests/test_tts_providers.py
+++ b/backend/tests/test_tts_providers.py
@@ -105,6 +105,27 @@ async def test_omnivoice_batches_multiple_sentences_in_one_model_request():
 
 
 @pytest.mark.asyncio
+async def test_punctuation_only_batch_uses_local_silence(monkeypatch):
+    settings = models.AudiobookSettings(
+        tts_provider="omnivoice",
+        tts_base_url="http://omnivoice:8001",
+    )
+
+    async def silence(_text):
+        return b"silent-mp3"
+
+    monkeypatch.setattr(tts_providers, "_stub_speech", silence)
+
+    results = await tts_providers.synthesize_speech_batch(
+        settings,
+        [TTSRequest(text="."), TTSRequest(text="[sigh] !")],
+    )
+
+    assert [result.audio_bytes for result in results] == [b"silent-mp3", b"silent-mp3"]
+    assert _Client.calls == []
+
+
+@pytest.mark.asyncio
 async def test_openai_compatible_uses_voice_id_and_compatible_payload():
     settings = models.AudiobookSettings(
         tts_provider="openai-compatible",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1562,9 +1562,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1203,7 +1203,11 @@
 }
 
 .book-rows--web .book-row {
-  background: linear-gradient(180deg, var(--surface), color-mix(in srgb, var(--accent) 6%, transparent));
+  background: linear-gradient(
+    180deg,
+    var(--surface),
+    color-mix(in srgb, var(--accent) 6%, transparent)
+  );
 }
 
 .library-filters {
@@ -1559,6 +1563,13 @@
   align-items: flex-start;
   justify-content: space-between;
   gap: 1rem;
+}
+
+.imported-edition-badges {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.4rem;
 }
 
 .import-progress {
@@ -2159,8 +2170,7 @@
 .audiobook-reader-text .audiobook-sentence--active {
   color: var(--text);
   background: color-mix(in srgb, var(--accent) 24%, var(--surface));
-  box-shadow: 0 0 0 0.15rem
-    color-mix(in srgb, var(--accent) 12%, transparent);
+  box-shadow: 0 0 0 0.15rem color-mix(in srgb, var(--accent) 12%, transparent);
 }
 
 .audiobook-reader-chapters {
@@ -3280,7 +3290,14 @@
 /* ─── Editorial desk redesign ────────────────────────────── */
 body {
   background:
-    linear-gradient(90deg, transparent 0, transparent calc(50% - 590px), rgba(226, 214, 192, 0.035) calc(50% - 590px), rgba(226, 214, 192, 0.035) calc(50% - 589px), transparent calc(50% - 589px)),
+    linear-gradient(
+      90deg,
+      transparent 0,
+      transparent calc(50% - 590px),
+      rgba(226, 214, 192, 0.035) calc(50% - 590px),
+      rgba(226, 214, 192, 0.035) calc(50% - 589px),
+      transparent calc(50% - 589px)
+    ),
     var(--bg);
 }
 
@@ -3974,10 +3991,18 @@ body {
   background: var(--bg);
 }
 
-.processing-job--running { border-left-color: var(--accent); }
-.processing-job--queued { border-left-color: var(--warning); }
-.processing-job--completed { border-left-color: var(--success); }
-.processing-job--error { border-left-color: var(--danger); }
+.processing-job--running {
+  border-left-color: var(--accent);
+}
+.processing-job--queued {
+  border-left-color: var(--warning);
+}
+.processing-job--completed {
+  border-left-color: var(--success);
+}
+.processing-job--error {
+  border-left-color: var(--danger);
+}
 
 .processing-job-main a {
   color: var(--accent);
@@ -3989,10 +4014,22 @@ body {
   background: transparent;
 }
 
-.processing-status--running { color: var(--accent); background: transparent; }
-.processing-status--queued { color: var(--warning); background: transparent; }
-.processing-status--completed { color: var(--success); background: transparent; }
-.processing-status--error { color: var(--danger); background: transparent; }
+.processing-status--running {
+  color: var(--accent);
+  background: transparent;
+}
+.processing-status--queued {
+  color: var(--warning);
+  background: transparent;
+}
+.processing-status--completed {
+  color: var(--success);
+  background: transparent;
+}
+.processing-status--error {
+  color: var(--danger);
+  background: transparent;
+}
 
 .processing-job-progress progress {
   accent-color: var(--accent);

--- a/frontend/src/api/audiobook.js
+++ b/frontend/src/api/audiobook.js
@@ -43,6 +43,13 @@ export function rebuildPipeline(bookId) {
   });
 }
 
+export function rebuildAudioOnly(bookId) {
+  return sendWithoutBody(`/api/books/${bookId}/audiobook/audio/rebuild`, {
+    method: "POST",
+    fallbackMessage: "Failed to regenerate AI audio",
+  });
+}
+
 export function rebuildCharacterRoster(bookId) {
   return sendWithoutBody(`/api/books/${bookId}/audiobook/roster/rebuild`, {
     method: "POST",
@@ -163,6 +170,13 @@ export function alignImportedAudiobook(editionId) {
   return sendWithoutBody(`/api/imported-audiobooks/${editionId}/align`, {
     method: "POST",
     fallbackMessage: "Failed to start audiobook timestamp alignment",
+  });
+}
+
+export function rematchImportedAudiobook(editionId) {
+  return sendWithoutBody(`/api/imported-audiobooks/${editionId}/rematch`, {
+    method: "POST",
+    fallbackMessage: "Failed to rematch audiobook to book text",
   });
 }
 

--- a/frontend/src/components/AudiobookPipeline.jsx
+++ b/frontend/src/components/AudiobookPipeline.jsx
@@ -9,6 +9,7 @@ import {
   runPipelineBatch,
   pausePipeline,
   rebuildPipeline,
+  rebuildAudioOnly,
   getAudiobookDownloadUrl,
   getImportedAudiobooks,
 } from "../api/audiobook";
@@ -135,6 +136,7 @@ function AudiobookPipeline({
     book.audiobook_enabled === undefined ? "progress" : "sources",
   );
   const [confirmRebuild, setConfirmRebuild] = useState(false);
+  const [confirmAudioRebuild, setConfirmAudioRebuild] = useState(false);
   const [lastQueuedJob, setLastQueuedJob] = useState(null);
 
   const isActive = (status) => ACTIVE_STATUSES.has(status);
@@ -232,6 +234,15 @@ function AudiobookPipeline({
     },
   });
 
+  const audioRebuildMutation = useMutation({
+    mutationFn: () => rebuildAudioOnly(bookId),
+    onSuccess: (data) => {
+      setLastQueuedJob(data.processing_job_id || true);
+      setConfirmAudioRebuild(false);
+      invalidateAll();
+    },
+  });
+
   const pipelineStatus = statusData?.pipeline_status ?? null;
   const nextPhase = statusData?.next_phase ?? "ingesting";
   const pauseRequested = statusData?.pause_requested ?? false;
@@ -278,148 +289,189 @@ function AudiobookPipeline({
   return (
     <div className="audiobook-pipeline">
       {aiEnabled && (
-      <div className="pipeline-header">
-        <PipelineProgress status={progressStatus} />
+        <div className="pipeline-header">
+          <PipelineProgress status={progressStatus} />
 
-        <div className="pipeline-meta">
-          {totalSentences > 0 && (
-            <span className="pipeline-sentence-count">
-              {doneCount} / {totalSentences} sentences with audio
-            </span>
-          )}
-          {pipelineStatus === "error" && (
-            <span className="badge badge--error">Pipeline error</span>
-          )}
-          {pipelineStatus === "paused" && (
-            <span className="badge badge--warning">
-              Paused — next: {nextPhaseLabel}
-            </span>
-          )}
-          {pauseRequested && (
-            <span className="badge badge--warning">Pause requested…</span>
-          )}
-          {statusData?.last_error && (
-            <details className="pipeline-error-summary">
-              <summary>Last pipeline error</summary>
-              <pre>{statusData.last_error}</pre>
-            </details>
-          )}
-        </div>
+          <div className="pipeline-meta">
+            {totalSentences > 0 && (
+              <span className="pipeline-sentence-count">
+                {doneCount} / {totalSentences} sentences with audio
+              </span>
+            )}
+            {pipelineStatus === "error" && (
+              <span className="badge badge--error">Pipeline error</span>
+            )}
+            {pipelineStatus === "paused" && (
+              <span className="badge badge--warning">
+                Paused — next: {nextPhaseLabel}
+              </span>
+            )}
+            {pauseRequested && (
+              <span className="badge badge--warning">Pause requested…</span>
+            )}
+            {statusData?.last_error && (
+              <details className="pipeline-error-summary">
+                <summary>Last pipeline error</summary>
+                <pre>{statusData.last_error}</pre>
+              </details>
+            )}
+          </div>
 
-        <JobInspector
-          statusData={statusData}
-          totalSentences={totalSentences}
-          doneCount={doneCount}
-        />
+          <JobInspector
+            statusData={statusData}
+            totalSentences={totalSentences}
+            doneCount={doneCount}
+          />
 
-        <div className="pipeline-controls">
-          {pipelineStatus === "complete" && (
-            <a
-              className="btn btn-primary"
-              href={getAudiobookDownloadUrl(bookId)}
-              download
-            >
-              Download Audiobook EPUB
-            </a>
-          )}
-          {pipelineStatus !== "complete" && !isActive(pipelineStatus) && (
-            <>
-              {BATCHABLE_STATUSES.has(nextPhase) && (
+          <div className="pipeline-controls">
+            {pipelineStatus === "complete" && (
+              <a
+                className="btn btn-primary"
+                href={getAudiobookDownloadUrl(bookId)}
+                download
+              >
+                Download Audiobook EPUB
+              </a>
+            )}
+            {pipelineStatus !== "complete" && !isActive(pipelineStatus) && (
+              <>
+                {BATCHABLE_STATUSES.has(nextPhase) && (
+                  <button
+                    onClick={() => batchMutation.mutate()}
+                    disabled={
+                      batchMutation.isPending ||
+                      stepMutation.isPending ||
+                      startMutation.isPending
+                    }
+                  >
+                    {batchMutation.isPending
+                      ? "Starting Batch…"
+                      : "Run One Batch"}
+                  </button>
+                )}
                 <button
-                  onClick={() => batchMutation.mutate()}
+                  onClick={() => stepMutation.mutate()}
                   disabled={
-                    batchMutation.isPending ||
                     stepMutation.isPending ||
-                    startMutation.isPending
+                    startMutation.isPending ||
+                    batchMutation.isPending
                   }
                 >
-                  {batchMutation.isPending
-                    ? "Starting Batch…"
-                    : "Run One Batch"}
+                  Run Next Stage: {nextPhaseLabel}
                 </button>
-              )}
+                <button
+                  onClick={() => startMutation.mutate()}
+                  disabled={
+                    startMutation.isPending ||
+                    stepMutation.isPending ||
+                    batchMutation.isPending
+                  }
+                  className="btn-primary"
+                >
+                  Run to Completion
+                </button>
+              </>
+            )}
+            {isActive(pipelineStatus) && (
               <button
-                onClick={() => stepMutation.mutate()}
-                disabled={
-                  stepMutation.isPending ||
-                  startMutation.isPending ||
-                  batchMutation.isPending
-                }
+                onClick={() => pauseMutation.mutate()}
+                disabled={pauseMutation.isPending || pauseRequested}
               >
-                Run Next Stage: {nextPhaseLabel}
+                {pauseRequested ? "Pause Requested…" : "Pause Safely"}
               </button>
-              <button
-                onClick={() => startMutation.mutate()}
-                disabled={
-                  startMutation.isPending ||
-                  stepMutation.isPending ||
-                  batchMutation.isPending
-                }
-                className="btn-primary"
-              >
-                Run to Completion
-              </button>
-            </>
-          )}
-          {isActive(pipelineStatus) && (
-            <button
-              onClick={() => pauseMutation.mutate()}
-              disabled={pauseMutation.isPending || pauseRequested}
-            >
-              {pauseRequested ? "Pause Requested…" : "Pause Safely"}
-            </button>
-          )}
-          {!isActive(pipelineStatus) &&
-            (!confirmRebuild ? (
-              <button
-                className="btn-danger"
-                onClick={() => setConfirmRebuild(true)}
-              >
-                Force Full Rebuild
-              </button>
-            ) : (
-              <span className="confirm-inline">
-                Destroy all audio and re-run from scratch?{" "}
+            )}
+            {!isActive(pipelineStatus) &&
+              !confirmAudioRebuild &&
+              (!confirmRebuild ? (
                 <button
                   className="btn-danger"
-                  onClick={() => rebuildMutation.mutate()}
-                  disabled={rebuildMutation.isPending}
+                  onClick={() => {
+                    setConfirmAudioRebuild(false);
+                    setConfirmRebuild(true);
+                  }}
                 >
-                  {rebuildMutation.isPending ? "Queueing…" : "Yes, queue rebuild"}
-                </button>{" "}
-                <button
-                  className="btn-text"
-                  onClick={() => setConfirmRebuild(false)}
-                >
-                  Cancel
+                  Rebuild AI Audiobook
                 </button>
-              </span>
-            ))}
+              ) : (
+                <span className="confirm-inline">
+                  Rebuild the AI roster, speaker assignments, TTS, and assembly?
+                  Imported human audiobooks and alignments will be preserved.{" "}
+                  <button
+                    className="btn-danger"
+                    onClick={() => rebuildMutation.mutate()}
+                    disabled={rebuildMutation.isPending}
+                  >
+                    {rebuildMutation.isPending
+                      ? "Queueing…"
+                      : "Yes, queue rebuild"}
+                  </button>{" "}
+                  <button
+                    className="btn-text"
+                    onClick={() => setConfirmRebuild(false)}
+                  >
+                    Cancel
+                  </button>
+                </span>
+              ))}
+            {!isActive(pipelineStatus) &&
+              !confirmRebuild &&
+              (!confirmAudioRebuild ? (
+                <button
+                  onClick={() => {
+                    setConfirmRebuild(false);
+                    setConfirmAudioRebuild(true);
+                  }}
+                >
+                  Regenerate AI Audio (Keep Speakers)
+                </button>
+              ) : (
+                <span className="confirm-inline">
+                  Replace AI TTS clips and assembly only? Speaker assignments
+                  and imported human audiobooks will be preserved.{" "}
+                  <button
+                    onClick={() => audioRebuildMutation.mutate()}
+                    disabled={audioRebuildMutation.isPending}
+                  >
+                    {audioRebuildMutation.isPending
+                      ? "Queueing…"
+                      : "Yes, regenerate AI audio"}
+                  </button>{" "}
+                  <button
+                    className="btn-text"
+                    onClick={() => setConfirmAudioRebuild(false)}
+                  >
+                    Cancel
+                  </button>
+                </span>
+              ))}
+          </div>
+
+          {lastQueuedJob && (
+            <p className="job-queued-notice" role="status">
+              Processing job
+              {typeof lastQueuedJob === "number" ? ` #${lastQueuedJob}` : ""}{" "}
+              queued. <a href="/processing">View processing</a>
+            </p>
+          )}
+
+          {(startMutation.isError ||
+            stepMutation.isError ||
+            batchMutation.isError ||
+            pauseMutation.isError ||
+            rebuildMutation.isError ||
+            audioRebuildMutation.isError) && (
+            <p className="error">
+              {(
+                startMutation.error ||
+                stepMutation.error ||
+                batchMutation.error ||
+                pauseMutation.error ||
+                rebuildMutation.error ||
+                audioRebuildMutation.error
+              )?.message || "Action failed"}
+            </p>
+          )}
         </div>
-
-        {lastQueuedJob && (
-          <p className="job-queued-notice" role="status">
-            Processing job{typeof lastQueuedJob === "number" ? ` #${lastQueuedJob}` : ""} queued.{" "}
-            <a href="/processing">View processing</a>
-          </p>
-        )}
-
-        {(startMutation.isError ||
-          stepMutation.isError ||
-          batchMutation.isError ||
-          pauseMutation.isError ||
-          rebuildMutation.isError) && (
-          <p className="error">
-            {(
-              startMutation.error ||
-              stepMutation.error ||
-              batchMutation.error ||
-              pauseMutation.error ||
-              rebuildMutation.error
-            )?.message || "Action failed"}
-          </p>
-        )}
-      </div>
       )}
 
       <nav className="sub-tabs">

--- a/frontend/src/components/AudiobookPipeline.jsx
+++ b/frontend/src/components/AudiobookPipeline.jsx
@@ -9,7 +9,6 @@ import {
   runPipelineBatch,
   pausePipeline,
   rebuildPipeline,
-  rebuildAudioOnly,
   getAudiobookDownloadUrl,
   getImportedAudiobooks,
 } from "../api/audiobook";
@@ -136,7 +135,6 @@ function AudiobookPipeline({
     book.audiobook_enabled === undefined ? "progress" : "sources",
   );
   const [confirmRebuild, setConfirmRebuild] = useState(false);
-  const [confirmAudioRebuild, setConfirmAudioRebuild] = useState(false);
   const [lastQueuedJob, setLastQueuedJob] = useState(null);
 
   const isActive = (status) => ACTIVE_STATUSES.has(status);
@@ -230,15 +228,6 @@ function AudiobookPipeline({
     onSuccess: (data) => {
       setLastQueuedJob(data.processing_job_id || true);
       setConfirmRebuild(false);
-      invalidateAll();
-    },
-  });
-
-  const audioRebuildMutation = useMutation({
-    mutationFn: () => rebuildAudioOnly(bookId),
-    onSuccess: (data) => {
-      setLastQueuedJob(data.processing_job_id || true);
-      setConfirmAudioRebuild(false);
       invalidateAll();
     },
   });
@@ -381,14 +370,10 @@ function AudiobookPipeline({
               </button>
             )}
             {!isActive(pipelineStatus) &&
-              !confirmAudioRebuild &&
               (!confirmRebuild ? (
                 <button
                   className="btn-danger"
-                  onClick={() => {
-                    setConfirmAudioRebuild(false);
-                    setConfirmRebuild(true);
-                  }}
+                  onClick={() => setConfirmRebuild(true)}
                 >
                   Rebuild AI Audiobook
                 </button>
@@ -413,43 +398,14 @@ function AudiobookPipeline({
                   </button>
                 </span>
               ))}
-            {!isActive(pipelineStatus) &&
-              !confirmRebuild &&
-              (!confirmAudioRebuild ? (
-                <button
-                  onClick={() => {
-                    setConfirmRebuild(false);
-                    setConfirmAudioRebuild(true);
-                  }}
-                >
-                  Regenerate AI Audio (Keep Speakers)
-                </button>
-              ) : (
-                <span className="confirm-inline">
-                  Replace AI TTS clips and assembly only? Speaker assignments
-                  and imported human audiobooks will be preserved.{" "}
-                  <button
-                    onClick={() => audioRebuildMutation.mutate()}
-                    disabled={audioRebuildMutation.isPending}
-                  >
-                    {audioRebuildMutation.isPending
-                      ? "Queueing…"
-                      : "Yes, regenerate AI audio"}
-                  </button>{" "}
-                  <button
-                    className="btn-text"
-                    onClick={() => setConfirmAudioRebuild(false)}
-                  >
-                    Cancel
-                  </button>
-                </span>
-              ))}
           </div>
 
           {lastQueuedJob && (
             <p className="job-queued-notice" role="status">
               Processing job
-              {typeof lastQueuedJob === "number" ? ` #${lastQueuedJob}` : ""}{" "}
+              {typeof lastQueuedJob === "number"
+                ? ` #${lastQueuedJob}`
+                : ""}{" "}
               queued. <a href="/processing">View processing</a>
             </p>
           )}
@@ -458,16 +414,14 @@ function AudiobookPipeline({
             stepMutation.isError ||
             batchMutation.isError ||
             pauseMutation.isError ||
-            rebuildMutation.isError ||
-            audioRebuildMutation.isError) && (
+            rebuildMutation.isError) && (
             <p className="error">
               {(
                 startMutation.error ||
                 stepMutation.error ||
                 batchMutation.error ||
                 pauseMutation.error ||
-                rebuildMutation.error ||
-                audioRebuildMutation.error
+                rebuildMutation.error
               )?.message || "Action failed"}
             </p>
           )}
@@ -493,6 +447,7 @@ function AudiobookPipeline({
             chapters={chapters}
             imports={importedAudiobooks}
             aiEnabled={aiEnabled}
+            aiPipelineActive={isActive(pipelineStatus)}
             onEnableAi={onEnableAi}
           />
         )}

--- a/frontend/src/components/AudiobookPipeline.test.jsx
+++ b/frontend/src/components/AudiobookPipeline.test.jsx
@@ -105,20 +105,22 @@ describe("AudiobookPipeline", () => {
     });
     globalThis.fetch = fetchMock;
 
-    renderWithClient(<AudiobookPipeline book={{ id: 11 }} />);
+    renderWithClient(
+      <AudiobookPipeline book={{ id: 11, audiobook_enabled: true }} />,
+    );
 
     fireEvent.click(
       await screen.findByRole("button", {
-        name: "Regenerate AI Audio (Keep Speakers)",
+        name: "Regenerate AI TTS Only",
       }),
     );
     expect(
       screen.getByText(
-        /Speaker assignments and imported human audiobooks will be preserved/,
+        /roster, speaker assignments, and imported human audiobooks will be preserved/,
       ),
     ).toBeInTheDocument();
     fireEvent.click(
-      screen.getByRole("button", { name: "Yes, regenerate AI audio" }),
+      screen.getByRole("button", { name: "Yes, regenerate AI TTS" }),
     );
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(

--- a/frontend/src/components/AudiobookPipeline.test.jsx
+++ b/frontend/src/components/AudiobookPipeline.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import AudiobookPipeline from "./AudiobookPipeline";
@@ -63,6 +63,201 @@ describe("AudiobookPipeline", () => {
         method: "POST",
       });
     });
+  });
+
+  it("clearly separates AI audio regeneration from an AI analysis rebuild", async () => {
+    const fetchMock = vi.fn((url, options) => {
+      if (url === "/api/books/11/audiobook/status") {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              pipeline_status: "complete",
+              next_phase: "complete",
+              pause_requested: false,
+              sentence_counts: { audio_generated: 2 },
+            }),
+        });
+      }
+      if (url === "/api/books/11/audiobook/characters") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([{ id: 4, name: "Avery" }]),
+        });
+      }
+      if (url === "/api/books/11/audiobook/chapters") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([{ id: 9, sentence_count: 2 }]),
+        });
+      }
+      if (
+        (url === "/api/books/11/audiobook/audio/rebuild" ||
+          url === "/api/books/11/audiobook/rebuild") &&
+        options?.method === "POST"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ queued: true }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+    globalThis.fetch = fetchMock;
+
+    renderWithClient(<AudiobookPipeline book={{ id: 11 }} />);
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "Regenerate AI Audio (Keep Speakers)",
+      }),
+    );
+    expect(
+      screen.getByText(
+        /Speaker assignments and imported human audiobooks will be preserved/,
+      ),
+    ).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Yes, regenerate AI audio" }),
+    );
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/books/11/audiobook/audio/rebuild",
+        { method: "POST" },
+      );
+    });
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Rebuild AI Audiobook" }),
+    );
+    expect(
+      screen.getByText(
+        /Imported human audiobooks and alignments will be preserved/,
+      ),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Yes, queue rebuild" }));
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/books/11/audiobook/rebuild",
+        { method: "POST" },
+      );
+    });
+  });
+
+  it("shows import times and identifies the reader app default edition", async () => {
+    const fetchMock = vi.fn((url, options) => {
+      if (url === "/api/books/11/audiobook/imports") {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve([
+              {
+                id: 10,
+                name: "Newest narration",
+                source_type: "upload",
+                status: "ready",
+                duration_ms: 3_600_000,
+                created_at: "2026-07-02T15:30:00Z",
+                is_reader_default: true,
+                tracks: [
+                  {
+                    id: 100,
+                    title: "Chapter 1",
+                    matched_chapter_id: null,
+                    cue_count: 0,
+                  },
+                ],
+              },
+              {
+                id: 9,
+                name: "Older narration",
+                source_type: "upload",
+                status: "ready",
+                duration_ms: 3_600_000,
+                created_at: "2026-07-01T15:30:00Z",
+                is_reader_default: false,
+                tracks: [
+                  {
+                    id: 90,
+                    title: "Chapter 1",
+                    matched_chapter_id: null,
+                    cue_count: 0,
+                  },
+                ],
+              },
+            ]),
+        });
+      }
+      if (url === "/api/books/11/audiobook/status") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ pipeline_status: "complete" }),
+        });
+      }
+      if (
+        url === "/api/books/11/audiobook/characters" ||
+        url === "/api/books/11/audiobook/chapters"
+      ) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+      }
+      if (
+        url === "/api/imported-audiobooks/10/rematch" &&
+        options?.method === "POST"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ status: "stale" }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+    globalThis.fetch = fetchMock;
+
+    renderWithClient(
+      <AudiobookPipeline book={{ id: 11, audiobook_enabled: true }} />,
+    );
+
+    const newestHeading = await screen.findByRole("heading", {
+      name: "Newest narration",
+    });
+    const newestCard = newestHeading.closest("section");
+    const olderCard = screen
+      .getByRole("heading", { name: "Older narration" })
+      .closest("section");
+    expect(
+      within(newestCard).getByText("Reader app default"),
+    ).toBeInTheDocument();
+    expect(
+      within(olderCard).queryByText("Reader app default"),
+    ).not.toBeInTheDocument();
+    expect(within(newestCard).getByText(/^Imported /)).toHaveAttribute(
+      "datetime",
+      "2026-07-02T15:30:00Z",
+    );
+    expect(within(olderCard).getByText(/^Imported /)).toHaveAttribute(
+      "datetime",
+      "2026-07-01T15:30:00Z",
+    );
+
+    fireEvent.click(
+      within(newestCard).getByRole("button", {
+        name: "Rematch Newest narration to book text",
+      }),
+    );
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/imported-audiobooks/10/rematch",
+        { method: "POST" },
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Listen & Read" }));
+    expect(
+      await screen.findByRole("option", { name: "Newest narration" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/imported audio is intact, but it has no synchronized/),
+    ).toBeInTheDocument();
   });
 
   it("shows model progress and can run exactly one diarization batch", async () => {

--- a/frontend/src/components/audiobook/AudiobookReader.jsx
+++ b/frontend/src/components/audiobook/AudiobookReader.jsx
@@ -100,8 +100,8 @@ function ImportedEditionReader({ edition }) {
   if (!playable.length) {
     return (
       <p className="empty-state">
-        This edition has no tracks matched to book text. Review its track
-        matching in Sources.
+        This edition's imported audio is intact, but it has no synchronized book
+        text. Use Rematch to Book Text in Sources to restore it.
       </p>
     );
   }
@@ -353,7 +353,7 @@ function AudiobookReader({
       imports.filter(
         (edition) =>
           ["ready", "aligning"].includes(edition.status) &&
-          edition.tracks.some((track) => track.cue_count > 0),
+          edition.tracks.length > 0,
       ),
     [imports],
   );

--- a/frontend/src/components/audiobook/AudiobookSources.jsx
+++ b/frontend/src/components/audiobook/AudiobookSources.jsx
@@ -5,6 +5,7 @@ import {
   alignImportedAudiobook,
   deleteImportedAudiobook,
   matchImportedAudiobookTrack,
+  rematchImportedAudiobook,
   retryImportedAudiobook,
   uploadImportedAudiobook,
 } from "../../api/audiobook";
@@ -16,6 +17,16 @@ function durationLabel(durationMs) {
   const hours = Math.floor(seconds / 3600);
   const minutes = Math.floor((seconds % 3600) / 60);
   return hours ? `${hours}h ${minutes}m` : `${minutes}m`;
+}
+
+function importedAtLabel(createdAt) {
+  if (!createdAt) return "Import date unavailable";
+  const date = new Date(createdAt);
+  if (Number.isNaN(date.getTime())) return "Import date unavailable";
+  return `Imported ${new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date)}`;
 }
 
 function AudiobookSources({
@@ -60,6 +71,13 @@ function AudiobookSources({
     mutationFn: alignImportedAudiobook,
     onSuccess: () => {
       setJobNotice("Human audiobook timestamp alignment queued.");
+      invalidate();
+    },
+  });
+  const rematchMutation = useMutation({
+    mutationFn: rematchImportedAudiobook,
+    onSuccess: () => {
+      setJobNotice("Human audiobook chapter rematch queued.");
       invalidate();
     },
   });
@@ -164,12 +182,24 @@ function AudiobookSources({
                     {durationLabel(edition.duration_ms)} · {matched} of{" "}
                     {edition.tracks.length} tracks matched
                   </p>
+                  <p>
+                    <time dateTime={edition.created_at}>
+                      {importedAtLabel(edition.created_at)}
+                    </time>
+                  </p>
                 </div>
-                <span
-                  className={`badge${edition.status === "error" ? " badge--error" : active ? " badge--warning" : ""}`}
-                >
-                  {edition.status}
-                </span>
+                <div className="imported-edition-badges">
+                  {edition.is_reader_default && (
+                    <span className="badge badge--success">
+                      Reader app default
+                    </span>
+                  )}
+                  <span
+                    className={`badge${edition.status === "error" ? " badge--error" : active ? " badge--warning" : ""}`}
+                  >
+                    {edition.status}
+                  </span>
+                </div>
               </header>
               {active && (
                 <div className="import-progress" role="status">
@@ -197,6 +227,25 @@ function AudiobookSources({
               )}
               {edition.status === "ready" && (
                 <>
+                  {edition.tracks.length > 0 && matched === 0 && (
+                    <div className="alignment-note">
+                      <p>
+                        The imported audio is intact, but its chapter matches
+                        and synchronized text need to be restored.
+                      </p>
+                      <button
+                        type="button"
+                        className="btn-primary"
+                        aria-label={`Rematch ${edition.name} to book text`}
+                        disabled={rematchMutation.isPending}
+                        onClick={() => rematchMutation.mutate(edition.id)}
+                      >
+                        {rematchMutation.isPending
+                          ? "Queueing…"
+                          : "Rematch to Book Text"}
+                      </button>
+                    </div>
+                  )}
                   <p className="alignment-note">
                     {edition.alignment_method === "transcribed"
                       ? "Sentence timestamps are aligned to WhisperX word timestamps."
@@ -286,12 +335,14 @@ function AudiobookSources({
       )}
       {(retryMutation.isError ||
         alignMutation.isError ||
+        rematchMutation.isError ||
         deleteMutation.isError ||
         matchMutation.isError) && (
         <p className="error">
           {(
             retryMutation.error ||
             alignMutation.error ||
+            rematchMutation.error ||
             deleteMutation.error ||
             matchMutation.error
           )?.message || "Audiobook action failed"}

--- a/frontend/src/components/audiobook/AudiobookSources.jsx
+++ b/frontend/src/components/audiobook/AudiobookSources.jsx
@@ -5,6 +5,7 @@ import {
   alignImportedAudiobook,
   deleteImportedAudiobook,
   matchImportedAudiobookTrack,
+  rebuildAudioOnly,
   rematchImportedAudiobook,
   retryImportedAudiobook,
   uploadImportedAudiobook,
@@ -34,6 +35,7 @@ function AudiobookSources({
   chapters = [],
   imports = [],
   aiEnabled = false,
+  aiPipelineActive = false,
   onEnableAi,
 }) {
   const queryClient = useQueryClient();
@@ -41,10 +43,12 @@ function AudiobookSources({
   const [files, setFiles] = useState([]);
   const [name, setName] = useState("");
   const [jobNotice, setJobNotice] = useState("");
+  const [confirmAiTtsRebuild, setConfirmAiTtsRebuild] = useState(false);
 
   const invalidate = () => {
     queryClient.invalidateQueries({ queryKey: ["audiobook-imports", bookId] });
     queryClient.invalidateQueries({ queryKey: ["audiobook-chapters", bookId] });
+    queryClient.invalidateQueries({ queryKey: ["audiobook-status", bookId] });
   };
   const uploadMutation = useMutation({
     mutationFn: () => uploadImportedAudiobook(bookId, files, name),
@@ -85,6 +89,16 @@ function AudiobookSources({
     mutationFn: ({ editionId, trackId, chapterId }) =>
       matchImportedAudiobookTrack(editionId, trackId, chapterId),
     onSuccess: invalidate,
+  });
+  const aiTtsMutation = useMutation({
+    mutationFn: () => rebuildAudioOnly(bookId),
+    onSuccess: () => {
+      setConfirmAiTtsRebuild(false);
+      setJobNotice(
+        "AI TTS-only regeneration queued; speaker analysis preserved.",
+      );
+      invalidate();
+    },
   });
 
   return (
@@ -156,6 +170,52 @@ function AudiobookSources({
           <button type="button" onClick={onEnableAi}>
             Enable AI Audiobook Pipeline
           </button>
+        )}
+        {aiEnabled && !confirmAiTtsRebuild && (
+          <button
+            type="button"
+            className="btn-primary"
+            disabled={aiPipelineActive || aiTtsMutation.isPending}
+            onClick={() => setConfirmAiTtsRebuild(true)}
+          >
+            Regenerate AI TTS Only
+          </button>
+        )}
+        {aiEnabled && aiPipelineActive && (
+          <p className="hint">
+            Pause the active AI pipeline before regenerating TTS.
+          </p>
+        )}
+        {aiEnabled && confirmAiTtsRebuild && (
+          <div className="alignment-note">
+            <p>
+              Replace AI TTS clips and assembly only? The roster, speaker
+              assignments, and imported human audiobooks will be preserved.
+            </p>
+            <div className="confirm-inline">
+              <button
+                type="button"
+                className="btn-primary"
+                disabled={aiTtsMutation.isPending}
+                onClick={() => aiTtsMutation.mutate()}
+              >
+                {aiTtsMutation.isPending
+                  ? "Queueing…"
+                  : "Yes, regenerate AI TTS"}
+              </button>
+              <button
+                type="button"
+                className="btn-text"
+                disabled={aiTtsMutation.isPending}
+                onClick={() => setConfirmAiTtsRebuild(false)}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+        {aiTtsMutation.isError && (
+          <p className="error">{aiTtsMutation.error.message}</p>
         )}
       </section>
 

--- a/services/omnivoice/README.md
+++ b/services/omnivoice/README.md
@@ -63,6 +63,8 @@ The image is rebuilt and published only when files under `services/omnivoice/` o
 | `OMNIVOICE_NUM_STEPS` | `16` | Diffusion steps; use `32` for higher quality/slower output |
 | `OMNIVOICE_MP3_BITRATE` | `96k` | Returned MP3 bitrate |
 | `OMNIVOICE_MAX_BATCH_SIZE` | `8` | Maximum items accepted by `POST /generate-batch` |
+| `OMNIVOICE_NATIVE_BATCHING` | `false` | Opt into native model batching. Keep disabled on MPS, where native batches can produce stationary mechanical noise. |
+| `OMNIVOICE_QUALITY_ATTEMPTS` | `3` | Maximum individual generations attempted when the signal-quality gate rejects an output. |
 | `OMNIVOICE_PORT` | `8001` | Port used by the Make target |
 
 Story Manager controls submitted batch size with `AUDIOBOOK_TTS_BATCH_SIZE` (default `4`) and length-buckets

--- a/services/omnivoice/audio_quality.py
+++ b/services/omnivoice/audio_quality.py
@@ -1,0 +1,82 @@
+"""Signal-level quality checks for generated OmniVoice audio."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+class AudioQualityError(RuntimeError):
+    """Raised when generated audio is unsafe to publish."""
+
+
+@dataclass(frozen=True)
+class AudioQualityReport:
+    duration_seconds: float
+    active_ratio: float
+    rms_variation: float
+    spectral_flatness: float
+    zero_crossing_rate: float
+
+    @property
+    def has_stationary_mechanical_noise(self) -> bool:
+        return (
+            self.active_ratio > 0.80
+            and self.rms_variation < 0.35
+            and self.spectral_flatness > 0.065
+            and self.zero_crossing_rate > 0.16
+        )
+
+
+def inspect_audio_quality(audio: np.ndarray, sampling_rate: int) -> AudioQualityReport:
+    """Measure traits that distinguish speech from stationary mechanical noise."""
+    samples = np.asarray(audio, dtype=np.float32).reshape(-1)
+    if not samples.size:
+        raise AudioQualityError("generated audio is empty")
+    if not np.isfinite(samples).all():
+        raise AudioQualityError("generated audio contains non-finite samples")
+    if sampling_rate <= 0:
+        raise ValueError("sampling_rate must be positive")
+
+    frame_size = min(1024, samples.size)
+    if frame_size < 64:
+        raise AudioQualityError("generated audio is too short to validate")
+    hop_size = max(1, frame_size // 4)
+    if samples.size == frame_size:
+        frames = samples[np.newaxis, :]
+    else:
+        frames = np.lib.stride_tricks.sliding_window_view(samples, frame_size)[::hop_size]
+
+    windowed = frames * np.hanning(frame_size)
+    rms = np.sqrt(np.mean(windowed**2, axis=1) + 1e-12)
+    active_threshold = max(float(rms.max()) * 0.03, 1e-4)
+    active = rms > active_threshold
+    active_rms = rms[active]
+    active_frames = windowed[active]
+    if not active_frames.size:
+        raise AudioQualityError("generated audio is silent")
+
+    magnitudes = np.abs(np.fft.rfft(active_frames, axis=1)) + 1e-12
+    flatness = np.exp(np.mean(np.log(magnitudes), axis=1)) / np.mean(magnitudes, axis=1)
+    zero_crossings = np.mean(samples[1:] * samples[:-1] < 0) if samples.size > 1 else 0.0
+
+    return AudioQualityReport(
+        duration_seconds=samples.size / sampling_rate,
+        active_ratio=float(np.mean(active)),
+        rms_variation=float(np.std(active_rms) / np.mean(active_rms)),
+        spectral_flatness=float(np.median(flatness)),
+        zero_crossing_rate=float(zero_crossings),
+    )
+
+
+def validate_generated_audio(audio: np.ndarray, sampling_rate: int) -> AudioQualityReport:
+    """Reject known catastrophic outputs and return measurements for logging."""
+    report = inspect_audio_quality(audio, sampling_rate)
+    if report.has_stationary_mechanical_noise:
+        raise AudioQualityError(
+            "generated audio resembles stationary mechanical noise "
+            f"(active={report.active_ratio:.3f}, rms_cv={report.rms_variation:.3f}, "
+            f"flatness={report.spectral_flatness:.3f}, zcr={report.zero_crossing_rate:.3f})"
+        )
+    return report

--- a/services/omnivoice/server.py
+++ b/services/omnivoice/server.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, Field  # noqa: E402
 from pydub import AudioSegment  # noqa: E402
 import torch  # noqa: E402
 
+from .audio_quality import AudioQualityError, validate_generated_audio  # noqa: E402
 from .prompt import translate_generation_prompt  # noqa: E402
 
 logger = logging.getLogger(__name__)
@@ -32,6 +33,8 @@ DEVICE = os.getenv("OMNIVOICE_DEVICE", "auto")
 NUM_STEPS = int(os.getenv("OMNIVOICE_NUM_STEPS", "16"))
 MP3_BITRATE = os.getenv("OMNIVOICE_MP3_BITRATE", "96k")
 MAX_BATCH_SIZE = max(1, int(os.getenv("OMNIVOICE_MAX_BATCH_SIZE", "8")))
+NATIVE_BATCHING = os.getenv("OMNIVOICE_NATIVE_BATCHING", "false").lower() in {"1", "true", "yes"}
+QUALITY_ATTEMPTS = max(1, int(os.getenv("OMNIVOICE_QUALITY_ATTEMPTS", "3")))
 
 
 class GenerateRequest(BaseModel):
@@ -86,13 +89,13 @@ class OmniVoiceRuntime:
     def generate(self, request: GenerateRequest) -> tuple[bytes, int]:
         return self.generate_batch([request])[0]
 
-    def generate_batch(self, requests: list[GenerateRequest]) -> list[tuple[bytes, int]]:
+    def _generate_audio(self, requests: list[GenerateRequest]) -> list[np.ndarray]:
         if self.model is None:
             raise RuntimeError("OmniVoice model is not loaded")
 
         prompts = [translate_generation_prompt(request.voice, request.text) for request in requests]
         with self._generate_lock:
-            audios = self.model.generate(
+            return self.model.generate(
                 text=[prompt.text for prompt in prompts],
                 language=[request.language for request in requests],
                 instruct=[prompt.instruct for prompt in prompts],
@@ -102,7 +105,57 @@ class OmniVoiceRuntime:
                 postprocess_output=True,
             )
 
-        return [_encode_audio(audio, self.model.sampling_rate) for audio in audios]
+    def _generate_valid_audio(self, request: GenerateRequest, request_number: int) -> np.ndarray:
+        if self.model is None:
+            raise RuntimeError("OmniVoice model is not loaded")
+
+        last_error = None
+        for attempt in range(1, QUALITY_ATTEMPTS + 1):
+            audio = self._generate_audio([request])[0]
+            try:
+                validate_generated_audio(audio, self.model.sampling_rate)
+                return audio
+            except AudioQualityError as exc:
+                last_error = exc
+                logger.warning(
+                    "Rejected generated audio for request %d on quality attempt %d/%d: %s",
+                    request_number,
+                    attempt,
+                    QUALITY_ATTEMPTS,
+                    exc,
+                )
+
+        text = request.text.replace("\n", " ")[:120]
+        raise AudioQualityError(
+            f"request {request_number} ({text!r}) failed quality validation after "
+            f"{QUALITY_ATTEMPTS} attempts: {last_error}"
+        ) from last_error
+
+    def generate_batch(self, requests: list[GenerateRequest]) -> list[tuple[bytes, int]]:
+        if self.model is None:
+            raise RuntimeError("OmniVoice model is not loaded")
+
+        if NATIVE_BATCHING and len(requests) > 1:
+            audios = self._generate_audio(requests)
+            valid_audios = []
+            for index, (request, audio) in enumerate(zip(requests, audios, strict=True), start=1):
+                try:
+                    validate_generated_audio(audio, self.model.sampling_rate)
+                    valid_audios.append(audio)
+                except AudioQualityError as exc:
+                    logger.warning(
+                        "Rejected native batch output for request %d; regenerating individually: %s",
+                        index,
+                        exc,
+                    )
+                    valid_audios.append(self._generate_valid_audio(request, index))
+        else:
+            valid_audios = [
+                self._generate_valid_audio(request, index)
+                for index, request in enumerate(requests, start=1)
+            ]
+
+        return [_encode_audio(audio, self.model.sampling_rate) for audio in valid_audios]
 
 
 runtime = OmniVoiceRuntime()
@@ -125,6 +178,8 @@ async def health() -> dict[str, object]:
         "device": runtime.device,
         "num_steps": NUM_STEPS,
         "max_batch_size": MAX_BATCH_SIZE,
+        "native_batching": NATIVE_BATCHING,
+        "quality_attempts": QUALITY_ATTEMPTS,
     }
 
 


### PR DESCRIPTION
## Summary

- reject and retry catastrophic mechanical-noise TTS output
- recover punctuation-only and interrupted sentence generation
- preserve human audiobook tracks and alignments during AI rebuilds
- add TTS-only regeneration that keeps speaker analysis
- show human-edition import times and identify the reader app default
- add supported rematching for intact human audio with missing text cues

## Root causes

Punctuation-only sentences were sent to a speech model that could not synthesize them, and clips left in in-memory generating states were not reclaimed after a worker restart. OmniVoice native batching on MPS could also emit stationary mechanical noise without any output validation.

The force rebuild deleted shared audiobook chapter and sentence rows. Imported human tracks and cues reference those rows, so foreign-key cascades removed their matches and synchronized text even though the human audio files remained intact.

## Impact

AI rebuilds now reset only AI-derived analysis and audio while preserving stable ingestion IDs and human editions. Operators can regenerate TTS without re-diarizing, and damaged human alignments can be rebuilt from existing imported audio without another upload.

The reader app default is explicitly marked as the newest ready human edition.

## Validation

- `make lint`
- `make test`
  - 333 backend tests passed
  - 48 frontend tests passed
