### PR TITLE
Consolidate background execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ In the Unraid web UI, open **Docker**, choose **Add Container**, switch to **Adv
 
 The FanFicFare mapping is optional. If it is present, put custom settings in
 `/mnt/user/appdata/story-manager/fanficfare/personal.ini`. The production image always starts one application worker
-because Story Manager's scheduler and background queues run in process.
+because Story Manager runs its API and PostgreSQL-backed processing workers together by default. Worker concurrency
+can be tuned per resource lane; see `docs/deployment.md`.
 
 For a terminal-based installation, the equivalent command is:
 

--- a/backend/alembic/versions/0032_processing_job_leases.py
+++ b/backend/alembic/versions/0032_processing_job_leases.py
@@ -1,0 +1,222 @@
+"""add processing job resource lanes and leases
+
+Revision ID: 0032
+Revises: 0031
+Create Date: 2026-08-09 00:00:00
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0032"
+down_revision = "0031"
+branch_labels = None
+depends_on = None
+
+_COLUMN_COMMENT = "story-manager:alembic:0032"
+
+_LANES = {
+    "clean_book": "cpu",
+    "clean_all": "cpu",
+    "refresh_book": "maintenance",
+    "refresh_all": "maintenance",
+    "import_web_book": "maintenance",
+    "retry_cover": "maintenance",
+    "metadata_sync": "llm",
+    "audiobook_pipeline": "llm",
+    "generate_sentence_audio": "tts",
+    "generate_chapter_preview": "tts",
+    "import_audiobook": "cpu",
+    "rematch_imported_audiobook": "cpu",
+    "align_imported_audiobook": "transcription",
+}
+
+
+def _columns(conn) -> set[str]:
+    inspector = sa.inspect(conn)
+    if not inspector.has_table("processing_jobs"):
+        return set()
+    return {column["name"] for column in inspector.get_columns("processing_jobs")}
+
+
+def _indexes(conn) -> set[str]:
+    return {index["name"] for index in sa.inspect(conn).get_indexes("processing_jobs")}
+
+
+def upgrade():
+    conn = op.get_bind()
+    if not sa.inspect(conn).has_table("processing_jobs"):
+        return
+
+    columns = _columns(conn)
+    additions = (
+        (
+            "resource_lane",
+            sa.Column("resource_lane", sa.String(), nullable=False, server_default="maintenance", comment=_COLUMN_COMMENT),
+        ),
+        ("max_attempts", sa.Column("max_attempts", sa.Integer(), nullable=False, server_default="3", comment=_COLUMN_COMMENT)),
+        (
+            "available_at",
+            sa.Column(
+                "available_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+                comment=_COLUMN_COMMENT,
+            ),
+        ),
+        ("lease_owner", sa.Column("lease_owner", sa.String(), nullable=True, comment=_COLUMN_COMMENT)),
+        (
+            "lease_expires_at",
+            sa.Column("lease_expires_at", sa.DateTime(timezone=True), nullable=True, comment=_COLUMN_COMMENT),
+        ),
+        ("heartbeat_at", sa.Column("heartbeat_at", sa.DateTime(timezone=True), nullable=True, comment=_COLUMN_COMMENT)),
+    )
+    for name, column in additions:
+        if name not in columns:
+            op.add_column("processing_jobs", column)
+
+    jobs = sa.table(
+        "processing_jobs",
+        sa.column("job_type", sa.String),
+        sa.column("status", sa.String),
+        sa.column("resource_lane", sa.String),
+        sa.column("lease_owner", sa.String),
+        sa.column("lease_expires_at", sa.DateTime(timezone=True)),
+    )
+    for job_type, lane in _LANES.items():
+        conn.execute(jobs.update().where(jobs.c.job_type == job_type).values(resource_lane=lane))
+
+    conn.execute(
+        jobs.update()
+        .where(jobs.c.status == "running")
+        .values(lease_owner="pre-0032-worker", lease_expires_at=sa.func.current_timestamp())
+    )
+
+    if sa.inspect(conn).has_table("books"):
+        books = sa.table(
+            "books",
+            sa.column("id", sa.Integer),
+            sa.column("source_url", sa.String),
+            sa.column("download_status", sa.String),
+        )
+        pending_books = conn.execute(
+            sa.select(books.c.id, books.c.source_url).where(
+                books.c.source_url.is_not(None),
+                books.c.download_status == "pending",
+            )
+        ).fetchall()
+        processing_jobs = sa.table(
+            "processing_jobs",
+            sa.column("job_type", sa.String),
+            sa.column("status", sa.String),
+            sa.column("resource_lane", sa.String),
+            sa.column("book_id", sa.Integer),
+            sa.column("target_type", sa.String),
+            sa.column("target_id", sa.Integer),
+            sa.column("payload", sa.JSON),
+            sa.column("dedupe_key", sa.String),
+            sa.column("progress_detail", sa.String),
+        )
+        for book_id, source_url in pending_books:
+            active = conn.execute(
+                sa.select(processing_jobs.c.target_id).where(
+                    processing_jobs.c.dedupe_key == f"import_web_book:book:{book_id}",
+                    processing_jobs.c.status.in_(("queued", "running")),
+                )
+            ).fetchone()
+            if active is None:
+                conn.execute(
+                    processing_jobs.insert().values(
+                        job_type="import_web_book",
+                        status="queued",
+                        resource_lane="maintenance",
+                        book_id=book_id,
+                        target_type="book",
+                        target_id=book_id,
+                        payload={"source_url": source_url, "legacy_resume": True},
+                        dedupe_key=f"import_web_book:book:{book_id}",
+                        progress_detail="Queued after leased-worker migration",
+                    )
+                )
+
+    # Keep the newest active owner for each idempotency key before enforcing
+    # the invariant at the database boundary.
+    conn.execute(
+        sa.text(
+            "UPDATE processing_jobs SET status = 'canceled', "
+            "progress_detail = 'Superseded during worker consolidation', completed_at = CURRENT_TIMESTAMP "
+            "WHERE id IN ("
+            "SELECT id FROM ("
+            "SELECT id, row_number() OVER (PARTITION BY dedupe_key ORDER BY id DESC) AS position "
+            "FROM processing_jobs WHERE dedupe_key IS NOT NULL AND status IN ('queued', 'running')"
+            ") duplicates WHERE position > 1"
+            ")"
+        )
+    )
+
+    indexes = _indexes(conn)
+    if "ix_processing_jobs_resource_lane" not in indexes:
+        op.create_index("ix_processing_jobs_resource_lane", "processing_jobs", ["resource_lane"])
+    if "ix_processing_jobs_available_at" not in indexes:
+        op.create_index("ix_processing_jobs_available_at", "processing_jobs", ["available_at"])
+    if "ix_processing_jobs_lease_expires_at" not in indexes:
+        op.create_index("ix_processing_jobs_lease_expires_at", "processing_jobs", ["lease_expires_at"])
+    if "ix_processing_jobs_claim" not in indexes:
+        op.create_index(
+            "ix_processing_jobs_claim",
+            "processing_jobs",
+            ["status", "resource_lane", "available_at", "lease_expires_at", "created_at"],
+        )
+    if "uq_processing_jobs_active_dedupe" not in indexes:
+        op.create_index(
+            "uq_processing_jobs_active_dedupe",
+            "processing_jobs",
+            ["dedupe_key"],
+            unique=True,
+            postgresql_where=sa.text("dedupe_key IS NOT NULL AND status IN ('queued', 'running')"),
+            sqlite_where=sa.text("dedupe_key IS NOT NULL AND status IN ('queued', 'running')"),
+        )
+
+
+def downgrade():
+    conn = op.get_bind()
+    if not sa.inspect(conn).has_table("processing_jobs"):
+        return
+    jobs = sa.table(
+        "processing_jobs",
+        sa.column("id", sa.Integer),
+        sa.column("job_type", sa.String),
+        sa.column("payload", sa.JSON),
+        sa.column("progress_detail", sa.String),
+    )
+    seeded_ids = [
+        row.id
+        for row in conn.execute(
+            sa.select(jobs.c.id, jobs.c.payload).where(
+                jobs.c.job_type == "import_web_book",
+                jobs.c.progress_detail == "Queued after leased-worker migration",
+            )
+        )
+        if (row.payload or {}).get("legacy_resume") is True
+    ]
+    if seeded_ids:
+        conn.execute(jobs.delete().where(jobs.c.id.in_(seeded_ids)))
+
+    indexes = _indexes(conn)
+    for name in (
+        "uq_processing_jobs_active_dedupe",
+        "ix_processing_jobs_claim",
+        "ix_processing_jobs_lease_expires_at",
+        "ix_processing_jobs_available_at",
+        "ix_processing_jobs_resource_lane",
+    ):
+        if name in indexes:
+            op.drop_index(name, table_name="processing_jobs")
+
+    columns = {column["name"]: column for column in sa.inspect(conn).get_columns("processing_jobs")}
+    for name in ("heartbeat_at", "lease_expires_at", "lease_owner", "available_at", "max_attempts", "resource_lane"):
+        if columns.get(name, {}).get("comment") == _COLUMN_COMMENT:
+            op.drop_column("processing_jobs", name)

--- a/backend/app/crud/__init__.py
+++ b/backend/app/crud/__init__.py
@@ -95,14 +95,16 @@ from .api_keys import (  # noqa: F401
     revoke_api_key,
 )
 from .processing import (  # noqa: F401
+    claim_processing_job,
     complete_processing_job,
     create_processing_job,
     fail_processing_job,
-    get_pending_processing_jobs,
     get_processing_job,
     get_processing_jobs,
+    heartbeat_processing_job,
     is_processing_job_cancel_requested,
-    mark_processing_job_running,
+    mark_processing_job_canceled,
+    recover_abandoned_processing_jobs,
     request_processing_job_cancel,
     retry_processing_job,
     update_processing_job_progress,

--- a/backend/app/crud/processing.py
+++ b/backend/app/crud/processing.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Iterable
 
-from sqlalchemy import desc, select
+from sqlalchemy import and_, desc, or_, select, update
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..models import Book, ProcessingJob
@@ -24,6 +25,8 @@ async def create_processing_job(
     parent_job_id: int | None = None,
     payload: dict | None = None,
     dedupe_key: str | None = None,
+    resource_lane: str = "maintenance",
+    max_attempts: int = 3,
     progress_detail: str | None = "Queued",
 ) -> tuple[ProcessingJob, bool]:
     """Create a queued job, returning an active duplicate when one exists."""
@@ -32,7 +35,7 @@ async def create_processing_job(
             select(ProcessingJob)
             .where(
                 ProcessingJob.dedupe_key == dedupe_key,
-                ProcessingJob.status == "queued",
+                ProcessingJob.status.in_(ACTIVE_PROCESSING_STATUSES),
             )
             .order_by(desc(ProcessingJob.id))
         )
@@ -50,10 +53,34 @@ async def create_processing_job(
         parent_job_id=parent_job_id,
         payload=payload or {},
         dedupe_key=dedupe_key,
+        resource_lane=resource_lane,
+        max_attempts=max_attempts,
         progress_detail=progress_detail,
     )
     db.add(job)
-    await db.commit()
+    try:
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        if not dedupe_key:
+            raise
+        existing = (
+            (
+                await db.execute(
+                    select(ProcessingJob)
+                    .where(
+                        ProcessingJob.dedupe_key == dedupe_key,
+                        ProcessingJob.status.in_(ACTIVE_PROCESSING_STATUSES),
+                    )
+                    .order_by(desc(ProcessingJob.id))
+                )
+            )
+            .scalars()
+            .first()
+        )
+        if existing is None:
+            raise
+        return existing, False
     await db.refresh(job)
     return job, True
 
@@ -86,40 +113,110 @@ async def get_processing_jobs(
     return list(result.all())
 
 
-async def get_pending_processing_jobs(db: AsyncSession) -> list[ProcessingJob]:
-    result = await db.execute(
-        select(ProcessingJob)
-        .where(ProcessingJob.status.in_(ACTIVE_PROCESSING_STATUSES))
-        .order_by(ProcessingJob.created_at, ProcessingJob.id)
+async def claim_processing_job(
+    db: AsyncSession,
+    *,
+    resource_lane: str,
+    lease_owner: str,
+    lease_seconds: int,
+) -> ProcessingJob | None:
+    """Atomically claim the oldest runnable job in a resource lane."""
+    now = datetime.now(timezone.utc)
+    runnable = or_(
+        and_(ProcessingJob.status == "queued", ProcessingJob.available_at <= now),
+        and_(ProcessingJob.status == "running", ProcessingJob.lease_expires_at <= now),
     )
-    jobs = list(result.scalars().all())
-    for job in jobs:
-        if job.status == "running":
-            job.status = "queued"
-            job.progress_detail = "Queued after restart"
-            job.started_at = None
-    if jobs:
-        await db.commit()
-    return jobs
-
-
-async def mark_processing_job_running(db: AsyncSession, job_id: int) -> ProcessingJob | None:
-    job = await db.get(ProcessingJob, job_id)
-    if job is None or job.status != "queued":
+    query = (
+        select(ProcessingJob)
+        .where(
+            ProcessingJob.resource_lane == resource_lane,
+            ProcessingJob.cancel_requested.is_(False),
+            ProcessingJob.attempt_count < ProcessingJob.max_attempts,
+            runnable,
+        )
+        .order_by(ProcessingJob.available_at, ProcessingJob.created_at, ProcessingJob.id)
+        .limit(1)
+        .with_for_update(skip_locked=True)
+    )
+    job = (await db.execute(query)).scalar_one_or_none()
+    if job is None:
+        await db.rollback()
         return None
-    if job.cancel_requested:
-        job.status = "canceled"
-        job.completed_at = datetime.now(timezone.utc)
-        await db.commit()
-        return None
+
     job.status = "running"
     job.attempt_count = (job.attempt_count or 0) + 1
-    job.started_at = datetime.now(timezone.utc)
+    job.started_at = now
     job.completed_at = None
     job.error = None
+    job.lease_owner = lease_owner
+    job.heartbeat_at = now
+    job.lease_expires_at = now + timedelta(seconds=lease_seconds)
+    job.progress_detail = "Running" if job.attempt_count == 1 else f"Retry attempt {job.attempt_count}"
     await db.commit()
     await db.refresh(job)
     return job
+
+
+async def heartbeat_processing_job(
+    db: AsyncSession,
+    job_id: int,
+    *,
+    lease_owner: str,
+    lease_seconds: int,
+) -> bool:
+    now = datetime.now(timezone.utc)
+    result = await db.execute(
+        update(ProcessingJob)
+        .where(
+            ProcessingJob.id == job_id,
+            ProcessingJob.status == "running",
+            ProcessingJob.lease_owner == lease_owner,
+        )
+        .values(heartbeat_at=now, lease_expires_at=now + timedelta(seconds=lease_seconds))
+    )
+    await db.commit()
+    return bool(result.rowcount)
+
+
+async def recover_abandoned_processing_jobs(db: AsyncSession) -> tuple[int, int]:
+    """Cancel or exhaust expired leases; claimable jobs remain available to workers."""
+    now = datetime.now(timezone.utc)
+    canceled = await db.execute(
+        update(ProcessingJob)
+        .where(
+            ProcessingJob.status == "running",
+            ProcessingJob.lease_expires_at <= now,
+            ProcessingJob.cancel_requested.is_(True),
+        )
+        .values(
+            status="canceled",
+            progress_detail="Canceled after worker lease expired",
+            completed_at=now,
+            lease_owner=None,
+            lease_expires_at=None,
+            heartbeat_at=None,
+        )
+    )
+    exhausted = await db.execute(
+        update(ProcessingJob)
+        .where(
+            ProcessingJob.status == "running",
+            ProcessingJob.lease_expires_at <= now,
+            ProcessingJob.cancel_requested.is_(False),
+            ProcessingJob.attempt_count >= ProcessingJob.max_attempts,
+        )
+        .values(
+            status="error",
+            error="Worker lease expired and the retry limit was reached.",
+            progress_detail="Failed after worker interruption",
+            completed_at=now,
+            lease_owner=None,
+            lease_expires_at=None,
+            heartbeat_at=None,
+        )
+    )
+    await db.commit()
+    return canceled.rowcount or 0, exhausted.rowcount or 0
 
 
 async def update_processing_job_progress(
@@ -142,29 +239,62 @@ async def update_processing_job_progress(
     await db.commit()
 
 
-async def complete_processing_job(db: AsyncSession, job_id: int, detail: str | None = None) -> None:
+async def complete_processing_job(
+    db: AsyncSession,
+    job_id: int,
+    detail: str | None = None,
+    *,
+    lease_owner: str | None = None,
+) -> bool:
     job = await db.get(ProcessingJob, job_id)
-    if job is None:
-        return
+    if job is None or (lease_owner is not None and job.lease_owner != lease_owner):
+        return False
     job.status = "completed"
     job.cancel_requested = False
     job.completed_at = datetime.now(timezone.utc)
+    job.lease_owner = None
+    job.lease_expires_at = None
+    job.heartbeat_at = None
     if detail is not None:
         job.progress_detail = detail
     if job.progress_total:
         job.progress_current = job.progress_total
     await db.commit()
+    return True
 
 
-async def fail_processing_job(db: AsyncSession, job_id: int, error: str) -> None:
+async def fail_processing_job(
+    db: AsyncSession,
+    job_id: int,
+    error: str,
+    *,
+    lease_owner: str | None = None,
+    retry_backoff_seconds: int = 5,
+) -> str | None:
     job = await db.get(ProcessingJob, job_id)
-    if job is None:
-        return
-    job.status = "error"
+    if job is None or (lease_owner is not None and job.lease_owner != lease_owner):
+        return None
+    now = datetime.now(timezone.utc)
     job.error = error
-    job.progress_detail = "Failed"
-    job.completed_at = datetime.now(timezone.utc)
+    job.lease_owner = None
+    job.lease_expires_at = None
+    job.heartbeat_at = None
+    if job.cancel_requested:
+        job.status = "canceled"
+        job.progress_detail = "Canceled"
+        job.completed_at = now
+    elif job.attempt_count < job.max_attempts:
+        delay = retry_backoff_seconds * (2 ** max(0, job.attempt_count - 1))
+        job.status = "queued"
+        job.available_at = now + timedelta(seconds=delay)
+        job.progress_detail = f"Retrying in {delay} seconds"
+        job.completed_at = None
+    else:
+        job.status = "error"
+        job.progress_detail = "Failed"
+        job.completed_at = now
     await db.commit()
+    return job.status
 
 
 async def mark_processing_job_canceled(db: AsyncSession, job_id: int) -> None:
@@ -174,6 +304,9 @@ async def mark_processing_job_canceled(db: AsyncSession, job_id: int) -> None:
     job.status = "canceled"
     job.progress_detail = "Canceled"
     job.completed_at = datetime.now(timezone.utc)
+    job.lease_owner = None
+    job.lease_expires_at = None
+    job.heartbeat_at = None
     await db.commit()
 
 
@@ -198,6 +331,18 @@ async def retry_processing_job(db: AsyncSession, job_id: int) -> ProcessingJob |
     job = await db.get(ProcessingJob, job_id)
     if job is None or job.status not in ("error", "canceled"):
         return None
+    if job.dedupe_key:
+        active = (
+            await db.execute(
+                select(ProcessingJob.id).where(
+                    ProcessingJob.id != job.id,
+                    ProcessingJob.dedupe_key == job.dedupe_key,
+                    ProcessingJob.status.in_(ACTIVE_PROCESSING_STATUSES),
+                )
+            )
+        ).scalar_one_or_none()
+        if active is not None:
+            return None
     job.status = "queued"
     job.cancel_requested = False
     job.error = None
@@ -205,7 +350,16 @@ async def retry_processing_job(db: AsyncSession, job_id: int) -> ProcessingJob |
     job.completed_at = None
     job.progress_current = 0
     job.progress_detail = "Queued for retry"
-    await db.commit()
+    job.attempt_count = 0
+    job.available_at = datetime.now(timezone.utc)
+    job.lease_owner = None
+    job.lease_expires_at = None
+    job.heartbeat_at = None
+    try:
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        return None
     await db.refresh(job)
     return job
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -36,9 +36,7 @@ from .routers import (
     upload,
     web_novels,
 )
-from .services.audiobook_queue import get_audiobook_queue
 from .services.update_scheduler import get_scheduler, schedule_next_metadata_recheck, schedule_next_web_novel_update
-from .services.web_import_queue import get_web_import_queue
 from .services.processing_queue import get_processing_queue
 
 logger = logging.getLogger(__name__)
@@ -60,8 +58,6 @@ class RasterCoverStaticFiles(StaticFiles):
 
 _console_handler, _mem_handler = setup_logging()
 _scheduler = get_scheduler()
-_web_import_queue = get_web_import_queue()
-_audiobook_queue = get_audiobook_queue()
 _processing_queue = get_processing_queue()
 
 
@@ -78,24 +74,17 @@ async def lifespan(app: FastAPI):
     logger.info("Starting up Story Manager services.")
     async with SessionLocal() as db:
         await crud.reset_stuck_update_tasks(db)
-    await _web_import_queue.start()
-    await _audiobook_queue.start()
     await _processing_queue.start()
-    requeued = await _web_import_queue.requeue_pending_books()
-    if requeued:
-        logger.info("Re-queued %s pending web novel imports.", requeued)
     if not is_test_app:
         processing_requeued = await _processing_queue.requeue_pending()
         if processing_requeued:
-            logger.info("Re-queued %s durable processing jobs.", processing_requeued)
+            logger.info("Finalized %s abandoned processing jobs at startup.", processing_requeued)
     if not _scheduler.running:
         _scheduler.start()
     await schedule_next_web_novel_update()
     if not is_test_app:
         await schedule_next_metadata_recheck()
     yield
-    await _web_import_queue.stop()
-    await _audiobook_queue.stop()
     await _processing_queue.stop()
     if _scheduler.running:
         _scheduler.shutdown()

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -14,6 +14,7 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
     event,
+    text,
 )
 from sqlalchemy.sql import func
 from .database import Base
@@ -135,6 +136,7 @@ class ProcessingJob(Base):
     id = Column(Integer, primary_key=True)
     job_type = Column(String, nullable=False, index=True)
     status = Column(String, nullable=False, default="queued", server_default="queued", index=True)
+    resource_lane = Column(String, nullable=False, default="maintenance", server_default="maintenance", index=True)
     book_id = Column(Integer, ForeignKey("books.id", ondelete="CASCADE"), nullable=True, index=True)
     target_type = Column(String, nullable=True)
     target_id = Column(Integer, nullable=True)
@@ -146,12 +148,27 @@ class ProcessingJob(Base):
     progress_total = Column(Integer, nullable=False, default=0, server_default="0")
     progress_detail = Column(String, nullable=True)
     attempt_count = Column(Integer, nullable=False, default=0, server_default="0")
+    max_attempts = Column(Integer, nullable=False, default=3, server_default="3")
+    available_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False, index=True)
+    lease_owner = Column(String, nullable=True)
+    lease_expires_at = Column(DateTime(timezone=True), nullable=True, index=True)
+    heartbeat_at = Column(DateTime(timezone=True), nullable=True)
     cancel_requested = Column(Boolean, nullable=False, default=False, server_default="false")
     error = Column(Text, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False, index=True)
     started_at = Column(DateTime(timezone=True), nullable=True)
     completed_at = Column(DateTime(timezone=True), nullable=True)
     updated_at = Column(DateTime(timezone=True), onupdate=func.now(), nullable=True)
+
+    __table_args__ = (
+        Index(
+            "uq_processing_jobs_active_dedupe",
+            "dedupe_key",
+            unique=True,
+            postgresql_where=text("dedupe_key IS NOT NULL AND status IN ('queued', 'running')"),
+            sqlite_where=text("dedupe_key IS NOT NULL AND status IN ('queued', 'running')"),
+        ),
+    )
 
 
 class SeriesMetadata(Base):

--- a/backend/app/routers/processing.py
+++ b/backend/app/routers/processing.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import crud, schemas
 from ..database import get_db
-from ..services.processing_queue import get_processing_queue, queue_processing_job
+from ..services.processing_queue import queue_processing_job
 
 router = APIRouter()
 
@@ -121,8 +121,6 @@ async def retry_processing_job(job_id: int, db: AsyncSession = Depends(get_db)) 
     job = await crud.retry_processing_job(db, job_id)
     if job is None:
         raise HTTPException(status_code=409, detail="Only failed or canceled jobs can be retried")
-    if get_processing_queue().is_running:
-        await get_processing_queue().enqueue(job.id)
     return _response(job)
 
 

--- a/backend/app/routers/web_novels.py
+++ b/backend/app/routers/web_novels.py
@@ -8,7 +8,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import crud, models, schemas
 from ..database import get_db
-from ..services.web_import_queue import get_web_import_queue
 from ..services.processing_queue import queue_processing_job
 from ..services.refresh_queue import RefreshQueue, get_refresh_queue
 
@@ -32,8 +31,6 @@ async def add_web_novel(
 ) -> models.Book:
     """Creates a pending book record immediately and queues the download."""
     source_url_str = str(request.url)
-    queue = get_web_import_queue()
-
     existing_book = await crud.get_book_by_source_url(db, source_url=source_url_str)
     if existing_book:
         if existing_book.deleted_at is not None:
@@ -49,7 +46,16 @@ async def add_web_novel(
         ):
             logger.info("Retrying failed web import placeholder for %s (book_id=%s).", source_url_str, existing_book.id)
             retried_book = await crud.reset_failed_web_book_for_retry(db, existing_book, source_url_str)
-            await queue.enqueue(retried_book.id, source_url_str)
+            await queue_processing_job(
+                db=db,
+                job_type="import_web_book",
+                book_id=retried_book.id,
+                target_type="book",
+                target_id=retried_book.id,
+                payload={"source_url": source_url_str},
+                dedupe_key=f"import_web_book:book:{retried_book.id}",
+                progress_detail="Queued web book import retry",
+            )
             return retried_book
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -64,7 +70,16 @@ async def add_web_novel(
         download_status="pending",
     )
     db_book = await crud.create_book(db=db, book=book_to_create)
-    await queue.enqueue(db_book.id, source_url_str)
+    await queue_processing_job(
+        db=db,
+        job_type="import_web_book",
+        book_id=db_book.id,
+        target_type="book",
+        target_id=db_book.id,
+        payload={"source_url": source_url_str},
+        dedupe_key=f"import_web_book:book:{db_book.id}",
+        progress_detail="Queued web book import",
+    )
     return db_book
 
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -392,6 +392,7 @@ class ProcessingJob(BaseModel):
     id: int
     job_type: str
     status: str
+    resource_lane: str
     book_id: Optional[int] = None
     book_title: Optional[str] = None
     target_type: Optional[str] = None
@@ -403,6 +404,10 @@ class ProcessingJob(BaseModel):
     progress_total: int
     progress_detail: Optional[str] = None
     attempt_count: int
+    max_attempts: int
+    available_at: datetime
+    lease_expires_at: Optional[datetime] = None
+    heartbeat_at: Optional[datetime] = None
     cancel_requested: bool
     error: Optional[str] = None
     created_at: datetime

--- a/backend/app/services/audiobook_queue.py
+++ b/backend/app/services/audiobook_queue.py
@@ -58,7 +58,16 @@ class AudiobookQueue:
         if self._worker_task and not self._worker_task.done():
             return
         self._worker_task = asyncio.create_task(self._run(), name="audiobook-worker")
-        worker_count = max(1, int(os.getenv("AUDIOBOOK_TTS_WORKERS", "1")))
+        await self.start_background_audio()
+
+    async def start_background_audio(self) -> None:
+        """Start internal TTS batching used by leased processing jobs."""
+        if self._background_audio_tasks:
+            return
+        worker_count = max(
+            1,
+            int(os.getenv("PROCESSING_TTS_CONCURRENCY", os.getenv("AUDIOBOOK_TTS_WORKERS", "1"))),
+        )
         self._background_audio_tasks = [
             asyncio.create_task(
                 self._run_background_audio(),
@@ -70,19 +79,23 @@ class AudiobookQueue:
     async def stop(self) -> None:
         if not self._worker_task:
             return
-        tasks = [self._worker_task, *self._background_audio_tasks]
-        for task in tasks:
-            task.cancel()
-        await asyncio.gather(*tasks, return_exceptions=True)
+        self._worker_task.cancel()
+        await asyncio.gather(self._worker_task, return_exceptions=True)
         self._worker_task = None
-        self._background_audio_tasks.clear()
+        await self.stop_background_audio()
         self._queue = asyncio.Queue()
-        self._background_audio_queue = asyncio.PriorityQueue()
-        self._background_audio_sequence = itertools.count()
         self._queued_book_ids.clear()
         self._rerun_book_ids.clear()
         self._queued_preview_ids.clear()
         self._queued_sentence_ids.clear()
+
+    async def stop_background_audio(self) -> None:
+        for task in self._background_audio_tasks:
+            task.cancel()
+        await asyncio.gather(*self._background_audio_tasks, return_exceptions=True)
+        self._background_audio_tasks.clear()
+        self._background_audio_queue = asyncio.PriorityQueue()
+        self._background_audio_sequence = itertools.count()
         self._background_audio_ids.clear()
 
     async def enqueue(self, book_id: int) -> bool:

--- a/backend/app/services/processing_queue.py
+++ b/backend/app/services/processing_queue.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-from contextlib import asynccontextmanager
-from typing import AsyncIterator, Awaitable, Callable, TypeVar
+import socket
+from typing import Awaitable, Callable, TypeVar
+from uuid import uuid4
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -25,31 +26,75 @@ from .metadata_jobs import process_metadata_sync_job
 from .transcription_providers import transcription_provider_name
 from .update_scheduler import run_web_novel_update
 from .web_novel import run_book_refresh
+from .web_novel import finish_web_novel_download
 
 logger = logging.getLogger(__name__)
 
 _Result = TypeVar("_Result")
+
+RESOURCE_LANES = ("cpu", "maintenance", "llm", "tts", "transcription")
+JOB_POLICIES: dict[str, tuple[str, int]] = {
+    "clean_book": ("cpu", 3),
+    "clean_all": ("cpu", 3),
+    "refresh_book": ("maintenance", 3),
+    "refresh_all": ("maintenance", 3),
+    "import_web_book": ("maintenance", 3),
+    "retry_cover": ("maintenance", 3),
+    "metadata_sync": ("llm", 3),
+    "audiobook_pipeline": ("llm", 3),
+    "generate_sentence_audio": ("tts", 3),
+    "generate_chapter_preview": ("tts", 3),
+    "import_audiobook": ("cpu", 3),
+    "rematch_imported_audiobook": ("cpu", 3),
+    "align_imported_audiobook": ("transcription", 3),
+}
+
+
+def _positive_int_env(name: str, default: int) -> int:
+    try:
+        return max(1, int(os.getenv(name, str(default))))
+    except ValueError:
+        logger.warning("Ignoring invalid %s; using %s.", name, default)
+        return default
+
+
+def _positive_float_env(name: str, default: float) -> float:
+    try:
+        return max(0.1, float(os.getenv(name, str(default))))
+    except ValueError:
+        logger.warning("Ignoring invalid %s; using %s.", name, default)
+        return default
 
 
 class ProcessingQueue:
     """A durable ledger backed by a small set of resource-aware workers."""
 
     def __init__(self) -> None:
-        self._queue: asyncio.Queue[int | None] = asyncio.Queue()
-        self._queued_ids: set[int] = set()
         self._worker_tasks: list[asyncio.Task[None]] = []
-        self._lanes = {
-            "audiobook": asyncio.Semaphore(1),
-            "maintenance": asyncio.Semaphore(1),
-        }
+        self._wake = asyncio.Event()
+        self._instance_id = f"{socket.gethostname()}:{os.getpid()}:{uuid4().hex[:8]}"
+        self._lease_seconds = _positive_int_env("PROCESSING_LEASE_SECONDS", 60)
+        self._heartbeat_seconds = min(
+            _positive_int_env("PROCESSING_HEARTBEAT_SECONDS", 15),
+            max(1, self._lease_seconds // 2),
+        )
+        self._poll_seconds = _positive_float_env("PROCESSING_POLL_SECONDS", 1)
+        self._retry_backoff_seconds = _positive_int_env("PROCESSING_RETRY_BACKOFF_SECONDS", 5)
 
     async def start(self) -> None:
         if self._worker_tasks:
             return
-        worker_count = max(1, int(os.getenv("PROCESSING_WORKERS", "3")))
-        self._worker_tasks = [
-            asyncio.create_task(self._run(), name=f"processing-worker-{index + 1}") for index in range(worker_count)
-        ]
+        for lane in RESOURCE_LANES:
+            count = _positive_int_env(f"PROCESSING_{lane.upper()}_CONCURRENCY", 1)
+            for index in range(count):
+                self._worker_tasks.append(
+                    asyncio.create_task(
+                        self._run(lane, index + 1),
+                        name=f"processing-{lane}-worker-{index + 1}",
+                    )
+                )
+        await get_audiobook_queue().start_background_audio()
+        self._wake.set()
 
     @property
     def is_running(self) -> bool:
@@ -62,72 +107,100 @@ class ProcessingQueue:
             task.cancel()
         await asyncio.gather(*self._worker_tasks, return_exceptions=True)
         self._worker_tasks.clear()
-        self._queued_ids.clear()
-        self._queue = asyncio.Queue()
+        await get_audiobook_queue().stop_background_audio()
+        self._wake = asyncio.Event()
 
     async def enqueue(self, job_id: int) -> bool:
-        if job_id in self._queued_ids:
-            return False
-        self._queued_ids.add(job_id)
-        await self._queue.put(job_id)
+        """Wake database pollers; the job ID is never held as queue ownership."""
+        del job_id
+        self._wake.set()
         return True
 
     async def requeue_pending(self) -> int:
         async with SessionLocal() as db:
-            jobs = await crud.get_pending_processing_jobs(db)
-        return sum([await self.enqueue(job.id) for job in jobs])
+            canceled, exhausted = await crud.recover_abandoned_processing_jobs(db)
+        self._wake.set()
+        return canceled + exhausted
 
-    @asynccontextmanager
-    async def _lane(self, job_type: str) -> AsyncIterator[None]:
-        if job_type in {
-            "audiobook_pipeline",
-            "import_audiobook",
-            "rematch_imported_audiobook",
-            "align_imported_audiobook",
-            "generate_sentence_audio",
-            "generate_chapter_preview",
-        }:
-            semaphore = self._lanes["audiobook"]
-        elif job_type in {"clean_all", "refresh_all"}:
-            semaphore = self._lanes["maintenance"]
-        else:
-            semaphore = None
-        if semaphore is None:
-            yield
-        else:
-            async with semaphore:
-                yield
-
-    async def _run(self) -> None:
+    async def _run(self, lane: str, worker_number: int) -> None:
+        lease_owner = f"{self._instance_id}:{lane}:{worker_number}"
         while True:
-            job_id = await self._queue.get()
-            try:
-                if job_id is None:
-                    return
-                async with SessionLocal() as db:
-                    job = await crud.mark_processing_job_running(db, job_id)
-                if job is None:
-                    continue
+            async with SessionLocal() as db:
+                await crud.recover_abandoned_processing_jobs(db)
+                job = await crud.claim_processing_job(
+                    db,
+                    resource_lane=lane,
+                    lease_owner=lease_owner,
+                    lease_seconds=self._lease_seconds,
+                )
+            if job is None:
+                self._wake.clear()
                 try:
-                    async with self._lane(job.job_type):
-                        async with SessionLocal() as db:
-                            if await crud.is_processing_job_cancel_requested(db, job.id):
-                                await crud.mark_processing_job_canceled(db, job.id)
-                                continue
-                        detail = await self._execute(job)
-                    async with SessionLocal() as db:
-                        if await crud.is_processing_job_cancel_requested(db, job.id):
-                            await crud.mark_processing_job_canceled(db, job.id)
-                        else:
-                            await crud.complete_processing_job(db, job.id, detail)
-                except Exception as exc:
-                    logger.exception("Processing job %s (%s) failed.", job.id, job.job_type)
-                    async with SessionLocal() as db:
-                        await crud.fail_processing_job(db, job.id, str(exc))
-            finally:
-                if job_id is not None:
-                    self._queued_ids.discard(job_id)
-                self._queue.task_done()
+                    await asyncio.wait_for(self._wake.wait(), timeout=self._poll_seconds)
+                except asyncio.TimeoutError:
+                    pass
+                continue
+
+            try:
+                detail = await self._execute_with_heartbeat(job, lease_owner)
+                async with SessionLocal() as db:
+                    if await crud.is_processing_job_cancel_requested(db, job.id):
+                        await crud.mark_processing_job_canceled(db, job.id)
+                    else:
+                        await crud.complete_processing_job(db, job.id, detail, lease_owner=lease_owner)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.exception("Processing job %s (%s) failed.", job.id, job.job_type)
+                async with SessionLocal() as db:
+                    status = await crud.fail_processing_job(
+                        db,
+                        job.id,
+                        str(exc),
+                        lease_owner=lease_owner,
+                        retry_backoff_seconds=self._retry_backoff_seconds,
+                    )
+                if status == "queued":
+                    self._wake.set()
+
+    async def _execute_with_heartbeat(self, job: ProcessingJob, lease_owner: str) -> str:
+        operation = asyncio.create_task(self._execute(job), name=f"processing-operation-{job.id}")
+        heartbeat = asyncio.create_task(
+            self._heartbeat(job.id, lease_owner),
+            name=f"processing-heartbeat-{job.id}",
+        )
+        try:
+            done, _pending = await asyncio.wait({operation, heartbeat}, return_when=asyncio.FIRST_COMPLETED)
+            if operation in done:
+                return await operation
+            reason = await heartbeat
+            operation.cancel()
+            await asyncio.gather(operation, return_exceptions=True)
+            if reason == "canceled":
+                raise RuntimeError("Processing job was canceled.")
+            raise RuntimeError("Processing job lease ownership was lost.")
+        except asyncio.CancelledError:
+            operation.cancel()
+            await asyncio.gather(operation, return_exceptions=True)
+            raise
+        finally:
+            heartbeat.cancel()
+            await asyncio.gather(heartbeat, return_exceptions=True)
+
+    async def _heartbeat(self, job_id: int, lease_owner: str) -> str:
+        while True:
+            await asyncio.sleep(self._heartbeat_seconds)
+            async with SessionLocal() as db:
+                if await crud.is_processing_job_cancel_requested(db, job_id):
+                    return "canceled"
+                renewed = await crud.heartbeat_processing_job(
+                    db,
+                    job_id,
+                    lease_owner=lease_owner,
+                    lease_seconds=self._lease_seconds,
+                )
+            if not renewed:
+                return "lost"
 
     async def _execute(self, job: ProcessingJob) -> str:
         payload = job.payload or {}
@@ -146,6 +219,22 @@ class ProcessingQueue:
                     raise RuntimeError("Book refresh failed; check the application logs.")
                 await crud.update_processing_job_progress(db, job.id, current=1, total=1, detail="Web book refreshed")
             return "Book refresh completed"
+        if job.job_type == "import_web_book":
+            if job.book_id is None:
+                raise ValueError("Web import job has no book.")
+            source_url = str(payload.get("source_url") or "")
+            if not source_url:
+                raise ValueError("Web import job has no source URL.")
+            await self._update_progress(job.id, 0, 1, "Downloading web book")
+            await finish_web_novel_download(job.book_id, source_url)
+            async with SessionLocal() as db:
+                book = await db.get(Book, job.book_id)
+                if book is None:
+                    raise ValueError("Web import book no longer exists.")
+                if book.download_status == "error":
+                    raise RuntimeError(f"Web import failed: {book.title}")
+                await crud.update_processing_job_progress(db, job.id, current=1, total=1, detail="Web book imported")
+            return "Web book import completed"
         if job.job_type == "refresh_all":
 
             async def refresh_all() -> bool:
@@ -550,6 +639,10 @@ async def queue_processing_job(
     dedupe_key: str | None = None,
     progress_detail: str | None = "Queued",
 ) -> ProcessingJob:
+    try:
+        resource_lane, max_attempts = JOB_POLICIES[job_type]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported processing job type: {job_type}") from exc
     owns_session = db is None
     session = db or SessionLocal()
     try:
@@ -563,6 +656,8 @@ async def queue_processing_job(
             parent_job_id=parent_job_id,
             payload=payload,
             dedupe_key=dedupe_key,
+            resource_lane=resource_lane,
+            max_attempts=max_attempts,
             progress_detail=progress_detail,
         )
         if created and get_processing_queue().is_running:

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -4,6 +4,7 @@ import zipfile
 from datetime import datetime, timedelta, timezone
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
 from sqlalchemy.pool import StaticPool
 from pathlib import Path
@@ -1049,16 +1050,11 @@ async def test_static_cover_files_reject_active_formats(db_session):
 
 
 @pytest.mark.asyncio
-async def test_add_web_novel(db_session, mocker):
+async def test_add_web_novel(db_session):
     """
     Test adding a new web novel. The endpoint returns immediately with a pending record
-    and enqueues the actual download onto the app-scoped worker queue.
+    and records the actual download in the durable processing ledger.
     """
-    queue = mocker.Mock()
-    queue.enqueue = mocker.AsyncMock(return_value=True)
-
-    mocker.patch("backend.app.routers.web_novels.get_web_import_queue", return_value=queue)
-
     payload = {"url": "http://example.com/story/123"}
     response = client.post("/api/books/add_web_novel", json=payload)
 
@@ -1068,7 +1064,13 @@ async def test_add_web_novel(db_session, mocker):
     assert data["source_url"] == "http://example.com/story/123"
     assert data["immutable_path"] is None
     assert data["current_path"] is None
-    queue.enqueue.assert_awaited_once_with(data["id"], "http://example.com/story/123")
+    async with AsyncTestingSessionLocal() as session:
+        job = (
+            await session.execute(select(models.ProcessingJob).where(models.ProcessingJob.book_id == data["id"]))
+        ).scalar_one()
+        assert job.job_type == "import_web_book"
+        assert job.resource_lane == "maintenance"
+        assert job.payload["source_url"] == "http://example.com/story/123"
 
     # Verify that the pending book appears in the book list
     response = client.get("/api/books")
@@ -1104,11 +1106,7 @@ async def test_add_existing_web_novel(db_session):
 
 
 @pytest.mark.asyncio
-async def test_add_failed_web_novel_retries_placeholder(db_session, mocker):
-    queue = mocker.Mock()
-    queue.enqueue = mocker.AsyncMock(return_value=True)
-    mocker.patch("backend.app.routers.web_novels.get_web_import_queue", return_value=queue)
-
+async def test_add_failed_web_novel_retries_placeholder(db_session):
     async with AsyncTestingSessionLocal() as session:
         book = await crud.create_book(
             session,
@@ -1128,7 +1126,10 @@ async def test_add_failed_web_novel_retries_placeholder(db_session, mocker):
     assert data["id"] == book.id
     assert data["download_status"] == "pending"
     assert data["title"] == "https://example.com/story/retry"
-    queue.enqueue.assert_awaited_once_with(book.id, "https://example.com/story/retry")
+    async with AsyncTestingSessionLocal() as session:
+        job = (await session.execute(select(models.ProcessingJob).where(models.ProcessingJob.book_id == book.id))).scalar_one()
+        assert job.job_type == "import_web_book"
+        assert job.payload["source_url"] == "https://example.com/story/retry"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_processing_jobs.py
+++ b/backend/tests/test_processing_jobs.py
@@ -1,6 +1,7 @@
 """Tests for the durable processing ledger and audio invalidation graph."""
 
 import asyncio
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from sqlalchemy import select
@@ -16,7 +17,200 @@ from backend.app.models import (
     SourceType,
 )
 from backend.app.services import processing_queue as processing_queue_module
-from backend.app.services.processing_queue import ProcessingQueue, queue_audio_reconciliation
+from backend.app.services.processing_queue import ProcessingQueue, queue_audio_reconciliation, queue_processing_job
+
+
+@pytest.mark.asyncio
+async def test_processing_jobs_use_explicit_resource_policies(sqlite_sessionmaker):
+    expected = {
+        "clean_book": "cpu",
+        "refresh_book": "maintenance",
+        "metadata_sync": "llm",
+        "generate_sentence_audio": "tts",
+        "align_imported_audiobook": "transcription",
+    }
+    async with sqlite_sessionmaker() as db:
+        for index, (job_type, lane) in enumerate(expected.items(), start=1):
+            job = await queue_processing_job(
+                db=db,
+                job_type=job_type,
+                dedupe_key=f"lane-test-{index}",
+            )
+            assert job.resource_lane == lane
+            assert job.max_attempts == 3
+
+
+@pytest.mark.asyncio
+async def test_processing_job_claim_is_exclusive_and_heartbeated(sqlite_sessionmaker):
+    async with sqlite_sessionmaker() as db:
+        job, _created = await crud.create_processing_job(
+            db,
+            job_type="clean_book",
+            resource_lane="cpu",
+        )
+
+    async with sqlite_sessionmaker() as db:
+        claimed = await crud.claim_processing_job(
+            db,
+            resource_lane="cpu",
+            lease_owner="worker-one",
+            lease_seconds=30,
+        )
+        assert claimed is not None
+        assert claimed.id == job.id
+        first_expiry = claimed.lease_expires_at
+
+    async with sqlite_sessionmaker() as db:
+        assert (
+            await crud.claim_processing_job(
+                db,
+                resource_lane="cpu",
+                lease_owner="worker-two",
+                lease_seconds=30,
+            )
+            is None
+        )
+        assert await crud.heartbeat_processing_job(
+            db,
+            job.id,
+            lease_owner="worker-one",
+            lease_seconds=60,
+        )
+        renewed = await db.get(ProcessingJob, job.id)
+        assert renewed.lease_expires_at > first_expiry
+
+
+@pytest.mark.asyncio
+async def test_expired_processing_job_is_reclaimed_until_attempt_limit(sqlite_sessionmaker):
+    expired = datetime.now(timezone.utc) - timedelta(seconds=1)
+    async with sqlite_sessionmaker() as db:
+        job, _created = await crud.create_processing_job(
+            db,
+            job_type="refresh_book",
+            resource_lane="maintenance",
+            max_attempts=2,
+        )
+        job.status = "running"
+        job.attempt_count = 1
+        job.lease_owner = "dead-worker"
+        job.lease_expires_at = expired
+        await db.commit()
+        job_id = job.id
+
+    async with sqlite_sessionmaker() as db:
+        reclaimed = await crud.claim_processing_job(
+            db,
+            resource_lane="maintenance",
+            lease_owner="replacement-worker",
+            lease_seconds=30,
+        )
+        assert reclaimed is not None
+        assert reclaimed.id == job_id
+        assert reclaimed.attempt_count == 2
+        reclaimed.lease_expires_at = expired
+        await db.commit()
+
+    async with sqlite_sessionmaker() as db:
+        _canceled, exhausted = await crud.recover_abandoned_processing_jobs(db)
+        assert exhausted == 1
+        failed = await db.get(ProcessingJob, job_id)
+        assert failed.status == "error"
+        assert "retry limit" in failed.error
+
+
+@pytest.mark.asyncio
+async def test_processing_failure_backoff_and_manual_retry_reset(sqlite_sessionmaker):
+    async with sqlite_sessionmaker() as db:
+        job, _created = await crud.create_processing_job(
+            db,
+            job_type="metadata_sync",
+            resource_lane="llm",
+        )
+        claimed = await crud.claim_processing_job(
+            db,
+            resource_lane="llm",
+            lease_owner="worker",
+            lease_seconds=30,
+        )
+        assert claimed is not None
+        status = await crud.fail_processing_job(
+            db,
+            job.id,
+            "provider unavailable",
+            lease_owner="worker",
+            retry_backoff_seconds=5,
+        )
+        assert status == "queued"
+        await db.refresh(job)
+        available_at = job.available_at.replace(tzinfo=timezone.utc)
+        assert available_at > datetime.now(timezone.utc)
+
+        job.status = "error"
+        await db.commit()
+        retried = await crud.retry_processing_job(db, job.id)
+        assert retried is not None
+        assert retried.attempt_count == 0
+        retry_at = retried.available_at.replace(tzinfo=timezone.utc)
+        assert retry_at <= datetime.now(timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_active_processing_job_deduplication_includes_running(sqlite_sessionmaker):
+    async with sqlite_sessionmaker() as db:
+        first, created = await crud.create_processing_job(
+            db,
+            job_type="clean_all",
+            resource_lane="cpu",
+            dedupe_key="clean-all",
+        )
+        assert created
+        first.status = "running"
+        await db.commit()
+
+        duplicate, created = await crud.create_processing_job(
+            db,
+            job_type="clean_all",
+            resource_lane="cpu",
+            dedupe_key="clean-all",
+        )
+        assert not created
+        assert duplicate.id == first.id
+
+
+@pytest.mark.asyncio
+async def test_canceled_abandoned_job_is_not_reclaimed(sqlite_sessionmaker):
+    async with sqlite_sessionmaker() as db:
+        job, _created = await crud.create_processing_job(
+            db,
+            job_type="refresh_all",
+            resource_lane="maintenance",
+        )
+        claimed = await crud.claim_processing_job(
+            db,
+            resource_lane="maintenance",
+            lease_owner="stopped-worker",
+            lease_seconds=30,
+        )
+        assert claimed is not None
+        await crud.request_processing_job_cancel(db, job.id)
+        claimed.lease_expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+        await db.commit()
+
+    async with sqlite_sessionmaker() as db:
+        canceled, _exhausted = await crud.recover_abandoned_processing_jobs(db)
+        assert canceled == 1
+        recovered = await db.get(ProcessingJob, job.id)
+        assert recovered.status == "canceled"
+        assert recovered.lease_owner is None
+        assert (
+            await crud.claim_processing_job(
+                db,
+                resource_lane="maintenance",
+                lease_owner="replacement-worker",
+                lease_seconds=30,
+            )
+            is None
+        )
 
 
 @pytest.mark.asyncio

--- a/docs/IMPROVEMENT_ROADMAP.md
+++ b/docs/IMPROVEMENT_ROADMAP.md
@@ -91,7 +91,7 @@ The design should cover book deletion, bulk deletion, chapter removal, cleaning-
 
 ## 5. Server-side catalog pagination and filtering
 
-**Status:** In progress
+**Status:** Complete
 
 Stop loading the entire library for every catalog view. Introduce cursor-based pagination, server-side filtering, stable sorting, and aggregate facet counts while preserving the current series-oriented presentation.
 
@@ -108,7 +108,7 @@ Search should use PostgreSQL indexes suited to title, author, series, and tag lo
 
 ## 6. Consolidated background execution
 
-**Status:** Planned
+**Status:** In progress
 
 Complete the transition from specialized in-memory queues to the durable processing-job ledger. The API process should enqueue work, while a unified worker claims and executes jobs using explicit resource lanes.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -18,9 +18,31 @@ The default `docker-compose.yml` stores persistent data under `./config`:
 
 The production image runs PostgreSQL inside the app container for simple self-hosting. If you split PostgreSQL into a separate service, set `DATABASE_URL` for the app container.
 
-Story Manager's production image always starts one application worker because its scheduler and background queues
-run in process. The worker count is intentionally not configurable until distributed job coordination is
-implemented.
+Story Manager keeps a single-container deployment by default: the API, scheduler, and processing workers start in
+the same application process. Processing ownership lives in PostgreSQL rather than process memory, so an interrupted
+job is reclaimed after its lease expires and multiple application processes can claim different jobs safely.
+
+Each kind of constrained work has its own concurrency setting. All values default to `1`:
+
+| Variable | Work controlled |
+|---|---|
+| `PROCESSING_CPU_CONCURRENCY` | EPUB cleaning, audiobook import, and chapter matching |
+| `PROCESSING_MAINTENANCE_CONCURRENCY` | Web imports, refreshes, covers, and scheduled maintenance |
+| `PROCESSING_LLM_CONCURRENCY` | Metadata and AI audiobook analysis jobs |
+| `PROCESSING_TTS_CONCURRENCY` | Speech and chapter-preview generation |
+| `PROCESSING_TRANSCRIPTION_CONCURRENCY` | Human-audiobook timestamp alignment |
+
+Operational tuning is also available through `PROCESSING_LEASE_SECONDS` (default `60`),
+`PROCESSING_HEARTBEAT_SECONDS` (default `15`), `PROCESSING_POLL_SECONDS` (default `1`), and
+`PROCESSING_RETRY_BACKOFF_SECONDS` (default `5`). A failed job is attempted at most three times with exponential
+backoff. User-triggered retry resets that attempt budget. Cancellation is immediate for queued jobs and cooperative
+at heartbeat/progress boundaries for running jobs.
+
+Every job type has one resource lane and a stable deduplication key for its target. PostgreSQL rejects a second
+queued or running job with that key, while terminal history is retained. Handlers resume from persisted book,
+metadata, and audiobook state, so a worker can safely reclaim an expired lease instead of depending on an in-memory
+queue notification. Claims use row locks with `SKIP LOCKED`; only the current lease owner may heartbeat or finish a
+job.
 
 ## Admin Authentication
 


### PR DESCRIPTION
## Summary

- replace process-local processing ownership with atomic PostgreSQL claims, leases, and heartbeats
- add explicit CPU, maintenance, LLM, TTS, and transcription lanes with independent concurrency settings
- apply bounded retries with exponential backoff, cooperative cancellation, crash recovery, and database-enforced active-job deduplication
- move web imports into the durable processing ledger and retire production startup of the specialized in-memory queues
- preserve the single-container deployment and migrate pending legacy work safely

## Validation

- `make pr-check`
- `make test` (372 backend tests, 72 frontend tests)
- `make e2e` (4 Playwright tests)
- `make test-migrations`
- PostgreSQL 16 existing-data upgrade with active duplicate jobs, running jobs, and a pending legacy web import; verified downgrade removes migration-seeded work
- local API health and processing-job response smoke test on port 8000