### PR TITLE
Support Libation directory audiobook imports

### DIFF
--- a/backend/app/routers/audiobook.py
+++ b/backend/app/routers/audiobook.py
@@ -510,19 +510,22 @@ async def upload_imported_audiobook(
     book_id: int,
     files: list[UploadFile] = File(...),
     name: Optional[str] = Form(None),
+    source_paths: list[str] = Form(default=[]),
+    auto_align: bool = Form(default=True),
     db: AsyncSession = Depends(get_db),
 ) -> ImportedAudiobookResponse:
     await _get_book_or_404(book_id, db)
     filenames = [file.filename or "" for file in files]
+    display_names = source_paths if len(source_paths) == len(files) else filenames
     if not files or any(Path(filename).suffix.lower() not in IMPORT_EXTENSIONS for filename in filenames):
         supported = ", ".join(sorted(IMPORT_EXTENSIONS))
         raise HTTPException(status_code=400, detail=f"Upload audiobook audio, CUE, or ZIP files ({supported}).")
     edition = ImportedAudiobook(
         book_id=book_id,
-        name=(name or "").strip() or display_name_from_filename(filenames[0]),
-        asin=asin_from_names(filenames),
+        name=(name or "").strip() or display_name_from_filename(display_names[0]),
+        asin=asin_from_names(display_names),
         status="queued",
-        original_filenames=filenames,
+        original_filenames=display_names,
         progress_detail="Receiving upload",
     )
     db.add(edition)
@@ -546,6 +549,7 @@ async def upload_imported_audiobook(
             book_id=book_id,
             target_type="imported_audiobook",
             target_id=edition.id,
+            payload={"auto_align": auto_align},
             dedupe_key=f"import_audiobook:imported_audiobook:{edition.id}",
             progress_detail="Queued after audiobook upload",
         )

--- a/backend/app/services/audiobook_import.py
+++ b/backend/app/services/audiobook_import.py
@@ -136,11 +136,7 @@ def _extract_archive_sources(archive_path: Path, source_dir: Path) -> tuple[list
         if not audio_entries:
             raise ValueError(f"{archive_path.name} contains no supported audio files.")
 
-        # Libation commonly includes both M4B and MP3 renditions of the same
-        # recording. Prefer the smaller, chapter-capable M4B instead of
-        # importing two duplicate thirteen-hour editions.
-        m4b_entries = [entry for entry in audio_entries if Path(entry.filename).suffix.lower() == ".m4b"]
-        selected_audio = m4b_entries or audio_entries
+        selected_audio = _preferred_audio_files(audio_entries, lambda entry: Path(entry.filename))
         audio_paths: list[Path] = []
         cue_paths: list[Path] = []
         for entry in selected_audio:
@@ -152,6 +148,12 @@ def _extract_archive_sources(archive_path: Path, source_dir: Path) -> tuple[list
             _copy_zip_entry(archive, entry, destination)
             cue_paths.append(destination)
         return audio_paths, cue_paths
+
+
+def _preferred_audio_files(items: list, path_for_item=lambda item: item) -> list:
+    """Discard Libation's duplicate MP3 rendition when an M4B is present."""
+    m4b_items = [item for item in items if path_for_item(item).suffix.lower() == ".m4b"]
+    return m4b_items or items
 
 
 def _prepare_sources(edition_dir: Path) -> tuple[list[Path], list[Path]]:
@@ -180,6 +182,7 @@ def _prepare_sources(edition_dir: Path) -> tuple[list[Path], list[Path]]:
             destination = _unique_destination(source_dir, incoming.name)
             incoming.replace(destination)
             cue_paths.append(destination)
+    audio_paths = _preferred_audio_files(audio_paths)
     if not audio_paths:
         raise ValueError("No supported audiobook audio was uploaded.")
     return audio_paths, cue_paths

--- a/backend/app/services/processing_queue.py
+++ b/backend/app/services/processing_queue.py
@@ -8,12 +8,12 @@ import os
 from contextlib import asynccontextmanager
 from typing import AsyncIterator, Awaitable, Callable, TypeVar
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import crud
 from ..database import SessionLocal
-from ..models import Book, ImportedAudiobook, ProcessingJob
+from ..models import Book, ImportedAudiobook, ImportedAudiobookTrack, ProcessingJob
 from .audiobook_alignment import process_alignment
 from .audiobook_import import process_import, rematch_imported_audiobook
 from .audiobook_queue import get_audiobook_queue
@@ -22,6 +22,7 @@ from .audiobook_assembly import assemble_chapter_preview
 from .audiobook_tts import generate_audio_for_chapter_preview
 from .cover_processing import reextract_book_cover
 from .metadata_jobs import process_metadata_sync_job
+from .transcription_providers import transcription_provider_name
 from .update_scheduler import run_web_novel_update
 from .web_novel import run_book_refresh
 
@@ -178,6 +179,31 @@ class ProcessingQueue:
                 edition = await db.get(ImportedAudiobook, target_id)
                 if edition is not None and edition.status == "error":
                     raise RuntimeError(edition.error or "Human audiobook import failed.")
+                settings = await crud.audiobook.get_audiobook_settings(db)
+                matched_count = await db.scalar(
+                    select(func.count(ImportedAudiobookTrack.id)).where(
+                        ImportedAudiobookTrack.imported_audiobook_id == target_id,
+                        ImportedAudiobookTrack.matched_chapter_id.is_not(None),
+                    )
+                )
+            if (
+                payload.get("auto_align", True)
+                and edition is not None
+                and matched_count
+                and transcription_provider_name(settings) != "none"
+            ):
+                child = await queue_processing_job(
+                    job_type="align_imported_audiobook",
+                    book_id=job.book_id,
+                    target_type="imported_audiobook",
+                    target_id=target_id,
+                    target_content_version=edition.matched_content_version,
+                    parent_job_id=job.id,
+                    dedupe_key=f"align_imported_audiobook:imported_audiobook:{target_id}",
+                    progress_detail="Queued automatically after audiobook import",
+                )
+                await self.enqueue(child.id)
+                return "Human audiobook import completed; timestamp alignment queued"
             return "Human audiobook import completed"
         if job.job_type == "rematch_imported_audiobook":
             target_id = _required_target(job)

--- a/backend/tests/test_audiobook_import.py
+++ b/backend/tests/test_audiobook_import.py
@@ -228,6 +228,23 @@ def test_prepare_sources_reuses_extracted_files_on_retry(tmp_path, monkeypatch):
     assert cue_paths == [extracted_cue]
 
 
+def test_prepare_sources_prefers_m4b_from_unzipped_libation_folder(tmp_path):
+    edition_dir = tmp_path / "edition"
+    incoming_dir = edition_dir / "incoming"
+    incoming_dir.mkdir(parents=True)
+    (incoming_dir / "Book [B012345678].m4b").write_bytes(b"m4b")
+    (incoming_dir / "Book [B012345678].mp3").write_bytes(b"mp3")
+    (incoming_dir / "Book [B012345678].cue").write_text(
+        'TITLE "Book"\n',
+        encoding="utf-8",
+    )
+
+    audio_paths, cue_paths = audiobook_import._prepare_sources(edition_dir)
+
+    assert [path.suffix for path in audio_paths] == [".m4b"]
+    assert [path.suffix for path in cue_paths] == [".cue"]
+
+
 @pytest.mark.asyncio
 async def test_upload_endpoint_streams_large_format_to_staging(
     app_client,
@@ -252,6 +269,10 @@ async def test_upload_endpoint_streams_large_format_to_staging(
     response = app_client.post(
         f"/api/books/{book_id}/audiobook/imports",
         files={"files": ("Import Test [B012345678].m4b", b"not-buffered-by-the-handler", "audio/mp4")},
+        data={
+            "source_paths": "Import Test [B012345678]/Import Test.m4b",
+            "auto_align": "true",
+        },
     )
     assert response.status_code == 200
     payload = response.json()
@@ -261,6 +282,16 @@ async def test_upload_endpoint_streams_large_format_to_staging(
     assert (
         tmp_path / str(book_id) / str(payload["id"]) / "incoming" / "Import Test [B012345678].m4b"
     ).read_bytes() == b"not-buffered-by-the-handler"
+    async with sqlite_sessionmaker() as db:
+        job = (
+            await db.execute(
+                select(ProcessingJob).where(
+                    ProcessingJob.job_type == "import_audiobook",
+                    ProcessingJob.target_id == payload["id"],
+                )
+            )
+        ).scalar_one()
+        assert job.payload == {"auto_align": True}
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_processing_jobs.py
+++ b/backend/tests/test_processing_jobs.py
@@ -6,9 +6,103 @@ import pytest
 from sqlalchemy import select
 
 from backend.app import crud
-from backend.app.models import Book, ImportedAudiobook, ProcessingJob, SourceType
+from backend.app.models import (
+    AudiobookChapter,
+    AudiobookSettings,
+    Book,
+    ImportedAudiobook,
+    ImportedAudiobookTrack,
+    ProcessingJob,
+    SourceType,
+)
 from backend.app.services import processing_queue as processing_queue_module
 from backend.app.services.processing_queue import ProcessingQueue, queue_audio_reconciliation
+
+
+@pytest.mark.asyncio
+async def test_audiobook_import_automatically_queues_whisper_alignment(
+    sqlite_sessionmaker,
+    monkeypatch,
+):
+    async with sqlite_sessionmaker() as db:
+        book = Book(
+            title="Auto Align",
+            author="Narrator",
+            source_type=SourceType.epub,
+            immutable_path="library/auto-align-immutable.epub",
+            current_path="library/auto-align.epub",
+            content_version=1,
+        )
+        db.add(book)
+        await db.flush()
+        chapter = AudiobookChapter(
+            book_id=book.id,
+            chapter_number=1,
+            title="Chapter 1",
+            stable_chapter_key="auto-align-chapter",
+            spine_order=0,
+        )
+        edition = ImportedAudiobook(
+            book_id=book.id,
+            name="Human narration",
+            status="queued",
+        )
+        db.add_all([chapter, edition])
+        await db.flush()
+        db.add(
+            AudiobookSettings(
+                transcription_provider="whisperx",
+                transcription_base_url="http://whisper:8002",
+            )
+        )
+        job = ProcessingJob(
+            job_type="import_audiobook",
+            status="running",
+            book_id=book.id,
+            target_type="imported_audiobook",
+            target_id=edition.id,
+            payload={"auto_align": True},
+            dedupe_key=f"import_audiobook:imported_audiobook:{edition.id}",
+        )
+        db.add(job)
+        await db.commit()
+
+    async def fake_import(edition_id, db):
+        selected = await db.get(ImportedAudiobook, edition_id)
+        selected.status = "ready"
+        selected.matched_content_version = 1
+        db.add(
+            ImportedAudiobookTrack(
+                imported_audiobook_id=edition_id,
+                matched_chapter_id=chapter.id,
+                sequence_order=1,
+                title="Chapter 1",
+                audio_file_path="library/audio.m4b",
+                media_type="audio/mp4",
+                source_start_ms=0,
+                source_end_ms=10_000,
+                duration_ms=10_000,
+            )
+        )
+        await db.commit()
+
+    monkeypatch.setattr(processing_queue_module, "SessionLocal", sqlite_sessionmaker)
+    monkeypatch.setattr(processing_queue_module, "process_import", fake_import)
+    queue = ProcessingQueue()
+
+    detail = await queue._execute(job)
+
+    assert detail.endswith("timestamp alignment queued")
+    async with sqlite_sessionmaker() as db:
+        alignment_job = (
+            await db.execute(
+                select(ProcessingJob).where(
+                    ProcessingJob.job_type == "align_imported_audiobook",
+                    ProcessingJob.target_id == edition.id,
+                )
+            )
+        ).scalar_one()
+        assert alignment_job.parent_job_id == job.id
 
 
 @pytest.mark.asyncio

--- a/frontend/src/api/audiobook.js
+++ b/frontend/src/api/audiobook.js
@@ -163,10 +163,19 @@ export function getImportedAudiobooks(bookId) {
   );
 }
 
-export function uploadImportedAudiobook(bookId, files, name = "") {
+export function uploadImportedAudiobook(
+  bookId,
+  files,
+  name = "",
+  autoAlign = true,
+) {
   const body = new FormData();
-  files.forEach((file) => body.append("files", file));
+  files.forEach((file) => {
+    body.append("files", file);
+    body.append("source_paths", file.webkitRelativePath || file.name);
+  });
   if (name.trim()) body.append("name", name.trim());
+  body.append("auto_align", String(autoAlign));
   return sendForm(`/api/books/${bookId}/audiobook/imports`, body, {
     fallbackMessage: "Failed to upload audiobook",
   });

--- a/frontend/src/components/AudiobookPipeline.test.jsx
+++ b/frontend/src/components/AudiobookPipeline.test.jsx
@@ -262,6 +262,95 @@ describe("AudiobookPipeline", () => {
     ).toBeInTheDocument();
   });
 
+  it("uploads a Libation directory without its duplicate MP3 and enables Whisper alignment", async () => {
+    const fetchMock = vi.fn((url, options) => {
+      if (
+        url === "/api/books/11/audiobook/imports" &&
+        options?.method === "POST"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ id: 20, status: "queued" }),
+        });
+      }
+      if (
+        url === "/api/books/11/audiobook/status" ||
+        url === "/api/books/11/audiobook/characters" ||
+        url === "/api/books/11/audiobook/chapters" ||
+        url === "/api/books/11/audiobook/imports"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve(
+              url.endsWith("/status") ? { pipeline_status: "complete" } : [],
+            ),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+    globalThis.fetch = fetchMock;
+    const makeFile = (name, relativePath) => {
+      const file = new File(["audio"], name);
+      Object.defineProperty(file, "webkitRelativePath", {
+        value: relativePath,
+      });
+      return file;
+    };
+    const m4b = makeFile(
+      "Dungeon Crawler Carl [B08V8B2CGV].m4b",
+      "Dungeon Crawler Carl [B08V8B2CGV]/Dungeon Crawler Carl [B08V8B2CGV].m4b",
+    );
+    const mp3 = makeFile(
+      "Dungeon Crawler Carl [B08V8B2CGV].mp3",
+      "Dungeon Crawler Carl [B08V8B2CGV]/Dungeon Crawler Carl [B08V8B2CGV].mp3",
+    );
+    const cue = makeFile(
+      "Dungeon Crawler Carl [B08V8B2CGV].cue",
+      "Dungeon Crawler Carl [B08V8B2CGV]/Dungeon Crawler Carl [B08V8B2CGV].cue",
+    );
+    const cover = makeFile(
+      "cover.jpg",
+      "Dungeon Crawler Carl [B08V8B2CGV]/cover.jpg",
+    );
+
+    renderWithClient(
+      <AudiobookPipeline book={{ id: 11, audiobook_enabled: true }} />,
+    );
+
+    fireEvent.change(await screen.findByLabelText("Libation book directory"), {
+      target: { files: [m4b, mp3, cue, cover] },
+    });
+    expect(
+      screen.getByText("Ignored 2 duplicate or non-audio files."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("checkbox", {
+        name: "Improve sentence timestamps with Whisper after matching",
+      }),
+    ).toBeChecked();
+    fireEvent.click(screen.getByRole("button", { name: "Upload & Match" }));
+
+    await waitFor(() => {
+      const uploadCall = fetchMock.mock.calls.find(
+        ([url, options]) =>
+          url === "/api/books/11/audiobook/imports" &&
+          options?.method === "POST",
+      );
+      expect(uploadCall).toBeDefined();
+      const body = uploadCall[1].body;
+      expect(body.getAll("files").map((file) => file.name)).toEqual([
+        m4b.name,
+        cue.name,
+      ]);
+      expect(body.getAll("source_paths")).toEqual([
+        m4b.webkitRelativePath,
+        cue.webkitRelativePath,
+      ]);
+      expect(body.get("auto_align")).toBe("true");
+    });
+  });
+
   it("shows model progress and can run exactly one diarization batch", async () => {
     const fetchMock = vi.fn((url, options) => {
       if (url === "/api/books/11/audiobook/status") {

--- a/frontend/src/components/audiobook/AudiobookSources.jsx
+++ b/frontend/src/components/audiobook/AudiobookSources.jsx
@@ -30,6 +30,36 @@ function importedAtLabel(createdAt) {
   }).format(date)}`;
 }
 
+const AUDIO_EXTENSIONS = new Set([
+  ".aac",
+  ".flac",
+  ".m4a",
+  ".m4b",
+  ".mp3",
+  ".mp4",
+  ".ogg",
+  ".opus",
+  ".wav",
+]);
+const IMPORT_EXTENSIONS = new Set([...AUDIO_EXTENSIONS, ".cue", ".zip"]);
+
+function extension(file) {
+  const index = file.name.lastIndexOf(".");
+  return index < 0 ? "" : file.name.slice(index).toLowerCase();
+}
+
+function selectAudiobookFiles(selectedFiles) {
+  const supported = selectedFiles.filter((file) =>
+    IMPORT_EXTENSIONS.has(extension(file)),
+  );
+  const hasM4b = supported.some((file) => extension(file) === ".m4b");
+  if (!hasM4b) return supported;
+  return supported.filter(
+    (file) =>
+      !AUDIO_EXTENSIONS.has(extension(file)) || extension(file) === ".m4b",
+  );
+}
+
 function AudiobookSources({
   bookId,
   chapters = [],
@@ -40,8 +70,11 @@ function AudiobookSources({
 }) {
   const queryClient = useQueryClient();
   const inputRef = useRef(null);
+  const directoryInputRef = useRef(null);
   const [files, setFiles] = useState([]);
   const [name, setName] = useState("");
+  const [autoAlign, setAutoAlign] = useState(true);
+  const [ignoredFileCount, setIgnoredFileCount] = useState(0);
   const [jobNotice, setJobNotice] = useState("");
   const [confirmAiTtsRebuild, setConfirmAiTtsRebuild] = useState(false);
 
@@ -51,15 +84,23 @@ function AudiobookSources({
     queryClient.invalidateQueries({ queryKey: ["audiobook-status", bookId] });
   };
   const uploadMutation = useMutation({
-    mutationFn: () => uploadImportedAudiobook(bookId, files, name),
+    mutationFn: () => uploadImportedAudiobook(bookId, files, name, autoAlign),
     onSuccess: () => {
       setJobNotice("Human audiobook import and matching queued.");
       setFiles([]);
       setName("");
+      setIgnoredFileCount(0);
       if (inputRef.current) inputRef.current.value = "";
+      if (directoryInputRef.current) directoryInputRef.current.value = "";
       invalidate();
     },
   });
+  const chooseFiles = (selectedFiles) => {
+    const selected = Array.from(selectedFiles || []);
+    const usable = selectAudiobookFiles(selected);
+    setFiles(usable);
+    setIgnoredFileCount(selected.length - usable.length);
+  };
   const retryMutation = useMutation({
     mutationFn: retryImportedAudiobook,
     onSuccess: () => {
@@ -108,9 +149,9 @@ function AudiobookSources({
           <span className="metric-label">Human narration</span>
           <h3>Import an audiobook</h3>
           <p>
-            Upload a Libation ZIP unchanged, or select M4B, MP3, M4A, and CUE
-            files together. CUE and embedded chapter titles are matched against
-            this book automatically.
+            Select a Libation book folder unchanged, upload its ZIP, or choose
+            M4B, MP3, M4A, and CUE files together. Story Manager prefers the
+            chapter-capable M4B when Libation also created a duplicate MP3.
           </p>
         </div>
         <label>
@@ -122,13 +163,24 @@ function AudiobookSources({
           />
         </label>
         <label>
-          Audiobook file or files
+          Libation book directory
+          <input
+            ref={directoryInputRef}
+            type="file"
+            multiple
+            webkitdirectory=""
+            directory=""
+            onChange={(event) => chooseFiles(event.target.files)}
+          />
+        </label>
+        <label>
+          Or audiobook file / ZIP
           <input
             ref={inputRef}
             type="file"
             multiple
             accept=".zip,.cue,.m4b,.m4a,.mp3,.mp4,.aac,.flac,.ogg,.opus,.wav,audio/*"
-            onChange={(event) => setFiles(Array.from(event.target.files || []))}
+            onChange={(event) => chooseFiles(event.target.files)}
           />
         </label>
         {files.length > 0 && (
@@ -136,6 +188,20 @@ function AudiobookSources({
             {files.map((file) => file.name).join(", ")}
           </p>
         )}
+        {ignoredFileCount > 0 && (
+          <p className="hint">
+            Ignored {ignoredFileCount} duplicate or non-audio{" "}
+            {ignoredFileCount === 1 ? "file" : "files"}.
+          </p>
+        )}
+        <label>
+          <input
+            type="checkbox"
+            checked={autoAlign}
+            onChange={(event) => setAutoAlign(event.target.checked)}
+          />{" "}
+          Improve sentence timestamps with Whisper after matching
+        </label>
         <button
           type="button"
           className="btn-primary"


### PR DESCRIPTION
## What changed

- adds a browser directory picker for unzipped Libation book folders
- ignores non-audio files and prefers Libation’s M4B when a duplicate MP3 exists
- preserves relative source paths for Libation ASIN detection
- defaults human audiobook imports to automatic Whisper timestamp alignment when transcription is configured
- keeps a checkbox to opt out of automatic alignment

## Why

Libation exports audiobooks as ordinary directories by default. Requiring users to ZIP each directory or manually choose individual files made the direct-to-book import flow unnecessarily cumbersome, and timestamp alignment required a second manual action.

## Validation

- `make test` (345 backend tests, 50 frontend tests)
- `make lint`
- Black and autoflake CI-equivalent checks
- regression test modeled on the local `Dungeon Crawler Carl [B08V8B2CGV]` Libation folder