### PR TITLE
Add Needs Attention dashboard and improvement roadmap

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -27,6 +27,7 @@ from .routers import (
     books,
     cleaning,
     covers,
+    dashboard,
     metadata,
     processing,
     reader,
@@ -124,6 +125,7 @@ app.include_router(upload.router)
 app.include_router(web_novels.router)
 app.include_router(cleaning.router)
 app.include_router(covers.router)
+app.include_router(dashboard.router)
 app.include_router(scheduler.router)
 app.include_router(storage.router)
 app.include_router(api_keys.router)

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -27,10 +27,36 @@ def _book_item(book: models.Book, issue: str, detail: str | None = None) -> sche
 
 
 async def _failed_jobs(db: AsyncSession, limit: int) -> schemas.AttentionJobCategory:
-    count = await db.scalar(
-        select(func.count()).select_from(models.ProcessingJob).where(models.ProcessingJob.status == "error")
+    scope = (
+        models.ProcessingJob.job_type,
+        func.coalesce(models.ProcessingJob.book_id, -1),
+        func.coalesce(models.ProcessingJob.target_type, ""),
+        func.coalesce(models.ProcessingJob.target_id, -1),
     )
-    rows = await crud.get_processing_jobs(db, statuses=["error"], limit=limit)
+    ranked_jobs = select(
+        models.ProcessingJob.id.label("job_id"),
+        func.row_number()
+        .over(
+            partition_by=scope,
+            order_by=(models.ProcessingJob.created_at.desc(), models.ProcessingJob.id.desc()),
+        )
+        .label("recency"),
+    ).subquery()
+    latest_job_ids = select(ranked_jobs.c.job_id).where(ranked_jobs.c.recency == 1)
+    latest_failures = (
+        models.ProcessingJob.status == "error",
+        models.ProcessingJob.id.in_(latest_job_ids),
+    )
+    count = await db.scalar(select(func.count()).select_from(models.ProcessingJob).where(*latest_failures))
+    rows = (
+        await db.execute(
+            select(models.ProcessingJob, models.Book.title)
+            .outerjoin(models.Book, models.ProcessingJob.book_id == models.Book.id)
+            .where(*latest_failures)
+            .order_by(models.ProcessingJob.created_at.desc(), models.ProcessingJob.id.desc())
+            .limit(limit)
+        )
+    ).all()
     return schemas.AttentionJobCategory(
         count=count or 0,
         items=[

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -1,0 +1,170 @@
+"""Aggregated, actionable library attention signals."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import crud, models, schemas
+from ..config import LIBRARY_PATH
+from ..database import get_db
+from ..services.library_health import find_missing_covers, inspect_library_files
+
+router = APIRouter()
+
+
+def _book_item(book: models.Book, issue: str, detail: str | None = None) -> schemas.AttentionBookItem:
+    return schemas.AttentionBookItem(
+        book_id=book.id,
+        title=book.title,
+        author=book.author,
+        issue=issue,
+        detail=detail,
+    )
+
+
+async def _failed_jobs(db: AsyncSession, limit: int) -> schemas.AttentionJobCategory:
+    count = await db.scalar(
+        select(func.count()).select_from(models.ProcessingJob).where(models.ProcessingJob.status == "error")
+    )
+    rows = await crud.get_processing_jobs(db, statuses=["error"], limit=limit)
+    return schemas.AttentionJobCategory(
+        count=count or 0,
+        items=[
+            schemas.AttentionJobItem(
+                id=job.id,
+                job_type=job.job_type,
+                book_id=job.book_id,
+                book_title=book_title,
+                error=job.error,
+                completed_at=job.completed_at,
+            )
+            for job, book_title in rows
+        ],
+    )
+
+
+async def _failed_refreshes(db: AsyncSession, limit: int) -> schemas.AttentionBookCategory:
+    query = (
+        select(models.Book)
+        .where(models.Book.refresh_status == "error")
+        .order_by(models.Book.updated_at.desc(), models.Book.id.desc())
+    )
+    count = await db.scalar(select(func.count()).select_from(query.subquery()))
+    books = list((await db.execute(query.limit(limit))).scalars().all())
+    return schemas.AttentionBookCategory(
+        count=count or 0,
+        items=[_book_item(book, "refresh_failed", "The most recent source refresh failed.") for book in books],
+    )
+
+
+async def _stale_audiobooks(db: AsyncSession, limit: int) -> schemas.AttentionBookCategory:
+    ai_query = select(models.Book).where(
+        models.Book.audiobook_enabled.is_(True),
+        models.Book.audiobook_publication_state == "stale",
+    )
+    human_query = (
+        select(models.Book, models.ImportedAudiobook)
+        .join(models.ImportedAudiobook, models.ImportedAudiobook.book_id == models.Book.id)
+        .where(models.ImportedAudiobook.status == "stale")
+    )
+
+    reasons: dict[int, list[str]] = defaultdict(list)
+    books_by_id: dict[int, models.Book] = {}
+    for book in (await db.execute(ai_query)).scalars().all():
+        books_by_id[book.id] = book
+        reasons[book.id].append("Generated audiobook")
+    for book, edition in (await db.execute(human_query)).all():
+        books_by_id[book.id] = book
+        reasons[book.id].append(edition.name or "Imported audiobook")
+
+    ordered = sorted(
+        books_by_id.values(), key=lambda book: (book.updated_at is not None, book.updated_at, book.id), reverse=True
+    )
+    return schemas.AttentionBookCategory(
+        count=len(ordered),
+        items=[
+            _book_item(book, "audiobook_stale", f"{', '.join(reasons[book.id])} needs reconciliation with the current text.")
+            for book in ordered[:limit]
+        ],
+    )
+
+
+async def _metadata_proposals(db: AsyncSession, limit: int) -> schemas.AttentionMetadataCategory:
+    count = await db.scalar(
+        select(func.count()).select_from(models.MetadataProposal).where(models.MetadataProposal.status == "open")
+    )
+    rows = (
+        await db.execute(
+            select(models.MetadataProposal, models.Book)
+            .join(models.Book, models.MetadataProposal.book_id == models.Book.id)
+            .where(models.MetadataProposal.status == "open")
+            .order_by(models.MetadataProposal.created_at.desc(), models.MetadataProposal.id.desc())
+            .limit(limit)
+        )
+    ).all()
+    return schemas.AttentionMetadataCategory(
+        count=count or 0,
+        items=[
+            schemas.AttentionMetadataItem(
+                proposal_id=proposal.id,
+                book_id=book.id,
+                title=book.title,
+                author=book.author,
+                note=proposal.note,
+            )
+            for proposal, book in rows
+        ],
+    )
+
+
+@router.get("/api/dashboard/attention", response_model=schemas.AttentionDashboard)
+async def get_attention_dashboard(
+    limit: int = Query(5, ge=1, le=25),
+    db: AsyncSession = Depends(get_db),
+) -> schemas.AttentionDashboard:
+    books = await crud.get_books(db, limit=100000)
+    file_issues = inspect_library_files(books, library_path=LIBRARY_PATH)
+    broken_files = [
+        issue
+        for issue in file_issues
+        if issue["issue"]
+        in {"missing_immutable_path", "immutable_file_not_found", "missing_current_path", "current_file_not_found"}
+    ]
+    missing_covers = find_missing_covers(books, library_path=LIBRARY_PATH)
+
+    failed_jobs = await _failed_jobs(db, limit)
+    failed_refreshes = await _failed_refreshes(db, limit)
+    stale_audiobooks = await _stale_audiobooks(db, limit)
+    metadata_proposals = await _metadata_proposals(db, limit)
+    broken_category = schemas.AttentionFileCategory(
+        count=len(broken_files),
+        items=[schemas.AttentionFileItem(**issue) for issue in broken_files[:limit]],
+    )
+    cover_category = schemas.AttentionFileCategory(
+        count=len(missing_covers),
+        items=[schemas.AttentionFileItem(**issue) for issue in missing_covers[:limit]],
+    )
+    total_count = sum(
+        category.count
+        for category in (
+            failed_jobs,
+            failed_refreshes,
+            stale_audiobooks,
+            metadata_proposals,
+            broken_category,
+            cover_category,
+        )
+    )
+    return schemas.AttentionDashboard(
+        total_count=total_count,
+        failed_jobs=failed_jobs,
+        failed_refreshes=failed_refreshes,
+        stale_audiobooks=stale_audiobooks,
+        metadata_proposals=metadata_proposals,
+        broken_files=broken_category,
+        missing_covers=cover_category,
+    )

--- a/backend/app/routers/storage.py
+++ b/backend/app/routers/storage.py
@@ -11,15 +11,12 @@ from .. import crud
 from ..config import LIBRARY_PATH
 from ..database import get_db
 from ..logging_config import _LOG_BUFFER
+from ..services.library_health import inspect_library_files, is_failed_web_import_placeholder
 
 logger = logging.getLogger(__name__)
 _ui_logger = logging.getLogger("frontend")
 
 router = APIRouter()
-
-
-def _is_failed_web_import_placeholder(book) -> bool:
-    return bool(book.source_url and book.download_status == "error" and not book.immutable_path and not book.current_path)
 
 
 class ClientLogEntry(BaseModel):
@@ -55,32 +52,7 @@ async def validate_library(db: AsyncSession = Depends(get_db)):
     Returns a list of issues found (empty list means everything is healthy).
     """
     books = await crud.get_books(db, limit=100000)
-    issues: list[dict] = []
-    for book in books:
-        book_info = {"book_id": book.id, "title": book.title, "author": book.author}
-        if book.source_url and not book.immutable_path and not book.current_path:
-            if book.download_status == "pending":
-                issues.append({**book_info, "issue": "pending_web_import", "source_url": book.source_url})
-                continue
-            if _is_failed_web_import_placeholder(book):
-                issues.append({**book_info, "issue": "failed_web_import", "source_url": book.source_url})
-                continue
-        if not book.immutable_path:
-            issues.append({**book_info, "issue": "missing_immutable_path"})
-        else:
-            full = LIBRARY_PATH.parent / book.immutable_path
-            if not full.exists():
-                issues.append({**book_info, "issue": "immutable_file_not_found", "path": book.immutable_path})
-        if not book.current_path:
-            issues.append({**book_info, "issue": "missing_current_path"})
-        else:
-            full = LIBRARY_PATH.parent / book.current_path
-            if not full.exists():
-                issues.append({**book_info, "issue": "current_file_not_found", "path": book.current_path})
-        if book.cover_path:
-            full = LIBRARY_PATH.parent / book.cover_path
-            if not full.exists():
-                issues.append({**book_info, "issue": "cover_file_not_found", "path": book.cover_path})
+    issues = inspect_library_files(books, library_path=LIBRARY_PATH)
 
     if issues:
         logger.warning("Library validation found %d issue(s)", len(issues))
@@ -108,7 +80,7 @@ async def cleanup_storage(dry_run: bool = True, db: AsyncSession = Depends(get_d
             "issue": "failed_web_import",
         }
         for book in books
-        if _is_failed_web_import_placeholder(book)
+        if is_failed_web_import_placeholder(book)
     ]
 
     # Refuse to run if any downloads are still in progress — their files
@@ -156,7 +128,7 @@ async def cleanup_storage(dry_run: bool = True, db: AsyncSession = Depends(get_d
             logger.info("Storage cleanup: deleting %s", f["path"])
             full.unlink(missing_ok=True)
         for book in books:
-            if not _is_failed_web_import_placeholder(book):
+            if not is_failed_web_import_placeholder(book):
                 continue
             logger.info("Storage cleanup: deleting failed web import placeholder book %s (%s)", book.id, book.source_url)
             await crud.delete_book(db, book=book)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -368,6 +368,65 @@ class ProcessingJobsCreated(BaseModel):
     jobs: List[ProcessingJob] = Field(default_factory=list)
 
 
+class AttentionBookItem(BaseModel):
+    book_id: int
+    title: str
+    author: str
+    issue: str
+    detail: Optional[str] = None
+
+
+class AttentionFileItem(AttentionBookItem):
+    path: Optional[str] = None
+
+
+class AttentionJobItem(BaseModel):
+    id: int
+    job_type: str
+    book_id: Optional[int] = None
+    book_title: Optional[str] = None
+    error: Optional[str] = None
+    completed_at: Optional[datetime] = None
+
+
+class AttentionMetadataItem(BaseModel):
+    proposal_id: int
+    book_id: int
+    title: str
+    author: str
+    note: Optional[str] = None
+
+
+class AttentionBookCategory(BaseModel):
+    count: int
+    items: List[AttentionBookItem] = Field(default_factory=list)
+
+
+class AttentionFileCategory(BaseModel):
+    count: int
+    items: List[AttentionFileItem] = Field(default_factory=list)
+
+
+class AttentionJobCategory(BaseModel):
+    count: int
+    items: List[AttentionJobItem] = Field(default_factory=list)
+
+
+class AttentionMetadataCategory(BaseModel):
+    count: int
+    items: List[AttentionMetadataItem] = Field(default_factory=list)
+
+
+class AttentionDashboard(BaseModel):
+    total_count: int
+    failed_jobs: AttentionJobCategory
+    failed_refreshes: AttentionBookCategory
+    stale_audiobooks: AttentionBookCategory
+    metadata_proposals: AttentionMetadataCategory
+    broken_files: AttentionFileCategory
+    missing_covers: AttentionFileCategory
+
+
 class ReaderSeriesSummary(BaseModel):
     name: str
     book_count: int

--- a/backend/app/services/library_health.py
+++ b/backend/app/services/library_health.py
@@ -1,0 +1,76 @@
+"""Shared library file-health inspection used by dashboards and maintenance tools."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+from ..models import Book
+
+
+def is_failed_web_import_placeholder(book: Book) -> bool:
+    return bool(book.source_url and book.download_status == "error" and not book.immutable_path and not book.current_path)
+
+
+def inspect_library_files(books: Iterable[Book], *, library_path: Path) -> list[dict]:
+    """Return missing or broken EPUB and cover paths for the supplied books."""
+    issues: list[dict] = []
+    for book in books:
+        book_info = {"book_id": book.id, "title": book.title, "author": book.author}
+        if book.source_url and not book.immutable_path and not book.current_path:
+            if book.download_status == "pending":
+                issues.append({**book_info, "issue": "pending_web_import", "source_url": str(book.source_url)})
+                continue
+            if is_failed_web_import_placeholder(book):
+                issues.append({**book_info, "issue": "failed_web_import", "source_url": str(book.source_url)})
+                continue
+
+        if not book.immutable_path:
+            issues.append({**book_info, "issue": "missing_immutable_path"})
+        else:
+            full_path = library_path.parent / book.immutable_path
+            if not full_path.exists():
+                issues.append({**book_info, "issue": "immutable_file_not_found", "path": book.immutable_path})
+
+        if not book.current_path:
+            issues.append({**book_info, "issue": "missing_current_path"})
+        else:
+            full_path = library_path.parent / book.current_path
+            if not full_path.exists():
+                issues.append({**book_info, "issue": "current_file_not_found", "path": book.current_path})
+
+        if book.cover_path:
+            full_path = library_path.parent / book.cover_path
+            if not full_path.exists():
+                issues.append({**book_info, "issue": "cover_file_not_found", "path": book.cover_path})
+
+    return issues
+
+
+def find_missing_covers(books: Iterable[Book], *, library_path: Path) -> list[dict]:
+    """Return completed books with no usable local cover image."""
+    issues: list[dict] = []
+    for book in books:
+        if book.download_status == "pending" or is_failed_web_import_placeholder(book):
+            continue
+        if not book.cover_path:
+            issues.append(
+                {
+                    "book_id": book.id,
+                    "title": book.title,
+                    "author": book.author,
+                    "issue": "missing_cover",
+                }
+            )
+            continue
+        if not (library_path.parent / book.cover_path).exists():
+            issues.append(
+                {
+                    "book_id": book.id,
+                    "title": book.title,
+                    "author": book.author,
+                    "issue": "cover_file_not_found",
+                    "path": book.cover_path,
+                }
+            )
+    return issues

--- a/backend/tests/test_dashboard.py
+++ b/backend/tests/test_dashboard.py
@@ -1,0 +1,155 @@
+"""Tests for the aggregated Needs Attention dashboard."""
+
+from pathlib import Path
+
+import pytest
+
+from backend.app import crud, models, schemas
+from backend.app.routers import dashboard as dashboard_router
+
+
+def _book_paths(library_path: Path, slug: str) -> tuple[str, str]:
+    immutable = library_path / f"immutable_{slug}.epub"
+    current = library_path / f"{slug}.epub"
+    immutable.write_bytes(b"original")
+    current.write_bytes(b"current")
+    return (
+        str(immutable.relative_to(library_path.parent)),
+        str(current.relative_to(library_path.parent)),
+    )
+
+
+def _add_cover(library_path: Path, book: models.Book) -> None:
+    cover = library_path / "covers" / f"{book.id}.jpg"
+    cover.parent.mkdir(parents=True, exist_ok=True)
+    cover.write_bytes(b"cover")
+    book.cover_path = str(cover.relative_to(library_path.parent))
+
+
+@pytest.mark.asyncio
+async def test_attention_dashboard_aggregates_actionable_categories(
+    app_client,
+    sqlite_sessionmaker,
+    tmp_path,
+    monkeypatch,
+):
+    library_path = tmp_path / "library"
+    library_path.mkdir()
+    monkeypatch.setattr(dashboard_router, "LIBRARY_PATH", library_path)
+
+    async with sqlite_sessionmaker() as db:
+        refresh_paths = _book_paths(library_path, "refresh")
+        refresh_book = await crud.create_book(
+            db,
+            schemas.BookCreate(
+                title="Refresh Me",
+                author="Web Author",
+                source_url="https://example.com/refresh",
+                source_type=models.SourceType.web,
+                immutable_path=refresh_paths[0],
+                current_path=refresh_paths[1],
+                refresh_status="error",
+            ),
+        )
+        _add_cover(library_path, refresh_book)
+
+        stale_paths = _book_paths(library_path, "stale")
+        stale_book = await crud.create_book(
+            db,
+            schemas.BookCreate(
+                title="Stale Audio",
+                author="Narrated Author",
+                source_type=models.SourceType.epub,
+                immutable_path=stale_paths[0],
+                current_path=stale_paths[1],
+                audiobook_enabled=True,
+            ),
+        )
+        stale_book.audiobook_publication_state = "stale"
+        _add_cover(library_path, stale_book)
+        db.add(
+            models.ImportedAudiobook(
+                book_id=stale_book.id,
+                name="Human edition",
+                source_type="upload",
+                status="stale",
+            )
+        )
+
+        broken_book = await crud.create_book(
+            db,
+            schemas.BookCreate(
+                title="Broken Paths",
+                author="Missing Author",
+                source_type=models.SourceType.epub,
+                immutable_path="library/missing-original.epub",
+                current_path="library/missing-current.epub",
+            ),
+        )
+        _add_cover(library_path, broken_book)
+
+        cover_paths = _book_paths(library_path, "coverless")
+        await crud.create_book(
+            db,
+            schemas.BookCreate(
+                title="Coverless",
+                author="Cover Author",
+                source_type=models.SourceType.epub,
+                immutable_path=cover_paths[0],
+                current_path=cover_paths[1],
+            ),
+        )
+
+        db.add(
+            models.ProcessingJob(
+                job_type="refresh_book",
+                status="error",
+                book_id=refresh_book.id,
+                payload={},
+                progress_current=0,
+                progress_total=1,
+                attempt_count=1,
+                cancel_requested=False,
+                error="Source unavailable",
+            )
+        )
+        db.add(
+            models.MetadataProposal(
+                book_id=refresh_book.id,
+                status="open",
+                proposed_genre_tags=["Fantasy"],
+                possible_missing_series_books=[],
+                note="Review the proposed genre.",
+            )
+        )
+        await db.commit()
+
+    response = app_client.get("/api/dashboard/attention?limit=5")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_count"] == 7
+    assert data["failed_jobs"]["count"] == 1
+    assert data["failed_jobs"]["items"][0]["book_title"] == "Refresh Me"
+    assert data["failed_refreshes"]["count"] == 1
+    assert data["stale_audiobooks"]["count"] == 1
+    assert "Generated audiobook" in data["stale_audiobooks"]["items"][0]["detail"]
+    assert "Human edition" in data["stale_audiobooks"]["items"][0]["detail"]
+    assert data["metadata_proposals"]["count"] == 1
+    assert data["broken_files"]["count"] == 2
+    assert data["missing_covers"]["count"] == 1
+    assert data["missing_covers"]["items"][0]["title"] == "Coverless"
+
+
+@pytest.mark.asyncio
+async def test_attention_dashboard_has_clear_healthy_state(app_client, tmp_path, monkeypatch):
+    library_path = tmp_path / "library"
+    library_path.mkdir()
+    monkeypatch.setattr(dashboard_router, "LIBRARY_PATH", library_path)
+
+    response = app_client.get("/api/dashboard/attention")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_count"] == 0
+    assert all(category["count"] == 0 for key, category in data.items() if key != "total_count")

--- a/backend/tests/test_dashboard.py
+++ b/backend/tests/test_dashboard.py
@@ -153,3 +153,50 @@ async def test_attention_dashboard_has_clear_healthy_state(app_client, tmp_path,
     data = response.json()
     assert data["total_count"] == 0
     assert all(category["count"] == 0 for key, category in data.items() if key != "total_count")
+
+
+@pytest.mark.asyncio
+async def test_attention_dashboard_hides_failure_after_newer_success(
+    app_client,
+    sqlite_sessionmaker,
+    tmp_path,
+    monkeypatch,
+):
+    library_path = tmp_path / "library"
+    library_path.mkdir()
+    monkeypatch.setattr(dashboard_router, "LIBRARY_PATH", library_path)
+
+    async with sqlite_sessionmaker() as db:
+        db.add(
+            models.ProcessingJob(
+                job_type="refresh_all",
+                status="error",
+                payload={"trigger": "manual"},
+                progress_current=2,
+                progress_total=5,
+                attempt_count=1,
+                cancel_requested=False,
+                error="One source failed",
+            )
+        )
+        await db.flush()
+        db.add(
+            models.ProcessingJob(
+                job_type="refresh_all",
+                status="completed",
+                payload={"trigger": "manual"},
+                progress_current=5,
+                progress_total=5,
+                attempt_count=1,
+                cancel_requested=False,
+                progress_detail="Refreshed 5 of 5 web books",
+            )
+        )
+        await db.commit()
+
+    response = app_client.get("/api/dashboard/attention")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["failed_jobs"] == {"count": 0, "items": []}
+    assert data["total_count"] == 0

--- a/docs/IMPROVEMENT_ROADMAP.md
+++ b/docs/IMPROVEMENT_ROADMAP.md
@@ -35,6 +35,7 @@ The dashboard should favor resolution over raw diagnostics. Every category shoul
 - The UI displays each supported category with a count, explanation, and action link.
 - Broken paths and missing covers reuse one library-health implementation rather than duplicating storage-audit rules.
 - Failed jobs and refreshes identify the affected book when possible.
+- A failed job clears automatically when a newer equivalent operation succeeds.
 - The dashboard refreshes while relevant background work is active.
 - Backend and frontend tests cover populated and healthy states.
 

--- a/docs/IMPROVEMENT_ROADMAP.md
+++ b/docs/IMPROVEMENT_ROADMAP.md
@@ -1,0 +1,157 @@
+# Story Manager Improvement Roadmap
+
+This roadmap captures the next major product and technical improvements for Story Manager. Work is intentionally ordered so that user-facing consolidation comes first, followed by the technical changes needed to support larger libraries and more reliable background processing.
+
+## Delivery rules
+
+- Complete one roadmap item per pull request.
+- Keep each pull request independently deployable and reversible.
+- Include focused unit or integration tests and update end-to-end coverage when a user workflow changes.
+- Do not combine opportunistic refactors with a roadmap item unless they are required to deliver it safely.
+- Mark an item complete here only after its pull request has been merged.
+
+## Sequence
+
+1. [Needs Attention dashboard](#1-needs-attention-dashboard)
+2. [Simplified navigation](#2-simplified-navigation)
+3. [Unified import workflow](#3-unified-import-workflow)
+4. [Recoverable destructive changes](#4-recoverable-destructive-changes)
+5. [Server-side catalog pagination and filtering](#5-server-side-catalog-pagination-and-filtering)
+6. [Consolidated background execution](#6-consolidated-background-execution)
+7. [Centralized state-machine definitions](#7-centralized-state-machine-definitions)
+8. [Stronger observability](#8-stronger-observability)
+
+## 1. Needs Attention dashboard
+
+**Status:** In progress
+
+Give users one actionable view of problems and pending decisions across the library. The first version should summarize failed processing jobs, failed web refreshes, stale audiobooks, open metadata proposals, broken library files, and missing covers.
+
+The dashboard should favor resolution over raw diagnostics. Every category should explain why it matters and link to the page where the user can act. A healthy library should have a clear empty state rather than a blank screen.
+
+### Acceptance criteria
+
+- A single API response aggregates attention counts and representative recent items.
+- The UI displays each supported category with a count, explanation, and action link.
+- Broken paths and missing covers reuse one library-health implementation rather than duplicating storage-audit rules.
+- Failed jobs and refreshes identify the affected book when possible.
+- The dashboard refreshes while relevant background work is active.
+- Backend and frontend tests cover populated and healthy states.
+
+## 2. Simplified navigation
+
+**Status:** Planned
+
+Replace the current tool-oriented top-level navigation with three user-oriented destinations: **Library**, **Activity**, and **Settings**. The Needs Attention dashboard should become the default overview within this structure.
+
+Activity will own processing jobs, failures, scheduled runs, and history. Settings will own cleaning rules, reader access, audio and AI providers, storage utilities, and application logs. Existing deep links should redirect or continue to resolve.
+
+### Acceptance criteria
+
+- The primary navigation contains only Library, Activity, and Settings.
+- Existing pages remain reachable and are grouped under the appropriate destination.
+- Active-job and attention counts remain visible from anywhere in the app.
+- Browser back/forward behavior and direct links work for every nested section.
+- Mobile and keyboard navigation are covered by tests.
+
+## 3. Unified import workflow
+
+**Status:** Planned
+
+Create one guided **Add to library** workflow for EPUB files, ZIP archives, folders, web-novel URLs, human audiobook files, and Libation backups. The workflow should separate selection, inspection, conflict resolution, execution, and results.
+
+Preflight inspection should show detected metadata, likely duplicates, audiobook-to-book matches, applicable cleaning rules, and any unsupported input before work begins.
+
+### Acceptance criteria
+
+- All current import entry points are available through one workflow.
+- Inputs are inspected before durable work is queued.
+- Duplicate books and ambiguous audiobook matches require an explicit decision.
+- The results view distinguishes succeeded, skipped, queued, and failed items.
+- Long-running work remains visible after leaving or reloading the page.
+- Existing focused import APIs remain backward compatible during migration.
+
+## 4. Recoverable destructive changes
+
+**Status:** Planned
+
+Make deletion and content-changing operations recoverable. Build on the existing immutable EPUB copy to support restoring original content, reviewing cleaning changes, and recovering accidentally deleted records where practical.
+
+The design should cover book deletion, bulk deletion, chapter removal, cleaning-rule application, series changes, and metadata replacement. Recovery guarantees must be explicit; a recycle bin should not imply that externally deleted source files can always be restored.
+
+### Acceptance criteria
+
+- Destructive actions use an application confirmation experience that states exactly what will change.
+- Eligible deleted books enter a recycle bin for a configurable retention period.
+- Users can restore the original EPUB after cleaning or chapter edits.
+- Metadata and series changes record enough history to explain or revert them.
+- Permanent deletion remains available and clearly distinguished from recoverable removal.
+- Cleanup jobs do not remove files still required for recovery.
+
+## 5. Server-side catalog pagination and filtering
+
+**Status:** Planned
+
+Stop loading the entire library for every catalog view. Introduce cursor-based pagination, server-side filtering, stable sorting, and aggregate facet counts while preserving the current series-oriented presentation.
+
+Search should use PostgreSQL indexes suited to title, author, series, and tag lookup rather than casting JSON fields to text for every query.
+
+### Acceptance criteria
+
+- Catalog responses are paginated and include a continuation cursor.
+- Search, sorting, and all visible filters execute on the server.
+- Series, standalone, web, audiobook, status, and genre counts remain accurate without loading every book.
+- Scrolling does not duplicate or omit books when records change between requests.
+- Query plans and a representative large-library benchmark are documented.
+- Reader API behavior remains backward compatible.
+
+## 6. Consolidated background execution
+
+**Status:** Planned
+
+Complete the transition from specialized in-memory queues to the durable processing-job ledger. The API process should enqueue work, while a unified worker claims and executes jobs using explicit resource lanes.
+
+The first deployment can retain a single-container experience, but job ownership must no longer depend on application-local queue memory.
+
+### Acceptance criteria
+
+- All user-visible background operations are represented by processing jobs.
+- Workers claim jobs atomically from PostgreSQL with leases and heartbeats.
+- Abandoned jobs are recoverable after crashes or restarts.
+- Retry limits, backoff, cancellation, idempotency, and deduplication are defined consistently.
+- CPU, maintenance, LLM, TTS, and transcription concurrency can be configured independently.
+- The existing single-container deployment remains supported.
+
+## 7. Centralized state-machine definitions
+
+**Status:** Planned
+
+Replace scattered lifecycle strings and implicit transitions with centralized state definitions for processing jobs, web imports and refreshes, metadata jobs, generated audiobooks, imported audiobooks, alignment, and publication.
+
+State machines should define valid transitions, terminal states, retry behavior, and how parent and child operations interact. Database constraints should reject impossible values.
+
+### Acceptance criteria
+
+- Each lifecycle has one authoritative state definition.
+- Services transition state through shared helpers rather than assigning strings directly.
+- Alembic migrations add safe database constraints for existing populated databases.
+- Invalid transitions fail with actionable errors and are tested.
+- Frontend labels and status groupings derive from the same documented vocabulary.
+- Recovery behavior for every non-terminal state is documented.
+
+## 8. Stronger observability
+
+**Status:** Planned
+
+Make failures diagnosable without reading raw container output. Connect request IDs to log records, expose worker and dependency health, measure job behavior, and provide a user-downloadable diagnostic bundle with secrets removed.
+
+Observability should remain useful for a small self-hosted deployment and should not require an external monitoring stack.
+
+### Acceptance criteria
+
+- Request IDs appear in API responses, structured logs, and related failure details.
+- Health endpoints distinguish liveness, database readiness, worker availability, storage capacity, and optional provider status.
+- Job duration, queue delay, retry, cancellation, and failure metrics are available by job type.
+- Logs required for recent diagnostics survive ordinary application restarts.
+- Users can download a redacted diagnostic bundle from the UI.
+- Metrics and logs never expose API keys, session secrets, book contents, or generated audio.

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -28,6 +28,168 @@
   margin-right: auto;
 }
 
+/* ─── Needs Attention dashboard ─────────────────────────── */
+.attention-page {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.attention-page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.attention-page-header p {
+  color: var(--text-muted);
+  margin: 0.35rem 0 0;
+  max-width: 42rem;
+}
+
+.attention-eyebrow {
+  display: block;
+  color: var(--accent);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  margin-bottom: 0.25rem;
+}
+
+.attention-healthy {
+  display: grid;
+  gap: 0.2rem;
+  border: 1px solid color-mix(in srgb, var(--success) 55%, var(--border));
+  background: color-mix(in srgb, var(--success) 9%, var(--surface));
+  padding: 1rem 1.1rem;
+}
+
+.attention-healthy span {
+  color: var(--text-muted);
+  font-size: 0.875rem;
+}
+
+.attention-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.9rem;
+}
+
+.attention-card {
+  border: 1px solid var(--border);
+  background: var(--surface);
+  padding: 1rem;
+  min-width: 0;
+}
+
+.attention-card--open {
+  border-color: color-mix(in srgb, var(--warning) 45%, var(--border));
+}
+
+.attention-card-header,
+.attention-card-header > div {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.attention-card-header {
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.attention-count {
+  display: inline-grid;
+  place-items: center;
+  min-width: 2rem;
+  height: 2rem;
+  padding: 0 0.4rem;
+  border: 1px solid var(--border-strong);
+  color: var(--text-muted);
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.attention-card--open .attention-count {
+  color: var(--warning);
+  border-color: color-mix(in srgb, var(--warning) 65%, var(--border));
+  background: color-mix(in srgb, var(--warning) 8%, transparent);
+}
+
+.attention-card > p {
+  color: var(--text-muted);
+  font-size: 0.82rem;
+  margin: 0.8rem 0;
+}
+
+.attention-card .attention-clear {
+  color: var(--success);
+  margin-bottom: 0;
+}
+
+.attention-list {
+  list-style: none;
+  padding: 0;
+  margin: 0.9rem 0 0;
+  border-top: 1px solid var(--border);
+}
+
+.attention-item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.15rem 0.75rem;
+  padding: 0.65rem 0;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.82rem;
+}
+
+.attention-item > a,
+.attention-item > strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.attention-item > span {
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.attention-item > small {
+  grid-column: 1 / -1;
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.attention-item > .attention-item-error {
+  color: var(--danger);
+}
+
+.attention-more {
+  display: block;
+  color: var(--text-muted);
+  margin-top: 0.6rem;
+}
+
+@media (max-width: 700px) {
+  .attention-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .attention-page-header {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .attention-page-header > button {
+    align-self: flex-start;
+  }
+}
+
 .login-panel {
   display: flex;
   justify-content: center;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,6 +14,8 @@ import Logs from "./components/Logs.jsx";
 import Utilities from "./components/Utilities.jsx";
 import ProcessingJobs from "./components/ProcessingJobs.jsx";
 import { getProcessingJobs } from "./api/processing";
+import { getAttentionDashboard } from "./api/dashboard";
+import AttentionDashboard from "./components/AttentionDashboard.jsx";
 import useDebouncedValue from "./hooks/useDebouncedValue";
 import useLibraryCatalog from "./hooks/useLibraryCatalog";
 import {
@@ -165,6 +167,14 @@ function App() {
     refetchInterval: 3000,
   });
 
+  const attentionQuery = useQuery({
+    queryKey: ["attention-dashboard"],
+    queryFn: () => getAttentionDashboard(5),
+    enabled: Boolean(authStatus?.authenticated),
+    staleTime: 30_000,
+    refetchInterval: activeProcessingJobs.length > 0 ? 5000 : 60_000,
+  });
+
   const handleClearSearch = () => {
     setQ("");
   };
@@ -280,6 +290,16 @@ function App() {
 
   const renderTabContent = () => {
     switch (activeTab) {
+      case "attention":
+        return (
+          <AttentionDashboard
+            data={attentionQuery.data}
+            isLoading={attentionQuery.isLoading}
+            error={attentionQuery.error}
+            onRefresh={attentionQuery.refetch}
+            isRefreshing={attentionQuery.isFetching}
+          />
+        );
       case "configs":
         return <CleaningConfigs />;
       case "scheduler":
@@ -398,6 +418,9 @@ function App() {
             {tab.label}
             {tab.key === "processing" && activeProcessingJobs.length > 0 && (
               <span className="nav-job-count">{activeProcessingJobs.length}</span>
+            )}
+            {tab.key === "attention" && attentionQuery.data?.total_count > 0 && (
+              <span className="nav-job-count">{attentionQuery.data.total_count}</span>
             )}
           </button>
         ))}

--- a/frontend/src/api/dashboard.js
+++ b/frontend/src/api/dashboard.js
@@ -1,0 +1,8 @@
+import { getJson } from "./client";
+
+export function getAttentionDashboard(limit = 5) {
+  return getJson(
+    `/api/dashboard/attention?limit=${limit}`,
+    "Failed to load library attention items",
+  );
+}

--- a/frontend/src/components/AttentionDashboard.jsx
+++ b/frontend/src/components/AttentionDashboard.jsx
@@ -1,0 +1,210 @@
+const JOB_LABELS = {
+  clean_book: "Clean book",
+  clean_all: "Clean library",
+  refresh_book: "Refresh book",
+  refresh_all: "Refresh web library",
+  audiobook_pipeline: "Generate AI audiobook",
+  import_audiobook: "Import human audiobook",
+  rematch_imported_audiobook: "Rematch human audiobook",
+  align_imported_audiobook: "Align human audiobook",
+  metadata_sync: "Sync metadata",
+  generate_sentence_audio: "Generate sentence audio",
+  generate_chapter_preview: "Generate chapter preview",
+  retry_cover: "Re-extract book cover",
+};
+
+function BookItem({ item, audiobook = false }) {
+  const href = audiobook
+    ? `/books/${item.book_id}/audiobooks?tab=sources`
+    : `/books/${item.book_id}/details`;
+  return (
+    <li className="attention-item">
+      <a href={href}>{item.title}</a>
+      <span>{item.author || "Unknown author"}</span>
+      {item.detail && <small>{item.detail}</small>}
+    </li>
+  );
+}
+
+function FileItem({ item }) {
+  return (
+    <li className="attention-item">
+      <a href={`/books/${item.book_id}/details`}>{item.title}</a>
+      <span>{item.issue.replaceAll("_", " ")}</span>
+      {item.path && <small title={item.path}>{item.path}</small>}
+    </li>
+  );
+}
+
+function JobItem({ item }) {
+  return (
+    <li className="attention-item">
+      <strong>{JOB_LABELS[item.job_type] || item.job_type.replaceAll("_", " ")}</strong>
+      {item.book_id ? (
+        <a href={`/books/${item.book_id}/details`}>
+          {item.book_title || `Book ${item.book_id}`}
+        </a>
+      ) : (
+        <span>Library operation</span>
+      )}
+      {item.error && <small className="attention-item-error">{item.error}</small>}
+    </li>
+  );
+}
+
+function MetadataItem({ item }) {
+  return (
+    <li className="attention-item">
+      <a href={`/books/${item.book_id}/details`}>{item.title}</a>
+      <span>{item.author || "Unknown author"}</span>
+      {item.note && <small>{item.note}</small>}
+    </li>
+  );
+}
+
+function AttentionCard({ title, description, category, actionHref, actionLabel, children }) {
+  const hasItems = category.count > 0;
+  return (
+    <article className={`attention-card${hasItems ? " attention-card--open" : ""}`}>
+      <header className="attention-card-header">
+        <div>
+          <span className="attention-count" aria-label={`${category.count} ${title.toLowerCase()}`}>
+            {category.count}
+          </span>
+          <h3>{title}</h3>
+        </div>
+        {hasItems && (
+          <a className="btn btn-sm" href={actionHref}>
+            {actionLabel}
+          </a>
+        )}
+      </header>
+      <p>{description}</p>
+      {hasItems ? (
+        <>
+          <ul className="attention-list">{children}</ul>
+          {category.count > category.items.length && (
+            <small className="attention-more">
+              {category.count - category.items.length} more not shown
+            </small>
+          )}
+        </>
+      ) : (
+        <p className="attention-clear">No attention needed</p>
+      )}
+    </article>
+  );
+}
+
+function AttentionDashboard({ data, isLoading, error, onRefresh, isRefreshing }) {
+  if (isLoading) {
+    return <p>Checking library health…</p>;
+  }
+  if (error) {
+    return (
+      <div className="attention-page">
+        <h2>Needs attention</h2>
+        <p className="error" role="alert">{error.message}</p>
+        <button onClick={onRefresh}>Try again</button>
+      </div>
+    );
+  }
+  if (!data) return null;
+
+  const healthy = data.total_count === 0;
+  return (
+    <div className="attention-page">
+      <header className="attention-page-header">
+        <div>
+          <span className="attention-eyebrow">LIBRARY OVERVIEW</span>
+          <h2>Needs attention</h2>
+          <p>
+            Problems and pending decisions that may keep books, updates, or audiobooks from being ready.
+          </p>
+        </div>
+        <button className="btn-text" onClick={onRefresh} disabled={isRefreshing}>
+          {isRefreshing ? "Checking…" : "Refresh"}
+        </button>
+      </header>
+
+      {healthy && (
+        <section className="attention-healthy" role="status">
+          <strong>Your library looks healthy.</strong>
+          <span>No failed work, stale audio, pending metadata, or missing files were found.</span>
+        </section>
+      )}
+
+      <div className="attention-grid">
+        <AttentionCard
+          title="Failed processing"
+          description="Durable jobs that stopped before completing. Retry them after reviewing the error."
+          category={data.failed_jobs}
+          actionHref="/processing?status=error"
+          actionLabel="Review jobs"
+        >
+          {data.failed_jobs.items.map((item) => <JobItem key={item.id} item={item} />)}
+        </AttentionCard>
+
+        <AttentionCard
+          title="Failed refreshes"
+          description="Web books whose latest source refresh did not complete."
+          category={data.failed_refreshes}
+          actionHref="/#web"
+          actionLabel="View web books"
+        >
+          {data.failed_refreshes.items.map((item) => <BookItem key={item.book_id} item={item} />)}
+        </AttentionCard>
+
+        <AttentionCard
+          title="Stale audiobooks"
+          description="Audio that no longer matches the current cleaned book text."
+          category={data.stale_audiobooks}
+          actionHref="/processing"
+          actionLabel="View processing"
+        >
+          {data.stale_audiobooks.items.map((item) => (
+            <BookItem key={item.book_id} item={item} audiobook />
+          ))}
+        </AttentionCard>
+
+        <AttentionCard
+          title="Metadata decisions"
+          description="Matches or proposed metadata waiting for approval or dismissal."
+          category={data.metadata_proposals}
+          actionHref="/utilities?section=metadata"
+          actionLabel="Review metadata"
+        >
+          {data.metadata_proposals.items.map((item) => (
+            <MetadataItem key={item.proposal_id} item={item} />
+          ))}
+        </AttentionCard>
+
+        <AttentionCard
+          title="Broken library files"
+          description="Book records whose original or current EPUB file cannot be found."
+          category={data.broken_files}
+          actionHref="/utilities?section=audit"
+          actionLabel="Run audit"
+        >
+          {data.broken_files.items.map((item, index) => (
+            <FileItem key={`${item.book_id}-${item.issue}-${index}`} item={item} />
+          ))}
+        </AttentionCard>
+
+        <AttentionCard
+          title="Missing covers"
+          description="Completed books with no usable local cover image."
+          category={data.missing_covers}
+          actionHref="/utilities?section=audit"
+          actionLabel="Review library"
+        >
+          {data.missing_covers.items.map((item) => (
+            <FileItem key={`${item.book_id}-${item.issue}`} item={item} />
+          ))}
+        </AttentionCard>
+      </div>
+    </div>
+  );
+}
+
+export default AttentionDashboard;

--- a/frontend/src/components/AttentionDashboard.test.jsx
+++ b/frontend/src/components/AttentionDashboard.test.jsx
@@ -1,0 +1,99 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import AttentionDashboard from "./AttentionDashboard";
+
+const emptyCategory = { count: 0, items: [] };
+
+function dashboard(overrides = {}) {
+  return {
+    total_count: 0,
+    failed_jobs: emptyCategory,
+    failed_refreshes: emptyCategory,
+    stale_audiobooks: emptyCategory,
+    metadata_proposals: emptyCategory,
+    broken_files: emptyCategory,
+    missing_covers: emptyCategory,
+    ...overrides,
+  };
+}
+
+describe("AttentionDashboard", () => {
+  it("shows a clear healthy state", () => {
+    render(<AttentionDashboard data={dashboard()} onRefresh={() => {}} />);
+
+    expect(screen.getByText("Your library looks healthy.")).toBeInTheDocument();
+    expect(screen.getAllByText("No attention needed")).toHaveLength(6);
+  });
+
+  it("shows actionable items and their destinations", () => {
+    const data = dashboard({
+      total_count: 3,
+      failed_jobs: {
+        count: 1,
+        items: [
+          {
+            id: 8,
+            job_type: "refresh_book",
+            book_id: 2,
+            book_title: "Failed Story",
+            error: "Source unavailable",
+          },
+        ],
+      },
+      stale_audiobooks: {
+        count: 1,
+        items: [
+          {
+            book_id: 3,
+            title: "Stale Audio",
+            author: "Narrator",
+            issue: "audiobook_stale",
+            detail: "Generated audiobook needs reconciliation.",
+          },
+        ],
+      },
+      metadata_proposals: {
+        count: 1,
+        items: [
+          {
+            proposal_id: 9,
+            book_id: 4,
+            title: "Metadata Book",
+            author: "Metadata Author",
+            note: "Review genres",
+          },
+        ],
+      },
+    });
+
+    render(<AttentionDashboard data={data} onRefresh={() => {}} />);
+
+    expect(screen.getByText("Source unavailable")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Review jobs" })).toHaveAttribute(
+      "href",
+      "/processing?status=error",
+    );
+    expect(screen.getByRole("link", { name: "Stale Audio" })).toHaveAttribute(
+      "href",
+      "/books/3/audiobooks?tab=sources",
+    );
+    expect(screen.getByRole("link", { name: "Review metadata" })).toHaveAttribute(
+      "href",
+      "/utilities?section=metadata",
+    );
+  });
+
+  it("lets the user retry a failed dashboard request", () => {
+    const refresh = vi.fn();
+    render(
+      <AttentionDashboard
+        error={new Error("Dashboard unavailable")}
+        onRefresh={refresh}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(refresh).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/components/ProcessingJobs.jsx
+++ b/frontend/src/components/ProcessingJobs.jsx
@@ -60,7 +60,12 @@ function JobProgress({ job }) {
 
 function ProcessingJobs() {
   const queryClient = useQueryClient();
-  const [statusFilter, setStatusFilter] = useState("active");
+  const [statusFilter, setStatusFilter] = useState(() => {
+    const requested = new URLSearchParams(window.location.search).get("status");
+    return ["active", "all", "error", "completed", "canceled"].includes(requested)
+      ? requested
+      : "active";
+  });
   const [operation, setOperation] = useState("clean_book");
   const [bookSearch, setBookSearch] = useState("");
   const [selectedIds, setSelectedIds] = useState([]);

--- a/frontend/src/components/Utilities.jsx
+++ b/frontend/src/components/Utilities.jsx
@@ -95,7 +95,10 @@ function formatMetadataMatchOption(match) {
 
 function Utilities({ onBack }) {
   const queryClient = useQueryClient();
-  const [activeTab, setActiveTab] = useState("audit");
+  const [activeTab, setActiveTab] = useState(() => {
+    const requested = new URLSearchParams(window.location.search).get("section");
+    return utilityTabs.some((tab) => tab.key === requested) ? requested : "audit";
+  });
   const [preview, setPreview] = useState(null);
   const [detectState, setDetectState] = useState(null); // null | "pending" | { updated, series_detected, error? }
   const [selectedMatchIds, setSelectedMatchIds] = useState({});

--- a/frontend/src/lib/navigation.js
+++ b/frontend/src/lib/navigation.js
@@ -1,5 +1,6 @@
 export const TABS = [
   { key: "library", label: "Library", path: "/" },
+  { key: "attention", label: "Needs Attention", path: "/attention" },
   { key: "configs", label: "Cleaning Configs", path: "/configs" },
   { key: "scheduler", label: "Scheduler", path: "/scheduler" },
   { key: "processing", label: "Processing", path: "/processing" },

--- a/frontend/src/lib/navigation.test.js
+++ b/frontend/src/lib/navigation.test.js
@@ -3,6 +3,14 @@ import { describe, expect, it } from "vitest";
 import { buildBookPath, parseLocation } from "./navigation";
 
 describe("book navigation", () => {
+  it("parses the Needs Attention dashboard route", () => {
+    expect(parseLocation("/attention", "", "")).toEqual({
+      view: "tab",
+      tab: "attention",
+      libraryView: "series",
+    });
+  });
+
   it("parses canonical book sections and audiobook tabs", () => {
     expect(
       parseLocation(


### PR DESCRIPTION
## What changed

- add a sequenced improvement roadmap with one independently deployable PR per item
- add a Needs Attention dashboard for failed processing jobs, failed web refreshes, stale audiobooks, metadata proposals, broken EPUB paths, and missing covers
- add direct links from each attention category to the existing resolution workflow
- clear historical processing failures once a newer equivalent operation succeeds
- share library file-health inspection between the dashboard and Storage Audit
- support deep links into failed processing jobs and metadata utilities

## Why

Story Manager already records these conditions, but users have to discover them across Processing, Utilities, individual books, and scheduler-related views. The dashboard makes outstanding work visible and actionable from one place without introducing new lifecycle state.

## User impact

Users get a responsive, read-only overview with a clear healthy state, per-category counts, representative recent items, a top-level attention badge, and direct paths to resolve each problem. Failed operations remain visible only while the latest matching operation is still failed, so a successful retry automatically removes the resolved warning.

## Validation

- `PYTHONPATH=. uv run pytest -q` — 367 passed
- `uv run black --check backend`
- `uv run autoflake --check --remove-all-unused-imports --recursive backend`
- `uv run flake8 backend --count --statistics`
- `npm test -- --run` — 56 passed
- `npm run lint`
- `npm run build`
- browser verification at desktop and mobile breakpoints with no console warnings or errors