### PR TITLE
Simplify application navigation

### DIFF
--- a/docs/IMPROVEMENT_ROADMAP.md
+++ b/docs/IMPROVEMENT_ROADMAP.md
@@ -23,7 +23,7 @@ This roadmap captures the next major product and technical improvements for Stor
 
 ## 1. Needs Attention dashboard
 
-**Status:** In progress
+**Status:** Complete
 
 Give users one actionable view of problems and pending decisions across the library. The first version should summarize failed processing jobs, failed web refreshes, stale audiobooks, open metadata proposals, broken library files, and missing covers.
 
@@ -41,7 +41,7 @@ The dashboard should favor resolution over raw diagnostics. Every category shoul
 
 ## 2. Simplified navigation
 
-**Status:** Planned
+**Status:** In progress
 
 Replace the current tool-oriented top-level navigation with three user-oriented destinations: **Library**, **Activity**, and **Settings**. The Needs Attention dashboard should become the default overview within this structure.
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -3712,6 +3712,10 @@ body {
 }
 
 .main-tab {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
   min-height: 2.8rem;
   padding: 0.65rem 1rem;
   border: 0;
@@ -3721,6 +3725,7 @@ body {
   color: var(--text-muted);
   font-size: 0.78rem;
   letter-spacing: 0.025em;
+  text-decoration: none;
 }
 
 .main-tab:first-child {
@@ -3744,10 +3749,58 @@ body {
 .nav-job-count {
   min-width: 1.15rem;
   height: 1.15rem;
+  margin-left: 0;
   border-radius: 50%;
   background: var(--accent);
   color: var(--bg);
   font-weight: 600;
+}
+
+.nav-status-counts {
+  display: inline-flex;
+  gap: 0.25rem;
+}
+
+.nav-job-count--active {
+  background: var(--success);
+}
+
+.section-navigation {
+  display: flex;
+  gap: 1.25rem;
+  margin: -1rem 0 1.75rem;
+  padding: 0 0 0.65rem;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--border);
+}
+
+.section-navigation-link {
+  padding: 0.25rem 0;
+  border-bottom: 1px solid transparent;
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  letter-spacing: 0.025em;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.section-navigation-link:hover,
+.section-navigation-link--active {
+  border-bottom-color: var(--accent);
+  color: var(--text);
+}
+
+.section-navigation-link--active {
+  font-weight: 600;
+}
+
+.app-container--book {
+  max-width: 1440px;
+}
+
+.app-container--book .book-settings {
+  border-left: 0;
+  border-right: 0;
 }
 
 .library-page-heading {
@@ -4535,8 +4588,13 @@ body {
   }
 
   .main-tab {
+    flex: 1 1 0;
     min-height: 2.5rem;
     padding: 0.55rem 0.75rem;
+  }
+
+  .section-navigation {
+    margin-top: -0.5rem;
   }
 
   .library-page-heading,
@@ -4588,6 +4646,11 @@ body {
   .main-tab,
   .main-tab--active {
     border-radius: 0;
+  }
+
+  .main-tab {
+    padding-right: 0.45rem;
+    padding-left: 0.45rem;
   }
 
   .library-page-heading,

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -21,8 +21,11 @@ import useLibraryCatalog from "./hooks/useLibraryCatalog";
 import {
   buildBookPath,
   buildTabPath,
+  getPrimarySection,
+  getRoute,
   parseLocation,
-  TABS,
+  PRIMARY_NAV,
+  SECTION_NAV,
 } from "./lib/navigation";
 
 function App() {
@@ -87,6 +90,13 @@ function App() {
         return;
       }
 
+      if (parsed.redirectPath) {
+        window.history.replaceState(
+          window.history.state,
+          "",
+          `${parsed.redirectPath}${search}${hash || ""}`,
+        );
+      }
       setEditingBook(null);
       setActiveTab(parsed.tab);
       setLibraryView(parsed.libraryView);
@@ -106,10 +116,14 @@ function App() {
       setAudiobookTab("sources");
     } else {
       const nextPath = buildTabPath(view, libraryView);
-      const tab = TABS.find((item) => item.key === view) || TABS[0];
-      window.history.pushState({ view: "tab", tab: tab.key }, "", nextPath);
+      const route = getRoute(view);
+      window.history.pushState(
+        { view: "tab", tab: route.key },
+        "",
+        nextPath,
+      );
       setEditingBook(null);
-      setActiveTab(tab.key);
+      setActiveTab(route.key);
     }
   };
 
@@ -276,18 +290,6 @@ function App() {
     return <AdminLogin onAuthenticated={setAuthStatus} />;
   }
 
-  if (editingBook) {
-    return (
-      <BookSettings
-        book={editingBook}
-        onBack={() => navigate("library")}
-        bookSection={bookSection}
-        audiobookTab={audiobookTab}
-        onNavigationChange={handleBookNavigation}
-      />
-    );
-  }
-
   const renderTabContent = () => {
     switch (activeTab) {
       case "attention":
@@ -397,8 +399,39 @@ function App() {
     }
   };
 
+  const activePrimary = editingBook
+    ? "library"
+    : getPrimarySection(activeTab);
+  const secondaryItems = editingBook ? [] : SECTION_NAV[activePrimary] || [];
+
+  const renderPrimaryBadge = (sectionKey) => {
+    if (sectionKey !== "activity") return null;
+    return (
+      <span className="nav-status-counts">
+        {attentionQuery.data?.total_count > 0 && (
+          <span
+            className="nav-job-count nav-job-count--attention"
+            aria-label={`${attentionQuery.data.total_count} ${attentionQuery.data.total_count === 1 ? "item needs" : "items need"} attention`}
+          >
+            {attentionQuery.data.total_count}
+          </span>
+        )}
+        {activeProcessingJobs.length > 0 && (
+          <span
+            className="nav-job-count nav-job-count--active"
+            aria-label={`${activeProcessingJobs.length} active processing ${activeProcessingJobs.length === 1 ? "job" : "jobs"}`}
+          >
+            {activeProcessingJobs.length}
+          </span>
+        )}
+      </span>
+    );
+  };
+
   return (
-    <div className={`app-container${globalDragging ? " drag-over" : ""}`}>
+    <div
+      className={`app-container${editingBook ? " app-container--book" : ""}${globalDragging ? " drag-over" : ""}`}
+    >
       <header className="app-header">
         <h1>Story Manager</h1>
         {authStatus.mode === "password" && (
@@ -407,25 +440,57 @@ function App() {
           </button>
         )}
       </header>
-      <nav className="main-tabs">
-        {TABS.map((tab) => (
-          <button
-            key={tab.key}
-            className={`main-tab${activeTab === tab.key ? " main-tab--active" : ""}`}
-            onClick={() => navigate(tab.key)}
-            aria-current={activeTab === tab.key ? "page" : undefined}
+      <nav className="main-tabs" aria-label="Primary navigation">
+        {PRIMARY_NAV.map((section) => (
+          <a
+            key={section.key}
+            className={`main-tab${activePrimary === section.key ? " main-tab--active" : ""}`}
+            href={section.path}
+            onClick={(event) => {
+              event.preventDefault();
+              navigate(section.defaultTab);
+            }}
+            aria-current={activePrimary === section.key ? "page" : undefined}
           >
-            {tab.label}
-            {tab.key === "processing" && activeProcessingJobs.length > 0 && (
-              <span className="nav-job-count">{activeProcessingJobs.length}</span>
-            )}
-            {tab.key === "attention" && attentionQuery.data?.total_count > 0 && (
-              <span className="nav-job-count">{attentionQuery.data.total_count}</span>
-            )}
-          </button>
+            {section.label}
+            {renderPrimaryBadge(section.key)}
+          </a>
         ))}
       </nav>
-      {renderTabContent()}
+      {secondaryItems.length > 0 && (
+        <nav
+          className="section-navigation"
+          aria-label={`${PRIMARY_NAV.find((item) => item.key === activePrimary)?.label} sections`}
+        >
+          {secondaryItems.map((item) => (
+            <a
+              key={item.key}
+              className={`section-navigation-link${activeTab === item.key ? " section-navigation-link--active" : ""}`}
+              href={item.path}
+              onClick={(event) => {
+                event.preventDefault();
+                navigate(item.key);
+              }}
+              aria-current={activeTab === item.key ? "page" : undefined}
+            >
+              {item.label}
+            </a>
+          ))}
+        </nav>
+      )}
+      <main>
+        {editingBook ? (
+          <BookSettings
+            book={editingBook}
+            onBack={() => navigate("library")}
+            bookSection={bookSection}
+            audiobookTab={audiobookTab}
+            onNavigationChange={handleBookNavigation}
+          />
+        ) : (
+          renderTabContent()
+        )}
+      </main>
     </div>
   );
 }

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1,4 +1,4 @@
-import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import App from "./App";
 import { renderWithClient } from "./test-utils";
@@ -60,6 +60,122 @@ describe("App", () => {
       expect(screen.getAllByText("Author A")[0]).toBeInTheDocument();
     });
   });
+
+  it("groups every page under Library, Activity, and Settings", async () => {
+    window.innerWidth = 390;
+    const emptyCategory = { count: 0, items: [] };
+    const attention = {
+      total_count: 2,
+      failed_jobs: emptyCategory,
+      failed_refreshes: emptyCategory,
+      stale_audiobooks: emptyCategory,
+      metadata_proposals: emptyCategory,
+      broken_files: emptyCategory,
+      missing_covers: emptyCategory,
+    };
+
+    globalThis.fetch = vi.fn((url) => {
+      if (url === "/api/dashboard/attention?limit=5") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(attention),
+        });
+      }
+      if (url.startsWith("/api/processing/jobs?")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve([
+              {
+                id: 91,
+                job_type: "refresh_all",
+                status: "running",
+                progress_current: 1,
+                progress_total: 2,
+                payload: {},
+              },
+            ]),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([]),
+      });
+    });
+
+    renderWithClient(<App />);
+
+    const primary = await screen.findByRole("navigation", {
+      name: "Primary navigation",
+    });
+    const primaryLinks = within(primary).getAllByRole("link");
+    expect(primaryLinks.map((link) => link.firstChild.textContent)).toEqual([
+      "Library",
+      "Activity",
+      "Settings",
+    ]);
+    expect(primaryLinks.map((link) => link.getAttribute("href"))).toEqual([
+      "/",
+      "/activity",
+      "/settings",
+    ]);
+    expect(
+      await screen.findByLabelText("2 items need attention"),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByLabelText("1 active processing job"),
+    ).toBeInTheDocument();
+
+    primaryLinks[1].focus();
+    expect(primaryLinks[1]).toHaveFocus();
+    fireEvent.click(primaryLinks[1]);
+
+    expect(window.location.pathname).toBe("/activity");
+    expect(
+      await screen.findByRole("heading", { name: "Needs attention" }),
+    ).toBeInTheDocument();
+    expect(
+      within(
+        screen.getByRole("navigation", { name: "Activity sections" }),
+      ).getAllByRole("link").map((link) => link.textContent),
+    ).toEqual(["Overview", "Processing jobs", "Scheduled runs"]);
+
+    fireEvent.click(screen.getByRole("link", { name: "Settings" }));
+    expect(window.location.pathname).toBe("/settings");
+    expect(
+      within(
+        screen.getByRole("navigation", { name: "Settings sections" }),
+      ).getAllByRole("link").map((link) => link.textContent),
+    ).toEqual(["Cleaning rules", "Audio & AI", "Library tools", "Logs"]);
+  });
+
+  it(
+    "canonicalizes legacy deep links and responds to history navigation",
+    async () => {
+      window.history.replaceState(null, "", "/processing?status=error");
+      globalThis.fetch = vi.fn(() =>
+        Promise.resolve({ ok: true, json: () => Promise.resolve([]) }),
+      );
+
+      renderWithClient(<App />);
+
+      expect(
+        await screen.findByRole("heading", { name: "Processing control" }),
+      ).toBeInTheDocument();
+      expect(window.location.pathname).toBe("/activity/processing");
+      expect(window.location.search).toBe("?status=error");
+
+      window.history.replaceState(null, "", "/settings/logs");
+      window.dispatchEvent(new PopStateEvent("popstate"));
+
+      expect(
+        await screen.findByRole("heading", { name: "Application Logs" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("link", { name: "Settings" }),
+      ).toHaveAttribute("aria-current", "page");
+    },
+  );
 
   it("searches by unified query", async () => {
     const mockBooks = [
@@ -524,6 +640,38 @@ describe("App", () => {
       if (url === "/api/books/44") {
         return Promise.resolve({ ok: true, json: () => Promise.resolve(book) });
       }
+      if (url === "/api/dashboard/attention?limit=5") {
+        const emptyCategory = { count: 0, items: [] };
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              total_count: 1,
+              failed_jobs: emptyCategory,
+              failed_refreshes: emptyCategory,
+              stale_audiobooks: emptyCategory,
+              metadata_proposals: emptyCategory,
+              broken_files: emptyCategory,
+              missing_covers: emptyCategory,
+            }),
+        });
+      }
+      if (url.startsWith("/api/processing/jobs?")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve([
+              {
+                id: 92,
+                job_type: "refresh_all",
+                status: "running",
+                progress_current: 1,
+                progress_total: 2,
+                payload: {},
+              },
+            ]),
+        });
+      }
       return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
     });
 
@@ -535,6 +683,12 @@ describe("App", () => {
     expect(characters).toHaveClass("sub-tab--active");
     expect(window.location.pathname).toBe("/books/44/audiobooks");
     expect(window.location.search).toBe("?tab=characters");
+    expect(
+      await screen.findByLabelText("1 item needs attention"),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByLabelText("1 active processing job"),
+    ).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Analysis" }));
     expect(window.location.search).toBe("?tab=analysis");

--- a/frontend/src/components/AttentionDashboard.jsx
+++ b/frontend/src/components/AttentionDashboard.jsx
@@ -139,7 +139,7 @@ function AttentionDashboard({ data, isLoading, error, onRefresh, isRefreshing })
           title="Failed processing"
           description="Durable jobs that stopped before completing. Retry them after reviewing the error."
           category={data.failed_jobs}
-          actionHref="/processing?status=error"
+          actionHref="/activity/processing?status=error"
           actionLabel="Review jobs"
         >
           {data.failed_jobs.items.map((item) => <JobItem key={item.id} item={item} />)}
@@ -159,7 +159,7 @@ function AttentionDashboard({ data, isLoading, error, onRefresh, isRefreshing })
           title="Stale audiobooks"
           description="Audio that no longer matches the current cleaned book text."
           category={data.stale_audiobooks}
-          actionHref="/processing"
+          actionHref="/activity/processing"
           actionLabel="View processing"
         >
           {data.stale_audiobooks.items.map((item) => (
@@ -171,7 +171,7 @@ function AttentionDashboard({ data, isLoading, error, onRefresh, isRefreshing })
           title="Metadata decisions"
           description="Matches or proposed metadata waiting for approval or dismissal."
           category={data.metadata_proposals}
-          actionHref="/utilities?section=metadata"
+          actionHref="/settings/library-tools?section=metadata"
           actionLabel="Review metadata"
         >
           {data.metadata_proposals.items.map((item) => (
@@ -183,7 +183,7 @@ function AttentionDashboard({ data, isLoading, error, onRefresh, isRefreshing })
           title="Broken library files"
           description="Book records whose original or current EPUB file cannot be found."
           category={data.broken_files}
-          actionHref="/utilities?section=audit"
+          actionHref="/settings/library-tools?section=audit"
           actionLabel="Run audit"
         >
           {data.broken_files.items.map((item, index) => (
@@ -195,7 +195,7 @@ function AttentionDashboard({ data, isLoading, error, onRefresh, isRefreshing })
           title="Missing covers"
           description="Completed books with no usable local cover image."
           category={data.missing_covers}
-          actionHref="/utilities?section=audit"
+          actionHref="/settings/library-tools?section=audit"
           actionLabel="Review library"
         >
           {data.missing_covers.items.map((item) => (

--- a/frontend/src/components/AttentionDashboard.test.jsx
+++ b/frontend/src/components/AttentionDashboard.test.jsx
@@ -72,7 +72,7 @@ describe("AttentionDashboard", () => {
     expect(screen.getByText("Source unavailable")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Review jobs" })).toHaveAttribute(
       "href",
-      "/processing?status=error",
+      "/activity/processing?status=error",
     );
     expect(screen.getByRole("link", { name: "Stale Audio" })).toHaveAttribute(
       "href",
@@ -80,7 +80,7 @@ describe("AttentionDashboard", () => {
     );
     expect(screen.getByRole("link", { name: "Review metadata" })).toHaveAttribute(
       "href",
-      "/utilities?section=metadata",
+      "/settings/library-tools?section=metadata",
     );
   });
 

--- a/frontend/src/components/BookSettings.jsx
+++ b/frontend/src/components/BookSettings.jsx
@@ -833,7 +833,8 @@ function BookSettings({
         </div>
         {jobNotice && (
           <p className="job-queued-notice" role="status">
-            {jobNotice} <a href="/processing">View processing</a>
+            {jobNotice}{" "}
+            <a href="/activity/processing">View processing</a>
           </p>
         )}
         <p className="hint actions-hint">

--- a/frontend/src/components/CleaningConfigs.jsx
+++ b/frontend/src/components/CleaningConfigs.jsx
@@ -199,12 +199,12 @@ function CleaningConfigs({ onBack }) {
 
   return (
     <div className={onBack ? "cleaning-configs" : undefined}>
-      {onBack && (
-        <div className="settings-header">
+      <div className="settings-header">
+        {onBack && (
           <button className="btn-text" onClick={onBack} style={{ flexShrink: 0 }}>← Back</button>
-          <h2>Cleaning Configs</h2>
-        </div>
-      )}
+        )}
+        <h2>Cleaning Rules</h2>
+      </div>
       {isLoading && <p>Loading...</p>}
       {error && <p className="error">{error.message}</p>}
 

--- a/frontend/src/components/Logs.jsx
+++ b/frontend/src/components/Logs.jsx
@@ -29,14 +29,14 @@ function Logs({ onBack }) {
 
   return (
     <div className={onBack ? "book-settings" : undefined}>
-      {onBack && (
-        <div className="settings-header">
+      <div className="settings-header">
+        {onBack && (
           <button className="btn-text" onClick={onBack} style={{ flexShrink: 0 }}>
             ← Back
           </button>
-          <h2>Application Logs</h2>
-        </div>
-      )}
+        )}
+        <h2>Application Logs</h2>
+      </div>
 
       <section className="settings-section">
         <div style={{ display: "flex", gap: "0.75rem", alignItems: "center", flexWrap: "wrap", marginBottom: "0.75rem" }}>

--- a/frontend/src/components/Utilities.jsx
+++ b/frontend/src/components/Utilities.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   approveMetadataMatch,
@@ -19,6 +19,11 @@ const utilityTabs = [
   { key: "storage", label: "Storage" },
   { key: "reader-access", label: "Reader Access" },
 ];
+
+function getRequestedUtilityTab() {
+  const requested = new URLSearchParams(window.location.search).get("section");
+  return utilityTabs.some((tab) => tab.key === requested) ? requested : "audit";
+}
 
 function formatBytes(bytes) {
   if (bytes === 0) return "0 B";
@@ -95,13 +100,32 @@ function formatMetadataMatchOption(match) {
 
 function Utilities({ onBack }) {
   const queryClient = useQueryClient();
-  const [activeTab, setActiveTab] = useState(() => {
-    const requested = new URLSearchParams(window.location.search).get("section");
-    return utilityTabs.some((tab) => tab.key === requested) ? requested : "audit";
-  });
+  const [activeTab, setActiveTab] = useState(getRequestedUtilityTab);
   const [preview, setPreview] = useState(null);
   const [detectState, setDetectState] = useState(null); // null | "pending" | { updated, series_detected, error? }
   const [selectedMatchIds, setSelectedMatchIds] = useState({});
+
+  useEffect(() => {
+    const onPopState = () => setActiveTab(getRequestedUtilityTab());
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, []);
+
+  const selectUtilityTab = (tabKey) => {
+    const params = new URLSearchParams(window.location.search);
+    if (tabKey === "audit") {
+      params.delete("section");
+    } else {
+      params.set("section", tabKey);
+    }
+    const query = params.toString();
+    window.history.pushState(
+      window.history.state,
+      "",
+      `${window.location.pathname}${query ? `?${query}` : ""}${window.location.hash}`,
+    );
+    setActiveTab(tabKey);
+  };
 
   const previewMutation = useMutation({
     mutationFn: () => runCleanup(true),
@@ -184,14 +208,14 @@ function Utilities({ onBack }) {
 
   return (
     <div className={`${onBack ? "book-settings " : ""}utilities-page`}>
-      {onBack && (
-        <div className="settings-header">
+      <div className="settings-header">
+        {onBack && (
           <button className="btn-text" onClick={onBack} style={{ flexShrink: 0 }}>
             ← Back
           </button>
-          <h2>Utilities</h2>
-        </div>
-      )}
+        )}
+        <h2>Library Tools</h2>
+      </div>
 
       <nav className="sub-tabs utilities-tabs" aria-label="Utility sections" role="tablist">
         {utilityTabs.map((tab) => (
@@ -201,7 +225,7 @@ function Utilities({ onBack }) {
             type="button"
             role="tab"
             aria-selected={activeTab === tab.key}
-            onClick={() => setActiveTab(tab.key)}
+            onClick={() => selectUtilityTab(tab.key)}
           >
             {tab.label}
           </button>

--- a/frontend/src/components/Utilities.test.jsx
+++ b/frontend/src/components/Utilities.test.jsx
@@ -8,9 +8,10 @@ describe("Utilities", () => {
     vi.restoreAllMocks();
     vi.stubGlobal("confirm", vi.fn(() => true));
     vi.stubGlobal("alert", vi.fn());
+    window.history.replaceState(null, "", "/settings/library-tools");
   });
 
-  it("organizes utilities into focused tabs and shows the audit by default", () => {
+  it("organizes utilities into focused tabs and shows the audit by default", async () => {
     globalThis.fetch = vi.fn((url) => {
       if (url === "/api/metadata/jobs/latest") {
         return Promise.resolve({ ok: true, json: () => Promise.resolve(null) });
@@ -43,6 +44,16 @@ describe("Utilities", () => {
 
     fireEvent.click(screen.getByRole("tab", { name: "Reader Access" }));
     expect(screen.getByRole("heading", { name: "Reader API Keys" })).toBeInTheDocument();
+    expect(window.location.search).toBe("?section=reader-access");
+
+    window.history.replaceState(null, "", "/settings/library-tools?section=metadata");
+    window.dispatchEvent(new PopStateEvent("popstate"));
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: "Metadata" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+    });
   });
 
   it("runs library audit and shows results", async () => {

--- a/frontend/src/lib/navigation.js
+++ b/frontend/src/lib/navigation.js
@@ -1,13 +1,70 @@
-export const TABS = [
-  { key: "library", label: "Library", path: "/" },
-  { key: "attention", label: "Needs Attention", path: "/attention" },
-  { key: "configs", label: "Cleaning Configs", path: "/configs" },
-  { key: "scheduler", label: "Scheduler", path: "/scheduler" },
-  { key: "processing", label: "Processing", path: "/processing" },
-  { key: "logs", label: "Logs", path: "/logs" },
-  { key: "utilities", label: "Utilities", path: "/utilities" },
-  { key: "audio-settings", label: "Audio Settings", path: "/audio-settings" },
+export const PRIMARY_NAV = [
+  { key: "library", label: "Library", path: "/", defaultTab: "library" },
+  {
+    key: "activity",
+    label: "Activity",
+    path: "/activity",
+    defaultTab: "attention",
+  },
+  {
+    key: "settings",
+    label: "Settings",
+    path: "/settings",
+    defaultTab: "configs",
+  },
 ];
+
+export const SECTION_NAV = {
+  activity: [
+    { key: "attention", label: "Overview", path: "/activity" },
+    {
+      key: "processing",
+      label: "Processing jobs",
+      path: "/activity/processing",
+    },
+    {
+      key: "scheduler",
+      label: "Scheduled runs",
+      path: "/activity/scheduled-runs",
+    },
+  ],
+  settings: [
+    { key: "configs", label: "Cleaning rules", path: "/settings" },
+    {
+      key: "audio-settings",
+      label: "Audio & AI",
+      path: "/settings/audio-ai",
+    },
+    {
+      key: "utilities",
+      label: "Library tools",
+      path: "/settings/library-tools",
+    },
+    { key: "logs", label: "Logs", path: "/settings/logs" },
+  ],
+};
+
+const ROUTES = [
+  { key: "library", path: "/", section: "library" },
+  ...SECTION_NAV.activity.map((route) => ({
+    ...route,
+    section: "activity",
+  })),
+  ...SECTION_NAV.settings.map((route) => ({
+    ...route,
+    section: "settings",
+  })),
+];
+
+const LEGACY_ROUTES = {
+  "/attention": "attention",
+  "/processing": "processing",
+  "/scheduler": "scheduler",
+  "/configs": "configs",
+  "/audio-settings": "audio-settings",
+  "/utilities": "utilities",
+  "/logs": "logs",
+};
 
 export const LIBRARY_VIEWS = ["series", "standalone", "web"];
 
@@ -23,11 +80,28 @@ export const AUDIOBOOK_TABS = [
   { key: "chapter-assembly", label: "Chapter Assembly" },
 ];
 
+function normalizePath(pathname) {
+  return pathname.length > 1 ? pathname.replace(/\/+$/, "") : pathname;
+}
+
+export function getRoute(tabKey) {
+  return ROUTES.find((route) => route.key === tabKey) || ROUTES[0];
+}
+
+export function getPrimarySection(tabKey) {
+  return getRoute(tabKey).section;
+}
+
 export function parseLocation(pathname, hash, search = "") {
-  const match = pathname.match(/^\/books\/(\d+)(?:\/(details|audiobooks))?\/?$/);
+  const normalizedPath = normalizePath(pathname);
+  const match = normalizedPath.match(
+    /^\/books\/(\d+)(?:\/(details|audiobooks))?$/,
+  );
   if (match) {
     const requestedTab = new URLSearchParams(search).get("tab");
-    const audiobookTab = AUDIOBOOK_TABS.some((tab) => tab.key === requestedTab)
+    const audiobookTab = AUDIOBOOK_TABS.some(
+      (tab) => tab.key === requestedTab,
+    )
       ? requestedTab
       : "sources";
     return {
@@ -39,9 +113,19 @@ export function parseLocation(pathname, hash, search = "") {
     };
   }
 
-  const tab = TABS.find((item) => item.path === pathname);
-  const libraryView = LIBRARY_VIEWS.includes(hash?.slice(1)) ? hash.slice(1) : "series";
-  return { view: "tab", tab: tab?.key || "library", libraryView };
+  const legacyTab = LEGACY_ROUTES[normalizedPath];
+  const route = legacyTab
+    ? getRoute(legacyTab)
+    : ROUTES.find((item) => item.path === normalizedPath) || ROUTES[0];
+  const libraryView = LIBRARY_VIEWS.includes(hash?.slice(1))
+    ? hash.slice(1)
+    : "series";
+  return {
+    view: "tab",
+    tab: route.key,
+    libraryView,
+    ...(legacyTab ? { redirectPath: route.path } : {}),
+  };
 }
 
 export function buildBookPath(
@@ -59,7 +143,9 @@ export function buildBookPath(
   return `/books/${bookId}/details`;
 }
 
-export function buildTabPath(tabKey, libraryView) {
-  const tab = TABS.find((item) => item.key === tabKey) || TABS[0];
-  return tab.key === "library" ? `${tab.path}#${libraryView}` : tab.path;
+export function buildTabPath(tabKey, libraryView = "series") {
+  const route = getRoute(tabKey);
+  return route.key === "library"
+    ? `${route.path}#${libraryView}`
+    : route.path;
 }

--- a/frontend/src/lib/navigation.test.js
+++ b/frontend/src/lib/navigation.test.js
@@ -1,13 +1,47 @@
 import { describe, expect, it } from "vitest";
 
-import { buildBookPath, parseLocation } from "./navigation";
+import {
+  buildBookPath,
+  buildTabPath,
+  getPrimarySection,
+  parseLocation,
+  PRIMARY_NAV,
+} from "./navigation";
 
-describe("book navigation", () => {
-  it("parses the Needs Attention dashboard route", () => {
-    expect(parseLocation("/attention", "", "")).toEqual({
+describe("application navigation", () => {
+  it("exposes only the three user-oriented primary destinations", () => {
+    expect(
+      PRIMARY_NAV.map(({ key, label, path }) => ({ key, label, path })),
+    ).toEqual([
+      { key: "library", label: "Library", path: "/" },
+      { key: "activity", label: "Activity", path: "/activity" },
+      { key: "settings", label: "Settings", path: "/settings" },
+    ]);
+  });
+
+  it("uses Needs Attention as the Activity overview", () => {
+    expect(parseLocation("/activity", "", "")).toEqual({
       view: "tab",
       tab: "attention",
       libraryView: "series",
+    });
+    expect(getPrimarySection("attention")).toBe("activity");
+    expect(buildTabPath("attention")).toBe("/activity");
+  });
+
+  it.each([
+    ["/attention", "attention", "/activity"],
+    ["/processing", "processing", "/activity/processing"],
+    ["/scheduler", "scheduler", "/activity/scheduled-runs"],
+    ["/configs", "configs", "/settings"],
+    ["/audio-settings", "audio-settings", "/settings/audio-ai"],
+    ["/utilities", "utilities", "/settings/library-tools"],
+    ["/logs", "logs", "/settings/logs"],
+  ])("keeps legacy route %s working", (legacyPath, tab, redirectPath) => {
+    expect(parseLocation(legacyPath, "", "?section=metadata")).toMatchObject({
+      view: "tab",
+      tab,
+      redirectPath,
     });
   });
 

--- a/frontend/tests-e2e/Navigation.spec.ts
+++ b/frontend/tests-e2e/Navigation.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "@playwright/test";
+
+test("groups pages under canonical destinations and preserves history", async ({
+  page,
+}) => {
+  await page.goto("/activity");
+
+  const primary = page.getByRole("navigation", { name: "Primary navigation" });
+  await expect(primary.getByRole("link")).toHaveCount(3);
+  await expect(primary.getByRole("link", { name: "Library" })).toBeVisible();
+  await expect(primary.getByRole("link", { name: /Activity/ })).toHaveAttribute(
+    "aria-current",
+    "page",
+  );
+  await expect(primary.getByRole("link", { name: "Settings" })).toBeVisible();
+
+  await page.getByRole("link", { name: "Processing jobs" }).click();
+  await expect(page).toHaveURL(/\/activity\/processing$/);
+  await expect(
+    page.getByRole("heading", { name: "Processing control" }),
+  ).toBeVisible();
+
+  await page.goBack();
+  await expect(page).toHaveURL(/\/activity$/);
+  await expect(
+    page.getByRole("heading", { name: "Needs attention" }),
+  ).toBeVisible();
+
+  await page.goto("/utilities?section=reader-access");
+  await expect(page).toHaveURL(
+    /\/settings\/library-tools\?section=reader-access$/,
+  );
+  await expect(
+    page.getByRole("tab", { name: "Reader Access" }),
+  ).toHaveAttribute("aria-selected", "true");
+
+  await page.getByRole("tab", { name: "Storage" }).click();
+  await expect(page).toHaveURL(/\?section=storage$/);
+  await page.goBack();
+  await expect(
+    page.getByRole("tab", { name: "Reader Access" }),
+  ).toHaveAttribute("aria-selected", "true");
+});
+
+test("keeps primary navigation visible and keyboard accessible on mobile", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/");
+
+  const primary = page.getByRole("navigation", { name: "Primary navigation" });
+  const links = primary.getByRole("link");
+  await expect(links).toHaveCount(3);
+  for (const link of await links.all()) {
+    await expect(link).toBeVisible();
+  }
+
+  const activity = primary.getByRole("link", { name: /Activity/ });
+  await primary.getByRole("link", { name: "Library" }).focus();
+  await page.keyboard.press("Tab");
+  await expect(activity).toBeFocused();
+  await page.keyboard.press("Enter");
+
+  await expect(page).toHaveURL(/\/activity$/);
+  await expect(
+    page.getByRole("navigation", { name: "Activity sections" }),
+  ).toBeVisible();
+});


### PR DESCRIPTION
## What changed

- replace the eight tool-oriented top-level tabs with Library, Activity, and Settings
- make Needs Attention the default Activity overview
- group processing jobs and scheduled runs under Activity
- group cleaning rules, Audio & AI, library tools, reader access, storage utilities, and logs under Settings
- keep attention and active-job counts visible in the shared application shell, including book detail pages
- add canonical nested URLs while redirecting every legacy top-level route and preserving query parameters
- make Library Tools tabs participate in direct linking and browser back/forward history
- mark the merged Needs Attention roadmap item complete and this item in progress

## Why

The previous navigation exposed implementation-oriented features as eight peers. Users had to know which tool owned a task, and status counts disappeared while working inside a book. The new hierarchy keeps the full feature set but organizes it around browsing the library, monitoring work, and configuring the application.

## User impact

Users see only three primary destinations. Existing bookmarks such as `/processing?status=error` and `/utilities?section=metadata` continue to work and are replaced with canonical URLs. Native links, responsive styling, and route-backed nested tabs improve keyboard, mobile, direct-link, and history behavior.

## Validation

- `npm test -- --run` — 66 passed
- `npm run lint`
- `npm run build`
- `npm run test:e2e` — 4 passed
- desktop and 390px mobile browser review with no console warnings or errors