### PR TITLE
Fix human audiobook highlighting

### DIFF
--- a/backend/app/routers/audiobook.py
+++ b/backend/app/routers/audiobook.py
@@ -714,7 +714,9 @@ async def get_imported_track_cues(
     reading_blocks: dict[str, ReadingBlock] = {}
     if track.matched_chapter_id is not None:
         chapter = await db.get(AudiobookChapter, track.matched_chapter_id)
-        book = await _get_audiobook_book_or_404(edition.book_id, db)
+        # Imported narration is independent of the opt-in AI generation
+        # pipeline. Human-only books still need their synchronized text cues.
+        book = await _get_book_or_404(edition.book_id, db)
         if chapter is not None:
             reading_blocks = chapter_reading_blocks(book, chapter)
     result = await db.execute(

--- a/backend/app/routers/reader.py
+++ b/backend/app/routers/reader.py
@@ -732,8 +732,18 @@ async def reader_download_book(book_id: int, db: AsyncSession = Depends(get_db))
     current_path = LIBRARY_PATH.parent / book.current_path
     if not current_path.is_file():
         raise HTTPException(status_code=404, detail="EPUB file not found")
+
+    # Human-audiobook SMIL targets the stable sentence spans injected into the
+    # reader text rendition. Serve that rendition when it matches the current
+    # book content, while retaining the normal EPUB as a safe stale fallback.
+    reader_text_path = text_reader_path(book)
+    download_path = (
+        reader_text_path
+        if reader_text_path is not None and book.audiobook_text_content_version == (book.content_version or 1)
+        else current_path
+    )
     return FileResponse(
-        current_path,
+        download_path,
         media_type="application/epub+zip",
         headers={"Content-Disposition": f'attachment; filename="{current_path.name}"'},
     )

--- a/backend/tests/test_reader_audiobook.py
+++ b/backend/tests/test_reader_audiobook.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 from datetime import datetime, timezone
 from pathlib import Path
+from zipfile import ZipFile
 
 import pytest
 
@@ -403,6 +404,128 @@ async def test_reader_book_exposes_a_human_only_audiobook_type(app_client, sqlit
         ).json()
         == []
     )
+
+
+@pytest.mark.asyncio
+async def test_human_only_audiobook_exposes_cues_and_downloads_anchored_text(
+    app_client,
+    sqlite_sessionmaker,
+    tmp_path,
+    monkeypatch,
+):
+    library = tmp_path / "library"
+    current_path = library / "human.epub"
+    reader_path = library / "audiobooks" / "841" / "reader" / "text-v1.epub"
+    audio_path = library / "audiobooks" / "841" / "imports" / "70" / "human.m4b"
+    current_path.parent.mkdir(parents=True)
+    reader_path.parent.mkdir(parents=True)
+    audio_path.parent.mkdir(parents=True)
+    with ZipFile(current_path, "w") as archive:
+        archive.writestr("EPUB/Text/chapter.xhtml", "<html><body><p>Human narration.</p></body></html>")
+    with ZipFile(reader_path, "w") as archive:
+        archive.writestr(
+            "EPUB/Text/chapter.xhtml",
+            '<html><body><p><span id="sentence-1">Human narration.</span></p></body></html>',
+        )
+    audio_path.write_bytes(b"human-audio")
+
+    monkeypatch.setattr(reader, "LIBRARY_PATH", library)
+    monkeypatch.setattr(reader.audiobook_router, "LIBRARY_PATH", library)
+    monkeypatch.setattr(audiobook_publication, "LIBRARY_PATH", library)
+
+    async with sqlite_sessionmaker() as db:
+        book = models.Book(
+            id=841,
+            title="Human Audio With Text",
+            author="Reader",
+            source_type=models.SourceType.epub,
+            immutable_path="library/human-source.epub",
+            current_path=_relative(library, current_path),
+            content_version=1,
+            audiobook_enabled=False,
+            audiobook_text_content_version=1,
+            audiobook_text_file_path=_relative(library, reader_path),
+        )
+        chapter = models.AudiobookChapter(
+            id=801,
+            book_id=book.id,
+            chapter_number=1,
+            content_file_name="Text/chapter.xhtml",
+            source_href="Text/chapter.xhtml",
+            title="Chapter One",
+        )
+        sentence = models.AudiobookSentence(
+            id=802,
+            chapter_id=chapter.id,
+            html_element_id="sentence-1",
+            sequence_order=0,
+            original_text="Human narration.",
+        )
+        edition = models.ImportedAudiobook(
+            id=70,
+            book_id=book.id,
+            name="Human narration",
+            status="ready",
+            matched_content_version=1,
+        )
+        track = models.ImportedAudiobookTrack(
+            id=71,
+            imported_audiobook_id=edition.id,
+            matched_chapter_id=chapter.id,
+            sequence_order=1,
+            title="Chapter One",
+            audio_file_path=_relative(library, audio_path),
+            media_type="audio/mp4",
+            source_start_ms=0,
+            source_end_ms=1250,
+            duration_ms=1250,
+        )
+        cue = models.ImportedAudiobookCue(
+            track_id=track.id,
+            sentence_id=sentence.id,
+            sequence_order=0,
+            clip_begin_ms=0,
+            clip_end_ms=1250,
+            method="transcribed",
+        )
+        db.add_all([book, chapter, sentence, edition, track, cue])
+        await db.commit()
+
+    cues = app_client.get("/api/imported-audiobooks/70/tracks/71/cues")
+    assert cues.status_code == 200
+    assert cues.json() == [
+        {
+            "sentence_id": 802,
+            "html_element_id": "sentence-1",
+            "text": "Human narration.",
+            "clip_begin_ms": 0,
+            "clip_end_ms": 1250,
+            "confidence": None,
+            "method": "transcribed",
+            "reading_block_index": 0,
+            "reading_block_type": "paragraph",
+        }
+    ]
+
+    key_response = app_client.post("/api/reader-keys", json={"label": "Human Audio Reader"})
+    auth = ("reader", key_response.json()["token"])
+    download = app_client.get("/reader/books/841/download", auth=auth)
+    assert download.status_code == 200
+    assert download.content == reader_path.read_bytes()
+    assert download.headers["content-disposition"] == 'attachment; filename="human.epub"'
+    assert b"sentence-1" in download.content
+
+    editions = app_client.get("/reader/books/841/human-audiobooks", auth=auth).json()
+    smil = app_client.get(editions[0]["tracks"][0]["smil_url"], auth=auth)
+    assert smil.status_code == 200
+    assert b'src="chapter.xhtml#sentence-1"' in smil.content
+
+    async with sqlite_sessionmaker() as db:
+        book = await db.get(models.Book, 841)
+        book.content_version = 2
+        await db.commit()
+    stale_fallback = app_client.get("/reader/books/841/download", auth=auth)
+    assert stale_fallback.content == current_path.read_bytes()
 
 
 def test_reader_audiobook_capability_supports_all_publication_states():

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2769,9 +2769,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

- allow imported human-narration cues to load when the AI audiobook pipeline is disabled
- serve the current span-anchored EPUB rendition through the Reader download endpoint
- fall back to the ordinary EPUB when the anchored rendition is stale
- add regression coverage for human-only cue retrieval, SMIL anchors, Reader downloads, and stale fallback

## Root cause

Human-only books correctly keep `audiobook_enabled=false`, but the imported cue endpoint used the AI-pipeline authorization helper and returned 403. Separately, human-audiobook SMIL referenced stable sentence IDs from the span-injected reader EPUB while Story Reader downloaded the ordinary EPUB, which did not contain those IDs.

## Impact

The Story Manager Listen & Read tab now loads synchronized text for imported human narration without enabling AI generation. Story Reader receives EPUB content containing the sentence anchors referenced by human-audiobook SMIL, restoring follow-along highlighting.

## Validation

- `346 passed, 1 deselected` backend tests
- `50 passed` frontend tests
- Black and Flake8 pass for the changed files
- verified against the isolated Dungeon Crawler Carl reproduction with `audiobook_enabled=false`; the cue endpoint returns 200 and synchronized text renders