### PR TITLE
Add AI endpoint connection metrics

### DIFF
--- a/backend/alembic/versions/0028_llm_endpoint_request_metrics.py
+++ b/backend/alembic/versions/0028_llm_endpoint_request_metrics.py
@@ -1,0 +1,71 @@
+"""add LLM endpoint request metrics
+
+Revision ID: 0028
+Revises: 0027
+Create Date: 2026-08-08 00:00:00
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0028"
+down_revision = "0027"
+branch_labels = None
+depends_on = None
+
+_TABLE_COMMENT = "story-manager:alembic:0028"
+
+
+def upgrade():
+    conn = op.get_bind()
+    if sa.inspect(conn).has_table("llm_endpoint_request_metrics"):
+        return
+
+    op.create_table(
+        "llm_endpoint_request_metrics",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("settings_id", sa.Integer(), nullable=False),
+        sa.Column("endpoint_id", sa.String(), nullable=False),
+        sa.Column("endpoint_name", sa.String(), nullable=False),
+        sa.Column("provider", sa.String(), nullable=False),
+        sa.Column("model", sa.String(), nullable=True),
+        sa.Column("success", sa.Boolean(), nullable=False),
+        sa.Column("duration_ms", sa.Float(), nullable=False),
+        sa.Column("error_type", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["settings_id"],
+            ["audiobook_settings.id"],
+            name="fk_llm_endpoint_request_metrics_settings_id",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        comment=_TABLE_COMMENT,
+    )
+    op.create_index(
+        "ix_llm_endpoint_metrics_settings_endpoint_created",
+        "llm_endpoint_request_metrics",
+        ["settings_id", "endpoint_id", "created_at"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_llm_endpoint_request_metrics_success",
+        "llm_endpoint_request_metrics",
+        ["success"],
+        unique=False,
+    )
+
+
+def downgrade():
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    if not inspector.has_table("llm_endpoint_request_metrics"):
+        return
+    try:
+        comment = inspector.get_table_comment("llm_endpoint_request_metrics").get("text")
+    except NotImplementedError:
+        comment = None
+    if comment == _TABLE_COMMENT:
+        op.drop_table("llm_endpoint_request_metrics")

--- a/backend/alembic/versions/0029_generalize_ai_endpoint_metrics.py
+++ b/backend/alembic/versions/0029_generalize_ai_endpoint_metrics.py
@@ -1,0 +1,102 @@
+"""generalize endpoint metrics to every AI capability
+
+Revision ID: 0029
+Revises: 0028
+Create Date: 2026-08-08 00:00:00
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0029"
+down_revision = "0028"
+branch_labels = None
+depends_on = None
+
+_OLD_TABLE = "llm_endpoint_request_metrics"
+_TABLE = "ai_endpoint_request_metrics"
+_OLD_INDEX = "ix_llm_endpoint_metrics_settings_endpoint_created"
+_INDEX = "ix_ai_endpoint_metrics_settings_capability_endpoint_created"
+_OLD_SUCCESS_INDEX = "ix_llm_endpoint_request_metrics_success"
+_SUCCESS_INDEX = "ix_ai_endpoint_request_metrics_success"
+_COLUMN_COMMENT = "story-manager:alembic:0029"
+_TABLE_COMMENT = "story-manager:alembic:0028"
+
+
+def _index_names(conn, table_name: str) -> set[str]:
+    return {index["name"] for index in sa.inspect(conn).get_indexes(table_name)}
+
+
+def upgrade():
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    if inspector.has_table(_OLD_TABLE) and not inspector.has_table(_TABLE):
+        op.rename_table(_OLD_TABLE, _TABLE)
+
+    inspector = sa.inspect(conn)
+    if not inspector.has_table(_TABLE):
+        return
+
+    columns = {column["name"]: column for column in inspector.get_columns(_TABLE)}
+    if "capability" not in columns:
+        op.add_column(
+            _TABLE,
+            sa.Column(
+                "capability",
+                sa.String(),
+                nullable=False,
+                server_default="llm",
+                comment=_COLUMN_COMMENT,
+            ),
+        )
+        op.alter_column(_TABLE, "capability", server_default=None)
+
+    indexes = _index_names(conn, _TABLE)
+    if _OLD_INDEX in indexes:
+        op.drop_index(_OLD_INDEX, table_name=_TABLE)
+    if _INDEX not in indexes:
+        op.create_index(
+            _INDEX,
+            _TABLE,
+            ["settings_id", "capability", "endpoint_id", "created_at"],
+            unique=False,
+        )
+    if _OLD_SUCCESS_INDEX in indexes:
+        op.drop_index(_OLD_SUCCESS_INDEX, table_name=_TABLE)
+    if _SUCCESS_INDEX not in indexes:
+        op.create_index(_SUCCESS_INDEX, _TABLE, ["success"], unique=False)
+
+
+def downgrade():
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    if not inspector.has_table(_TABLE):
+        return
+
+    indexes = _index_names(conn, _TABLE)
+    if _INDEX in indexes:
+        op.drop_index(_INDEX, table_name=_TABLE)
+    if _OLD_INDEX not in indexes:
+        op.create_index(
+            _OLD_INDEX,
+            _TABLE,
+            ["settings_id", "endpoint_id", "created_at"],
+            unique=False,
+        )
+    if _SUCCESS_INDEX in indexes:
+        op.drop_index(_SUCCESS_INDEX, table_name=_TABLE)
+    if _OLD_SUCCESS_INDEX not in indexes:
+        op.create_index(_OLD_SUCCESS_INDEX, _TABLE, ["success"], unique=False)
+
+    columns = {column["name"]: column for column in sa.inspect(conn).get_columns(_TABLE)}
+    if columns.get("capability", {}).get("comment") == _COLUMN_COMMENT:
+        op.drop_column(_TABLE, "capability")
+
+    try:
+        table_comment = sa.inspect(conn).get_table_comment(_TABLE).get("text")
+    except NotImplementedError:
+        table_comment = None
+    if table_comment == _TABLE_COMMENT and not sa.inspect(conn).has_table(_OLD_TABLE):
+        op.rename_table(_TABLE, _OLD_TABLE)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -9,6 +9,7 @@ from sqlalchemy import (
     ForeignKey,
     Enum,
     JSON,
+    Index,
     Numeric,
     Text,
     UniqueConstraint,
@@ -257,6 +258,37 @@ class AudiobookSettings(Base):
     transcription_endpoints = Column(JSON, nullable=True)
     roster_prompt_template = Column(Text, nullable=True)
     diarization_prompt_template = Column(Text, nullable=True)
+
+
+class AiEndpointRequestMetric(Base):
+    """One completed attempt against a configured AI endpoint."""
+
+    __tablename__ = "ai_endpoint_request_metrics"
+    __table_args__ = (
+        Index(
+            "ix_ai_endpoint_metrics_settings_capability_endpoint_created",
+            "settings_id",
+            "capability",
+            "endpoint_id",
+            "created_at",
+        ),
+    )
+
+    id = Column(BigInteger().with_variant(Integer, "sqlite"), primary_key=True, autoincrement=True)
+    settings_id = Column(
+        Integer,
+        ForeignKey("audiobook_settings.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    capability = Column(String, nullable=False)
+    endpoint_id = Column(String, nullable=False)
+    endpoint_name = Column(String, nullable=False)
+    provider = Column(String, nullable=False)
+    model = Column(String, nullable=True)
+    success = Column(Boolean, nullable=False, index=True)
+    duration_ms = Column(Float, nullable=False)
+    error_type = Column(String, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
 
 
 class AudiobookChapter(Base):

--- a/backend/app/routers/audiobook.py
+++ b/backend/app/routers/audiobook.py
@@ -47,6 +47,7 @@ from ..services.transcription_providers import (
     transcription_service_health,
 )
 from ..services.endpoint_pool import configured_endpoints, primary_provider
+from ..services.endpoint_metrics import endpoint_summaries
 from ..services.metadata.scoring import normalize_text
 from ..services.tts_providers import (
     TTSRequest,
@@ -245,6 +246,43 @@ class EndpointUpdate(BaseModel):
     model: Optional[str] = None
     default_voice: Optional[str] = None
     language: Optional[str] = None
+
+
+class EndpointSpeedBuckets(BaseModel):
+    under_5s: int
+    from_5s_to_15s: int
+    from_15s_to_60s: int
+    over_60s: int
+
+
+class EndpointStats(BaseModel):
+    endpoint_id: str
+    name: str
+    provider: str
+    model: Optional[str]
+    requests: int
+    answered: int
+    failed: int
+    success_rate: Optional[float]
+    average_ms: Optional[float]
+    p50_ms: Optional[float]
+    p95_ms: Optional[float]
+    fastest_ms: Optional[float]
+    slowest_ms: Optional[float]
+    answered_24h: int
+    average_24h_ms: Optional[float]
+    speed_buckets: EndpointSpeedBuckets
+    last_answered_at: Optional[datetime]
+
+
+class EndpointStatsResponse(BaseModel):
+    endpoints: list[EndpointStats]
+
+
+class AllEndpointStatsResponse(BaseModel):
+    llm: list[EndpointStats]
+    tts: list[EndpointStats]
+    transcription: list[EndpointStats]
 
 
 class SettingsUpdate(BaseModel):
@@ -1756,6 +1794,24 @@ async def update_settings(body: SettingsUpdate, db: AsyncSession = Depends(get_d
     if tts_changed:
         await crud.audiobook.invalidate_generated_audio_for_tts_change(db)
     return _settings_response(settings)
+
+
+@router.get("/api/audiobook/settings/llm-stats", response_model=EndpointStatsResponse)
+async def get_llm_endpoint_stats(db: AsyncSession = Depends(get_db)) -> EndpointStatsResponse:
+    """Compare reliability and response latency across configured LLM endpoints."""
+    settings = await crud.audiobook.get_audiobook_settings(db)
+    return EndpointStatsResponse(endpoints=await endpoint_summaries(db, settings, "llm"))
+
+
+@router.get("/api/audiobook/settings/endpoint-stats", response_model=AllEndpointStatsResponse)
+async def get_endpoint_stats(db: AsyncSession = Depends(get_db)) -> AllEndpointStatsResponse:
+    """Compare reliability and response latency across all configured AI endpoints."""
+    settings = await crud.audiobook.get_audiobook_settings(db)
+    return AllEndpointStatsResponse(
+        llm=await endpoint_summaries(db, settings, "llm"),
+        tts=await endpoint_summaries(db, settings, "tts"),
+        transcription=await endpoint_summaries(db, settings, "transcription"),
+    )
 
 
 @router.post("/api/audiobook/settings/test-llm")

--- a/backend/app/services/endpoint_metrics.py
+++ b/backend/app/services/endpoint_metrics.py
@@ -1,0 +1,127 @@
+"""Durable measurements and summaries for routed AI endpoint attempts."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..database import SessionLocal
+from ..models import AiEndpointRequestMetric, AudiobookSettings
+from .endpoint_pool import configured_endpoints
+
+
+async def record_attempt(
+    settings_id: int,
+    capability: str,
+    endpoint: dict[str, Any],
+    *,
+    success: bool,
+    duration_ms: float,
+    error_type: str | None = None,
+) -> None:
+    """Commit one metric independently from the audiobook job transaction."""
+    async with SessionLocal() as db:
+        db.add(
+            AiEndpointRequestMetric(
+                settings_id=settings_id,
+                capability=capability,
+                endpoint_id=str(endpoint.get("id") or "unknown"),
+                endpoint_name=str(endpoint.get("name") or "Unnamed endpoint"),
+                provider=str(endpoint.get("provider") or "unknown"),
+                model=str(endpoint["model"]) if endpoint.get("model") else None,
+                success=success,
+                duration_ms=max(0.0, duration_ms),
+                error_type=error_type,
+            )
+        )
+        await db.commit()
+
+
+def _percentile(sorted_values: list[float], percentile: float) -> float | None:
+    if not sorted_values:
+        return None
+    position = (len(sorted_values) - 1) * percentile
+    lower = int(position)
+    upper = min(lower + 1, len(sorted_values) - 1)
+    fraction = position - lower
+    return sorted_values[lower] + (sorted_values[upper] - sorted_values[lower]) * fraction
+
+
+def _rounded(value: float | None) -> float | None:
+    return round(value, 1) if value is not None else None
+
+
+async def endpoint_summaries(
+    db: AsyncSession,
+    settings: AudiobookSettings | None,
+    capability: str,
+) -> list[dict[str, Any]]:
+    """Return all-time and recent comparison metrics for configured endpoints."""
+    endpoints = configured_endpoints(settings, capability) if settings is not None else []
+    rows: list[AiEndpointRequestMetric] = []
+    if settings is not None and settings.id is not None:
+        rows = list(
+            (
+                await db.scalars(
+                    select(AiEndpointRequestMetric)
+                    .where(
+                        AiEndpointRequestMetric.settings_id == settings.id,
+                        AiEndpointRequestMetric.capability == capability,
+                    )
+                    .order_by(AiEndpointRequestMetric.created_at.asc())
+                )
+            ).all()
+        )
+
+    by_endpoint: dict[str, list[AiEndpointRequestMetric]] = defaultdict(list)
+    for row in rows:
+        by_endpoint[row.endpoint_id].append(row)
+
+    now = datetime.now(timezone.utc)
+    recent_cutoff = now - timedelta(hours=24)
+    summaries = []
+    for index, endpoint in enumerate(endpoints):
+        endpoint_id = str(endpoint.get("id") or f"{capability}-{index + 1}")
+        attempts = by_endpoint.get(endpoint_id, [])
+        answered = [row for row in attempts if row.success]
+        durations = sorted(float(row.duration_ms) for row in answered)
+        recent = [
+            row
+            for row in answered
+            if row.created_at is not None
+            and (row.created_at if row.created_at.tzinfo else row.created_at.replace(tzinfo=timezone.utc)) >= recent_cutoff
+        ]
+        recent_durations = [float(row.duration_ms) for row in recent]
+        summaries.append(
+            {
+                "endpoint_id": endpoint_id,
+                "name": str(endpoint.get("name") or f"Endpoint {index + 1}"),
+                "provider": str(endpoint.get("provider") or "unknown"),
+                "model": endpoint.get("model"),
+                "requests": len(attempts),
+                "answered": len(answered),
+                "failed": len(attempts) - len(answered),
+                "success_rate": _rounded(100 * len(answered) / len(attempts)) if attempts else None,
+                "average_ms": _rounded(sum(durations) / len(durations)) if durations else None,
+                "p50_ms": _rounded(_percentile(durations, 0.50)),
+                "p95_ms": _rounded(_percentile(durations, 0.95)),
+                "fastest_ms": _rounded(durations[0]) if durations else None,
+                "slowest_ms": _rounded(durations[-1]) if durations else None,
+                "answered_24h": len(recent),
+                "average_24h_ms": _rounded(sum(recent_durations) / len(recent_durations))
+                if recent_durations
+                else None,
+                "speed_buckets": {
+                    "under_5s": sum(duration < 5_000 for duration in durations),
+                    "from_5s_to_15s": sum(5_000 <= duration < 15_000 for duration in durations),
+                    "from_15s_to_60s": sum(15_000 <= duration < 60_000 for duration in durations),
+                    "over_60s": sum(duration >= 60_000 for duration in durations),
+                },
+                "last_answered_at": answered[-1].created_at if answered else None,
+            }
+        )
+    return summaries

--- a/backend/app/services/endpoint_metrics.py
+++ b/backend/app/services/endpoint_metrics.py
@@ -112,9 +112,7 @@ async def endpoint_summaries(
                 "fastest_ms": _rounded(durations[0]) if durations else None,
                 "slowest_ms": _rounded(durations[-1]) if durations else None,
                 "answered_24h": len(recent),
-                "average_24h_ms": _rounded(sum(recent_durations) / len(recent_durations))
-                if recent_durations
-                else None,
+                "average_24h_ms": _rounded(sum(recent_durations) / len(recent_durations)) if recent_durations else None,
                 "speed_buckets": {
                     "under_5s": sum(duration < 5_000 for duration in durations),
                     "from_5s_to_15s": sum(5_000 <= duration < 15_000 for duration in durations),

--- a/backend/app/services/endpoint_pool.py
+++ b/backend/app/services/endpoint_pool.py
@@ -110,9 +110,18 @@ async def route_request(
     last_error: Exception | None = None
     for endpoint in available:
         key = _endpoint_key(capability, endpoint)
+        started_at = time.perf_counter()
         try:
             value = await attempt(_endpoint_settings(settings, capability, endpoint))
         except Exception as exc:
+            await _record_endpoint_attempt(
+                settings,
+                capability,
+                endpoint,
+                success=False,
+                duration_ms=(time.perf_counter() - started_at) * 1000,
+                error_type=type(exc).__name__,
+            )
             _cooldowns[key] = time.monotonic() + COOLDOWN_SECONDS
             logger.warning(
                 "%s endpoint %r failed and will cool down for %.0f seconds: %s",
@@ -123,11 +132,35 @@ async def route_request(
             )
             last_error = exc
             continue
+        await _record_endpoint_attempt(
+            settings,
+            capability,
+            endpoint,
+            success=True,
+            duration_ms=(time.perf_counter() - started_at) * 1000,
+        )
         _cooldowns.pop(key, None)
         return RoutedResult(value=value, endpoint=endpoint)
 
     assert last_error is not None
     raise last_error
+
+
+async def _record_endpoint_attempt(
+    settings: AudiobookSettings,
+    capability: str,
+    endpoint: dict[str, Any],
+    **measurement: Any,
+) -> None:
+    """Keep observability failures from affecting the routed AI request."""
+    if settings.id is None:
+        return
+    try:
+        from .endpoint_metrics import record_attempt
+
+        await record_attempt(settings.id, capability, endpoint, **measurement)
+    except Exception:
+        logger.exception("Failed to record %s endpoint request metric", capability.upper())
 
 
 def reset_cooldowns() -> None:

--- a/backend/tests/test_endpoint_pool.py
+++ b/backend/tests/test_endpoint_pool.py
@@ -175,9 +175,7 @@ async def test_endpoint_summaries_include_latency_percentiles_and_buckets(db):
 @pytest.mark.asyncio
 async def test_llm_stats_api_returns_configured_endpoint_metrics(app_client, sqlite_sessionmaker):
     async with sqlite_sessionmaker() as db:
-        settings = models.AudiobookSettings(
-            llm_endpoints=[{"id": "api-host", "name": "API Host", "provider": "ollama"}]
-        )
+        settings = models.AudiobookSettings(llm_endpoints=[{"id": "api-host", "name": "API Host", "provider": "ollama"}])
         db.add(settings)
         await db.flush()
         db.add(
@@ -208,9 +206,7 @@ async def test_all_endpoint_stats_api_includes_tts_and_transcription(app_client,
         settings = models.AudiobookSettings(
             llm_endpoints=[{"id": "llm-host", "name": "LLM Host", "provider": "ollama"}],
             tts_endpoints=[{"id": "tts-host", "name": "TTS Host", "provider": "omnivoice"}],
-            transcription_endpoints=[
-                {"id": "stt-host", "name": "STT Host", "provider": "whisperx"}
-            ],
+            transcription_endpoints=[{"id": "stt-host", "name": "STT Host", "provider": "whisperx"}],
         )
         db.add(settings)
         await db.flush()

--- a/backend/tests/test_endpoint_pool.py
+++ b/backend/tests/test_endpoint_pool.py
@@ -1,8 +1,9 @@
 import httpx
 import pytest
+from sqlalchemy import select
 
 from backend.app import models
-from backend.app.services import endpoint_pool
+from backend.app.services import endpoint_metrics, endpoint_pool
 
 
 @pytest.fixture(autouse=True)
@@ -81,3 +82,156 @@ async def test_all_cooling_endpoints_fail_fast(monkeypatch):
         await endpoint_pool.route_request(settings, "tts", fail)
     with pytest.raises(RuntimeError, match="All tts endpoints are cooling down"):
         await endpoint_pool.route_request(settings, "tts", fail)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("capability", ["llm", "tts", "transcription"])
+async def test_routes_record_successful_endpoint_attempt(monkeypatch, sqlite_sessionmaker, capability):
+    monkeypatch.setattr(endpoint_metrics, "SessionLocal", sqlite_sessionmaker)
+    endpoint = {
+        "id": f"local-{capability}",
+        "name": f"Local {capability}",
+        "provider": "local",
+        "base_url": "http://local",
+        "model": "test-model",
+    }
+    async with sqlite_sessionmaker() as db:
+        settings = models.AudiobookSettings(**{f"{capability}_endpoints": [endpoint]})
+        db.add(settings)
+        await db.commit()
+
+    async def succeed(_endpoint_settings):
+        return "answer"
+
+    routed = await endpoint_pool.route_request(settings, capability, succeed)
+    assert routed.value == "answer"
+
+    async with sqlite_sessionmaker() as db:
+        metric = await db.scalar(select(models.AiEndpointRequestMetric))
+    assert metric is not None
+    assert metric.capability == capability
+    assert metric.endpoint_id == f"local-{capability}"
+    assert metric.success is True
+    assert metric.duration_ms >= 0
+
+
+@pytest.mark.asyncio
+async def test_endpoint_summaries_include_latency_percentiles_and_buckets(db):
+    settings = models.AudiobookSettings(
+        llm_endpoints=[
+            {"id": "fast", "name": "Fast host", "provider": "ollama", "model": "small"},
+            {"id": "unused", "name": "Unused host", "provider": "ollama", "model": "large"},
+        ]
+    )
+    db.add(settings)
+    await db.flush()
+    for duration in (1_000, 10_000, 20_000, 70_000):
+        db.add(
+            models.AiEndpointRequestMetric(
+                settings_id=settings.id,
+                capability="llm",
+                endpoint_id="fast",
+                endpoint_name="Fast host",
+                provider="ollama",
+                model="small",
+                success=True,
+                duration_ms=duration,
+            )
+        )
+    db.add(
+        models.AiEndpointRequestMetric(
+            settings_id=settings.id,
+            capability="llm",
+            endpoint_id="fast",
+            endpoint_name="Fast host",
+            provider="ollama",
+            model="small",
+            success=False,
+            duration_ms=500,
+            error_type="ConnectError",
+        )
+    )
+    await db.commit()
+
+    summaries = await endpoint_metrics.endpoint_summaries(db, settings, "llm")
+
+    assert summaries[0]["requests"] == 5
+    assert summaries[0]["answered"] == 4
+    assert summaries[0]["failed"] == 1
+    assert summaries[0]["success_rate"] == 80.0
+    assert summaries[0]["average_ms"] == 25_250.0
+    assert summaries[0]["p50_ms"] == 15_000.0
+    assert summaries[0]["p95_ms"] == 62_500.0
+    assert summaries[0]["speed_buckets"] == {
+        "under_5s": 1,
+        "from_5s_to_15s": 1,
+        "from_15s_to_60s": 1,
+        "over_60s": 1,
+    }
+    assert summaries[1]["requests"] == 0
+    assert summaries[1]["average_ms"] is None
+
+
+@pytest.mark.asyncio
+async def test_llm_stats_api_returns_configured_endpoint_metrics(app_client, sqlite_sessionmaker):
+    async with sqlite_sessionmaker() as db:
+        settings = models.AudiobookSettings(
+            llm_endpoints=[{"id": "api-host", "name": "API Host", "provider": "ollama"}]
+        )
+        db.add(settings)
+        await db.flush()
+        db.add(
+            models.AiEndpointRequestMetric(
+                settings_id=settings.id,
+                capability="llm",
+                endpoint_id="api-host",
+                endpoint_name="API Host",
+                provider="ollama",
+                success=True,
+                duration_ms=1_250,
+            )
+        )
+        await db.commit()
+
+    response = app_client.get("/api/audiobook/settings/llm-stats")
+
+    assert response.status_code == 200
+    endpoint = response.json()["endpoints"][0]
+    assert endpoint["name"] == "API Host"
+    assert endpoint["answered"] == 1
+    assert endpoint["average_ms"] == 1_250.0
+
+
+@pytest.mark.asyncio
+async def test_all_endpoint_stats_api_includes_tts_and_transcription(app_client, sqlite_sessionmaker):
+    async with sqlite_sessionmaker() as db:
+        settings = models.AudiobookSettings(
+            llm_endpoints=[{"id": "llm-host", "name": "LLM Host", "provider": "ollama"}],
+            tts_endpoints=[{"id": "tts-host", "name": "TTS Host", "provider": "omnivoice"}],
+            transcription_endpoints=[
+                {"id": "stt-host", "name": "STT Host", "provider": "whisperx"}
+            ],
+        )
+        db.add(settings)
+        await db.flush()
+        for capability, endpoint_id in (("tts", "tts-host"), ("transcription", "stt-host")):
+            db.add(
+                models.AiEndpointRequestMetric(
+                    settings_id=settings.id,
+                    capability=capability,
+                    endpoint_id=endpoint_id,
+                    endpoint_name=endpoint_id,
+                    provider="local",
+                    success=True,
+                    duration_ms=2_500,
+                )
+            )
+        await db.commit()
+
+    response = app_client.get("/api/audiobook/settings/endpoint-stats")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["llm"][0]["answered"] == 0
+    assert payload["tts"][0]["answered"] == 1
+    assert payload["transcription"][0]["answered"] == 1

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1487,9 +1487,103 @@
   margin: 0;
 }
 
+.llm-metrics {
+  margin-top: 1.25rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--border);
+}
+
+.llm-metrics-heading,
+.llm-metric-card header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.llm-metrics-heading h4 {
+  margin: 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 1rem;
+  font-weight: 500;
+}
+
+.llm-metric-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(290px, 1fr));
+  gap: 0.75rem;
+  margin-top: 0.8rem;
+}
+
+.llm-metric-card {
+  padding: 0.9rem;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+}
+
+.llm-metric-card header strong,
+.llm-metric-card header span {
+  display: block;
+}
+
+.llm-metric-card header span {
+  color: var(--text-muted);
+  font-size: 0.78rem;
+}
+
+.llm-metric-card header .llm-success-rate {
+  color: var(--success);
+  white-space: nowrap;
+}
+
+.llm-metric-summary {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.65rem;
+  margin: 1rem 0;
+}
+
+.llm-metric-summary div {
+  min-width: 0;
+}
+
+.llm-metric-summary dt {
+  color: var(--text-muted);
+  font-size: 0.7rem;
+}
+
+.llm-metric-summary dd {
+  margin: 0.15rem 0 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.llm-speed-breakdown {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1px;
+  background: var(--border);
+  border: 1px solid var(--border);
+}
+
+.llm-speed-breakdown span {
+  padding: 0.45rem 0.25rem;
+  background: var(--surface);
+  color: var(--text-muted);
+  font-size: 0.68rem;
+  text-align: center;
+}
+
+.llm-speed-breakdown strong {
+  display: block;
+  color: var(--text);
+  font-size: 0.82rem;
+  font-variant-numeric: tabular-nums;
+}
+
 @media (max-width: 700px) {
   .endpoint-pool-heading,
-  .endpoint-card-header {
+  .endpoint-card-header,
+  .llm-metrics-heading {
     align-items: stretch;
     flex-direction: column;
   }

--- a/frontend/src/api/audiobook.js
+++ b/frontend/src/api/audiobook.js
@@ -250,6 +250,13 @@ export function updateAudiobookSettings(data) {
   });
 }
 
+export function getAudiobookEndpointStats() {
+  return getJson(
+    "/api/audiobook/settings/endpoint-stats",
+    "Failed to fetch AI endpoint metrics",
+  );
+}
+
 export function testAudiobookLlm() {
   return sendWithoutBody("/api/audiobook/settings/test-llm", {
     method: "POST",

--- a/frontend/src/components/AudiobookSettings.jsx
+++ b/frontend/src/components/AudiobookSettings.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
+  getAudiobookEndpointStats,
   getAudiobookSettings,
   testAudiobookLlm,
   testAudiobookTranscription,
@@ -338,11 +339,78 @@ function useEndpointTestMutation(testFunction, buildPayload, refreshSettings) {
   });
 }
 
+function formatDuration(milliseconds) {
+  if (milliseconds === null || milliseconds === undefined) return "—";
+  if (milliseconds < 1000) return `${Math.round(milliseconds)} ms`;
+  if (milliseconds < 60_000) return `${(milliseconds / 1000).toFixed(1)} s`;
+  return `${(milliseconds / 60_000).toFixed(1)} min`;
+}
+
+function EndpointMetrics({ stats, capability, isLoading, error, onRefresh, isRefreshing }) {
+  return (
+    <div className="llm-metrics">
+      <div className="llm-metrics-heading">
+        <div>
+          <h4>Connection performance</h4>
+          <p className="settings-hint">
+            Successful {capability} requests and endpoint failures are recorded from this upgrade onward.
+            Latency is measured end-to-end for each endpoint attempt.
+          </p>
+        </div>
+        <button type="button" className="btn-secondary" onClick={onRefresh} disabled={isRefreshing}>
+          {isRefreshing ? "Refreshing…" : "Refresh metrics"}
+        </button>
+      </div>
+      {isLoading && <p className="settings-hint">Loading connection metrics…</p>}
+      {error && <p className="error">{error.message || "Failed to load connection metrics"}</p>}
+      {!isLoading && !error && stats.length === 0 && (
+        <p className="settings-hint">Save an LLM endpoint to begin collecting metrics.</p>
+      )}
+      {stats.length > 0 && (
+        <div className="llm-metric-grid">
+          {stats.map((endpoint) => (
+            <article className="llm-metric-card" key={endpoint.endpoint_id}>
+              <header>
+                <div>
+                  <strong>{endpoint.name}</strong>
+                  <span>{endpoint.provider}{endpoint.model ? ` · ${endpoint.model}` : ""}</span>
+                </div>
+                <span className="llm-success-rate">
+                  {endpoint.success_rate === null ? "No data" : `${endpoint.success_rate}% answered`}
+                </span>
+              </header>
+              <dl className="llm-metric-summary">
+                <div><dt>Answered</dt><dd>{endpoint.answered}</dd></div>
+                <div><dt>Failed attempts</dt><dd>{endpoint.failed}</dd></div>
+                <div><dt>Average</dt><dd>{formatDuration(endpoint.average_ms)}</dd></div>
+                <div><dt>P50</dt><dd>{formatDuration(endpoint.p50_ms)}</dd></div>
+                <div><dt>P95</dt><dd>{formatDuration(endpoint.p95_ms)}</dd></div>
+                <div><dt>Last 24h</dt><dd>{endpoint.answered_24h}</dd></div>
+              </dl>
+              <div className="llm-speed-breakdown" aria-label={`${endpoint.name} speed breakdown`}>
+                <span>&lt;5s <strong>{endpoint.speed_buckets.under_5s}</strong></span>
+                <span>5–15s <strong>{endpoint.speed_buckets.from_5s_to_15s}</strong></span>
+                <span>15–60s <strong>{endpoint.speed_buckets.from_15s_to_60s}</strong></span>
+                <span>60s+ <strong>{endpoint.speed_buckets.over_60s}</strong></span>
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 function AudiobookSettings() {
   const queryClient = useQueryClient();
   const { data: settings, isLoading } = useQuery({
     queryKey: ["audiobook-settings"],
     queryFn: getAudiobookSettings,
+  });
+  const endpointStatsQuery = useQuery({
+    queryKey: ["audiobook-endpoint-stats"],
+    queryFn: getAudiobookEndpointStats,
+    refetchInterval: 30_000,
   });
 
   const [llmEndpoints, setLlmEndpoints] = useState([]);
@@ -385,6 +453,7 @@ function AudiobookSettings() {
     setTtsEndpoints(clearTypedSecrets);
     setTranscriptionEndpoints(clearTypedSecrets);
     queryClient.invalidateQueries({ queryKey: ["audiobook-settings"] });
+    queryClient.invalidateQueries({ queryKey: ["audiobook-endpoint-stats"] });
   };
 
   const saveMutation = useMutation({
@@ -453,6 +522,14 @@ function AudiobookSettings() {
             setEndpoints={setLlmEndpoints}
           />
           {testStatus(llmTest, "LLM")}
+          <EndpointMetrics
+            stats={endpointStatsQuery.data?.llm || []}
+            capability="LLM"
+            isLoading={endpointStatsQuery.isLoading}
+            error={endpointStatsQuery.error}
+            onRefresh={() => endpointStatsQuery.refetch()}
+            isRefreshing={endpointStatsQuery.isFetching}
+          />
         </section>
 
         <section className="settings-section">
@@ -462,6 +539,14 @@ function AudiobookSettings() {
             setEndpoints={setTtsEndpoints}
           />
           {testStatus(ttsTest, "TTS")}
+          <EndpointMetrics
+            stats={endpointStatsQuery.data?.tts || []}
+            capability="TTS"
+            isLoading={endpointStatsQuery.isLoading}
+            error={endpointStatsQuery.error}
+            onRefresh={() => endpointStatsQuery.refetch()}
+            isRefreshing={endpointStatsQuery.isFetching}
+          />
         </section>
 
         <section className="settings-section">
@@ -471,6 +556,14 @@ function AudiobookSettings() {
             setEndpoints={setTranscriptionEndpoints}
           />
           {testStatus(transcriptionTest, "Transcription")}
+          <EndpointMetrics
+            stats={endpointStatsQuery.data?.transcription || []}
+            capability="speech-to-text"
+            isLoading={endpointStatsQuery.isLoading}
+            error={endpointStatsQuery.error}
+            onRefresh={() => endpointStatsQuery.refetch()}
+            isRefreshing={endpointStatsQuery.isFetching}
+          />
         </section>
 
         <section className="settings-section">

--- a/frontend/src/components/AudiobookSettings.test.jsx
+++ b/frontend/src/components/AudiobookSettings.test.jsx
@@ -124,4 +124,111 @@ describe("AudiobookSettings", () => {
       "always-on",
     ]);
   });
+
+  it("compares request counts and speed metrics for LLM endpoints", async () => {
+    globalThis.fetch = vi.fn((url) => {
+      if (url === "/api/audiobook/settings") {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              llm_endpoints: [
+                {
+                  id: "gaming-pc",
+                  name: "Gaming PC",
+                  provider: "ollama",
+                  model: "qwen3.5:27b",
+                },
+              ],
+              tts_provider: "stub",
+              transcription_provider: "none",
+            }),
+        });
+      }
+      if (url === "/api/audiobook/settings/endpoint-stats") {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              llm: [
+                {
+                  endpoint_id: "gaming-pc",
+                  name: "Gaming PC",
+                  provider: "ollama",
+                  model: "qwen3.5:27b",
+                  requests: 10,
+                  answered: 9,
+                  failed: 1,
+                  success_rate: 90,
+                  average_ms: 2400,
+                  p50_ms: 1900,
+                  p95_ms: 5200,
+                  answered_24h: 3,
+                  speed_buckets: {
+                    under_5s: 8,
+                    from_5s_to_15s: 1,
+                    from_15s_to_60s: 0,
+                    over_60s: 0,
+                  },
+                },
+              ],
+              tts: [
+                {
+                  endpoint_id: "tts-host",
+                  name: "TTS Host",
+                  provider: "omnivoice",
+                  requests: 5,
+                  answered: 5,
+                  failed: 0,
+                  success_rate: 100,
+                  average_ms: 800,
+                  p50_ms: 750,
+                  p95_ms: 1100,
+                  answered_24h: 2,
+                  speed_buckets: {
+                    under_5s: 5,
+                    from_5s_to_15s: 0,
+                    from_15s_to_60s: 0,
+                    over_60s: 0,
+                  },
+                },
+              ],
+              transcription: [
+                {
+                  endpoint_id: "stt-host",
+                  name: "Speech Host",
+                  provider: "whisperx",
+                  requests: 2,
+                  answered: 1,
+                  failed: 1,
+                  success_rate: 50,
+                  average_ms: 65_000,
+                  p50_ms: 65_000,
+                  p95_ms: 65_000,
+                  answered_24h: 1,
+                  speed_buckets: {
+                    under_5s: 0,
+                    from_5s_to_15s: 0,
+                    from_15s_to_60s: 0,
+                    over_60s: 1,
+                  },
+                },
+              ],
+            }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+
+    renderWithClient(<AudiobookSettings />);
+
+    expect(await screen.findAllByText("Connection performance")).toHaveLength(3);
+    expect(screen.getByText("90% answered")).toBeInTheDocument();
+    expect(screen.getByText("2.4 s")).toBeInTheDocument();
+    expect(screen.getByLabelText("Gaming PC speed breakdown")).toHaveTextContent("<5s 8");
+    expect(screen.getByText("TTS Host")).toBeInTheDocument();
+    expect(screen.getByText("800 ms")).toBeInTheDocument();
+    expect(screen.getByText("Speech Host")).toBeInTheDocument();
+    expect(screen.getAllByText("1.1 min")).toHaveLength(3);
+  });
 });


### PR DESCRIPTION
## Summary

- persist success, failure, and end-to-end latency for routed LLM, TTS, and speech-to-text endpoint attempts
- expose all-time and 24-hour endpoint summaries with success rate, average, P50/P95, fastest/slowest, and latency buckets
- add responsive connection-performance cards to each Audio & AI Configuration endpoint section
- retain the existing LLM history when generalizing the metrics ledger across AI capabilities

## Why

The ordered endpoint pools can fail over between multiple hosts, but there was no durable way to compare which connection answered requests most reliably or quickly. This adds per-endpoint observability without allowing metrics-write failures to interrupt audiobook processing.

## Database changes

- `0028` creates the durable LLM attempt ledger
- `0029` safely generalizes that ledger to LLM, TTS, and transcription while preserving existing rows
- both forward and reverse PostgreSQL migration paths were verified against existing data

## Validation

- `PYTHONPATH=. uv run pytest backend/tests -q` — 355 passed
- `npm test -- --run` — 52 passed
- `npm run lint`
- `npm run build`
- PostgreSQL clean upgrade and existing-data downgrade/re-upgrade checks
- live local requests recorded successfully for Ollama, OmniVoice, and WhisperX