### PR TITLE
Unified import workflow

### DIFF
--- a/backend/app/routers/upload.py
+++ b/backend/app/routers/upload.py
@@ -8,8 +8,8 @@ from collections.abc import Iterator
 from typing import List, Optional
 
 from ebooklib import epub
-from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
-from pydantic import BaseModel
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
+from pydantic import BaseModel, Field, HttpUrl, TypeAdapter, ValidationError
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -65,6 +65,28 @@ class EpubUploadResult(BaseModel):
     status: str  # "success" | "skipped" | "error"
     book: Optional[schemas.Book] = None
     error: Optional[str] = None
+
+
+class ImportPreviewItem(BaseModel):
+    key: str
+    input_type: str
+    name: str
+    status: str
+    title: Optional[str] = None
+    author: Optional[str] = None
+    series: Optional[str] = None
+    source_url: Optional[str] = None
+    duplicate_book_id: Optional[int] = None
+    cleaning_configs: list[str] = Field(default_factory=list)
+    detail: Optional[str] = None
+
+
+class ImportPreviewResponse(BaseModel):
+    items: list[ImportPreviewItem]
+    ready_count: int
+    duplicate_count: int
+    unsupported_count: int
+    error_count: int
 
 
 def _is_zip_upload(file: UploadFile) -> bool:
@@ -262,6 +284,208 @@ async def _upload_epub_bytes(filename: str, payload: bytes, db: AsyncSession) ->
 async def _upload_epub_file(file: UploadFile, db: AsyncSession) -> models.Book:
     payload = await read_and_validate_upload(file)
     return await _upload_epub_bytes(file.filename, payload, db)
+
+
+def _first_epub_metadata(epub_book, namespace: str, key: str) -> Optional[str]:
+    try:
+        values = epub_book.get_metadata(namespace, key)
+    except KeyError:
+        return None
+    if not values:
+        return None
+    value = values[0][0]
+    return str(value).strip() if value is not None else None
+
+
+async def _preview_epub_bytes(
+    *,
+    key: str,
+    name: str,
+    payload: bytes,
+    db: AsyncSession,
+    seen_books: set[tuple[str, str]],
+) -> ImportPreviewItem:
+    try:
+        epub_book = epub.read_epub(BytesIO(_fix_nested_epub(payload)))
+        title = _first_epub_metadata(epub_book, "DC", "title")
+        author = _first_epub_metadata(epub_book, "DC", "creator")
+        series = _first_epub_metadata(epub_book, "calibre", "series")
+        source_url = _first_epub_metadata(epub_book, "DC", "source")
+        if source_url and not source_url.lower().startswith(("http://", "https://")):
+            source_url = None
+        if not title or not author:
+            raise ValueError("EPUB metadata must include a title and author.")
+    except Exception as exc:
+        return ImportPreviewItem(
+            key=key,
+            input_type="epub",
+            name=name,
+            status="error",
+            detail=f"Could not read EPUB metadata: {exc}",
+        )
+
+    normalized = (title.casefold(), author.casefold())
+    existing_book = await crud.get_book_by_title_and_author(db, title=title, author=author)
+    existing = existing_book if existing_book and existing_book.source_type == models.SourceType.epub else None
+    duplicate_in_batch = normalized in seen_books
+    seen_books.add(normalized)
+    configs = await crud.get_all_matching_cleaning_configs(db, source_url) if source_url else []
+    duplicate_detail = None
+    if existing:
+        duplicate_detail = f"Already in the library as book {existing.id}."
+    elif duplicate_in_batch:
+        duplicate_detail = "The same title and author appear more than once in this import."
+
+    return ImportPreviewItem(
+        key=key,
+        input_type="epub",
+        name=name,
+        status="duplicate" if duplicate_detail else "ready",
+        title=title,
+        author=author,
+        series=series,
+        source_url=source_url,
+        duplicate_book_id=existing.id if existing else None,
+        cleaning_configs=[config.name for config in configs],
+        detail=duplicate_detail,
+    )
+
+
+@router.post("/api/imports/preview", response_model=ImportPreviewResponse)
+async def preview_imports(
+    files: List[UploadFile] = File(default=[]),
+    urls: List[str] = Form(default=[]),
+    db: AsyncSession = Depends(get_db),
+) -> ImportPreviewResponse:
+    """Inspect book files and web URLs without creating records or queueing work."""
+    items: list[ImportPreviewItem] = []
+    seen_books: set[tuple[str, str]] = set()
+    seen_urls: set[str] = set()
+
+    for file_index, file in enumerate(files):
+        filename = file.filename or f"upload-{file_index + 1}"
+        lower_name = filename.lower()
+        if not lower_name.endswith((".epub", ".zip")):
+            items.append(
+                ImportPreviewItem(
+                    key=f"file:{file_index}",
+                    input_type="file",
+                    name=filename,
+                    status="unsupported",
+                    detail="Choose an EPUB or ZIP containing EPUB files.",
+                )
+            )
+            continue
+
+        try:
+            if _is_zip_upload(file):
+                payload = await read_upload_limited(file, MAX_UPLOAD_BYTES, filename)
+                validate_upload(payload, filename)
+                entry_count = 0
+                for entry_index, (display_name, entry_payload, _safe_name) in enumerate(
+                    _extract_epubs_from_zip(filename, payload)
+                ):
+                    entry_count += 1
+                    items.append(
+                        await _preview_epub_bytes(
+                            key=f"file:{file_index}:{entry_index}",
+                            name=display_name,
+                            payload=entry_payload,
+                            db=db,
+                            seen_books=seen_books,
+                        )
+                    )
+                if entry_count == 0:
+                    items.append(
+                        ImportPreviewItem(
+                            key=f"file:{file_index}",
+                            input_type="zip",
+                            name=filename,
+                            status="unsupported",
+                            detail="No EPUB files were found in this ZIP archive.",
+                        )
+                    )
+                continue
+
+            payload = await read_and_validate_upload(file)
+            items.append(
+                await _preview_epub_bytes(
+                    key=f"file:{file_index}",
+                    name=filename,
+                    payload=payload,
+                    db=db,
+                    seen_books=seen_books,
+                )
+            )
+        except HTTPException as exc:
+            items.append(
+                ImportPreviewItem(
+                    key=f"file:{file_index}",
+                    input_type="file",
+                    name=filename,
+                    status="error",
+                    detail=str(exc.detail),
+                )
+            )
+        except Exception as exc:
+            items.append(
+                ImportPreviewItem(
+                    key=f"file:{file_index}",
+                    input_type="file",
+                    name=filename,
+                    status="error",
+                    detail=str(exc),
+                )
+            )
+
+    url_adapter = TypeAdapter(HttpUrl)
+    for url_index, raw_url in enumerate(urls):
+        candidate = raw_url.strip()
+        if not candidate:
+            continue
+        try:
+            normalized_url = str(url_adapter.validate_python(candidate))
+        except ValidationError:
+            items.append(
+                ImportPreviewItem(
+                    key=f"url:{url_index}",
+                    input_type="web",
+                    name=candidate,
+                    status="error",
+                    detail="Enter a valid HTTP or HTTPS web novel URL.",
+                )
+            )
+            continue
+
+        existing = await crud.get_book_by_source_url(db, source_url=normalized_url)
+        duplicate_in_batch = normalized_url in seen_urls
+        seen_urls.add(normalized_url)
+        configs = await crud.get_all_matching_cleaning_configs(db, normalized_url)
+        detail = None
+        if existing:
+            detail = f"This source is already attached to {existing.title}."
+        elif duplicate_in_batch:
+            detail = "This URL appears more than once in this import."
+        items.append(
+            ImportPreviewItem(
+                key=f"url:{url_index}",
+                input_type="web",
+                name=normalized_url,
+                status="duplicate" if detail else "ready",
+                source_url=normalized_url,
+                duplicate_book_id=existing.id if existing else None,
+                cleaning_configs=[config.name for config in configs],
+                detail=detail or "Metadata will be collected when the durable web import runs.",
+            )
+        )
+
+    return ImportPreviewResponse(
+        items=items,
+        ready_count=sum(item.status == "ready" for item in items),
+        duplicate_count=sum(item.status == "duplicate" for item in items),
+        unsupported_count=sum(item.status == "unsupported" for item in items),
+        error_count=sum(item.status == "error" for item in items),
+    )
 
 
 @router.post(

--- a/backend/tests/test_import_preview.py
+++ b/backend/tests/test_import_preview.py
@@ -1,0 +1,160 @@
+"""Preflight coverage for the guided import workflow."""
+
+from pathlib import Path
+import zipfile
+
+from ebooklib import epub
+import pytest
+from sqlalchemy import func, select
+
+from backend.app import crud, models, schemas
+
+
+def create_epub(
+    path: Path,
+    *,
+    title: str,
+    author: str,
+    series: str | None = None,
+    source_url: str | None = None,
+) -> bytes:
+    book = epub.EpubBook()
+    book.set_identifier(f"{title}-{author}")
+    book.set_title(title)
+    book.set_language("en")
+    book.add_author(author)
+    if series:
+        book.add_metadata("calibre", "series", series)
+    if source_url:
+        book.add_metadata("DC", "source", source_url)
+    chapter = epub.EpubHtml(title="Chapter 1", file_name="chapter.xhtml", lang="en")
+    chapter.content = "<h1>Chapter 1</h1><p>Preview-only content.</p>"
+    book.add_item(chapter)
+    book.toc = (epub.Link("chapter.xhtml", "Chapter 1", "chapter-1"),)
+    book.add_item(epub.EpubNcx())
+    book.add_item(epub.EpubNav())
+    book.spine = ["nav", chapter]
+    epub.write_epub(path, book, {})
+    return path.read_bytes()
+
+
+@pytest.mark.asyncio
+async def test_preview_epub_reports_metadata_rules_without_writing(app_client, db, tmp_path):
+    db.add(
+        models.CleaningConfig(
+            name="Example fiction",
+            url_pattern=r"example\.com/fiction",
+            chapter_selectors=[".chapter"],
+        )
+    )
+    await db.commit()
+    payload = create_epub(
+        tmp_path / "preview.epub",
+        title="The Preview Book",
+        author="A. Reader",
+        series="Preflight Stories",
+        source_url="https://example.com/fiction/42",
+    )
+
+    response = app_client.post(
+        "/api/imports/preview",
+        files={"files": ("preview.epub", payload, "application/epub+zip")},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "items": [
+            {
+                "key": "file:0",
+                "input_type": "epub",
+                "name": "preview.epub",
+                "status": "ready",
+                "title": "The Preview Book",
+                "author": "A. Reader",
+                "series": "Preflight Stories",
+                "source_url": "https://example.com/fiction/42",
+                "duplicate_book_id": None,
+                "cleaning_configs": ["Example fiction"],
+                "detail": None,
+            }
+        ],
+        "ready_count": 1,
+        "duplicate_count": 0,
+        "unsupported_count": 0,
+        "error_count": 0,
+    }
+    assert await db.scalar(select(func.count(models.Book.id))) == 0
+
+
+@pytest.mark.asyncio
+async def test_preview_marks_library_and_batch_duplicates(app_client, db, tmp_path):
+    existing = await crud.create_book(
+        db,
+        schemas.BookCreate(
+            title="Already Here",
+            author="Known Author",
+            immutable_path="already-here-immutable.epub",
+            current_path="already-here.epub",
+            source_type=models.SourceType.epub,
+        ),
+    )
+    existing_web = await crud.create_book(
+        db,
+        schemas.BookCreate(
+            title="Existing Web Story",
+            author="Known Web Author",
+            source_url="https://example.com/stories/already-here",
+            source_type=models.SourceType.web,
+        ),
+    )
+    existing_payload = create_epub(
+        tmp_path / "existing.epub",
+        title="Already Here",
+        author="Known Author",
+    )
+
+    response = app_client.post(
+        "/api/imports/preview",
+        files={"files": ("existing.epub", existing_payload, "application/epub+zip")},
+        data={
+            "urls": [
+                "https://example.com/stories/already-here",
+                "https://example.com/stories/new",
+                "https://example.com/stories/new",
+            ]
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert [item["status"] for item in data["items"]] == [
+        "duplicate",
+        "duplicate",
+        "ready",
+        "duplicate",
+    ]
+    assert data["items"][0]["duplicate_book_id"] == existing.id
+    assert data["items"][1]["duplicate_book_id"] == existing_web.id
+    assert data["items"][3]["detail"] == "This URL appears more than once in this import."
+    assert data["ready_count"] == 1
+    assert data["duplicate_count"] == 3
+    assert await db.scalar(select(func.count(models.Book.id))) == 2
+
+
+def test_preview_reports_archives_without_epubs_and_invalid_urls(app_client, tmp_path):
+    archive_path = tmp_path / "notes.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("notes.txt", "No books in this archive.")
+
+    response = app_client.post(
+        "/api/imports/preview",
+        files={"files": ("notes.zip", archive_path.read_bytes(), "application/zip")},
+        data={"urls": ["not a URL"]},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert [item["status"] for item in data["items"]] == ["unsupported", "error"]
+    assert data["unsupported_count"] == 1
+    assert data["error_count"] == 1
+    assert data["ready_count"] == 0

--- a/docs/IMPROVEMENT_ROADMAP.md
+++ b/docs/IMPROVEMENT_ROADMAP.md
@@ -41,7 +41,7 @@ The dashboard should favor resolution over raw diagnostics. Every category shoul
 
 ## 2. Simplified navigation
 
-**Status:** In progress
+**Status:** Complete
 
 Replace the current tool-oriented top-level navigation with three user-oriented destinations: **Library**, **Activity**, and **Settings**. The Needs Attention dashboard should become the default overview within this structure.
 
@@ -57,7 +57,7 @@ Activity will own processing jobs, failures, scheduled runs, and history. Settin
 
 ## 3. Unified import workflow
 
-**Status:** Planned
+**Status:** In progress
 
 Create one guided **Add to library** workflow for EPUB files, ZIP archives, folders, web-novel URLs, human audiobook files, and Libation backups. The workflow should separate selection, inspection, conflict resolution, execution, and results.
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -3804,7 +3804,301 @@ body {
 }
 
 .library-page-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
   padding-bottom: 1rem;
+}
+
+/* ─── Guided import workflow ────────────────────────────── */
+.import-workflow {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.import-workflow-header {
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--border-strong);
+}
+
+.import-workflow-header h2 {
+  margin: 0;
+}
+
+.import-workflow-header > p {
+  max-width: 42rem;
+  margin: 0.4rem 0 1.25rem;
+  color: var(--text-muted);
+}
+
+.import-steps {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  border: 1px solid var(--border);
+}
+
+.import-steps li {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  min-height: 2.8rem;
+  padding: 0.55rem 0.8rem;
+  border-right: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: 0.8rem;
+}
+
+.import-steps li:last-child {
+  border-right: 0;
+}
+
+.import-steps li > span {
+  display: grid;
+  place-items: center;
+  width: 1.4rem;
+  height: 1.4rem;
+  border: 1px solid var(--border-strong);
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 0.68rem;
+}
+
+.import-steps .import-steps--active {
+  color: var(--text);
+  background: color-mix(in srgb, var(--accent) 7%, var(--surface));
+}
+
+.import-steps .import-steps--active > span {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.import-type-picker {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0;
+  border: 1px solid var(--border-strong);
+}
+
+.import-type-picker button {
+  display: grid;
+  align-content: start;
+  gap: 0.3rem;
+  min-height: 5.2rem;
+  padding: 0.85rem;
+  border: 0;
+  border-right: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  color: var(--text);
+  text-align: left;
+}
+
+.import-type-picker button:last-child {
+  border-right: 0;
+}
+
+.import-type-picker button:hover:not(:disabled),
+.import-type-picker .import-type--active {
+  background: var(--surface);
+}
+
+.import-type-picker .import-type--active {
+  box-shadow: inset 0 -2px var(--accent);
+}
+
+.import-type-picker span {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  line-height: 1.35;
+}
+
+.import-panel {
+  display: grid;
+  gap: 1rem;
+  padding: 1.25rem;
+  border: 1px solid var(--border-strong);
+  background: var(--surface);
+}
+
+.import-panel h3 {
+  margin: -0.6rem 0 0;
+}
+
+.import-step-code {
+  color: var(--accent);
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.import-drop-zone {
+  display: grid;
+  place-items: center;
+  gap: 0.35rem;
+  min-height: 10rem;
+  padding: 2rem;
+  border-style: dashed;
+  background: var(--bg);
+  text-align: center;
+  cursor: pointer;
+}
+
+.import-drop-zone span {
+  color: var(--text-muted);
+  font-size: 0.82rem;
+}
+
+.import-selected-files {
+  max-height: 13rem;
+  padding: 0;
+  margin: 0;
+  overflow: auto;
+  list-style: none;
+  border-top: 1px solid var(--border);
+}
+
+.import-selected-files li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.55rem 0;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.82rem;
+}
+
+.import-selected-files li > span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.import-url-list,
+.import-audiobook-inputs {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.import-url-list label,
+.import-audiobook-inputs label {
+  display: grid;
+  gap: 0.35rem;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+}
+
+.import-url-row,
+.import-audio-pickers {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.65rem;
+  align-items: center;
+}
+
+.import-audio-pickers {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-items: start;
+}
+
+.import-checkbox {
+  display: flex !important;
+  grid-template-columns: none !important;
+  align-items: flex-start;
+  gap: 0.55rem !important;
+  color: var(--text) !important;
+}
+
+.import-checkbox input {
+  width: auto;
+  margin-top: 0.15rem;
+}
+
+.import-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.import-preview-summary {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.import-preview-list,
+.import-result-list {
+  display: grid;
+  border-top: 1px solid var(--border);
+}
+
+.import-preview-item,
+.import-result {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.2rem 1rem;
+  padding: 0.8rem 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.import-preview-item > div {
+  display: grid;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.import-preview-item span,
+.import-preview-item small,
+.import-result small {
+  color: var(--text-muted);
+}
+
+.import-preview-item strong,
+.import-preview-item span,
+.import-preview-item small,
+.import-result strong {
+  overflow-wrap: anywhere;
+}
+
+.import-preview-status,
+.import-result > span {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.import-preview-item--ready .import-preview-status,
+.import-result--succeeded > span {
+  color: var(--success);
+}
+
+.import-preview-item--duplicate .import-preview-status,
+.import-result--skipped > span,
+.import-result--queued > span {
+  color: var(--warning);
+}
+
+.import-preview-item--error .import-preview-status,
+.import-preview-item--unsupported .import-preview-status,
+.import-result--failed > span {
+  color: var(--danger);
+}
+
+.import-result small {
+  grid-column: 1 / -1;
+}
+
+.import-duplicate-confirmation {
+  padding: 0.8rem;
+  border: 1px solid color-mix(in srgb, var(--warning) 50%, var(--border));
+  background: color-mix(in srgb, var(--warning) 7%, transparent);
 }
 
 .search-controls {
@@ -4603,6 +4897,18 @@ body {
     align-items: flex-start;
   }
 
+  .import-type-picker {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .import-type-picker button:nth-child(2) {
+    border-right: 0;
+  }
+
+  .import-type-picker button:nth-child(-n + 2) {
+    border-bottom: 1px solid var(--border);
+  }
+
   .settings-header {
     flex-direction: column;
   }
@@ -4656,6 +4962,34 @@ body {
   .library-page-heading,
   .processing-console-header {
     flex-direction: column;
+  }
+
+  .import-steps li {
+    justify-content: center;
+    padding-right: 0.35rem;
+    padding-left: 0.35rem;
+  }
+
+  .import-type-picker,
+  .import-audio-pickers,
+  .import-url-row {
+    grid-template-columns: 1fr;
+  }
+
+  .import-type-picker button,
+  .import-type-picker button:nth-child(2) {
+    min-height: auto;
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .import-type-picker button:last-child {
+    border-bottom: 0;
+  }
+
+  .import-preview-item,
+  .import-result {
+    grid-template-columns: 1fr;
   }
 
   .library-view-tabs {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -3994,6 +3994,66 @@ body {
   font-size: 0.8rem;
 }
 
+.import-book-combobox {
+  position: relative;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.import-book-combobox > label {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+}
+
+.import-book-options {
+  position: absolute;
+  z-index: 20;
+  top: 100%;
+  right: 0;
+  left: 0;
+  max-height: 18rem;
+  padding: 0;
+  margin: 0.25rem 0 0;
+  overflow-y: auto;
+  list-style: none;
+  border: 1px solid var(--border-strong);
+  background: var(--bg);
+  box-shadow: 0 0.75rem 1.5rem color-mix(in srgb, #000 28%, transparent);
+}
+
+.import-book-options li {
+  display: grid;
+  gap: 0.15rem;
+  padding: 0.65rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+}
+
+.import-book-options li:last-child {
+  border-bottom: 0;
+}
+
+.import-book-options li:hover,
+.import-book-options .import-book-option--active,
+.import-book-options li[aria-selected="true"] {
+  background: var(--surface-2);
+}
+
+.import-book-options span,
+.import-book-options-empty {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+}
+
+.import-match-notice {
+  margin: 0;
+  padding: 0.7rem 0.8rem;
+  border-left: 2px solid var(--accent);
+  background: color-mix(in srgb, var(--accent) 7%, transparent);
+  color: var(--text-muted);
+  font-size: 0.8rem;
+}
+
 .import-url-row,
 .import-audio-pickers {
   display: grid;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import "./App.css";
 import { getAuthStatus, logout } from "./api/auth";
@@ -37,10 +37,9 @@ function App() {
   const [audiobookTab, setAudiobookTab] = useState("sources");
   const [activeTab, setActiveTab] = useState("library");
   const [libraryView, setLibraryView] = useState("series");
-  const [addBookOpen, setAddBookOpen] = useState(false);
+  const [pendingImportEntries, setPendingImportEntries] = useState([]);
   const [globalDragging, setGlobalDragging] = useState(false);
   const [authStatus, setAuthStatus] = useState(null);
-  const addBookRef = useRef(null);
   const debouncedQuery = useDebouncedValue(q.trim(), 300);
 
   useEffect(() => {
@@ -233,6 +232,10 @@ function App() {
     setAuthStatus(nextStatus);
   };
 
+  const handleImportEntriesConsumed = useCallback(() => {
+    setPendingImportEntries([]);
+  }, []);
+
   useEffect(() => {
     const onDragOver = (e) => {
       e.preventDefault();
@@ -260,9 +263,14 @@ function App() {
           entry.name.toLowerCase().endsWith(".zip"),
       );
       if (hasRelevant) {
-        setActiveTab("library");
-        setAddBookOpen(true);
-        addBookRef.current?.addFilesFromEntries(entries);
+        window.history.pushState(
+          { view: "tab", tab: "import" },
+          "",
+          "/import?type=books",
+        );
+        setEditingBook(null);
+        setActiveTab("import");
+        setPendingImportEntries(entries);
       }
     };
     window.addEventListener("dragover", onDragOver);
@@ -314,11 +322,25 @@ function App() {
         return <Utilities />;
       case "audio-settings":
         return <AudiobookSettings />;
+      case "import":
+        return (
+          <AddBook
+            initialEntries={pendingImportEntries}
+            onEntriesConsumed={handleImportEntriesConsumed}
+          />
+        );
       default:
         return (
           <>
             <div className="library-page-heading">
               <h2>Library</h2>
+              <button
+                type="button"
+                className="btn-primary"
+                onClick={() => navigate("import")}
+              >
+                Add to library
+              </button>
             </div>
             <div className="search-controls">
               <div className="search-input-wrap">
@@ -372,18 +394,6 @@ function App() {
                 </button>
               </div>
             </div>
-            <details className="add-book-details" open={addBookOpen}>
-              <summary
-                className="add-book-summary"
-                onClick={(e) => {
-                  e.preventDefault();
-                  setAddBookOpen((o) => !o);
-                }}
-              >
-                Add Books
-              </summary>
-              <AddBook ref={addBookRef} />
-            </details>
             {isLoading && <p>Loading...</p>}
             {error && <p className="error">{error.message}</p>}
             <BookList

--- a/frontend/src/api/imports.js
+++ b/frontend/src/api/imports.js
@@ -1,0 +1,25 @@
+import { sendForm, sendJson } from "./client";
+
+export function previewBookImports(files = [], urls = []) {
+  const body = new FormData();
+  files.forEach((file) => body.append("files", file));
+  urls.forEach((url) => body.append("urls", url));
+  return sendForm("/api/imports/preview", body, {
+    fallbackMessage: "Failed to inspect import inputs",
+  });
+}
+
+export function uploadEpubs(files) {
+  const body = new FormData();
+  files.forEach((file) => body.append("files", file));
+  return sendForm("/api/books/upload_epubs", body, {
+    fallbackMessage: "File upload failed",
+  });
+}
+
+export function addWebNovel(url) {
+  return sendJson("/api/books/add_web_novel", {
+    body: { url },
+    fallbackMessage: "Failed to add web novel",
+  });
+}

--- a/frontend/src/components/AddBook.jsx
+++ b/frontend/src/components/AddBook.jsx
@@ -1,59 +1,72 @@
-import { forwardRef, useImperativeHandle, useRef, useState } from "react";
-import { useQueryClient } from "@tanstack/react-query";
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 
-const uploadEpubs = async (files) => {
-  const formData = new FormData();
-  for (const file of files) {
-    formData.append("files", file);
-  }
-  const res = await fetch("/api/books/upload_epubs", {
-    method: "POST",
-    body: formData,
-  });
-  if (!res.ok) {
-    const error = await res.json();
-    throw new Error(error.detail || "File upload failed");
-  }
-  return res.json(); // List<EpubUploadResult>
-};
+import { getBookCatalog } from "../api/books";
+import { uploadImportedAudiobook } from "../api/audiobook";
+import {
+  addWebNovel,
+  previewBookImports,
+  uploadEpubs,
+} from "../api/imports";
+import LibationBackupImport from "./LibationBackupImport.jsx";
 
-const addWebNovel = async (url) => {
-  const res = await fetch("/api/books/add_web_novel", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ url }),
-  });
-  if (!res.ok) {
-    const error = await res.json();
-    throw new Error(error.detail || "Failed to add web novel");
-  }
-  return res.json();
-};
+const IMPORT_TYPES = [
+  {
+    key: "books",
+    label: "Book files",
+    description: "EPUB files, ZIP archives, or folders",
+  },
+  {
+    key: "web",
+    label: "Web novels",
+    description: "One or more source URLs",
+  },
+  {
+    key: "audiobook",
+    label: "Audiobook",
+    description: "Human narration for a library book",
+  },
+  {
+    key: "libation",
+    label: "Libation backup",
+    description: "Match and queue an entire backup",
+  },
+];
 
-const formatImportSummary = ({ totalProcessed, succeeded, skipped, failed }) => {
-  if (totalProcessed === 0) {
-    return "No books were processed.";
-  }
+const AUDIO_EXTENSIONS = new Set([
+  ".aac",
+  ".cue",
+  ".flac",
+  ".m4a",
+  ".m4b",
+  ".mp3",
+  ".mp4",
+  ".ogg",
+  ".opus",
+  ".wav",
+  ".zip",
+]);
 
-  const parts = [`Imported ${succeeded.length} of ${totalProcessed} book${totalProcessed === 1 ? "" : "s"}.`];
-  if (skipped.length > 0) {
-    parts.push(`${skipped.length} skipped.`);
-  }
-  if (failed.length > 0) {
-    parts.push(`${failed.length} failed.`);
-  }
-  return parts.join(" ");
-};
+function requestedImportType() {
+  const requested = new URLSearchParams(window.location.search).get("type");
+  return IMPORT_TYPES.some((item) => item.key === requested)
+    ? requested
+    : "books";
+}
 
-const formatSkippedMessage = (error) => {
-  const message = error || "Skipped";
-  const duplicateMatch = message.match(/A book with title '(.+)' by '(.+)' already exists/);
-  if (duplicateMatch) {
-    const [, title, author] = duplicateMatch;
-    return `"${title}" by ${author} is already in your library.`;
-  }
-  return message;
-};
+function requestedBookId() {
+  const value = Number.parseInt(
+    new URLSearchParams(window.location.search).get("book_id"),
+    10,
+  );
+  return Number.isInteger(value) ? value : null;
+}
 
 const readDirEntries = (reader) =>
   new Promise((resolve, reject) => reader.readEntries(resolve, reject));
@@ -61,7 +74,7 @@ const readDirEntries = (reader) =>
 const getFileFromEntry = (fileEntry) =>
   new Promise((resolve, reject) => fileEntry.file(resolve, reject));
 
-const extractEpubsFromEntries = async (entries) => {
+async function extractEpubsFromEntries(entries) {
   const readDir = async (dirEntry) => {
     const reader = dirEntry.createReader();
     const files = [];
@@ -69,13 +82,11 @@ const extractEpubsFromEntries = async (entries) => {
     do {
       batch = await readDirEntries(reader);
       for (const entry of batch) {
-        if (entry.isFile) {
-          if (entry.name.toLowerCase().endsWith(".epub")) {
-            try {
-              files.push(await getFileFromEntry(entry));
-            } catch {
-              // skip unreadable files
-            }
+        if (entry.isFile && entry.name.toLowerCase().endsWith(".epub")) {
+          try {
+            files.push(await getFileFromEntry(entry));
+          } catch {
+            // Unreadable files are reported by omission in the selection summary.
           }
         } else if (entry.isDirectory) {
           files.push(...(await readDir(entry)));
@@ -91,7 +102,7 @@ const extractEpubsFromEntries = async (entries) => {
       try {
         files.push(...(await readDir(entry)));
       } catch {
-        // skip unreadable directories
+        // Ignore unreadable directories.
       }
     } else if (entry.isFile) {
       const lower = entry.name.toLowerCase();
@@ -99,249 +110,651 @@ const extractEpubsFromEntries = async (entries) => {
         try {
           files.push(await getFileFromEntry(entry));
         } catch {
-          // skip
+          // Ignore unreadable files.
         }
       }
     }
   }
   return files;
-};
+}
 
-const AddBook = forwardRef(function AddBook(_props, ref) {
+function extension(name) {
+  const index = name.lastIndexOf(".");
+  return index < 0 ? "" : name.slice(index).toLowerCase();
+}
+
+function selectAudiobookFiles(selectedFiles) {
+  const supported = Array.from(selectedFiles || []).filter((file) =>
+    AUDIO_EXTENSIONS.has(extension(file.name)),
+  );
+  const hasM4b = supported.some((file) => extension(file.name) === ".m4b");
+  if (!hasM4b) return supported;
+  return supported.filter(
+    (file) =>
+      ![
+        ".aac",
+        ".flac",
+        ".m4a",
+        ".mp3",
+        ".mp4",
+        ".ogg",
+        ".opus",
+        ".wav",
+      ].includes(extension(file.name)) || extension(file.name) === ".m4b",
+  );
+}
+
+function previewStatusLabel(status) {
+  switch (status) {
+    case "ready":
+      return "Ready";
+    case "duplicate":
+      return "Duplicate — will skip";
+    case "unsupported":
+      return "Unsupported";
+    default:
+      return "Needs correction";
+  }
+}
+
+function resultLabel(status) {
+  return status.charAt(0).toUpperCase() + status.slice(1);
+}
+
+const AddBook = forwardRef(function AddBook(
+  { initialEntries = [], onEntriesConsumed },
+  ref,
+) {
   const queryClient = useQueryClient();
+  const fileInputRef = useRef(null);
+  const audioInputRef = useRef(null);
+  const audioDirectoryRef = useRef(null);
+  const [importType, setImportType] = useState(requestedImportType);
   const [files, setFiles] = useState([]);
   const [urls, setUrls] = useState([""]);
+  const [audioFiles, setAudioFiles] = useState([]);
+  const [selectedBookId, setSelectedBookId] = useState(requestedBookId);
+  const [editionName, setEditionName] = useState("");
+  const [autoAlign, setAutoAlign] = useState(true);
   const [dragging, setDragging] = useState(false);
-  const [pending, setPending] = useState(false);
+  const [preview, setPreview] = useState(null);
+  const [previewing, setPreviewing] = useState(false);
+  const [previewError, setPreviewError] = useState("");
+  const [duplicatesReviewed, setDuplicatesReviewed] = useState(false);
+  const [importing, setImporting] = useState(false);
   const [results, setResults] = useState(null);
-  const fileInputRef = useRef(null);
 
-  useImperativeHandle(ref, () => ({
-    addFilesFromEntries: async (entries) => {
-      const newFiles = await extractEpubsFromEntries(entries);
-      if (newFiles.length > 0) setFiles((prev) => [...prev, ...newFiles]);
-    },
-  }));
+  const { data: catalog = [] } = useQuery({
+    queryKey: ["import-book-catalog"],
+    queryFn: () =>
+      getBookCatalog({ q: "", sortBy: "title", sortOrder: "asc" }),
+    enabled: importType === "audiobook",
+    staleTime: 30_000,
+  });
 
-  const handleFileChange = (e) => {
-    setFiles((prev) => [...prev, ...Array.from(e.target.files)]);
-    e.target.value = "";
+  const addEntryFiles = async (entries) => {
+    const newFiles = await extractEpubsFromEntries(entries);
+    if (newFiles.length) {
+      setImportType("books");
+      setFiles((current) => [...current, ...newFiles]);
+      setPreview(null);
+      setResults(null);
+    }
   };
 
-  const removeFile = (index) => setFiles((prev) => prev.filter((_, i) => i !== index));
+  useImperativeHandle(ref, () => ({ addFilesFromEntries: addEntryFiles }));
 
-  const handleUrlChange = (index, value) =>
-    setUrls((prev) => prev.map((u, i) => (i === index ? value : u)));
+  useEffect(() => {
+    if (!initialEntries.length) return;
+    void addEntryFiles(initialEntries).finally(() => onEntriesConsumed?.());
+    // The parent clears the consumed entries; this effect should only rerun for
+    // a genuinely new browser drop, not because a callback identity changed.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialEntries]);
 
-  const addUrlField = () => setUrls((prev) => [...prev, ""]);
+  useEffect(() => {
+    const onPopState = () => {
+      setImportType(requestedImportType());
+      setSelectedBookId(requestedBookId());
+      setPreview(null);
+      setResults(null);
+    };
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, []);
 
-  const removeUrlField = (index) => setUrls((prev) => prev.filter((_, i) => i !== index));
-
-  const handleDragOver = (e) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setDragging(true);
+  const resetInspection = () => {
+    setPreview(null);
+    setPreviewError("");
+    setDuplicatesReviewed(false);
+    setResults(null);
   };
 
-  const handleDragLeave = (e) => {
-    e.preventDefault();
-    e.stopPropagation();
+  const chooseType = (type) => {
+    if (type === importType) return;
+    const params = new URLSearchParams();
+    params.set("type", type);
+    window.history.pushState(
+      { view: "tab", tab: "import" },
+      "",
+      `/import?${params}`,
+    );
+    setImportType(type);
+    resetInspection();
+  };
+
+  const handleDrop = async (event) => {
+    event.preventDefault();
+    event.stopPropagation();
     setDragging(false);
-  };
-
-  const handleDrop = async (e) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setDragging(false);
-    const entries = Array.from(e.dataTransfer.items)
+    const entries = Array.from(event.dataTransfer.items)
       .map((item) => item.webkitGetAsEntry?.())
       .filter(Boolean);
-    if (entries.length > 0) {
-      const newFiles = await extractEpubsFromEntries(entries);
-      setFiles((prev) => [...prev, ...newFiles]);
-    } else {
-      // Fallback for environments where webkitGetAsEntry is unavailable (e.g. synthetic events in tests).
-      // items[n].getAsFile() is more reliable than dataTransfer.files for programmatic DataTransfer objects.
-      const seen = new Set();
-      const newFiles = [
-        ...Array.from(e.dataTransfer.items)
-          .filter((item) => item.kind === "file")
-          .map((item) => item.getAsFile()),
-        ...Array.from(e.dataTransfer.files),
-      ]
-        .filter((f) => f && !seen.has(f.name) && seen.add(f.name))
-        .filter((f) => {
-          const lower = f.name.toLowerCase();
-          return lower.endsWith(".epub") || lower.endsWith(".zip");
+    if (entries.length) {
+      await addEntryFiles(entries);
+      return;
+    }
+    const selected = Array.from(event.dataTransfer.files).filter((file) =>
+      file.name.toLowerCase().endsWith(".epub") ||
+      file.name.toLowerCase().endsWith(".zip"),
+    );
+    setFiles((current) => [...current, ...selected]);
+    resetInspection();
+  };
+
+  const inspect = async () => {
+    setPreviewing(true);
+    setPreviewError("");
+    setResults(null);
+    setDuplicatesReviewed(false);
+    try {
+      if (importType === "books") {
+        setPreview(await previewBookImports(files, []));
+      } else if (importType === "web") {
+        setPreview(
+          await previewBookImports(
+            [],
+            urls.map((url) => url.trim()).filter(Boolean),
+          ),
+        );
+      } else if (importType === "audiobook") {
+        const book = catalog.find((item) => item.id === selectedBookId);
+        if (!book || !audioFiles.length) {
+          throw new Error("Choose a library book and at least one supported audio file.");
+        }
+        setPreview({
+          ready_count: 1,
+          duplicate_count: 0,
+          unsupported_count: 0,
+          error_count: 0,
+          items: [
+            {
+              key: "audiobook:0",
+              input_type: "audiobook",
+              name: editionName.trim() || audioFiles[0].name,
+              status: "ready",
+              title: book.title,
+              author: book.author,
+              detail: `${audioFiles.length} supported ${audioFiles.length === 1 ? "file" : "files"} will be attached to this book.`,
+            },
+          ],
         });
-      setFiles((prev) => [...prev, ...newFiles]);
+      }
+    } catch (error) {
+      setPreviewError(error.message);
+    } finally {
+      setPreviewing(false);
     }
   };
 
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-    const activeUrls = urls.filter((u) => u.trim());
-    if (files.length === 0 && activeUrls.length === 0) return;
-
-    setPending(true);
-    setResults(null);
-
-    const succeeded = [];
-    const skipped = [];
-    const failed = [];
-
-    if (files.length > 0) {
-      try {
-        const epubResults = await uploadEpubs(files);
-        for (const r of epubResults) {
-          if (r.status === "success") {
-            succeeded.push(r.book?.title || r.filename);
-          } else if (r.status === "skipped") {
-            skipped.push({ name: r.filename, error: formatSkippedMessage(r.error) });
-          } else {
-            failed.push({ name: r.filename, error: r.error || "Upload failed" });
+  const execute = async () => {
+    setImporting(true);
+    const completed = [];
+    try {
+      if (importType === "books") {
+        try {
+          const response = await uploadEpubs(files);
+          response.forEach((item) => {
+            completed.push({
+              name: item.book?.title || item.filename,
+              status:
+                item.status === "success"
+                  ? "succeeded"
+                  : item.status === "skipped"
+                    ? "skipped"
+                    : "failed",
+              detail: item.error,
+            });
+          });
+        } catch (error) {
+          files.forEach((file) =>
+            completed.push({
+              name: file.name,
+              status: "failed",
+              detail: error.message,
+            }),
+          );
+        }
+      } else if (importType === "web") {
+        for (const item of preview.items.filter((entry) => entry.status === "ready")) {
+          try {
+            const book = await addWebNovel(item.source_url);
+            completed.push({
+              name: book.title || item.source_url,
+              status: "queued",
+              detail: "The durable web import will continue in Activity.",
+            });
+          } catch (error) {
+            completed.push({
+              name: item.source_url,
+              status: "failed",
+              detail: error.message,
+            });
           }
         }
-      } catch (err) {
-        for (const file of files) {
-          failed.push({ name: file.name, error: err.message });
+      } else if (importType === "audiobook") {
+        try {
+          const edition = await uploadImportedAudiobook(
+            selectedBookId,
+            audioFiles,
+            editionName,
+            autoAlign,
+          );
+          completed.push({
+            name: edition.name || editionName || audioFiles[0].name,
+            status: "queued",
+            detail: "Import and chapter matching will continue in Activity.",
+          });
+        } catch (error) {
+          completed.push({
+            name: editionName || audioFiles[0].name,
+            status: "failed",
+            detail: error.message,
+          });
         }
       }
-    }
 
-    for (const url of activeUrls) {
-      try {
-        const book = await addWebNovel(url);
-        succeeded.push(book.title || url);
-      } catch (err) {
-        failed.push({ name: url, error: err.message });
+      if (importType === "web") {
+        preview.items
+          .filter((item) => item.status !== "ready")
+          .forEach((item) =>
+            completed.push({
+              name: item.title || item.source_url || item.name,
+              status: item.status === "duplicate" ? "skipped" : "failed",
+              detail: item.detail,
+            }),
+          );
       }
+      setResults(completed);
+      queryClient.invalidateQueries({ queryKey: ["book-catalog"] });
+      queryClient.invalidateQueries({ queryKey: ["active-processing-jobs"] });
+      queryClient.invalidateQueries({ queryKey: ["attention-dashboard"] });
+    } finally {
+      setImporting(false);
     }
-
-    queryClient.invalidateQueries({ queryKey: ["book-catalog"] });
-    setFiles([]);
-    setUrls([""]);
-    setPending(false);
-    setResults({ succeeded, skipped, failed, totalProcessed: succeeded.length + skipped.length + failed.length });
   };
 
-  const total = files.length + urls.filter((u) => u.trim()).length;
+  const activeUrls = urls.map((url) => url.trim()).filter(Boolean);
+  const canInspect =
+    (importType === "books" && files.length > 0) ||
+    (importType === "web" && activeUrls.length > 0) ||
+    (importType === "audiobook" && selectedBookId && audioFiles.length > 0);
+  const stage = results ? 3 : preview ? 2 : 1;
+  const canImport =
+    (preview?.ready_count > 0 || preview?.duplicate_count > 0) &&
+    (preview.duplicate_count === 0 || duplicatesReviewed);
+
+  if (importType === "libation") {
+    return (
+      <div className="import-workflow">
+        <ImportHeader stage={1} />
+        <ImportTypePicker selected={importType} onSelect={chooseType} />
+        <LibationBackupImport />
+      </div>
+    );
+  }
 
   return (
-    <div className="add-book-container">
-      <form onSubmit={handleSubmit}>
-        <div className="add-book-columns">
-          <div
-            id="drop-zone"
-            className={`drop-zone ${dragging ? "dragging" : ""} ${files.length > 0 ? "drop-zone--has-files" : ""}`}
-            onDragOver={handleDragOver}
-            onDragLeave={handleDragLeave}
-            onDrop={handleDrop}
-            onClick={() => fileInputRef.current.click()}
-          >
-            {files.length > 0 ? (
-              <ul className="file-list" onClick={(e) => e.stopPropagation()}>
-                {files.map((f, i) => (
-                  <li key={i}>
-                    <span>{f.name}</span>
-                    <button type="button" className="remove-btn" onClick={() => removeFile(i)}>
-                      ×
-                    </button>
-                  </li>
-                ))}
-                <li className="add-more-hint">+ more files</li>
-              </ul>
-            ) : (
-              <div className="drop-zone-empty">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" width="28" height="28">
-                  <path d="M12 16V6m0 0l-4 4m4-4l4 4" strokeLinecap="round" strokeLinejoin="round"/>
-                  <path d="M20 16.7V19a2 2 0 01-2 2H6a2 2 0 01-2-2v-2.3" strokeLinecap="round" strokeLinejoin="round"/>
-                </svg>
-                <span>Drop EPUBs, ZIPs, or folders here, or click to browse</span>
-              </div>
-            )}
-            <input
-              id="file-upload"
-              type="file"
-              accept=".epub,.zip"
-              multiple
-              onChange={handleFileChange}
-              ref={fileInputRef}
-              style={{ display: "none" }}
-            />
-          </div>
+    <div className="import-workflow">
+      <ImportHeader stage={stage} />
+      <ImportTypePicker selected={importType} onSelect={chooseType} />
 
-          <div className="add-book-divider">
-            <span>or</span>
-          </div>
+      {!preview && !results && (
+        <section className="import-panel" aria-labelledby="import-input-heading">
+          <span className="import-step-code">01 / SELECT</span>
+          <h3 id="import-input-heading">Choose what to inspect</h3>
 
-          <div className="url-section">
-            {urls.map((url, i) => (
-              <div key={i} className="url-row">
+          {importType === "books" && (
+            <>
+              <div
+                id="drop-zone"
+                className={`drop-zone import-drop-zone${dragging ? " dragging" : ""}`}
+                onDragOver={(event) => {
+                  event.preventDefault();
+                  setDragging(true);
+                }}
+                onDragLeave={() => setDragging(false)}
+                onDrop={handleDrop}
+                onClick={() => fileInputRef.current?.click()}
+              >
+                <strong>Drop EPUBs, ZIPs, or folders here</strong>
+                <span>or click to browse for files</span>
                 <input
-                  type="text"
-                  placeholder="Paste a web novel URL"
-                  value={url}
-                  onChange={(e) => handleUrlChange(i, e.target.value)}
+                  id="file-upload"
+                  ref={fileInputRef}
+                  type="file"
+                  accept=".epub,.zip"
+                  multiple
+                  hidden
+                  onChange={(event) => {
+                    setFiles((current) => [
+                      ...current,
+                      ...Array.from(event.target.files),
+                    ]);
+                    resetInspection();
+                    event.target.value = "";
+                  }}
                 />
-                {urls.length > 1 && (
-                  <button type="button" className="remove-btn" onClick={() => removeUrlField(i)}>
-                    ×
-                  </button>
-                )}
               </div>
-            ))}
-            <button type="button" className="add-url-btn" onClick={addUrlField}>
-              + Add another URL
+              <SelectedFiles files={files} onRemove={(index) => {
+                setFiles((current) => current.filter((_, itemIndex) => itemIndex !== index));
+                resetInspection();
+              }} />
+            </>
+          )}
+
+          {importType === "web" && (
+            <div className="import-url-list">
+              {urls.map((url, index) => (
+                <label key={index}>
+                  Web novel URL {urls.length > 1 ? index + 1 : ""}
+                  <span className="import-url-row">
+                    <input
+                      type="url"
+                      placeholder="https://example.com/story/..."
+                      value={url}
+                      onChange={(event) => {
+                        setUrls((current) =>
+                          current.map((item, itemIndex) =>
+                            itemIndex === index ? event.target.value : item,
+                          ),
+                        );
+                        resetInspection();
+                      }}
+                    />
+                    {urls.length > 1 && (
+                      <button
+                        type="button"
+                        className="btn-text"
+                        onClick={() =>
+                          setUrls((current) => {
+                            resetInspection();
+                            return current.filter(
+                              (_, itemIndex) => itemIndex !== index,
+                            );
+                          })
+                        }
+                      >
+                        Remove
+                      </button>
+                    )}
+                  </span>
+                </label>
+              ))}
+              <button
+                type="button"
+                className="btn-text"
+                onClick={() => setUrls((current) => [...current, ""])}
+              >
+                + Add another URL
+              </button>
+            </div>
+          )}
+
+          {importType === "audiobook" && (
+            <div className="import-audiobook-inputs">
+              <label>
+                Attach narration to
+                <select
+                  value={selectedBookId || ""}
+                  onChange={(event) => {
+                    setSelectedBookId(Number(event.target.value) || null);
+                    resetInspection();
+                  }}
+                >
+                  <option value="">Choose a library book</option>
+                  {catalog.map((book) => (
+                    <option key={book.id} value={book.id}>
+                      {book.title} — {book.author || "Unknown author"}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                Edition name (optional)
+                <input
+                  value={editionName}
+                  onChange={(event) => setEditionName(event.target.value)}
+                  placeholder="For example, Audible / Jeff Hays"
+                />
+              </label>
+              <div className="import-audio-pickers">
+                <label>
+                  Audiobook files or ZIP
+                  <input
+                    ref={audioInputRef}
+                    type="file"
+                    multiple
+                    accept=".zip,.cue,.m4b,.m4a,.mp3,.mp4,.aac,.flac,.ogg,.opus,.wav,audio/*"
+                    onChange={(event) => {
+                      setAudioFiles(selectAudiobookFiles(event.target.files));
+                      resetInspection();
+                    }}
+                  />
+                </label>
+                <label>
+                  Or audiobook directory
+                  <input
+                    ref={audioDirectoryRef}
+                    type="file"
+                    multiple
+                    webkitdirectory=""
+                    directory=""
+                    onChange={(event) => {
+                      setAudioFiles(selectAudiobookFiles(event.target.files));
+                      resetInspection();
+                    }}
+                  />
+                </label>
+              </div>
+              <SelectedFiles files={audioFiles} />
+              <label className="import-checkbox">
+                <input
+                  type="checkbox"
+                  checked={autoAlign}
+                  onChange={(event) => setAutoAlign(event.target.checked)}
+                />
+                Improve sentence timestamps with configured speech-to-text alignment
+              </label>
+            </div>
+          )}
+
+          <div className="import-actions">
+            <button
+              type="button"
+              className="btn-primary"
+              disabled={!canInspect || previewing}
+              onClick={inspect}
+            >
+              {previewing ? "Inspecting…" : "Inspect selection"}
             </button>
           </div>
-        </div>
+          {previewError && <p className="error">{previewError}</p>}
+        </section>
+      )}
 
-        <button className="btn-primary add-book-submit" type="submit" disabled={pending || total === 0}>
-          {pending ? "Adding..." : total > 1 ? `Add ${total} Books` : "Add Book"}
-        </button>
-      </form>
+      {preview && !results && (
+        <section className="import-panel" aria-labelledby="import-preview-heading">
+          <span className="import-step-code">02 / REVIEW</span>
+          <h3 id="import-preview-heading">Review before importing</h3>
+          <p className="import-preview-summary" role="status">
+            <strong>{preview.ready_count} ready</strong>
+            {` · ${preview.duplicate_count} duplicate · ${preview.unsupported_count} unsupported · ${preview.error_count} with errors`}
+          </p>
+          <div className="import-preview-list">
+            {preview.items.map((item) => (
+              <article
+                key={item.key}
+                className={`import-preview-item import-preview-item--${item.status}`}
+              >
+                <div>
+                  <strong>{item.title || item.source_url || item.name}</strong>
+                  {item.author && <span>{item.author}</span>}
+                  {item.series && <small>Series: {item.series}</small>}
+                  {item.cleaning_configs?.length > 0 && (
+                    <small>
+                      Cleaning: {item.cleaning_configs.join(", ")}
+                    </small>
+                  )}
+                  {item.detail && <small>{item.detail}</small>}
+                </div>
+                <span className="import-preview-status">
+                  {previewStatusLabel(item.status)}
+                </span>
+              </article>
+            ))}
+          </div>
+          {preview.duplicate_count > 0 && (
+            <label className="import-checkbox import-duplicate-confirmation">
+              <input
+                type="checkbox"
+                checked={duplicatesReviewed}
+                onChange={(event) => setDuplicatesReviewed(event.target.checked)}
+              />
+              I reviewed the duplicates and want to skip them.
+            </label>
+          )}
+          <div className="import-actions">
+            <button
+              type="button"
+              className="btn-primary"
+              disabled={!canImport || importing}
+              onClick={execute}
+            >
+              {importing
+                ? "Starting import…"
+                : preview.ready_count > 0
+                  ? `Import ${preview.ready_count} ready`
+                  : preview.duplicate_count > 0
+                    ? `Finish with ${preview.duplicate_count} skipped`
+                    : "Nothing ready to import"}
+            </button>
+            <button type="button" className="btn-text" onClick={resetInspection}>
+              Change selection
+            </button>
+          </div>
+        </section>
+      )}
 
       {results && (
-        <div className="add-results">
-          <p className="summary">{formatImportSummary(results)}</p>
-          {results.succeeded.length > 0 && (
-            <p className="success">
-              Added: {results.succeeded.length} book{results.succeeded.length === 1 ? "" : "s"}.
-            </p>
-          )}
-          {results.skipped.length > 0 && (
-            <div className="result-group">
-              <p className="skipped-summary">
-                Skipped: {results.skipped.length} book{results.skipped.length === 1 ? "" : "s"}.
-              </p>
-              <ul className="error-list">
-                {results.skipped.map((f, i) => (
-                  <li key={i} className="skipped">
-                    <strong>{f.name}</strong>: {f.error}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
-          {results.failed.length > 0 && (
-            <div className="result-group">
-              <p className="error-summary">
-                Failed: {results.failed.length} book{results.failed.length === 1 ? "" : "s"}.
-              </p>
-              <ul className="error-list">
-                {results.failed.map((f, i) => (
-                  <li key={i} className="error">
-                    <strong>{f.name}</strong>: {f.error}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
-        </div>
+        <section className="import-panel" aria-labelledby="import-results-heading">
+          <span className="import-step-code">03 / RESULTS</span>
+          <h3 id="import-results-heading">Import results</h3>
+          <div className="import-result-list" role="status">
+            {results.map((item, index) => (
+              <div className={`import-result import-result--${item.status}`} key={`${item.name}-${index}`}>
+                <strong>{item.name}</strong>
+                <span>{resultLabel(item.status)}</span>
+                {item.detail && <small>{item.detail}</small>}
+              </div>
+            ))}
+          </div>
+          <div className="import-actions">
+            <button
+              type="button"
+              className="btn-primary"
+              onClick={() => {
+                setFiles([]);
+                setAudioFiles([]);
+                setUrls([""]);
+                setPreview(null);
+                setResults(null);
+              }}
+            >
+              Import more
+            </button>
+            <a className="btn" href="/activity/processing">
+              View Activity
+            </a>
+          </div>
+        </section>
       )}
     </div>
   );
 });
+
+function ImportHeader({ stage }) {
+  return (
+    <header className="import-workflow-header">
+      <span className="attention-eyebrow">GUIDED WORKFLOW</span>
+      <h2>Add to library</h2>
+      <p>Inspect inputs, resolve conflicts, and then start durable import work.</p>
+      <ol className="import-steps" aria-label="Import progress">
+        {["Select", "Review", "Results"].map((label, index) => (
+          <li
+            key={label}
+            className={stage >= index + 1 ? "import-steps--active" : ""}
+            aria-current={stage === index + 1 ? "step" : undefined}
+          >
+            <span>{index + 1}</span>
+            {label}
+          </li>
+        ))}
+      </ol>
+    </header>
+  );
+}
+
+function ImportTypePicker({ selected, onSelect }) {
+  return (
+    <div className="import-type-picker" role="group" aria-label="Import source type">
+      {IMPORT_TYPES.map((item) => (
+        <button
+          key={item.key}
+          type="button"
+          className={selected === item.key ? "import-type--active" : ""}
+          aria-pressed={selected === item.key}
+          onClick={() => onSelect(item.key)}
+        >
+          <strong>{item.label}</strong>
+          <span>{item.description}</span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function SelectedFiles({ files, onRemove }) {
+  if (!files.length) return null;
+  return (
+    <ul className="import-selected-files">
+      {files.map((file, index) => (
+        <li key={`${file.name}-${index}`}>
+          <span>{file.webkitRelativePath || file.name}</span>
+          {onRemove && (
+            <button
+              type="button"
+              className="btn-text"
+              aria-label={`Remove ${file.name}`}
+              onClick={() => onRemove(index)}
+            >
+              Remove
+            </button>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}
 
 export default AddBook;

--- a/frontend/src/components/AddBook.jsx
+++ b/frontend/src/components/AddBook.jsx
@@ -53,6 +53,15 @@ const AUDIO_EXTENSIONS = new Set([
   ".zip",
 ]);
 
+const MATCH_STOP_WORDS = new Set([
+  "and",
+  "book",
+  "edition",
+  "series",
+  "the",
+  "volume",
+]);
+
 function requestedImportType() {
   const requested = new URLSearchParams(window.location.search).get("type");
   return IMPORT_TYPES.some((item) => item.key === requested)
@@ -144,6 +153,90 @@ function selectAudiobookFiles(selectedFiles) {
   );
 }
 
+function normalizeMatchText(value) {
+  return String(value || "")
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function bookLabel(book) {
+  return `${book.title} — ${book.author || "Unknown author"}`;
+}
+
+function titleVariants(title) {
+  const full = normalizeMatchText(title);
+  const titleText = String(title || "");
+  const primary = normalizeMatchText(
+    titleText.split(":", 1)[0].split("(", 1)[0].split("[", 1)[0],
+  );
+  return [...new Set([full, primary].filter(Boolean))];
+}
+
+function significantTokens(value) {
+  return normalizeMatchText(value)
+    .split(" ")
+    .filter((token) => token.length > 2 && !MATCH_STOP_WORDS.has(token));
+}
+
+function scoreFilenameMatch(book, fileText) {
+  const normalizedFile = normalizeMatchText(fileText);
+  const variants = titleVariants(book.title);
+  let score = 0;
+
+  variants.forEach((variant, index) => {
+    if (variant.length >= 4 && normalizedFile.includes(variant)) {
+      score = Math.max(score, (index === 0 ? 1000 : 900) + variant.length);
+    }
+  });
+
+  const titleTokens = significantTokens(book.title);
+  const fileTokens = new Set(significantTokens(fileText));
+  const matchedTokens = titleTokens.filter((token) => fileTokens.has(token));
+  const coverage = titleTokens.length
+    ? matchedTokens.length / titleTokens.length
+    : 0;
+  if (matchedTokens.length >= 2 && coverage >= 0.7) {
+    score = Math.max(score, 500 + coverage * 100 + matchedTokens.length);
+  }
+
+  if (score > 0) {
+    const authorTokens = significantTokens(book.author);
+    score += authorTokens.filter((token) => fileTokens.has(token)).length * 10;
+  }
+  return score;
+}
+
+function findFilenameBookMatch(files, catalog) {
+  const fileText = files
+    .map((file) => file.webkitRelativePath || file.name)
+    .join(" ");
+  const candidates = catalog
+    .map((book) => ({ book, score: scoreFilenameMatch(book, fileText) }))
+    .filter((candidate) => candidate.score > 0)
+    .sort((left, right) => right.score - left.score);
+
+  if (!candidates.length) return null;
+  if (candidates[1] && candidates[0].score - candidates[1].score < 5) {
+    return null;
+  }
+  return candidates[0].book;
+}
+
+function scoreBookSearch(book, normalizedQuery) {
+  const title = normalizeMatchText(book.title);
+  const author = normalizeMatchText(book.author);
+  if (title === normalizedQuery) return 100;
+  if (title.startsWith(normalizedQuery)) return 90;
+  if (title.includes(normalizedQuery)) return 80;
+  if (author === normalizedQuery) return 70;
+  if (author.startsWith(normalizedQuery)) return 60;
+  if (author.includes(normalizedQuery)) return 50;
+  return 0;
+}
+
 function previewStatusLabel(status) {
   switch (status) {
     case "ready":
@@ -169,11 +262,13 @@ const AddBook = forwardRef(function AddBook(
   const fileInputRef = useRef(null);
   const audioInputRef = useRef(null);
   const audioDirectoryRef = useRef(null);
+  const lastAutoMatchSignatureRef = useRef("");
   const [importType, setImportType] = useState(requestedImportType);
   const [files, setFiles] = useState([]);
   const [urls, setUrls] = useState([""]);
   const [audioFiles, setAudioFiles] = useState([]);
   const [selectedBookId, setSelectedBookId] = useState(requestedBookId);
+  const [audioMatchNotice, setAudioMatchNotice] = useState("");
   const [editionName, setEditionName] = useState("");
   const [autoAlign, setAutoAlign] = useState(true);
   const [dragging, setDragging] = useState(false);
@@ -216,6 +311,7 @@ const AddBook = forwardRef(function AddBook(
     const onPopState = () => {
       setImportType(requestedImportType());
       setSelectedBookId(requestedBookId());
+      setAudioMatchNotice("");
       setPreview(null);
       setResults(null);
     };
@@ -223,11 +319,41 @@ const AddBook = forwardRef(function AddBook(
     return () => window.removeEventListener("popstate", onPopState);
   }, []);
 
+  useEffect(() => {
+    const signature = audioFiles
+      .map((file) => file.webkitRelativePath || file.name)
+      .join("|");
+    if (
+      !signature ||
+      !catalog.length ||
+      selectedBookId ||
+      lastAutoMatchSignatureRef.current === signature
+    ) {
+      return;
+    }
+
+    lastAutoMatchSignatureRef.current = signature;
+    const matchedBook = findFilenameBookMatch(audioFiles, catalog);
+    if (matchedBook) {
+      setSelectedBookId(matchedBook.id);
+      setAudioMatchNotice(
+        `Matched from the filename: ${bookLabel(matchedBook)}. Please confirm before importing.`,
+      );
+    }
+  }, [audioFiles, catalog, selectedBookId]);
+
   const resetInspection = () => {
     setPreview(null);
     setPreviewError("");
     setDuplicatesReviewed(false);
     setResults(null);
+  };
+
+  const chooseAudioFiles = (selectedFiles) => {
+    lastAutoMatchSignatureRef.current = "";
+    setAudioMatchNotice("");
+    setAudioFiles(selectAudiobookFiles(selectedFiles));
+    resetInspection();
   };
 
   const chooseType = (type) => {
@@ -403,6 +529,11 @@ const AddBook = forwardRef(function AddBook(
   const canImport =
     (preview?.ready_count > 0 || preview?.duplicate_count > 0) &&
     (preview.duplicate_count === 0 || duplicatesReviewed);
+  const selectionHeading = {
+    books: "Select book files",
+    web: "Enter source URLs",
+    audiobook: "Match narration to a library book",
+  }[importType];
 
   if (importType === "libation") {
     return (
@@ -422,7 +553,7 @@ const AddBook = forwardRef(function AddBook(
       {!preview && !results && (
         <section className="import-panel" aria-labelledby="import-input-heading">
           <span className="import-step-code">01 / SELECT</span>
-          <h3 id="import-input-heading">Choose what to inspect</h3>
+          <h3 id="import-input-heading">{selectionHeading}</h3>
 
           {importType === "books" && (
             <>
@@ -513,23 +644,23 @@ const AddBook = forwardRef(function AddBook(
 
           {importType === "audiobook" && (
             <div className="import-audiobook-inputs">
-              <label>
-                Attach narration to
-                <select
-                  value={selectedBookId || ""}
-                  onChange={(event) => {
-                    setSelectedBookId(Number(event.target.value) || null);
-                    resetInspection();
-                  }}
-                >
-                  <option value="">Choose a library book</option>
-                  {catalog.map((book) => (
-                    <option key={book.id} value={book.id}>
-                      {book.title} — {book.author || "Unknown author"}
-                    </option>
-                  ))}
-                </select>
-              </label>
+              <BookCombobox
+                books={catalog}
+                selectedBookId={selectedBookId}
+                onSelect={(bookId) => {
+                  lastAutoMatchSignatureRef.current = audioFiles
+                    .map((file) => file.webkitRelativePath || file.name)
+                    .join("|");
+                  setSelectedBookId(bookId);
+                  setAudioMatchNotice("");
+                  resetInspection();
+                }}
+              />
+              {audioMatchNotice && (
+                <p className="import-match-notice" role="status">
+                  {audioMatchNotice}
+                </p>
+              )}
               <label>
                 Edition name (optional)
                 <input
@@ -546,10 +677,7 @@ const AddBook = forwardRef(function AddBook(
                     type="file"
                     multiple
                     accept=".zip,.cue,.m4b,.m4a,.mp3,.mp4,.aac,.flac,.ogg,.opus,.wav,audio/*"
-                    onChange={(event) => {
-                      setAudioFiles(selectAudiobookFiles(event.target.files));
-                      resetInspection();
-                    }}
+                    onChange={(event) => chooseAudioFiles(event.target.files)}
                   />
                 </label>
                 <label>
@@ -560,10 +688,7 @@ const AddBook = forwardRef(function AddBook(
                     multiple
                     webkitdirectory=""
                     directory=""
-                    onChange={(event) => {
-                      setAudioFiles(selectAudiobookFiles(event.target.files));
-                      resetInspection();
-                    }}
+                    onChange={(event) => chooseAudioFiles(event.target.files)}
                   />
                 </label>
               </div>
@@ -730,6 +855,128 @@ function ImportTypePicker({ selected, onSelect }) {
           <span>{item.description}</span>
         </button>
       ))}
+    </div>
+  );
+}
+
+function BookCombobox({ books, selectedBookId, onSelect }) {
+  const [query, setQuery] = useState("");
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const selectedBook = books.find((book) => book.id === selectedBookId);
+  const selectedLabel = selectedBook ? bookLabel(selectedBook) : "";
+  const normalizedQuery = normalizeMatchText(query);
+  const queryTokens = normalizedQuery.split(" ").filter(Boolean);
+  const showingSelectedLabel = selectedLabel && query === selectedLabel;
+  const options = (
+    !normalizedQuery || showingSelectedLabel
+      ? books
+      : books
+          .filter((book) => {
+            const searchable = normalizeMatchText(bookLabel(book));
+            return queryTokens.every((token) => searchable.includes(token));
+          })
+          .sort(
+            (left, right) =>
+              scoreBookSearch(right, normalizedQuery) -
+                scoreBookSearch(left, normalizedQuery) ||
+              bookLabel(left).localeCompare(bookLabel(right)),
+          )
+  ).slice(0, 20);
+
+  useEffect(() => {
+    if (selectedBook) {
+      setQuery(bookLabel(selectedBook));
+    }
+  }, [selectedBook]);
+
+  useEffect(() => {
+    setActiveIndex(-1);
+  }, [query]);
+
+  const chooseBook = (book) => {
+    setQuery(bookLabel(book));
+    setOpen(false);
+    onSelect(book.id);
+  };
+
+  return (
+    <div
+      className="import-book-combobox"
+      onBlur={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget)) {
+          setOpen(false);
+        }
+      }}
+    >
+      <label htmlFor="audiobook-book-search">Attach narration to</label>
+      <input
+        id="audiobook-book-search"
+        type="search"
+        role="combobox"
+        aria-autocomplete="list"
+        aria-expanded={open}
+        aria-controls="audiobook-book-options"
+        aria-activedescendant={
+          open && options[activeIndex]
+            ? `audiobook-book-option-${options[activeIndex].id}`
+            : undefined
+        }
+        placeholder="Search by title or author"
+        autoComplete="off"
+        value={query}
+        onFocus={(event) => {
+          event.currentTarget.select();
+          setOpen(true);
+        }}
+        onChange={(event) => {
+          setQuery(event.target.value);
+          setOpen(true);
+          if (selectedBookId) onSelect(null);
+        }}
+        onKeyDown={(event) => {
+          if (event.key === "ArrowDown") {
+            event.preventDefault();
+            setOpen(true);
+            setActiveIndex((current) =>
+              current < 0 ? 0 : Math.min(current + 1, options.length - 1),
+            );
+          } else if (event.key === "ArrowUp") {
+            event.preventDefault();
+            setOpen(true);
+            setActiveIndex((current) => Math.max(current - 1, 0));
+          } else if (event.key === "Enter" && open && options[activeIndex]) {
+            event.preventDefault();
+            chooseBook(options[activeIndex]);
+          } else if (event.key === "Escape") {
+            setOpen(false);
+          }
+        }}
+      />
+      {open && (
+        <ul
+          id="audiobook-book-options"
+          className="import-book-options"
+          role="listbox"
+          aria-label="Library book matches"
+        >
+          {options.map((book, index) => (
+            <li
+              id={`audiobook-book-option-${book.id}`}
+              key={book.id}
+              role="option"
+              aria-selected={book.id === selectedBookId}
+              className={index === activeIndex ? "import-book-option--active" : ""}
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={() => chooseBook(book)}
+            >
+              <strong>{book.title}</strong>
+              <span>{book.author || "Unknown author"}</span>
+            </li>
+          ))}
+          {!options.length && <li className="import-book-options-empty">No matching books</li>}
+        </ul>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/AddBook.test.jsx
+++ b/frontend/src/components/AddBook.test.jsx
@@ -1,13 +1,22 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react";
-import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import AddBook from "./AddBook.jsx";
 import { renderWithClient } from "../test-utils.jsx";
+
+function jsonResponse(payload, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => payload,
+  };
+}
 
 describe("AddBook", () => {
   const originalFetch = globalThis.fetch;
 
   beforeEach(() => {
+    window.history.replaceState({}, "", "/");
     globalThis.fetch = vi.fn();
   });
 
@@ -15,44 +24,184 @@ describe("AddBook", () => {
     globalThis.fetch = originalFetch;
   });
 
-  it("summarizes mixed import results and shows skipped duplicates separately", async () => {
-    globalThis.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => [
-        {
-          filename: "batch.zip:books/Book One.epub",
-          status: "success",
-          book: { title: "Book One" },
-        },
-        {
-          filename: "batch.zip:books/Book Two.epub",
-          status: "skipped",
-          error: "A book with title 'Book Two' by 'Author' already exists (id=7)",
-        },
-        {
-          filename: "batch.zip:books/Broken.epub",
-          status: "error",
-          error: "Failed to parse EPUB file",
-        },
-      ],
-    });
+  it("requires preflight and duplicate review before importing book files", async () => {
+    globalThis.fetch
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [
+            {
+              key: "file:0:0",
+              name: "batch.zip:Book One.epub",
+              status: "ready",
+              title: "Book One",
+              author: "Author",
+              cleaning_configs: ["Royal Road"],
+            },
+            {
+              key: "file:0:1",
+              name: "batch.zip:Book Two.epub",
+              status: "duplicate",
+              title: "Book Two",
+              author: "Author",
+              detail: "Already in the library as book 7.",
+            },
+            {
+              key: "file:0:2",
+              name: "batch.zip:Broken.epub",
+              status: "error",
+              detail: "Could not read EPUB metadata.",
+            },
+          ],
+          ready_count: 1,
+          duplicate_count: 1,
+          unsupported_count: 0,
+          error_count: 1,
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse([
+          {
+            filename: "batch.zip:Book One.epub",
+            status: "success",
+            book: { title: "Book One" },
+          },
+          {
+            filename: "batch.zip:Book Two.epub",
+            status: "skipped",
+            error: "Already in the library",
+          },
+          {
+            filename: "batch.zip:Broken.epub",
+            status: "error",
+            error: "Failed to parse EPUB file",
+          },
+        ]),
+      );
 
     const { container } = renderWithClient(<AddBook />);
-    const input = container.querySelector("#file-upload");
-    const submit = screen.getByRole("button", { name: "Add Book" });
-    const zipFile = new File(["zip"], "batch.zip", { type: "application/zip" });
-
-    fireEvent.change(input, { target: { files: [zipFile] } });
-    fireEvent.click(submit);
-
-    await waitFor(() => {
-      expect(screen.getByText("Imported 1 of 3 books. 1 skipped. 1 failed.")).toBeInTheDocument();
+    const zipFile = new File(["zip"], "batch.zip", {
+      type: "application/zip",
+    });
+    fireEvent.change(container.querySelector("#file-upload"), {
+      target: { files: [zipFile] },
     });
 
-    expect(screen.getByText("Added: 1 book.")).toBeInTheDocument();
-    expect(screen.getByText("Skipped: 1 book.")).toBeInTheDocument();
-    expect(screen.getByText("Failed: 1 book.")).toBeInTheDocument();
-    expect(screen.getByText((text) => text.includes('"Book Two" by Author is already in your library.'))).toBeInTheDocument();
-    expect(screen.getByText(/Broken\.epub/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Inspect selection" }));
+
+    expect(
+      await screen.findByRole("heading", { name: "Review before importing" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Cleaning: Royal Road")).toBeInTheDocument();
+    const importButton = screen.getByRole("button", { name: "Import 1 ready" });
+    expect(importButton).toBeDisabled();
+
+    fireEvent.click(
+      screen.getByRole("checkbox", {
+        name: "I reviewed the duplicates and want to skip them.",
+      }),
+    );
+    expect(importButton).toBeEnabled();
+    fireEvent.click(importButton);
+
+    expect(
+      await screen.findByRole("heading", { name: "Import results" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Succeeded")).toBeInTheDocument();
+    expect(screen.getByText("Skipped")).toBeInTheDocument();
+    expect(screen.getByText("Failed")).toBeInTheDocument();
+    expect(globalThis.fetch.mock.calls[0][0]).toBe("/api/imports/preview");
+    expect(globalThis.fetch.mock.calls[1][0]).toBe("/api/books/upload_epubs");
+  });
+
+  it("reports durable web work as queued and duplicate URLs as skipped", async () => {
+    globalThis.fetch
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [
+            {
+              key: "url:0",
+              status: "ready",
+              source_url: "https://example.com/new",
+              detail: "Metadata will be collected when the durable web import runs.",
+            },
+            {
+              key: "url:1",
+              status: "duplicate",
+              source_url: "https://example.com/existing",
+              detail: "This source is already attached to Existing Story.",
+            },
+          ],
+          ready_count: 1,
+          duplicate_count: 1,
+          unsupported_count: 0,
+          error_count: 0,
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ title: "New Story" }, 201));
+
+    renderWithClient(<AddBook />);
+    fireEvent.click(screen.getByRole("button", { name: /Web novels/ }));
+    fireEvent.change(screen.getByLabelText("Web novel URL"), {
+      target: { value: "https://example.com/new" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "+ Add another URL" }));
+    fireEvent.change(screen.getByLabelText("Web novel URL 2"), {
+      target: { value: "https://example.com/existing" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Inspect selection" }));
+
+    await screen.findByRole("heading", { name: "Review before importing" });
+    fireEvent.click(
+      screen.getByRole("checkbox", {
+        name: "I reviewed the duplicates and want to skip them.",
+      }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Import 1 ready" }));
+
+    expect(await screen.findByText("Queued")).toBeInTheDocument();
+    expect(screen.getByText("Skipped")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "View Activity" })).toHaveAttribute(
+      "href",
+      "/activity/processing",
+    );
+    expect(JSON.parse(globalThis.fetch.mock.calls[1][1].body)).toEqual({
+      url: "https://example.com/new",
+    });
+  });
+
+  it("requires an explicit library-book match for audiobook imports", async () => {
+    globalThis.fetch
+      .mockResolvedValueOnce(
+        jsonResponse([
+          { id: 42, title: "Matched Book", author: "Narrated Author" },
+        ]),
+      )
+      .mockResolvedValueOnce(jsonResponse({ id: 8, name: "Human edition" }));
+
+    const { container } = renderWithClient(<AddBook />);
+    fireEvent.click(screen.getByRole("button", { name: /Audiobook/ }));
+    await screen.findByRole("option", { name: /Matched Book/ });
+    fireEvent.change(screen.getByLabelText("Attach narration to"), {
+      target: { value: "42" },
+    });
+    fireEvent.change(
+      container.querySelector('input[accept^=".zip"]'),
+      {
+        target: {
+          files: [new File(["audio"], "narration.m4b", { type: "audio/mp4" })],
+        },
+      },
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Inspect selection" }));
+
+    expect(await screen.findByText("Matched Book")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Import 1 ready" }));
+
+    expect(await screen.findByText("Queued")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(globalThis.fetch.mock.calls[1][0]).toBe(
+        "/api/books/42/audiobook/imports",
+      );
+    });
   });
 });

--- a/frontend/src/components/AddBook.test.jsx
+++ b/frontend/src/components/AddBook.test.jsx
@@ -180,10 +180,19 @@ describe("AddBook", () => {
 
     const { container } = renderWithClient(<AddBook />);
     fireEvent.click(screen.getByRole("button", { name: /Audiobook/ }));
-    await screen.findByRole("option", { name: /Matched Book/ });
-    fireEvent.change(screen.getByLabelText("Attach narration to"), {
-      target: { value: "42" },
+    expect(
+      screen.getByRole("heading", {
+        name: "Match narration to a library book",
+      }),
+    ).toBeInTheDocument();
+    const bookSearch = await screen.findByRole("combobox", {
+      name: "Attach narration to",
     });
+    fireEvent.focus(bookSearch);
+    fireEvent.change(bookSearch, { target: { value: "Matched" } });
+    fireEvent.click(
+      await screen.findByRole("option", { name: /Matched Book/ }),
+    );
     fireEvent.change(
       container.querySelector('input[accept^=".zip"]'),
       {
@@ -203,5 +212,90 @@ describe("AddBook", () => {
         "/api/books/42/audiobook/imports",
       );
     });
+  });
+
+  it("suggests a strong library match from the audiobook filename", async () => {
+    globalThis.fetch.mockResolvedValueOnce(
+      jsonResponse([
+        {
+          id: 42,
+          title: "Dungeon Crawler Carl: A LitRPG/Gamelit Adventure",
+          author: "Matt Dinniman",
+        },
+        {
+          id: 43,
+          title: "Carl's Doomsday Scenario: Dungeon Crawler Carl Book 2",
+          author: "Matt Dinniman",
+        },
+      ]),
+    );
+
+    const { container } = renderWithClient(<AddBook />);
+    fireEvent.click(screen.getByRole("button", { name: /Audiobook/ }));
+    const bookSearch = await screen.findByRole("combobox", {
+      name: "Attach narration to",
+    });
+    fireEvent.focus(bookSearch);
+    await screen.findByRole("option", {
+      name: /Dungeon Crawler Carl: A LitRPG\/Gamelit Adventure/,
+    });
+    fireEvent.change(bookSearch, {
+      target: { value: "Dungeon Crawler Carl" },
+    });
+    expect(screen.getAllByRole("option")[0]).toHaveTextContent(
+      "Dungeon Crawler Carl: A LitRPG/Gamelit Adventure",
+    );
+    fireEvent.change(container.querySelector('input[accept^=".zip"]'), {
+      target: {
+        files: [
+          new File(
+            ["audio"],
+            "Dungeon Crawler Carl [B08V8B2CGV].m4b",
+            { type: "audio/mp4" },
+          ),
+        ],
+      },
+    });
+
+    await waitFor(() => {
+      expect(bookSearch).toHaveValue(
+        "Dungeon Crawler Carl: A LitRPG/Gamelit Adventure — Matt Dinniman",
+      );
+    });
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Matched from the filename",
+    );
+    expect(
+      screen.getByRole("button", { name: "Inspect selection" }),
+    ).toBeEnabled();
+  });
+
+  it("leaves ambiguous filename matches for the user to decide", async () => {
+    globalThis.fetch.mockResolvedValueOnce(
+      jsonResponse([
+        { id: 42, title: "Shared Title", author: "First Author" },
+        { id: 43, title: "Shared Title", author: "Second Author" },
+      ]),
+    );
+
+    const { container } = renderWithClient(<AddBook />);
+    fireEvent.click(screen.getByRole("button", { name: /Audiobook/ }));
+    const bookSearch = await screen.findByRole("combobox", {
+      name: "Attach narration to",
+    });
+    fireEvent.change(container.querySelector('input[accept^=".zip"]'), {
+      target: {
+        files: [new File(["audio"], "Shared Title.m4b")],
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Shared Title.m4b")).toBeInTheDocument();
+    });
+    expect(bookSearch).toHaveValue("");
+    expect(screen.queryByText(/Matched from the filename/)).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Inspect selection" }),
+    ).toBeDisabled();
   });
 });

--- a/frontend/src/components/AudiobookPipeline.test.jsx
+++ b/frontend/src/components/AudiobookPipeline.test.jsx
@@ -262,17 +262,8 @@ describe("AudiobookPipeline", () => {
     ).toBeInTheDocument();
   });
 
-  it("uploads a Libation directory without its duplicate MP3 and enables Whisper alignment", async () => {
-    const fetchMock = vi.fn((url, options) => {
-      if (
-        url === "/api/books/11/audiobook/imports" &&
-        options?.method === "POST"
-      ) {
-        return Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve({ id: 20, status: "queued" }),
-        });
-      }
+  it("routes human audiobook imports through the guided workflow with book context", async () => {
+    const fetchMock = vi.fn((url) => {
       if (
         url === "/api/books/11/audiobook/status" ||
         url === "/api/books/11/audiobook/characters" ||
@@ -290,65 +281,16 @@ describe("AudiobookPipeline", () => {
       return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
     });
     globalThis.fetch = fetchMock;
-    const makeFile = (name, relativePath) => {
-      const file = new File(["audio"], name);
-      Object.defineProperty(file, "webkitRelativePath", {
-        value: relativePath,
-      });
-      return file;
-    };
-    const m4b = makeFile(
-      "Dungeon Crawler Carl [B08V8B2CGV].m4b",
-      "Dungeon Crawler Carl [B08V8B2CGV]/Dungeon Crawler Carl [B08V8B2CGV].m4b",
-    );
-    const mp3 = makeFile(
-      "Dungeon Crawler Carl [B08V8B2CGV].mp3",
-      "Dungeon Crawler Carl [B08V8B2CGV]/Dungeon Crawler Carl [B08V8B2CGV].mp3",
-    );
-    const cue = makeFile(
-      "Dungeon Crawler Carl [B08V8B2CGV].cue",
-      "Dungeon Crawler Carl [B08V8B2CGV]/Dungeon Crawler Carl [B08V8B2CGV].cue",
-    );
-    const cover = makeFile(
-      "cover.jpg",
-      "Dungeon Crawler Carl [B08V8B2CGV]/cover.jpg",
-    );
 
     renderWithClient(
       <AudiobookPipeline book={{ id: 11, audiobook_enabled: true }} />,
     );
 
-    fireEvent.change(await screen.findByLabelText("Libation book directory"), {
-      target: { files: [m4b, mp3, cue, cover] },
-    });
     expect(
-      screen.getByText("Ignored 2 duplicate or non-audio files."),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("checkbox", {
-        name: "Improve sentence timestamps with Whisper after matching",
+      await screen.findByRole("link", {
+        name: "Open guided audiobook import",
       }),
-    ).toBeChecked();
-    fireEvent.click(screen.getByRole("button", { name: "Upload & Match" }));
-
-    await waitFor(() => {
-      const uploadCall = fetchMock.mock.calls.find(
-        ([url, options]) =>
-          url === "/api/books/11/audiobook/imports" &&
-          options?.method === "POST",
-      );
-      expect(uploadCall).toBeDefined();
-      const body = uploadCall[1].body;
-      expect(body.getAll("files").map((file) => file.name)).toEqual([
-        m4b.name,
-        cue.name,
-      ]);
-      expect(body.getAll("source_paths")).toEqual([
-        m4b.webkitRelativePath,
-        cue.webkitRelativePath,
-      ]);
-      expect(body.get("auto_align")).toBe("true");
-    });
+    ).toHaveAttribute("href", "/import?type=audiobook&book_id=11");
   });
 
   it("shows model progress and can run exactly one diarization batch", async () => {

--- a/frontend/src/components/Utilities.jsx
+++ b/frontend/src/components/Utilities.jsx
@@ -9,7 +9,6 @@ import {
   rejectMetadataMatch,
 } from "../api/metadata";
 import ReaderKeys from "./ReaderKeys.jsx";
-import LibationBackupImport from "./LibationBackupImport.jsx";
 
 const utilityTabs = [
   { key: "audit", label: "Audit" },
@@ -476,7 +475,18 @@ function Utilities({ onBack }) {
           </section>
         )}
 
-        {activeTab === "audiobooks" && <LibationBackupImport />}
+        {activeTab === "audiobooks" && (
+          <section className="settings-section">
+            <h3>Libation Backup Import</h3>
+            <p className="hint">
+              Preview book matches, resolve ambiguous titles, and queue the
+              selected backup through the guided import workflow.
+            </p>
+            <a className="btn btn-primary" href="/import?type=libation">
+              Open guided Libation import
+            </a>
+          </section>
+        )}
 
         {activeTab === "storage" && (
           <section className="settings-section">

--- a/frontend/src/components/audiobook/AudiobookSources.jsx
+++ b/frontend/src/components/audiobook/AudiobookSources.jsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import {
@@ -8,7 +8,6 @@ import {
   rebuildAudioOnly,
   rematchImportedAudiobook,
   retryImportedAudiobook,
-  uploadImportedAudiobook,
 } from "../../api/audiobook";
 import { chapterLabel } from "../../lib/audiobook";
 
@@ -30,36 +29,6 @@ function importedAtLabel(createdAt) {
   }).format(date)}`;
 }
 
-const AUDIO_EXTENSIONS = new Set([
-  ".aac",
-  ".flac",
-  ".m4a",
-  ".m4b",
-  ".mp3",
-  ".mp4",
-  ".ogg",
-  ".opus",
-  ".wav",
-]);
-const IMPORT_EXTENSIONS = new Set([...AUDIO_EXTENSIONS, ".cue", ".zip"]);
-
-function extension(file) {
-  const index = file.name.lastIndexOf(".");
-  return index < 0 ? "" : file.name.slice(index).toLowerCase();
-}
-
-function selectAudiobookFiles(selectedFiles) {
-  const supported = selectedFiles.filter((file) =>
-    IMPORT_EXTENSIONS.has(extension(file)),
-  );
-  const hasM4b = supported.some((file) => extension(file) === ".m4b");
-  if (!hasM4b) return supported;
-  return supported.filter(
-    (file) =>
-      !AUDIO_EXTENSIONS.has(extension(file)) || extension(file) === ".m4b",
-  );
-}
-
 function AudiobookSources({
   bookId,
   chapters = [],
@@ -69,12 +38,6 @@ function AudiobookSources({
   onEnableAi,
 }) {
   const queryClient = useQueryClient();
-  const inputRef = useRef(null);
-  const directoryInputRef = useRef(null);
-  const [files, setFiles] = useState([]);
-  const [name, setName] = useState("");
-  const [autoAlign, setAutoAlign] = useState(true);
-  const [ignoredFileCount, setIgnoredFileCount] = useState(0);
   const [jobNotice, setJobNotice] = useState("");
   const [confirmAiTtsRebuild, setConfirmAiTtsRebuild] = useState(false);
 
@@ -82,24 +45,6 @@ function AudiobookSources({
     queryClient.invalidateQueries({ queryKey: ["audiobook-imports", bookId] });
     queryClient.invalidateQueries({ queryKey: ["audiobook-chapters", bookId] });
     queryClient.invalidateQueries({ queryKey: ["audiobook-status", bookId] });
-  };
-  const uploadMutation = useMutation({
-    mutationFn: () => uploadImportedAudiobook(bookId, files, name, autoAlign),
-    onSuccess: () => {
-      setJobNotice("Human audiobook import and matching queued.");
-      setFiles([]);
-      setName("");
-      setIgnoredFileCount(0);
-      if (inputRef.current) inputRef.current.value = "";
-      if (directoryInputRef.current) directoryInputRef.current.value = "";
-      invalidate();
-    },
-  });
-  const chooseFiles = (selectedFiles) => {
-    const selected = Array.from(selectedFiles || []);
-    const usable = selectAudiobookFiles(selected);
-    setFiles(usable);
-    setIgnoredFileCount(selected.length - usable.length);
   };
   const retryMutation = useMutation({
     mutationFn: retryImportedAudiobook,
@@ -154,72 +99,12 @@ function AudiobookSources({
             chapter-capable M4B when Libation also created a duplicate MP3.
           </p>
         </div>
-        <label>
-          Edition name (optional)
-          <input
-            value={name}
-            onChange={(event) => setName(event.target.value)}
-            placeholder="For example, Audible / Jeff Hays"
-          />
-        </label>
-        <label>
-          Libation book directory
-          <input
-            ref={directoryInputRef}
-            type="file"
-            multiple
-            webkitdirectory=""
-            directory=""
-            onChange={(event) => chooseFiles(event.target.files)}
-          />
-        </label>
-        <label>
-          Or audiobook file / ZIP
-          <input
-            ref={inputRef}
-            type="file"
-            multiple
-            accept=".zip,.cue,.m4b,.m4a,.mp3,.mp4,.aac,.flac,.ogg,.opus,.wav,audio/*"
-            onChange={(event) => chooseFiles(event.target.files)}
-          />
-        </label>
-        {files.length > 0 && (
-          <p className="audiobook-selected-files">
-            {files.map((file) => file.name).join(", ")}
-          </p>
-        )}
-        {ignoredFileCount > 0 && (
-          <p className="hint">
-            Ignored {ignoredFileCount} duplicate or non-audio{" "}
-            {ignoredFileCount === 1 ? "file" : "files"}.
-          </p>
-        )}
-        <label>
-          <input
-            type="checkbox"
-            checked={autoAlign}
-            onChange={(event) => setAutoAlign(event.target.checked)}
-          />{" "}
-          Improve sentence timestamps with Whisper after matching
-        </label>
-        <button
-          type="button"
-          className="btn-primary"
-          disabled={!files.length || uploadMutation.isPending}
-          onClick={() => uploadMutation.mutate()}
+        <a
+          className="btn btn-primary"
+          href={`/import?type=audiobook&book_id=${bookId}`}
         >
-          {uploadMutation.isPending ? "Uploading…" : "Upload & Match"}
-        </button>
-        {uploadMutation.isPending && (
-          <p className="hint" role="status">
-            Large Libation archives can take a few minutes to transfer. Keep
-            this page open until the upload finishes; matching continues in the
-            background afterward.
-          </p>
-        )}
-        {uploadMutation.isError && (
-          <p className="error">{uploadMutation.error.message}</p>
-        )}
+          Open guided audiobook import
+        </a>
       </section>
 
       <section className="audiobook-ai-source">

--- a/frontend/src/lib/navigation.js
+++ b/frontend/src/lib/navigation.js
@@ -46,6 +46,7 @@ export const SECTION_NAV = {
 
 const ROUTES = [
   { key: "library", path: "/", section: "library" },
+  { key: "import", path: "/import", section: "library" },
   ...SECTION_NAV.activity.map((route) => ({
     ...route,
     section: "activity",

--- a/frontend/src/lib/navigation.test.js
+++ b/frontend/src/lib/navigation.test.js
@@ -29,6 +29,16 @@ describe("application navigation", () => {
     expect(buildTabPath("attention")).toBe("/activity");
   });
 
+  it("keeps the guided import workflow inside the Library section", () => {
+    expect(parseLocation("/import", "", "?type=audiobook")).toEqual({
+      view: "tab",
+      tab: "import",
+      libraryView: "series",
+    });
+    expect(getPrimarySection("import")).toBe("library");
+    expect(buildTabPath("import")).toBe("/import");
+  });
+
   it.each([
     ["/attention", "attention", "/activity"],
     ["/processing", "processing", "/activity/processing"],

--- a/frontend/tests-e2e/EpubEditor.spec.js
+++ b/frontend/tests-e2e/EpubEditor.spec.js
@@ -37,8 +37,8 @@ test("EpubEditor interactions", async ({ page }) => {
   // Delete the book if it exists
   await page.request.delete("/api/books/by-title/Test Book");
 
-  // Expand the Add Books section
-  await page.locator(".add-book-summary").click();
+  // Open the guided import workflow.
+  await page.getByRole("button", { name: "Add to library" }).click();
 
   // Upload a book
   const filePath = path.resolve("test.epub");
@@ -51,11 +51,27 @@ test("EpubEditor interactions", async ({ page }) => {
   );
 
   await Promise.all([
-    page.waitForResponse((r) => r.url().includes("/api/books/upload_epubs") && r.status() === 200),
-    page.getByRole("button", { name: /add book/i }).click(),
+    page.waitForResponse(
+      (response) =>
+        response.url().includes("/api/imports/preview") &&
+        response.status() === 200,
+    ),
+    page.getByRole("button", { name: "Inspect selection" }).click(),
   ]);
 
-  await page.reload();
+  await expect(
+    page.getByRole("heading", { name: "Review before importing" }),
+  ).toBeVisible();
+  await Promise.all([
+    page.waitForResponse(
+      (response) =>
+        response.url().includes("/api/books/upload_epubs") &&
+        response.status() === 200,
+    ),
+    page.getByRole("button", { name: /import 1 ready/i }).click(),
+  ]);
+
+  await page.getByRole("link", { name: "Library", exact: true }).click();
 
   // Narrow the library down so "Test Book" is in the first page (list renders 30 items at a time).
   await page.getByPlaceholder("Search by title, author, series, or tag").fill("Test Book");


### PR DESCRIPTION
## Summary

- add one guided Add to library workflow for EPUBs, ZIPs, folders, web novels, human audiobooks, and Libation backups
- add a read-only import preflight API that surfaces metadata, cleaning rules, duplicates, unsupported inputs, and validation errors before durable work starts
- route the library, audiobook sources, Libation utility, and global file drops into the workflow while preserving the focused import APIs
- report succeeded, skipped, queued, and failed results with a link to durable processing activity
- update focused unit, navigation, and end-to-end coverage

## Validation

- make test (360 backend tests and 69 frontend tests)
- make lint
- npm --prefix frontend run build
- npm run test:e2e -- EpubEditor.spec.js
- desktop and mobile in-app browser pass with no console errors

No database migration is required.