### PR TITLE
Fix imported audiobook SMIL text paths

### DIFF
--- a/backend/app/routers/audiobook.py
+++ b/backend/app/routers/audiobook.py
@@ -694,12 +694,13 @@ async def get_imported_track_smil(
     root = ET.Element("smil", {"xmlns": "http://www.w3.org/ns/SMIL", "version": "3.0"})
     body = ET.SubElement(root, "body")
     seq = ET.SubElement(body, "seq")
+    chapter_text_href = chapter.content_file_name.replace("\\", "/").rsplit("/", 1)[-1]
     for cue, sentence in result.all():
         par = ET.SubElement(seq, "par")
         ET.SubElement(
             par,
             "text",
-            {"src": f"{chapter.content_file_name}#{sentence.html_element_id}"},
+            {"src": f"{chapter_text_href}#{sentence.html_element_id}"},
         )
         ET.SubElement(
             par,

--- a/backend/tests/test_reader_audiobook.py
+++ b/backend/tests/test_reader_audiobook.py
@@ -244,6 +244,7 @@ async def test_reader_audiobook_capability_and_assets(
         imported_smil = app_client.get(track["smil_url"], auth=auth)
         assert imported_smil.status_code == 200
         assert f'src="{canonical_audio_url}"'.encode() in imported_smil.content
+        assert b'src="chapter.xhtml#' in imported_smil.content
     assert b'clipBegin="0.000s" clipEnd="1.250s"' in app_client.get(human[0]["tracks"][0]["smil_url"], auth=auth).content
     assert b'clipBegin="1.250s" clipEnd="2.500s"' in app_client.get(human[0]["tracks"][1]["smil_url"], auth=auth).content
     imported_audio = app_client.get(canonical_audio_url, auth=auth)


### PR DESCRIPTION
## Summary

Emit imported audiobook SMIL text references relative to the chapter directory instead of repeating the EPUB package path.

## Root cause

Imported chapters can store paths such as `text/part0004.html`. The generated SMIL was also using `text/part0004.html` while clients resolved it relative to that chapter directory, producing `text/text/part0004.html`. Reader validation rejected the timeline and fell back to TTS even though the human audio had downloaded successfully.

The endpoint now emits the chapter basename, such as `part0004.html#sentence-1`, which resolves to the correct publication resource. A regression assertion covers the response.

## Impact

Newly fetched human-audiobook SMIL files resolve correctly in readers. The companion story-reader PR also accepts existing cached package-relative SMIL, so users do not need to re-download audio.

## Validation

- `PYTHONPATH=. .venv/bin/pytest backend/tests/test_reader_audiobook.py` — 4 passed
- flake8 on the changed router and test
- `git diff --check`