### PR TITLE
Add bulk Libation backup import

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Story Manager is a self-hosted library manager for EPUBs and web novels. It give
 ## Features
 
 - Manage uploaded EPUBs and tracked web novels in one library.
-- Import human-narrated audiobooks, including Libation ZIP exports, and read
-  along with synchronized EPUB text.
+- Import individual human-narrated audiobooks or a complete Libation backup,
+  match them to library EPUBs, and read along with synchronized text.
 - Download and refresh supported web novels with FanFicFare.
 - Preserve existing chapters when source sites remove older content.
 - Edit book metadata, covers, chapters, cleaning configs, and series information.

--- a/backend/app/routers/audiobook.py
+++ b/backend/app/routers/audiobook.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import shutil
 from datetime import datetime
 from pathlib import Path
@@ -33,6 +34,7 @@ from ..services.audiobook_import import (
     asin_from_names,
     display_name_from_filename,
     imported_audiobook_dir,
+    libation_backup_groups,
     rematch_track,
     safe_import_filename,
     stream_upload_to_path,
@@ -45,6 +47,7 @@ from ..services.transcription_providers import (
     transcription_service_health,
 )
 from ..services.endpoint_pool import configured_endpoints, primary_provider
+from ..services.metadata.scoring import normalize_text
 from ..services.tts_providers import (
     TTSRequest,
     design_omnivoice_voice,
@@ -338,6 +341,34 @@ class ImportedTrackMatchUpdate(BaseModel):
     chapter_id: Optional[int] = None
 
 
+class LibationBackupPreviewRequest(BaseModel):
+    source_paths: list[str] = Field(min_length=1, max_length=50_000)
+
+
+class LibationBackupMatchResponse(BaseModel):
+    source_key: str
+    folder_name: str
+    source_title: str
+    product_id: str
+    file_count: int
+    status: str
+    match_method: Optional[str] = None
+    book_id: Optional[int] = None
+    book_title: Optional[str] = None
+    book_author: Optional[str] = None
+    existing_edition_id: Optional[int] = None
+    detail: Optional[str] = None
+
+
+class LibationBackupPreviewResponse(BaseModel):
+    groups: list[LibationBackupMatchResponse]
+    matched_count: int
+    unmatched_count: int
+    ambiguous_count: int
+    already_imported_count: int
+    ignored_file_count: int
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -471,9 +502,119 @@ async def _get_imported_track_or_404(
     return edition, track
 
 
+def _normalized_identifier(value: Any) -> str:
+    return re.sub(r"[^0-9a-z]", "", str(value).casefold())
+
+
+def _book_identifier_values(book: Book) -> set[str]:
+    values: set[str] = set()
+    for value in (book.metadata_remote_ids or {}).values():
+        candidates = value if isinstance(value, list) else [value]
+        for candidate in candidates:
+            if isinstance(candidate, (str, int)) and (normalized := _normalized_identifier(candidate)):
+                values.add(normalized)
+    return values
+
+
+def _single_book_match(candidates: list[Book]) -> tuple[Book | None, bool]:
+    unique = {book.id: book for book in candidates}
+    if len(unique) == 1:
+        return next(iter(unique.values())), False
+    return None, len(unique) > 1
+
+
 # ---------------------------------------------------------------------------
 # Human-narrated audiobook imports
 # ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/api/audiobook/libation-backup/preview",
+    response_model=LibationBackupPreviewResponse,
+)
+async def preview_libation_backup(
+    request: LibationBackupPreviewRequest,
+    db: AsyncSession = Depends(get_db),
+) -> LibationBackupPreviewResponse:
+    """Match a path-only Libation backup manifest before any audio is uploaded."""
+    groups, ignored_file_count = libation_backup_groups(request.source_paths)
+    books = list((await db.execute(select(Book).order_by(Book.title, Book.id))).scalars().all())
+    imports = list((await db.execute(select(ImportedAudiobook))).scalars().all())
+    imports_by_book_and_id = {
+        (edition.book_id, _normalized_identifier(edition.asin)): edition for edition in imports if edition.asin
+    }
+    books_by_identifier: dict[str, list[Book]] = {}
+    books_by_title: dict[str, list[Book]] = {}
+    for book in books:
+        for identifier in _book_identifier_values(book):
+            books_by_identifier.setdefault(identifier, []).append(book)
+        books_by_title.setdefault(normalize_text(book.title or ""), []).append(book)
+
+    matches: list[LibationBackupMatchResponse] = []
+    for group in groups:
+        normalized_id = _normalized_identifier(group.product_id)
+        identifier_candidates = books_by_identifier.get(normalized_id, [])
+        matched_book, ambiguous = _single_book_match(identifier_candidates)
+        match_method = "identifier" if matched_book else None
+        if not identifier_candidates:
+            title_candidates = books_by_title.get(normalize_text(group.title), [])
+            matched_book, ambiguous = _single_book_match(title_candidates)
+            match_method = "title" if matched_book else None
+
+        if ambiguous:
+            matches.append(
+                LibationBackupMatchResponse(
+                    source_key=group.source_key,
+                    folder_name=group.folder_name,
+                    source_title=group.title,
+                    product_id=group.product_id,
+                    file_count=len(group.source_paths),
+                    status="ambiguous",
+                    detail="More than one library book has this identifier or title.",
+                )
+            )
+            continue
+        if matched_book is None:
+            matches.append(
+                LibationBackupMatchResponse(
+                    source_key=group.source_key,
+                    folder_name=group.folder_name,
+                    source_title=group.title,
+                    product_id=group.product_id,
+                    file_count=len(group.source_paths),
+                    status="unmatched",
+                    detail="No library book has the same identifier or title.",
+                )
+            )
+            continue
+
+        existing = imports_by_book_and_id.get((matched_book.id, normalized_id))
+        status = "already_imported" if existing else "matched"
+        matches.append(
+            LibationBackupMatchResponse(
+                source_key=group.source_key,
+                folder_name=group.folder_name,
+                source_title=group.title,
+                product_id=group.product_id,
+                file_count=len(group.source_paths),
+                status=status,
+                match_method=match_method,
+                book_id=matched_book.id,
+                book_title=matched_book.title,
+                book_author=matched_book.author,
+                existing_edition_id=existing.id if existing else None,
+                detail=(f"Already attached as {existing.name} ({existing.status})." if existing else None),
+            )
+        )
+
+    return LibationBackupPreviewResponse(
+        groups=matches,
+        matched_count=sum(match.status == "matched" for match in matches),
+        unmatched_count=sum(match.status == "unmatched" for match in matches),
+        ambiguous_count=sum(match.status == "ambiguous" for match in matches),
+        already_imported_count=sum(match.status == "already_imported" for match in matches),
+        ignored_file_count=ignored_file_count,
+    )
 
 
 @router.get(

--- a/backend/app/services/audiobook_import.py
+++ b/backend/app/services/audiobook_import.py
@@ -33,7 +33,7 @@ AUDIO_EXTENSIONS = {".aac", ".flac", ".m4a", ".m4b", ".mp3", ".mp4", ".ogg", ".o
 IMPORT_EXTENSIONS = AUDIO_EXTENSIONS | {".cue", ".zip"}
 MAX_AUDIOBOOK_UPLOAD_BYTES = 8 * 1024 * 1024 * 1024
 UPLOAD_CHUNK_BYTES = 1024 * 1024
-_ASIN_RE = re.compile(r"\[(B[0-9A-Z]{9})\]", re.IGNORECASE)
+_ASIN_RE = re.compile(r"\[((?:B[0-9A-Z]{9})|(?:[0-9]{9}[0-9X]))\]", re.IGNORECASE)
 _CUE_TRACK_RE = re.compile(r"^\s*TRACK\s+(\d+)\s+AUDIO\s*$", re.IGNORECASE)
 _CUE_TITLE_RE = re.compile(r'^\s*TITLE\s+"(.*)"\s*$', re.IGNORECASE)
 _CUE_INDEX_RE = re.compile(r"^\s*INDEX\s+01\s+(\d+):(\d+):(\d+)\s*$", re.IGNORECASE)
@@ -70,11 +70,79 @@ def safe_import_filename(raw_name: str, fallback: str = "audiobook") -> str:
 
 
 def asin_from_names(names: list[str]) -> str | None:
+    """Return the Audible ASIN or ISBN-10 embedded in a Libation name."""
     for name in names:
         match = _ASIN_RE.search(name)
         if match:
             return match.group(1).upper()
     return None
+
+
+@dataclass(frozen=True)
+class LibationBackupGroup:
+    """Supported files belonging to one Libation book directory."""
+
+    source_key: str
+    folder_name: str
+    title: str
+    product_id: str
+    source_paths: tuple[str, ...]
+
+
+def libation_backup_groups(source_paths: list[str]) -> tuple[list[LibationBackupGroup], int]:
+    """Group a browser directory manifest by its ``Title [product-id]`` folder."""
+    grouped: dict[str, dict[str, object]] = {}
+    ignored_count = 0
+    for raw_path in source_paths:
+        normalized_path = (raw_path or "").replace("\\", "/").strip("/")
+        path = PurePosixPath(normalized_path)
+        if not normalized_path or path.suffix.lower() not in IMPORT_EXTENSIONS:
+            ignored_count += 1
+            continue
+
+        folder_index = None
+        folder_match = None
+        for index, part in enumerate(path.parts):
+            match = _ASIN_RE.search(part)
+            if match:
+                folder_index = index
+                folder_match = match
+                break
+        if folder_index is None or folder_match is None:
+            ignored_count += 1
+            continue
+
+        folder_name = path.parts[folder_index]
+        # A ZIP can itself be named like a Libation folder. Remove the archive
+        # extension for the user-facing title and stable grouping key.
+        if folder_index == len(path.parts) - 1 and path.suffix.lower() == ".zip":
+            folder_name = Path(folder_name).stem
+        product_id = folder_match.group(1).upper()
+        title = _ASIN_RE.sub("", folder_name).strip(" ._-") or "Untitled audiobook"
+        source_key = "/".join((*path.parts[:folder_index], folder_name))
+        entry = grouped.setdefault(
+            source_key,
+            {
+                "folder_name": folder_name,
+                "title": title,
+                "product_id": product_id,
+                "source_paths": [],
+            },
+        )
+        entry["source_paths"].append(normalized_path)
+
+    groups = [
+        LibationBackupGroup(
+            source_key=source_key,
+            folder_name=str(entry["folder_name"]),
+            title=str(entry["title"]),
+            product_id=str(entry["product_id"]),
+            source_paths=tuple(entry["source_paths"]),
+        )
+        for source_key, entry in grouped.items()
+    ]
+    groups.sort(key=lambda group: group.title.casefold())
+    return groups, ignored_count
 
 
 def display_name_from_filename(filename: str) -> str:

--- a/backend/tests/test_audiobook_import.py
+++ b/backend/tests/test_audiobook_import.py
@@ -245,6 +245,87 @@ def test_prepare_sources_prefers_m4b_from_unzipped_libation_folder(tmp_path):
     assert [path.suffix for path in cue_paths] == [".cue"]
 
 
+def test_libation_backup_groups_supports_audible_and_isbn_folders():
+    groups, ignored = audiobook_import.libation_backup_groups(
+        [
+            "Libation/A Court of Mist and Fury [B01DYO4QRQ]/book.m4b",
+            "Libation/A Court of Mist and Fury [B01DYO4QRQ]/book.cue",
+            "Libation/A Court of Silver Flames [1980085722]/book.mp3",
+            "Libation/A Court of Silver Flames [1980085722]/cover.jpg",
+        ]
+    )
+
+    assert ignored == 1
+    assert [(group.title, group.product_id, len(group.source_paths)) for group in groups] == [
+        ("A Court of Mist and Fury", "B01DYO4QRQ", 2),
+        ("A Court of Silver Flames", "1980085722", 1),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_libation_backup_preview_matches_identifiers_titles_and_skips_existing(
+    app_client,
+    sqlite_sessionmaker,
+):
+    async with sqlite_sessionmaker() as db:
+        identifier_book = Book(
+            title="Different Store Title",
+            author="Author One",
+            immutable_path="library/identifier-immutable.epub",
+            current_path="library/identifier.epub",
+            metadata_remote_ids={"isbn_10": "1980085722"},
+        )
+        title_book = Book(
+            title="Title Match",
+            author="Author Two",
+            immutable_path="library/title-immutable.epub",
+            current_path="library/title.epub",
+        )
+        existing_book = Book(
+            title="Already Here",
+            author="Author Three",
+            immutable_path="library/existing-immutable.epub",
+            current_path="library/existing.epub",
+        )
+        db.add_all([identifier_book, title_book, existing_book])
+        await db.flush()
+        existing = ImportedAudiobook(
+            book_id=existing_book.id,
+            name="Prior Libation import",
+            asin="B111111111",
+            status="ready",
+        )
+        db.add(existing)
+        await db.commit()
+
+    response = app_client.post(
+        "/api/audiobook/libation-backup/preview",
+        json={
+            "source_paths": [
+                "Backup/Store Name [1980085722]/book.m4b",
+                "Backup/Title Match [B012345678]/book.m4b",
+                "Backup/Already Here [B111111111]/book.m4b",
+                "Backup/Not In Library [B222222222]/book.m4b",
+                "Backup/Not In Library [B222222222]/cover.jpg",
+            ]
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["matched_count"] == 2
+    assert payload["unmatched_count"] == 1
+    assert payload["already_imported_count"] == 1
+    assert payload["ignored_file_count"] == 1
+    matches = {group["product_id"]: group for group in payload["groups"]}
+    assert matches["1980085722"]["match_method"] == "identifier"
+    assert matches["1980085722"]["book_title"] == "Different Store Title"
+    assert matches["B012345678"]["match_method"] == "title"
+    assert matches["B111111111"]["status"] == "already_imported"
+    assert matches["B111111111"]["existing_edition_id"] is not None
+    assert matches["B222222222"]["status"] == "unmatched"
+
+
 @pytest.mark.asyncio
 async def test_upload_endpoint_streams_large_format_to_staging(
     app_client,

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1639,6 +1639,76 @@
   margin-bottom: 1.5rem;
 }
 
+.libation-backup-import {
+  display: grid;
+  gap: 1rem;
+}
+
+.libation-backup-import > h3,
+.libation-backup-import > p,
+.libation-match p,
+.libation-import-progress p {
+  margin: 0;
+}
+
+.libation-directory-picker {
+  display: grid;
+  gap: 0.4rem;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.libation-preview-summary {
+  padding: 0.75rem;
+  border-radius: var(--radius);
+  background: color-mix(in srgb, var(--accent) 8%, var(--surface));
+}
+
+.libation-match-list {
+  display: grid;
+  gap: 0.5rem;
+  max-height: 32rem;
+  overflow: auto;
+}
+
+.libation-match {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 0.7rem 0.8rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+}
+
+.libation-match--matched {
+  border-color: color-mix(in srgb, var(--success) 35%, var(--border));
+}
+
+.libation-match-status {
+  flex-shrink: 0;
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.libation-import-progress {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.libation-import-progress progress {
+  width: 100%;
+  accent-color: var(--accent);
+}
+
+@media (max-width: 640px) {
+  .libation-match {
+    display: grid;
+  }
+}
+
 .utilities-tab-content > .settings-section:first-child {
   padding-top: 0;
   border-top: 0;

--- a/frontend/src/api/audiobook.js
+++ b/frontend/src/api/audiobook.js
@@ -163,6 +163,13 @@ export function getImportedAudiobooks(bookId) {
   );
 }
 
+export function previewLibationBackup(sourcePaths) {
+  return sendJson("/api/audiobook/libation-backup/preview", {
+    body: { source_paths: sourcePaths },
+    fallbackMessage: "Failed to inspect the Libation backup",
+  });
+}
+
 export function uploadImportedAudiobook(
   bookId,
   files,

--- a/frontend/src/components/LibationBackupImport.jsx
+++ b/frontend/src/components/LibationBackupImport.jsx
@@ -1,0 +1,292 @@
+import { useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+
+import {
+  previewLibationBackup,
+  uploadImportedAudiobook,
+} from "../api/audiobook";
+
+const AUDIO_EXTENSIONS = new Set([
+  ".aac",
+  ".flac",
+  ".m4a",
+  ".m4b",
+  ".mp3",
+  ".mp4",
+  ".ogg",
+  ".opus",
+  ".wav",
+]);
+const IMPORT_EXTENSIONS = new Set([...AUDIO_EXTENSIONS, ".cue", ".zip"]);
+const LIBATION_ID_RE = /\[((?:B[0-9A-Z]{9})|(?:[0-9]{9}[0-9X]))\]/i;
+
+function extension(name) {
+  const index = name.lastIndexOf(".");
+  return index < 0 ? "" : name.slice(index).toLowerCase();
+}
+
+function sourcePath(file) {
+  return file.webkitRelativePath || file.name;
+}
+
+function libationSourceKey(pathValue) {
+  const parts = pathValue.replaceAll("\\", "/").split("/").filter(Boolean);
+  const folderIndex = parts.findIndex((part) => LIBATION_ID_RE.test(part));
+  if (folderIndex < 0) return null;
+  let folderName = parts[folderIndex];
+  if (folderIndex === parts.length - 1 && extension(folderName) === ".zip") {
+    folderName = folderName.slice(0, -4);
+  }
+  return [...parts.slice(0, folderIndex), folderName].join("/");
+}
+
+function filesBySourceKey(files) {
+  const groups = new Map();
+  files.forEach((file) => {
+    if (!IMPORT_EXTENSIONS.has(extension(file.name))) return;
+    const key = libationSourceKey(sourcePath(file));
+    if (!key) return;
+    const group = groups.get(key) || [];
+    group.push(file);
+    groups.set(key, group);
+  });
+  groups.forEach((group, key) => {
+    if (!group.some((file) => extension(file.name) === ".m4b")) return;
+    groups.set(
+      key,
+      group.filter(
+        (file) =>
+          !AUDIO_EXTENSIONS.has(extension(file.name)) ||
+          extension(file.name) === ".m4b",
+      ),
+    );
+  });
+  return groups;
+}
+
+function statusLabel(group) {
+  switch (group.status) {
+    case "matched":
+      return group.match_method === "identifier"
+        ? "Matched by identifier"
+        : "Matched by title";
+    case "already_imported":
+      return "Already imported";
+    case "ambiguous":
+      return "Needs a unique match";
+    default:
+      return "No library match";
+  }
+}
+
+function LibationBackupImport() {
+  const queryClient = useQueryClient();
+  const inputRef = useRef(null);
+  const [files, setFiles] = useState([]);
+  const [preview, setPreview] = useState(null);
+  const [previewError, setPreviewError] = useState("");
+  const [previewing, setPreviewing] = useState(false);
+  const [autoAlign, setAutoAlign] = useState(true);
+  const [importState, setImportState] = useState(null);
+
+  const inspectFiles = async (selectedFiles) => {
+    const selected = Array.from(selectedFiles || []);
+    setFiles(selected);
+    setPreview(null);
+    setPreviewError("");
+    setImportState(null);
+    if (!selected.length) return;
+    setPreviewing(true);
+    try {
+      const result = await previewLibationBackup(selected.map(sourcePath));
+      setPreview(result);
+    } catch (error) {
+      setPreviewError(error.message);
+    } finally {
+      setPreviewing(false);
+    }
+  };
+
+  const importMatches = async () => {
+    const matches = (preview?.groups || []).filter(
+      (group) => group.status === "matched",
+    );
+    const groupedFiles = filesBySourceKey(files);
+    const results = [];
+    setImportState({ current: 0, total: matches.length, results, done: false });
+    for (const [index, group] of matches.entries()) {
+      const groupFiles = groupedFiles.get(group.source_key) || [];
+      try {
+        if (!groupFiles.length) {
+          throw new Error(
+            "No supported audio files were found in this folder.",
+          );
+        }
+        await uploadImportedAudiobook(
+          group.book_id,
+          groupFiles,
+          `Libation · ${group.product_id}`,
+          autoAlign,
+        );
+        results.push({ ...group, result: "queued" });
+      } catch (error) {
+        results.push({ ...group, result: "failed", error: error.message });
+      }
+      setImportState({
+        current: index + 1,
+        total: matches.length,
+        results: [...results],
+        done: index + 1 === matches.length,
+      });
+    }
+    queryClient.invalidateQueries({ queryKey: ["processing-jobs"] });
+    queryClient.invalidateQueries({ queryKey: ["book-catalog"] });
+  };
+
+  const reset = () => {
+    setFiles([]);
+    setPreview(null);
+    setPreviewError("");
+    setImportState(null);
+    if (inputRef.current) inputRef.current.value = "";
+  };
+
+  const queuedCount =
+    importState?.results.filter((result) => result.result === "queued")
+      .length || 0;
+  const failedCount =
+    importState?.results.filter((result) => result.result === "failed")
+      .length || 0;
+
+  return (
+    <section className="settings-section libation-backup-import">
+      <h3>Import a Libation Backup</h3>
+      <p className="hint">
+        Choose the directory that contains all of your Libation book folders.
+        Story Manager previews identifier and exact-title matches before any
+        audio is transferred, skips books that are not in this library, and
+        queues each matched book separately.
+      </p>
+      <label className="libation-directory-picker">
+        Libation backup directory
+        <input
+          ref={inputRef}
+          type="file"
+          multiple
+          webkitdirectory=""
+          directory=""
+          disabled={Boolean(importState && !importState.done)}
+          onChange={(event) => inspectFiles(event.target.files)}
+        />
+      </label>
+      {previewing && (
+        <p className="hint" role="status">
+          Inspecting backup…
+        </p>
+      )}
+      {previewError && <p className="error">{previewError}</p>}
+
+      {preview && (
+        <>
+          <p className="libation-preview-summary" role="status">
+            <strong>{preview.matched_count} ready to import</strong>
+            {` · ${preview.already_imported_count} already imported · ${preview.unmatched_count} unmatched`}
+            {preview.ambiguous_count
+              ? ` · ${preview.ambiguous_count} ambiguous`
+              : ""}
+          </p>
+          {preview.ignored_file_count > 0 && (
+            <p className="hint">
+              {preview.ignored_file_count} cover, metadata, duplicate, or
+              unsupported{" "}
+              {preview.ignored_file_count === 1 ? "file was" : "files were"}{" "}
+              ignored.
+            </p>
+          )}
+          <div className="libation-match-list">
+            {preview.groups.map((group) => (
+              <div
+                className={`libation-match libation-match--${group.status}`}
+                key={group.source_key}
+              >
+                <div>
+                  <strong>{group.source_title}</strong>
+                  <span className="hint"> · {group.product_id}</span>
+                  {group.book_title && (
+                    <p className="hint">
+                      Library: {group.book_title}
+                      {group.book_author ? ` by ${group.book_author}` : ""}
+                    </p>
+                  )}
+                  {!group.book_title && group.detail && (
+                    <p className="hint">{group.detail}</p>
+                  )}
+                </div>
+                <span className="libation-match-status">
+                  {statusLabel(group)}
+                </span>
+              </div>
+            ))}
+          </div>
+          <label>
+            <input
+              type="checkbox"
+              checked={autoAlign}
+              disabled={Boolean(importState)}
+              onChange={(event) => setAutoAlign(event.target.checked)}
+            />{" "}
+            Run configured speech-to-text alignment after matching (WhisperX
+            recommended)
+          </label>
+          <div className="settings-actions">
+            <button
+              type="button"
+              className="btn-primary"
+              disabled={
+                preview.matched_count === 0 ||
+                Boolean(importState) ||
+                previewing
+              }
+              onClick={importMatches}
+            >
+              Import {preview.matched_count} Matched{" "}
+              {preview.matched_count === 1 ? "Book" : "Books"}
+            </button>
+            <button
+              type="button"
+              className="btn-text"
+              disabled={Boolean(importState && !importState.done)}
+              onClick={reset}
+            >
+              Choose Another Backup
+            </button>
+          </div>
+        </>
+      )}
+
+      {importState && (
+        <div className="libation-import-progress" role="status">
+          <p>
+            {importState.done
+              ? `Queued ${queuedCount} of ${importState.total} matched books${failedCount ? `; ${failedCount} failed to upload` : ""}.`
+              : `Uploading book ${Math.min(importState.current + 1, importState.total)} of ${importState.total}. Keep this page open until all uploads are queued.`}
+          </p>
+          <progress value={importState.current} max={importState.total} />
+          {importState.results
+            .filter((result) => result.result === "failed")
+            .map((result) => (
+              <p className="error" key={result.source_key}>
+                {result.source_title}: {result.error}
+              </p>
+            ))}
+        </div>
+      )}
+      <p className="hint">
+        Unmatched books are not uploaded. Add their EPUBs to Story Manager and
+        select this backup again later; already imported books will be skipped.
+      </p>
+    </section>
+  );
+}
+
+export default LibationBackupImport;

--- a/frontend/src/components/LibationBackupImport.test.jsx
+++ b/frontend/src/components/LibationBackupImport.test.jsx
@@ -1,0 +1,109 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderWithClient } from "../test-utils";
+import LibationBackupImport from "./LibationBackupImport";
+
+function backupFile(name, relativePath) {
+  const file = new File(["audio"], name, { type: "audio/mp4" });
+  Object.defineProperty(file, "webkitRelativePath", {
+    configurable: true,
+    value: relativePath,
+  });
+  return file;
+}
+
+describe("LibationBackupImport", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("previews the whole backup and uploads only matched preferred audio", async () => {
+    const matchedM4b = backupFile(
+      "Matched.m4b",
+      "Backup/Matched Book [B012345678]/Matched.m4b",
+    );
+    const duplicateMp3 = backupFile(
+      "Matched.mp3",
+      "Backup/Matched Book [B012345678]/Matched.mp3",
+    );
+    const unmatchedM4b = backupFile(
+      "Unknown.m4b",
+      "Backup/Unknown Book [B111111111]/Unknown.m4b",
+    );
+
+    globalThis.fetch = vi.fn((url, options) => {
+      if (url === "/api/audiobook/libation-backup/preview") {
+        expect(JSON.parse(options.body).source_paths).toEqual([
+          "Backup/Matched Book [B012345678]/Matched.m4b",
+          "Backup/Matched Book [B012345678]/Matched.mp3",
+          "Backup/Unknown Book [B111111111]/Unknown.m4b",
+        ]);
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              matched_count: 1,
+              unmatched_count: 1,
+              ambiguous_count: 0,
+              already_imported_count: 0,
+              ignored_file_count: 0,
+              groups: [
+                {
+                  source_key: "Backup/Matched Book [B012345678]",
+                  folder_name: "Matched Book [B012345678]",
+                  source_title: "Matched Book",
+                  product_id: "B012345678",
+                  file_count: 2,
+                  status: "matched",
+                  match_method: "title",
+                  book_id: 7,
+                  book_title: "Matched Book",
+                  book_author: "Writer",
+                },
+                {
+                  source_key: "Backup/Unknown Book [B111111111]",
+                  folder_name: "Unknown Book [B111111111]",
+                  source_title: "Unknown Book",
+                  product_id: "B111111111",
+                  file_count: 1,
+                  status: "unmatched",
+                  detail: "No library book has the same identifier or title.",
+                },
+              ],
+            }),
+        });
+      }
+      if (url === "/api/books/7/audiobook/imports") {
+        expect(options.body.getAll("files").map((file) => file.name)).toEqual([
+          "Matched.m4b",
+        ]);
+        expect(options.body.get("auto_align")).toBe("true");
+        expect(options.body.get("name")).toBe("Libation · B012345678");
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ id: 19 }),
+        });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+
+    renderWithClient(<LibationBackupImport />);
+    fireEvent.change(screen.getByLabelText("Libation backup directory"), {
+      target: { files: [matchedM4b, duplicateMp3, unmatchedM4b] },
+    });
+
+    expect(await screen.findByText("1 ready to import")).toBeInTheDocument();
+    expect(screen.getByText("No library match")).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Import 1 Matched Book" }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Queued 1 of 1 matched books."),
+      ).toBeInTheDocument();
+    });
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/components/Utilities.jsx
+++ b/frontend/src/components/Utilities.jsx
@@ -9,11 +9,13 @@ import {
   rejectMetadataMatch,
 } from "../api/metadata";
 import ReaderKeys from "./ReaderKeys.jsx";
+import LibationBackupImport from "./LibationBackupImport.jsx";
 
 const utilityTabs = [
   { key: "audit", label: "Audit" },
   { key: "series", label: "Series Detection" },
   { key: "metadata", label: "Metadata" },
+  { key: "audiobooks", label: "Audiobooks" },
   { key: "storage", label: "Storage" },
   { key: "reader-access", label: "Reader Access" },
 ];
@@ -446,6 +448,8 @@ function Utilities({ onBack }) {
         )}
           </section>
         )}
+
+        {activeTab === "audiobooks" && <LibationBackupImport />}
 
         {activeTab === "storage" && (
           <section className="settings-section">

--- a/frontend/src/components/Utilities.test.jsx
+++ b/frontend/src/components/Utilities.test.jsx
@@ -26,6 +26,7 @@ describe("Utilities", () => {
     expect(screen.getByRole("tab", { name: "Audit" })).toHaveAttribute("aria-selected", "true");
     expect(screen.getByRole("tab", { name: "Series Detection" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Metadata" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Audiobooks" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Storage" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Reader Access" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Library Audit" })).toBeInTheDocument();


### PR DESCRIPTION
## Summary

- add a Utilities → Audiobooks workflow for selecting an entire Libation backup directory
- preview matches before transferring audio, using ASIN/ISBN metadata first and normalized exact titles second
- report unmatched, ambiguous, and already-imported folders without creating incomplete library books
- upload matched books sequentially through the existing durable audiobook import queue
- prefer Libation M4B files over duplicate MP3 renditions and optionally queue configured WhisperX alignment
- recognize both Audible ASIN and ISBN-10 folder identifiers

## User impact

Users can select one Libation backup root instead of importing every audiobook from each book page. Books without an EPUB are left untouched and listed as unmatched; after adding the EPUB, the same backup can be selected again while completed imports are skipped.

## Validation

- `PYTHONPATH=. uv run pytest -m 'not integration' backend/tests -q` — 348 passed, 1 deselected
- `cd frontend && npm test -- --run` — 51 passed
- backend Flake8 and frontend ESLint — passed
- `cd frontend && npm run build` — passed
