### PR TITLE
Centralize application lifecycle state machines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,19 @@ test-migrations:
 	DATABASE_URL="postgresql+psycopg://postgres:postgres@localhost:5433/story_manager" \
 	PYTHONPATH=. .venv/bin/alembic -c backend/alembic.ini downgrade 0023; \
 	docker exec -i story-manager-migration-test psql -v ON_ERROR_STOP=1 -U postgres -d story_manager \
-		< scripts/migration-preexisting-audiobook-verify.sql
+		< scripts/migration-preexisting-audiobook-verify.sql; \
+	DATABASE_URL="postgresql+psycopg://postgres:postgres@localhost:5433/story_manager" \
+	PYTHONPATH=. .venv/bin/alembic -c backend/alembic.ini upgrade 0032; \
+	docker exec -i story-manager-migration-test psql -v ON_ERROR_STOP=1 -U postgres -d story_manager \
+		< scripts/migration-lifecycle-setup.sql; \
+	DATABASE_URL="postgresql+psycopg://postgres:postgres@localhost:5433/story_manager" \
+	PYTHONPATH=. .venv/bin/alembic -c backend/alembic.ini upgrade head; \
+	docker exec -i story-manager-migration-test psql -v ON_ERROR_STOP=1 -U postgres -d story_manager \
+		< scripts/migration-lifecycle-verify.sql; \
+	DATABASE_URL="postgresql+psycopg://postgres:postgres@localhost:5433/story_manager" \
+	PYTHONPATH=. .venv/bin/alembic -c backend/alembic.ini downgrade -1; \
+	docker exec story-manager-migration-test psql -v ON_ERROR_STOP=1 -U postgres -d story_manager \
+		-c "UPDATE books SET refresh_status = 'constraint-removed' WHERE title = 'Migration Test';"
 
 e2e:
 	docker rm -f $(E2E_DB_CONTAINER) >/dev/null 2>&1 || true

--- a/backend/alembic/versions/0033_lifecycle_constraints.py
+++ b/backend/alembic/versions/0033_lifecycle_constraints.py
@@ -1,0 +1,196 @@
+"""centralize lifecycle values with database constraints
+
+Revision ID: 0033
+Revises: 0032
+Create Date: 2026-08-09 00:00:00
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0033"
+down_revision = "0032"
+branch_labels = None
+depends_on = None
+
+CONSTRAINTS = {
+    "books": {
+        "ck_books_download_status": ("download_status", ("pending", "error")),
+        "ck_books_refresh_status": ("refresh_status", ("queued", "processing", "error")),
+        "ck_books_audiobook_pipeline_status": (
+            "audiobook_pipeline_status",
+            ("ingesting", "roster_gen", "diarizing", "audio_gen", "assembling", "paused", "complete", "error"),
+        ),
+        "ck_books_audiobook_publication_state": (
+            "audiobook_publication_state",
+            ("processing", "partial", "complete", "stale", "error"),
+        ),
+    },
+    "processing_jobs": {
+        "ck_processing_jobs_status": ("status", ("queued", "running", "completed", "error", "canceled")),
+    },
+    "update_tasks": {
+        "ck_update_tasks_status": ("status", ("running", "completed", "failed", "interrupted")),
+    },
+    "metadata_sync_jobs": {
+        "ck_metadata_sync_jobs_status": ("status", ("queued", "running", "completed", "failed")),
+    },
+    "audiobook_chapters": {
+        "ck_audiobook_chapters_preview_status": ("preview_status", ("queued", "generating", "ready", "error")),
+        "ck_audiobook_chapters_generation_state": ("generation_state", ("pending", "processing", "ready", "error")),
+    },
+    "audiobook_sentences": {
+        "ck_audiobook_sentences_status": (
+            "status",
+            ("pending_diarization", "ready_for_audio", "audio_queued", "audio_generating", "audio_generated", "error"),
+        ),
+    },
+    "imported_audiobooks": {
+        "ck_imported_audiobooks_status": ("status", ("queued", "importing", "ready", "aligning", "stale", "error")),
+        "ck_imported_audiobooks_alignment_method": (
+            "alignment_method",
+            ("estimated", "transcribed", "hybrid"),
+        ),
+    },
+}
+
+
+def _table(conn, name: str, columns: dict[str, sa.types.TypeEngine]) -> sa.TableClause:
+    return sa.table(name, *(sa.column(column_name, column_type) for column_name, column_type in columns.items()))
+
+
+def _normalize_existing_values(conn) -> None:
+    if sa.inspect(conn).has_table("books"):
+        books = _table(
+            conn,
+            "books",
+            {
+                "download_status": sa.String(),
+                "refresh_status": sa.String(),
+                "audiobook_pipeline_status": sa.String(),
+                "audiobook_publication_state": sa.String(),
+                "audiobook_publication_error": sa.Text(),
+            },
+        )
+        conn.execute(books.update().where(books.c.download_status == "complete").values(download_status=None))
+        conn.execute(books.update().where(books.c.download_status == "processing").values(download_status="pending"))
+        conn.execute(
+            books.update()
+            .where(
+                books.c.download_status.is_not(None),
+                books.c.download_status.not_in(("pending", "error")),
+            )
+            .values(download_status="error")
+        )
+        conn.execute(
+            books.update()
+            .where(books.c.refresh_status.is_not(None), books.c.refresh_status.not_in(("queued", "processing", "error")))
+            .values(refresh_status="error")
+        )
+        conn.execute(
+            books.update()
+            .where(
+                books.c.audiobook_pipeline_status.is_not(None),
+                books.c.audiobook_pipeline_status.not_in(
+                    ("ingesting", "roster_gen", "diarizing", "audio_gen", "assembling", "paused", "complete", "error")
+                ),
+            )
+            .values(audiobook_pipeline_status="error")
+        )
+        conn.execute(
+            books.update()
+            .where(
+                books.c.audiobook_publication_state.is_not(None),
+                books.c.audiobook_publication_state.not_in(("processing", "partial", "complete", "stale", "error")),
+            )
+            .values(
+                audiobook_publication_state="error",
+                audiobook_publication_error="Unsupported publication state repaired by migration 0033.",
+            )
+        )
+
+    repairs = (
+        ("processing_jobs", "status", ("queued", "running", "completed", "error", "canceled"), "error"),
+        ("update_tasks", "status", ("running", "completed", "failed", "interrupted"), "interrupted"),
+        ("metadata_sync_jobs", "status", ("queued", "running", "completed", "failed"), "failed"),
+        (
+            "audiobook_sentences",
+            "status",
+            ("pending_diarization", "ready_for_audio", "audio_queued", "audio_generating", "audio_generated", "error"),
+            "error",
+        ),
+        ("imported_audiobooks", "status", ("queued", "importing", "ready", "aligning", "stale", "error"), "error"),
+    )
+    inspector = sa.inspect(conn)
+    for table_name, column_name, valid, replacement in repairs:
+        if not inspector.has_table(table_name):
+            continue
+        table = _table(conn, table_name, {column_name: sa.String()})
+        conn.execute(table.update().where(table.c[column_name].not_in(valid)).values({column_name: replacement}))
+
+    if inspector.has_table("audiobook_chapters"):
+        chapters = _table(
+            conn,
+            "audiobook_chapters",
+            {"preview_status": sa.String(), "preview_error": sa.Text(), "generation_state": sa.String()},
+        )
+        conn.execute(
+            chapters.update()
+            .where(
+                chapters.c.preview_status.is_not(None),
+                chapters.c.preview_status.not_in(("queued", "generating", "ready", "error")),
+            )
+            .values(preview_status="error", preview_error="Unsupported preview state repaired by migration 0033.")
+        )
+        conn.execute(
+            chapters.update()
+            .where(chapters.c.generation_state.not_in(("pending", "processing", "ready", "error")))
+            .values(generation_state="error")
+        )
+
+    if inspector.has_table("imported_audiobooks"):
+        editions = _table(
+            conn,
+            "imported_audiobooks",
+            {"alignment_method": sa.String(), "alignment_error": sa.Text()},
+        )
+        conn.execute(
+            editions.update()
+            .where(
+                editions.c.alignment_method.is_not(None),
+                editions.c.alignment_method.not_in(("estimated", "transcribed", "hybrid")),
+            )
+            .values(
+                alignment_method=None,
+                alignment_error="Unsupported alignment method cleared by migration 0033.",
+            )
+        )
+
+
+def upgrade():
+    conn = op.get_bind()
+    _normalize_existing_values(conn)
+    inspector = sa.inspect(conn)
+    for table_name, constraints in CONSTRAINTS.items():
+        if not inspector.has_table(table_name):
+            continue
+        existing = {constraint["name"] for constraint in inspector.get_check_constraints(table_name)}
+        for constraint_name, (column_name, values) in constraints.items():
+            if constraint_name in existing:
+                continue
+            allowed = ", ".join(f"'{value}'" for value in values)
+            op.create_check_constraint(constraint_name, table_name, f"{column_name} IN ({allowed})")
+
+
+def downgrade():
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    for table_name, constraints in CONSTRAINTS.items():
+        if not inspector.has_table(table_name):
+            continue
+        existing = {constraint["name"] for constraint in inspector.get_check_constraints(table_name)}
+        for constraint_name in reversed(tuple(constraints)):
+            if constraint_name in existing:
+                op.drop_constraint(constraint_name, table_name, type_="check")

--- a/backend/app/crud/audiobook.py
+++ b/backend/app/crud/audiobook.py
@@ -9,6 +9,15 @@ from sqlalchemy import and_, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..config import AUDIOBOOK_ASSEMBLY_MARKER, LIBRARY_PATH
+from ..lifecycle import (
+    AUDIOBOOK_PIPELINE,
+    CHAPTER_PREVIEW,
+    SENTENCE,
+    AudiobookPipelineStatus,
+    ChapterGenerationStatus,
+    SentenceStatus,
+    transition_state,
+)
 from ..models import (
     AudiobookSettings,
     AudiobookChapter,
@@ -34,9 +43,9 @@ async def invalidate_packaged_audiobook(db: AsyncSession, book_id: int) -> None:
     packaged_epub.unlink(missing_ok=True)
     await db.execute(
         update(Book)
-        .where(Book.id == book_id, Book.audiobook_pipeline_status == "complete")
+        .where(Book.id == book_id, Book.audiobook_pipeline_status == AudiobookPipelineStatus.COMPLETE.value)
         .values(
-            audiobook_pipeline_status="paused",
+            audiobook_pipeline_status=AudiobookPipelineStatus.PAUSED.value,
             audiobook_pipeline_updated_at=datetime.now(timezone.utc),
         )
     )
@@ -72,11 +81,11 @@ async def upsert_audiobook_settings(db: AsyncSession, data: dict) -> AudiobookSe
 
 
 async def set_book_pipeline_status(db: AsyncSession, book_id: int, status: Optional[str]) -> None:
-    await db.execute(
-        update(Book)
-        .where(Book.id == book_id)
-        .values(audiobook_pipeline_status=status, audiobook_pipeline_updated_at=datetime.now(timezone.utc))
-    )
+    book = await db.get(Book, book_id)
+    if book is None:
+        return
+    transition_state(book, "audiobook_pipeline_status", AUDIOBOOK_PIPELINE, status, context=f"book {book_id}")
+    book.audiobook_pipeline_updated_at = datetime.now(timezone.utc)
     await db.commit()
 
 
@@ -89,23 +98,20 @@ async def configure_book_pipeline_run(
     batch_limit: Optional[int] = None,
 ) -> None:
     """Start or resume a run and clear stale pause/error state atomically."""
-    await db.execute(
-        update(Book)
-        .where(Book.id == book_id)
-        .values(
-            audiobook_pipeline_status=status,
-            audiobook_stop_after_phase=stop_after_phase,
-            audiobook_pause_requested=False,
-            audiobook_last_error=None,
-            audiobook_batch_limit=batch_limit,
-            audiobook_progress_current=0,
-            audiobook_progress_total=0,
-            audiobook_progress_detail=None,
-            audiobook_pipeline_started_at=datetime.now(timezone.utc),
-            audiobook_pipeline_updated_at=datetime.now(timezone.utc),
-            audiobook_llm_requests=0,
-        )
-    )
+    book = await db.get(Book, book_id)
+    if book is None:
+        return
+    transition_state(book, "audiobook_pipeline_status", AUDIOBOOK_PIPELINE, status, context=f"book {book_id}")
+    book.audiobook_stop_after_phase = stop_after_phase
+    book.audiobook_pause_requested = False
+    book.audiobook_last_error = None
+    book.audiobook_batch_limit = batch_limit
+    book.audiobook_progress_current = 0
+    book.audiobook_progress_total = 0
+    book.audiobook_progress_detail = None
+    book.audiobook_pipeline_started_at = datetime.now(timezone.utc)
+    book.audiobook_pipeline_updated_at = datetime.now(timezone.utc)
+    book.audiobook_llm_requests = 0
     await db.commit()
 
 
@@ -146,90 +152,93 @@ async def set_book_audiobook_summary(db: AsyncSession, book_id: int, summary: Op
 
 async def consume_book_batch_limit(db: AsyncSession, book_id: int) -> bool:
     """Consume one durable work unit and pause when a one-batch run is exhausted."""
-    result = await db.execute(select(Book.audiobook_batch_limit).where(Book.id == book_id))
-    remaining = result.scalar_one_or_none()
-    if remaining is None:
+    book = await db.get(Book, book_id)
+    if book is None or book.audiobook_batch_limit is None:
         return False
-    remaining -= 1
+    remaining = book.audiobook_batch_limit - 1
     if remaining > 0:
         await db.execute(update(Book).where(Book.id == book_id).values(audiobook_batch_limit=remaining))
         await db.commit()
         return False
-    await db.execute(
-        update(Book)
-        .where(Book.id == book_id)
-        .values(
-            audiobook_pipeline_status="paused",
-            audiobook_batch_limit=None,
-            audiobook_stop_after_phase=None,
-            audiobook_pause_requested=False,
-            audiobook_pipeline_updated_at=datetime.now(timezone.utc),
-        )
+    transition_state(
+        book,
+        "audiobook_pipeline_status",
+        AUDIOBOOK_PIPELINE,
+        AudiobookPipelineStatus.PAUSED,
+        context=f"book {book_id}",
     )
+    book.audiobook_batch_limit = None
+    book.audiobook_stop_after_phase = None
+    book.audiobook_pause_requested = False
+    book.audiobook_pipeline_updated_at = datetime.now(timezone.utc)
     await db.commit()
     return True
 
 
 async def pause_book_pipeline_if_requested(db: AsyncSession, book_id: int) -> bool:
     """Acknowledge a cooperative pause request at a durable work boundary."""
-    result = await db.execute(select(Book.audiobook_pause_requested).where(Book.id == book_id))
-    if not result.scalar_one_or_none():
+    book = await db.get(Book, book_id)
+    if book is None or not book.audiobook_pause_requested:
         return False
-    await db.execute(
-        update(Book)
-        .where(Book.id == book_id)
-        .values(
-            audiobook_pipeline_status="paused",
-            audiobook_pause_requested=False,
-            audiobook_stop_after_phase=None,
-            audiobook_batch_limit=None,
-            audiobook_pipeline_updated_at=datetime.now(timezone.utc),
-        )
+    transition_state(
+        book,
+        "audiobook_pipeline_status",
+        AUDIOBOOK_PIPELINE,
+        AudiobookPipelineStatus.PAUSED,
+        context=f"book {book_id}",
     )
+    book.audiobook_pause_requested = False
+    book.audiobook_stop_after_phase = None
+    book.audiobook_batch_limit = None
+    book.audiobook_pipeline_updated_at = datetime.now(timezone.utc)
     await db.commit()
     return True
 
 
 async def pause_book_pipeline_after_phase(db: AsyncSession, book_id: int, phase: str) -> bool:
     """Stop a single-stage run once its requested phase has committed."""
-    result = await db.execute(
-        select(Book.audiobook_stop_after_phase, Book.audiobook_pipeline_status).where(Book.id == book_id)
-    )
-    row = result.one_or_none()
-    if row is None or row.audiobook_stop_after_phase != phase or row.audiobook_pipeline_status == "complete":
+    book = await db.get(Book, book_id)
+    if (
+        book is None
+        or book.audiobook_stop_after_phase != phase
+        or book.audiobook_pipeline_status == AudiobookPipelineStatus.COMPLETE.value
+    ):
         return False
-    await db.execute(
-        update(Book)
-        .where(Book.id == book_id)
-        .values(
-            audiobook_pipeline_status="paused",
-            audiobook_stop_after_phase=None,
-            audiobook_batch_limit=None,
-            audiobook_pipeline_updated_at=datetime.now(timezone.utc),
-        )
+    transition_state(
+        book,
+        "audiobook_pipeline_status",
+        AUDIOBOOK_PIPELINE,
+        AudiobookPipelineStatus.PAUSED,
+        context=f"book {book_id}",
     )
+    book.audiobook_stop_after_phase = None
+    book.audiobook_batch_limit = None
+    book.audiobook_pipeline_updated_at = datetime.now(timezone.utc)
     await db.commit()
     return True
 
 
 async def set_book_pipeline_error(db: AsyncSession, book_id: int, message: str) -> None:
-    await db.execute(
-        update(Book)
-        .where(Book.id == book_id)
-        .values(
-            audiobook_pipeline_status="error",
-            audiobook_pause_requested=False,
-            audiobook_stop_after_phase=None,
-            audiobook_batch_limit=None,
-            audiobook_pipeline_updated_at=datetime.now(timezone.utc),
-            audiobook_last_error=message,
-        )
+    book = await db.get(Book, book_id)
+    if book is None:
+        return
+    transition_state(
+        book,
+        "audiobook_pipeline_status",
+        AUDIOBOOK_PIPELINE,
+        AudiobookPipelineStatus.ERROR,
+        context=f"book {book_id}",
     )
+    book.audiobook_pause_requested = False
+    book.audiobook_stop_after_phase = None
+    book.audiobook_batch_limit = None
+    book.audiobook_pipeline_updated_at = datetime.now(timezone.utc)
+    book.audiobook_last_error = message
     await db.commit()
 
 
 async def get_in_progress_audiobook_books(db: AsyncSession) -> list[Book]:
-    active_statuses = ["ingesting", "roster_gen", "diarizing", "audio_gen", "assembling"]
+    active_statuses = tuple(AUDIOBOOK_PIPELINE.active_states)
     result = await db.execute(
         select(Book).where(
             Book.audiobook_enabled.is_(True),
@@ -367,14 +376,18 @@ async def set_chapter_preview_status(
     status: Optional[str],
     error: Optional[str] = None,
 ) -> None:
-    await db.execute(
-        update(AudiobookChapter).where(AudiobookChapter.id == chapter_id).values(preview_status=status, preview_error=error)
-    )
+    chapter = await db.get(AudiobookChapter, chapter_id)
+    if chapter is None:
+        return
+    transition_state(chapter, "preview_status", CHAPTER_PREVIEW, status, context=f"audiobook chapter {chapter_id}")
+    chapter.preview_error = error
     await db.commit()
 
 
 async def get_chapters_with_pending_previews(db: AsyncSession) -> list[AudiobookChapter]:
-    result = await db.execute(select(AudiobookChapter).where(AudiobookChapter.preview_status.in_(["queued", "generating"])))
+    result = await db.execute(
+        select(AudiobookChapter).where(AudiobookChapter.preview_status.in_(tuple(CHAPTER_PREVIEW.active_states)))
+    )
     return list(result.scalars().all())
 
 
@@ -568,7 +581,7 @@ async def cascade_voice_change(db: AsyncSession, char_id: int) -> None:
     await db.execute(
         update(AudiobookSentence)
         .where(AudiobookSentence.character_id == char_id)
-        .values(status="ready_for_audio", audio_file_path=None, audio_duration_ms=None)
+        .values(status=SentenceStatus.READY_FOR_AUDIO.value, audio_file_path=None, audio_duration_ms=None)
     )
     result = await db.execute(select(AudiobookSentence.chapter_id).where(AudiobookSentence.character_id == char_id).distinct())
     chapter_ids = [row[0] for row in result.all()]
@@ -596,13 +609,16 @@ async def invalidate_generated_audio_for_tts_change(
         select(
             Book.id,
             func.count(AudiobookSentence.id),
-            func.count(AudiobookSentence.id).filter(AudiobookSentence.status == "audio_generated"),
+            func.count(AudiobookSentence.id).filter(AudiobookSentence.status == SentenceStatus.AUDIO_GENERATED.value),
         )
         .join(AudiobookChapter, AudiobookChapter.book_id == Book.id)
         .join(AudiobookSentence, AudiobookSentence.chapter_id == AudiobookChapter.id)
         .where(
             Book.audiobook_enabled.is_(True),
-            or_(Book.audiobook_pipeline_status.is_(None), Book.audiobook_pipeline_status != "complete"),
+            or_(
+                Book.audiobook_pipeline_status.is_(None),
+                Book.audiobook_pipeline_status != AudiobookPipelineStatus.COMPLETE.value,
+            ),
         )
         .group_by(Book.id)
     )
@@ -619,7 +635,7 @@ async def invalidate_generated_audio_for_tts_change(
         .join(AudiobookChapter, AudiobookSentence.chapter_id == AudiobookChapter.id)
         .where(
             AudiobookChapter.book_id.in_(book_ids),
-            AudiobookSentence.status == "audio_generated",
+            AudiobookSentence.status == SentenceStatus.AUDIO_GENERATED.value,
         )
         .distinct()
     )
@@ -629,9 +645,9 @@ async def invalidate_generated_audio_for_tts_change(
         update(AudiobookSentence)
         .where(
             AudiobookSentence.chapter_id.in_(chapter_ids),
-            AudiobookSentence.status == "audio_generated",
+            AudiobookSentence.status == SentenceStatus.AUDIO_GENERATED.value,
         )
-        .values(status="ready_for_audio", audio_file_path=None, audio_duration_ms=None)
+        .values(status=SentenceStatus.READY_FOR_AUDIO.value, audio_file_path=None, audio_duration_ms=None)
     )
     if chapter_ids:
         await db.execute(
@@ -665,7 +681,7 @@ async def reset_roster_and_diarization_for_book(db: AsyncSession, book_id: int) 
             audio_duration_ms=None,
             speaker_confidence=None,
             speaker_reason=None,
-            status="pending_diarization",
+            status=SentenceStatus.PENDING_DIARIZATION.value,
         )
     )
     await db.execute(
@@ -686,7 +702,7 @@ async def reset_roster_and_diarization_for_book(db: AsyncSession, book_id: int) 
             smil_size_bytes=None,
             smil_sha256=None,
             duration_ms=None,
-            generation_state="pending",
+            generation_state=ChapterGenerationStatus.PENDING.value,
         )
     )
     await db.commit()
@@ -703,7 +719,7 @@ async def reset_audio_generation_for_book(db: AsyncSession, book_id: int) -> int
         .values(
             audio_file_path=None,
             audio_duration_ms=None,
-            status="ready_for_audio",
+            status=SentenceStatus.READY_FOR_AUDIO.value,
         )
     )
     await db.execute(
@@ -722,7 +738,7 @@ async def reset_audio_generation_for_book(db: AsyncSession, book_id: int) -> int
             smil_size_bytes=None,
             smil_sha256=None,
             duration_ms=None,
-            generation_state="pending",
+            generation_state=ChapterGenerationStatus.PENDING.value,
         )
     )
     await db.commit()
@@ -773,7 +789,7 @@ async def get_sentences_paginated(
         count_query = count_query.where(AudiobookSentence.chapter_id == chapter_id)
     if review_only:
         review_filter = and_(
-            AudiobookSentence.status != "pending_diarization",
+            AudiobookSentence.status != SentenceStatus.PENDING_DIARIZATION.value,
             or_(
                 AudiobookSentence.character_id.is_(None),
                 AudiobookSentence.speaker_confidence.is_(None),
@@ -805,7 +821,7 @@ async def get_sentences_pending_diarization(
         .join(AudiobookChapter, AudiobookSentence.chapter_id == AudiobookChapter.id)
         .where(
             AudiobookChapter.book_id == book_id,
-            AudiobookSentence.status == "pending_diarization",
+            AudiobookSentence.status == SentenceStatus.PENDING_DIARIZATION.value,
         )
         .order_by(AudiobookChapter.chapter_number, AudiobookSentence.sequence_order)
         .limit(limit)
@@ -822,7 +838,7 @@ async def get_sentences_ready_for_audio(db: AsyncSession, book_id: int, limit: i
         .join(AudiobookChapter, AudiobookSentence.chapter_id == AudiobookChapter.id)
         .where(
             AudiobookChapter.book_id == book_id,
-            AudiobookSentence.status == "ready_for_audio",
+            AudiobookSentence.status == SentenceStatus.READY_FOR_AUDIO.value,
         )
         .order_by(AudiobookChapter.chapter_number, AudiobookSentence.sequence_order)
         .limit(limit)
@@ -835,14 +851,17 @@ async def get_pending_sentence_audio_jobs(db: AsyncSession) -> list[tuple[int, i
     result = await db.execute(
         select(AudiobookChapter.book_id, AudiobookSentence.id)
         .join(AudiobookChapter, AudiobookSentence.chapter_id == AudiobookChapter.id)
-        .where(AudiobookSentence.status.in_(["audio_queued", "audio_generating"]))
+        .where(AudiobookSentence.status.in_((SentenceStatus.AUDIO_QUEUED.value, SentenceStatus.AUDIO_GENERATING.value)))
         .order_by(AudiobookSentence.id)
     )
     return [(book_id, sentence_id) for book_id, sentence_id in result.all()]
 
 
 async def set_sentence_status(db: AsyncSession, sentence_id: int, status: str) -> None:
-    await db.execute(update(AudiobookSentence).where(AudiobookSentence.id == sentence_id).values(status=status))
+    sentence = await db.get(AudiobookSentence, sentence_id)
+    if sentence is None:
+        return
+    transition_state(sentence, "status", SENTENCE, status, context=f"audiobook sentence {sentence_id}")
     await db.commit()
 
 
@@ -862,7 +881,7 @@ async def update_sentence_diarization(
             tagged_text=tagged_text,
             speaker_confidence=speaker_confidence,
             speaker_reason=speaker_reason,
-            status="ready_for_audio",
+            status=SentenceStatus.READY_FOR_AUDIO.value,
         )
     )
     await db.commit()
@@ -880,14 +899,14 @@ async def mark_sentences_as_narration(
         update(AudiobookSentence)
         .where(
             AudiobookSentence.id.in_(sentence_ids),
-            AudiobookSentence.status == "pending_diarization",
+            AudiobookSentence.status == SentenceStatus.PENDING_DIARIZATION.value,
         )
         .values(
             character_id=narrator_id,
             tagged_text=AudiobookSentence.original_text,
             speaker_confidence=1.0,
             speaker_reason="Deterministic prose outside dialogue",
-            status="ready_for_audio",
+            status=SentenceStatus.READY_FOR_AUDIO.value,
         )
     )
     await db.commit()
@@ -897,14 +916,17 @@ async def update_sentence_audio(db: AsyncSession, sentence_id: int, audio_file_p
     await db.execute(
         update(AudiobookSentence)
         .where(AudiobookSentence.id == sentence_id)
-        .values(audio_file_path=audio_file_path, audio_duration_ms=audio_duration_ms, status="audio_generated")
+        .values(
+            audio_file_path=audio_file_path,
+            audio_duration_ms=audio_duration_ms,
+            status=SentenceStatus.AUDIO_GENERATED.value,
+        )
     )
     await db.commit()
 
 
 async def mark_sentence_error(db: AsyncSession, sentence_id: int) -> None:
-    await db.execute(update(AudiobookSentence).where(AudiobookSentence.id == sentence_id).values(status="error"))
-    await db.commit()
+    await set_sentence_status(db, sentence_id, SentenceStatus.ERROR.value)
 
 
 async def reset_error_sentences_for_book(db: AsyncSession, book_id: int) -> int:
@@ -913,9 +935,9 @@ async def reset_error_sentences_for_book(db: AsyncSession, book_id: int) -> int:
         update(AudiobookSentence)
         .where(
             AudiobookSentence.chapter_id.in_(chapter_ids),
-            AudiobookSentence.status == "error",
+            AudiobookSentence.status == SentenceStatus.ERROR.value,
         )
-        .values(status="ready_for_audio", audio_file_path=None, audio_duration_ms=None)
+        .values(status=SentenceStatus.READY_FOR_AUDIO.value, audio_file_path=None, audio_duration_ms=None)
     )
     await db.execute(update(AudiobookChapter).where(AudiobookChapter.book_id == book_id).values(needs_reassembly=True))
     await db.commit()
@@ -929,9 +951,9 @@ async def reset_interrupted_sentences_for_book(db: AsyncSession, book_id: int) -
         update(AudiobookSentence)
         .where(
             AudiobookSentence.chapter_id.in_(chapter_ids),
-            AudiobookSentence.status.in_(("audio_queued", "audio_generating")),
+            AudiobookSentence.status.in_((SentenceStatus.AUDIO_QUEUED.value, SentenceStatus.AUDIO_GENERATING.value)),
         )
-        .values(status="ready_for_audio", audio_file_path=None, audio_duration_ms=None)
+        .values(status=SentenceStatus.READY_FOR_AUDIO.value, audio_file_path=None, audio_duration_ms=None)
     )
     await db.commit()
     return result.rowcount or 0
@@ -948,7 +970,13 @@ async def update_sentence_speaker(
     sentence.tagged_text = tagged_text
     sentence.speaker_confidence = 1.0
     sentence.speaker_reason = "Manually assigned"
-    sentence.status = "ready_for_audio"
+    transition_state(
+        sentence,
+        "status",
+        SENTENCE,
+        SentenceStatus.READY_FOR_AUDIO,
+        context=f"audiobook sentence {sentence_id}",
+    )
     sentence.audio_file_path = None
     sentence.audio_duration_ms = None
     await db.execute(
@@ -1039,32 +1067,47 @@ async def infer_audiobook_resume_status(db: AsyncSession, book_id: int) -> str:
     """Infer the earliest safe phase from durable chapter/sentence state."""
     chapters = await get_chapters_for_book(db, book_id)
     if not chapters:
-        return "ingesting"
+        return AudiobookPipelineStatus.INGESTING.value
 
     characters = await get_characters_for_book(db, book_id)
     if not characters:
-        return "roster_gen"
+        return AudiobookPipelineStatus.ROSTER_GENERATION.value
 
     counts = await count_sentences_by_status(db, book_id)
-    if counts.get("pending_diarization", 0) > 0:
-        return "diarizing"
-    if any(counts.get(status, 0) > 0 for status in ("ready_for_audio", "audio_queued", "audio_generating", "error")):
-        return "audio_gen"
+    if counts.get(SentenceStatus.PENDING_DIARIZATION.value, 0) > 0:
+        return AudiobookPipelineStatus.DIARIZING.value
+    if any(
+        counts.get(status, 0) > 0
+        for status in (
+            SentenceStatus.READY_FOR_AUDIO.value,
+            SentenceStatus.AUDIO_QUEUED.value,
+            SentenceStatus.AUDIO_GENERATING.value,
+            SentenceStatus.ERROR.value,
+        )
+    ):
+        return AudiobookPipelineStatus.AUDIO_GENERATION.value
 
     total = sum(counts.values())
-    if total > 0 and counts.get("audio_generated", 0) == total:
+    if total > 0 and counts.get(SentenceStatus.AUDIO_GENERATED.value, 0) == total:
         pending_chapters = await get_chapters_pending_assembly(db, book_id)
         output_dir = LIBRARY_PATH / "audiobooks" / str(book_id)
         packaged_epub = output_dir / "audiobook.epub"
         assembly_marker = output_dir / AUDIOBOOK_ASSEMBLY_MARKER
-        return "assembling" if pending_chapters or not packaged_epub.is_file() or not assembly_marker.is_file() else "complete"
+        return (
+            AudiobookPipelineStatus.ASSEMBLING.value
+            if pending_chapters or not packaged_epub.is_file() or not assembly_marker.is_file()
+            else AudiobookPipelineStatus.COMPLETE.value
+        )
 
-    return "ingesting"
+    return AudiobookPipelineStatus.INGESTING.value
 
 
 async def chapter_all_audio_generated(db: AsyncSession, chapter_id: int) -> bool:
     result = await db.execute(
-        select(func.count(), func.count().filter(AudiobookSentence.status != "audio_generated"))
+        select(
+            func.count(),
+            func.count().filter(AudiobookSentence.status != SentenceStatus.AUDIO_GENERATED.value),
+        )
         .select_from(AudiobookSentence)
         .where(AudiobookSentence.chapter_id == chapter_id)
     )
@@ -1074,7 +1117,10 @@ async def chapter_all_audio_generated(db: AsyncSession, chapter_id: int) -> bool
 
 async def all_sentences_audio_generated(db: AsyncSession, book_id: int) -> bool:
     result = await db.execute(
-        select(func.count(), func.count().filter(AudiobookSentence.status != "audio_generated"))
+        select(
+            func.count(),
+            func.count().filter(AudiobookSentence.status != SentenceStatus.AUDIO_GENERATED.value),
+        )
         .select_from(AudiobookSentence)
         .join(AudiobookChapter, AudiobookSentence.chapter_id == AudiobookChapter.id)
         .where(AudiobookChapter.book_id == book_id)

--- a/backend/app/crud/books.py
+++ b/backend/app/crud/books.py
@@ -7,6 +7,13 @@ from sqlalchemy import String, and_, asc, case, cast, delete, desc, exists, func
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 from .. import models, schemas
+from ..lifecycle import (
+    AUDIOBOOK_PUBLICATION,
+    WEB_IMPORT,
+    AudiobookPublicationStatus,
+    WebImportStatus,
+    transition_state,
+)
 
 
 def _build_books_query(sort_by: str = "title", sort_order: str = "asc"):
@@ -448,7 +455,7 @@ async def reset_failed_web_book_for_retry(
     book.current_word_count = None
     book.removed_chapters = []
     book.content_selectors = []
-    book.download_status = "pending"
+    transition_state(book, "download_status", WEB_IMPORT, WebImportStatus.PENDING, context=f"book {book.id}")
     book.source_url = source_url
     book.source_type = models.SourceType.web
     await db.commit()
@@ -460,7 +467,7 @@ async def detach_book_source(db: AsyncSession, book: models.Book) -> models.Book
     """Clear a book's remote source metadata and treat it as a normal EPUB."""
     book.source_url = None
     book.source_type = models.SourceType.epub
-    book.download_status = None
+    transition_state(book, "download_status", WEB_IMPORT, None, context=f"book {book.id}")
     await db.commit()
     await db.refresh(book)
     return book
@@ -475,7 +482,13 @@ async def touch_book_content(db: AsyncSession, book: models.Book) -> None:
             book.content_version,
         )
         if book.audiobook_revision or book.audiobook_source_content_version is not None:
-            book.audiobook_publication_state = "stale"
+            transition_state(
+                book,
+                "audiobook_publication_state",
+                AUDIOBOOK_PUBLICATION,
+                AudiobookPublicationStatus.STALE,
+                context=f"book {book.id}",
+            )
 
 
 async def get_books_by_author(db: AsyncSession, author: str, skip: int = 0, limit: int = 100) -> List[models.Book]:

--- a/backend/app/crud/logs.py
+++ b/backend/app/crud/logs.py
@@ -7,6 +7,7 @@ from sqlalchemy import func
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 from .. import models, schemas
+from ..lifecycle import UPDATE_TASK, UpdateTaskStatus, transition_state
 
 
 async def create_book_log(db: AsyncSession, log: schemas.BookLogCreate) -> models.BookLog:
@@ -43,12 +44,12 @@ async def get_latest_update_task(db: AsyncSession) -> Optional[models.UpdateTask
 
 
 async def get_active_update_task(db: AsyncSession) -> Optional[models.UpdateTask]:
-    result = await db.execute(select(models.UpdateTask).filter(models.UpdateTask.status == "running"))
+    result = await db.execute(select(models.UpdateTask).filter(models.UpdateTask.status == UpdateTaskStatus.RUNNING.value))
     return result.scalars().first()
 
 
 async def create_update_task(db: AsyncSession, total_books: int) -> models.UpdateTask:
-    task = models.UpdateTask(total_books=total_books, completed_books=0, status="running")
+    task = models.UpdateTask(total_books=total_books, completed_books=0, status=UpdateTaskStatus.RUNNING.value)
     db.add(task)
     await db.commit()
     await db.refresh(task)
@@ -62,21 +63,21 @@ async def increment_update_task(db: AsyncSession, task: models.UpdateTask) -> No
 
 
 async def complete_update_task(db: AsyncSession, task: models.UpdateTask) -> None:
-    task.status = "completed"
+    transition_state(task, "status", UPDATE_TASK, UpdateTaskStatus.COMPLETED, context=f"update task {task.id}")
     task.completed_at = datetime.now(timezone.utc)
     await db.commit()
     await db.refresh(task)
 
 
 async def fail_update_task(db: AsyncSession, task: models.UpdateTask) -> None:
-    task.status = "failed"
+    transition_state(task, "status", UPDATE_TASK, UpdateTaskStatus.FAILED, context=f"update task {task.id}")
     task.completed_at = datetime.now(timezone.utc)
     await db.commit()
     await db.refresh(task)
 
 
 async def interrupt_update_task(db: AsyncSession, task: models.UpdateTask) -> None:
-    task.status = "interrupted"
+    transition_state(task, "status", UPDATE_TASK, UpdateTaskStatus.INTERRUPTED, context=f"update task {task.id}")
     task.completed_at = datetime.now(timezone.utc)
     await db.commit()
     await db.refresh(task)
@@ -84,10 +85,10 @@ async def interrupt_update_task(db: AsyncSession, task: models.UpdateTask) -> No
 
 async def reset_stuck_update_tasks(db: AsyncSession) -> None:
     """Mark any tasks left in 'running' state (e.g. from a crashed run) as 'interrupted'."""
-    result = await db.execute(select(models.UpdateTask).filter(models.UpdateTask.status == "running"))
+    result = await db.execute(select(models.UpdateTask).filter(models.UpdateTask.status == UpdateTaskStatus.RUNNING.value))
     stuck = result.scalars().all()
     for task in stuck:
-        task.status = "interrupted"
+        transition_state(task, "status", UPDATE_TASK, UpdateTaskStatus.INTERRUPTED, context=f"update task {task.id}")
         task.completed_at = datetime.now(timezone.utc)
     if stuck:
         await db.commit()

--- a/backend/app/crud/metadata.py
+++ b/backend/app/crud/metadata.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 
 from .. import models
+from ..lifecycle import METADATA_JOB, MetadataJobStatus, transition_state
 
 
 async def create_metadata_sync_job(
@@ -20,7 +21,7 @@ async def create_metadata_sync_job(
 ) -> models.MetadataSyncJob:
     job = models.MetadataSyncJob(
         trigger=trigger,
-        status="queued",
+        status=MetadataJobStatus.QUEUED.value,
         total_books=len(book_ids),
         processed_books=0,
         matched_books=0,
@@ -47,17 +48,19 @@ async def get_latest_metadata_sync_job(db: AsyncSession) -> Optional[models.Meta
 async def get_pending_metadata_sync_jobs(db: AsyncSession) -> list[models.MetadataSyncJob]:
     result = await db.execute(
         select(models.MetadataSyncJob)
-        .where(models.MetadataSyncJob.status == "queued")
+        .where(models.MetadataSyncJob.status == MetadataJobStatus.QUEUED.value)
         .order_by(asc(models.MetadataSyncJob.created_at))
     )
     return result.scalars().all()
 
 
 async def reset_running_metadata_sync_jobs(db: AsyncSession) -> None:
-    result = await db.execute(select(models.MetadataSyncJob).where(models.MetadataSyncJob.status == "running"))
+    result = await db.execute(
+        select(models.MetadataSyncJob).where(models.MetadataSyncJob.status == MetadataJobStatus.RUNNING.value)
+    )
     jobs = result.scalars().all()
     for job in jobs:
-        job.status = "queued"
+        transition_state(job, "status", METADATA_JOB, MetadataJobStatus.QUEUED, context=f"metadata job {job.id}")
         job.started_at = None
         job.completed_at = None
         job.error = None
@@ -66,7 +69,7 @@ async def reset_running_metadata_sync_jobs(db: AsyncSession) -> None:
 
 
 async def mark_metadata_sync_job_running(db: AsyncSession, job: models.MetadataSyncJob) -> models.MetadataSyncJob:
-    job.status = "running"
+    transition_state(job, "status", METADATA_JOB, MetadataJobStatus.RUNNING, context=f"metadata job {job.id}")
     job.started_at = datetime.now(timezone.utc)
     job.completed_at = None
     job.error = None
@@ -94,7 +97,7 @@ async def mark_metadata_sync_job_progress(
 
 
 async def complete_metadata_sync_job(db: AsyncSession, job: models.MetadataSyncJob) -> models.MetadataSyncJob:
-    job.status = "completed"
+    transition_state(job, "status", METADATA_JOB, MetadataJobStatus.COMPLETED, context=f"metadata job {job.id}")
     job.completed_at = datetime.now(timezone.utc)
     await db.commit()
     await db.refresh(job)
@@ -102,7 +105,7 @@ async def complete_metadata_sync_job(db: AsyncSession, job: models.MetadataSyncJ
 
 
 async def fail_metadata_sync_job(db: AsyncSession, job: models.MetadataSyncJob, error: str) -> models.MetadataSyncJob:
-    job.status = "failed"
+    transition_state(job, "status", METADATA_JOB, MetadataJobStatus.FAILED, context=f"metadata job {job.id}")
     job.error = error
     job.completed_at = datetime.now(timezone.utc)
     await db.commit()

--- a/backend/app/crud/processing.py
+++ b/backend/app/crud/processing.py
@@ -9,9 +9,10 @@ from sqlalchemy import and_, desc, or_, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from ..lifecycle import PROCESSING_JOB, ProcessingJobStatus, transition_state
 from ..models import Book, ProcessingJob
 
-ACTIVE_PROCESSING_STATUSES = ("queued", "running")
+ACTIVE_PROCESSING_STATUSES = tuple(PROCESSING_JOB.active_states)
 
 
 async def create_processing_job(
@@ -45,7 +46,7 @@ async def create_processing_job(
 
     job = ProcessingJob(
         job_type=job_type,
-        status="queued",
+        status=ProcessingJobStatus.QUEUED.value,
         book_id=book_id,
         target_type=target_type,
         target_id=target_id,
@@ -123,8 +124,8 @@ async def claim_processing_job(
     """Atomically claim the oldest runnable job in a resource lane."""
     now = datetime.now(timezone.utc)
     runnable = or_(
-        and_(ProcessingJob.status == "queued", ProcessingJob.available_at <= now),
-        and_(ProcessingJob.status == "running", ProcessingJob.lease_expires_at <= now),
+        and_(ProcessingJob.status == ProcessingJobStatus.QUEUED.value, ProcessingJob.available_at <= now),
+        and_(ProcessingJob.status == ProcessingJobStatus.RUNNING.value, ProcessingJob.lease_expires_at <= now),
     )
     query = (
         select(ProcessingJob)
@@ -143,7 +144,7 @@ async def claim_processing_job(
         await db.rollback()
         return None
 
-    job.status = "running"
+    transition_state(job, "status", PROCESSING_JOB, ProcessingJobStatus.RUNNING, context=f"processing job {job.id}")
     job.attempt_count = (job.attempt_count or 0) + 1
     job.started_at = now
     job.completed_at = None
@@ -169,7 +170,7 @@ async def heartbeat_processing_job(
         update(ProcessingJob)
         .where(
             ProcessingJob.id == job_id,
-            ProcessingJob.status == "running",
+            ProcessingJob.status == ProcessingJobStatus.RUNNING.value,
             ProcessingJob.lease_owner == lease_owner,
         )
         .values(heartbeat_at=now, lease_expires_at=now + timedelta(seconds=lease_seconds))
@@ -184,12 +185,12 @@ async def recover_abandoned_processing_jobs(db: AsyncSession) -> tuple[int, int]
     canceled = await db.execute(
         update(ProcessingJob)
         .where(
-            ProcessingJob.status == "running",
+            ProcessingJob.status == ProcessingJobStatus.RUNNING.value,
             ProcessingJob.lease_expires_at <= now,
             ProcessingJob.cancel_requested.is_(True),
         )
         .values(
-            status="canceled",
+            status=ProcessingJobStatus.CANCELED.value,
             progress_detail="Canceled after worker lease expired",
             completed_at=now,
             lease_owner=None,
@@ -200,13 +201,13 @@ async def recover_abandoned_processing_jobs(db: AsyncSession) -> tuple[int, int]
     exhausted = await db.execute(
         update(ProcessingJob)
         .where(
-            ProcessingJob.status == "running",
+            ProcessingJob.status == ProcessingJobStatus.RUNNING.value,
             ProcessingJob.lease_expires_at <= now,
             ProcessingJob.cancel_requested.is_(False),
             ProcessingJob.attempt_count >= ProcessingJob.max_attempts,
         )
         .values(
-            status="error",
+            status=ProcessingJobStatus.ERROR.value,
             error="Worker lease expired and the retry limit was reached.",
             progress_detail="Failed after worker interruption",
             completed_at=now,
@@ -249,7 +250,7 @@ async def complete_processing_job(
     job = await db.get(ProcessingJob, job_id)
     if job is None or (lease_owner is not None and job.lease_owner != lease_owner):
         return False
-    job.status = "completed"
+    transition_state(job, "status", PROCESSING_JOB, ProcessingJobStatus.COMPLETED, context=f"processing job {job.id}")
     job.cancel_requested = False
     job.completed_at = datetime.now(timezone.utc)
     job.lease_owner = None
@@ -280,17 +281,17 @@ async def fail_processing_job(
     job.lease_expires_at = None
     job.heartbeat_at = None
     if job.cancel_requested:
-        job.status = "canceled"
+        transition_state(job, "status", PROCESSING_JOB, ProcessingJobStatus.CANCELED, context=f"processing job {job.id}")
         job.progress_detail = "Canceled"
         job.completed_at = now
     elif job.attempt_count < job.max_attempts:
         delay = retry_backoff_seconds * (2 ** max(0, job.attempt_count - 1))
-        job.status = "queued"
+        transition_state(job, "status", PROCESSING_JOB, ProcessingJobStatus.QUEUED, context=f"processing job {job.id}")
         job.available_at = now + timedelta(seconds=delay)
         job.progress_detail = f"Retrying in {delay} seconds"
         job.completed_at = None
     else:
-        job.status = "error"
+        transition_state(job, "status", PROCESSING_JOB, ProcessingJobStatus.ERROR, context=f"processing job {job.id}")
         job.progress_detail = "Failed"
         job.completed_at = now
     await db.commit()
@@ -301,7 +302,7 @@ async def mark_processing_job_canceled(db: AsyncSession, job_id: int) -> None:
     job = await db.get(ProcessingJob, job_id)
     if job is None:
         return
-    job.status = "canceled"
+    transition_state(job, "status", PROCESSING_JOB, ProcessingJobStatus.CANCELED, context=f"processing job {job.id}")
     job.progress_detail = "Canceled"
     job.completed_at = datetime.now(timezone.utc)
     job.lease_owner = None
@@ -314,12 +315,12 @@ async def request_processing_job_cancel(db: AsyncSession, job_id: int) -> Proces
     job = await db.get(ProcessingJob, job_id)
     if job is None:
         return None
-    if job.status == "queued":
-        job.status = "canceled"
+    if job.status == ProcessingJobStatus.QUEUED.value:
+        transition_state(job, "status", PROCESSING_JOB, ProcessingJobStatus.CANCELED, context=f"processing job {job.id}")
         job.cancel_requested = True
         job.progress_detail = "Canceled"
         job.completed_at = datetime.now(timezone.utc)
-    elif job.status == "running":
+    elif job.status == ProcessingJobStatus.RUNNING.value:
         job.cancel_requested = True
         job.progress_detail = "Cancellation requested"
     await db.commit()
@@ -329,7 +330,7 @@ async def request_processing_job_cancel(db: AsyncSession, job_id: int) -> Proces
 
 async def retry_processing_job(db: AsyncSession, job_id: int) -> ProcessingJob | None:
     job = await db.get(ProcessingJob, job_id)
-    if job is None or job.status not in ("error", "canceled"):
+    if job is None or job.status not in (ProcessingJobStatus.ERROR.value, ProcessingJobStatus.CANCELED.value):
         return None
     if job.dedupe_key:
         active = (
@@ -343,7 +344,7 @@ async def retry_processing_job(db: AsyncSession, job_id: int) -> ProcessingJob |
         ).scalar_one_or_none()
         if active is not None:
             return None
-    job.status = "queued"
+    transition_state(job, "status", PROCESSING_JOB, ProcessingJobStatus.QUEUED, context=f"processing job {job.id}")
     job.cancel_requested = False
     job.error = None
     job.started_at = None

--- a/backend/app/lifecycle.py
+++ b/backend/app/lifecycle.py
@@ -1,0 +1,604 @@
+"""Authoritative lifecycle vocabularies and transition rules.
+
+Persisted status columns remain strings for backward-compatible API and database
+storage. This module is the single source of truth for allowed values, labels,
+state groupings, recovery behavior, and valid transitions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any, Iterable, Mapping
+
+State = str | None
+
+
+class ProcessingJobStatus(StrEnum):
+    QUEUED = "queued"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    ERROR = "error"
+    CANCELED = "canceled"
+
+
+class WebImportStatus(StrEnum):
+    PENDING = "pending"
+    ERROR = "error"
+
+
+class WebRefreshStatus(StrEnum):
+    QUEUED = "queued"
+    PROCESSING = "processing"
+    ERROR = "error"
+
+
+class UpdateTaskStatus(StrEnum):
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    INTERRUPTED = "interrupted"
+
+
+class MetadataJobStatus(StrEnum):
+    QUEUED = "queued"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class AudiobookPipelineStatus(StrEnum):
+    INGESTING = "ingesting"
+    ROSTER_GENERATION = "roster_gen"
+    DIARIZING = "diarizing"
+    AUDIO_GENERATION = "audio_gen"
+    ASSEMBLING = "assembling"
+    PAUSED = "paused"
+    COMPLETE = "complete"
+    ERROR = "error"
+
+
+class AudiobookPublicationStatus(StrEnum):
+    PROCESSING = "processing"
+    PARTIAL = "partial"
+    COMPLETE = "complete"
+    STALE = "stale"
+    ERROR = "error"
+
+
+class ChapterPreviewStatus(StrEnum):
+    QUEUED = "queued"
+    GENERATING = "generating"
+    READY = "ready"
+    ERROR = "error"
+
+
+class ChapterGenerationStatus(StrEnum):
+    PENDING = "pending"
+    PROCESSING = "processing"
+    READY = "ready"
+    ERROR = "error"
+
+
+class SentenceStatus(StrEnum):
+    PENDING_DIARIZATION = "pending_diarization"
+    READY_FOR_AUDIO = "ready_for_audio"
+    AUDIO_QUEUED = "audio_queued"
+    AUDIO_GENERATING = "audio_generating"
+    AUDIO_GENERATED = "audio_generated"
+    ERROR = "error"
+
+
+class ImportedAudiobookStatus(StrEnum):
+    QUEUED = "queued"
+    IMPORTING = "importing"
+    READY = "ready"
+    ALIGNING = "aligning"
+    STALE = "stale"
+    ERROR = "error"
+
+
+class AlignmentMethod(StrEnum):
+    ESTIMATED = "estimated"
+    TRANSCRIBED = "transcribed"
+    HYBRID = "hybrid"
+
+
+class InvalidStateTransition(ValueError):
+    """Raised when application code attempts an impossible lifecycle change."""
+
+
+@dataclass(frozen=True)
+class StateMachine:
+    name: str
+    states: frozenset[State]
+    transitions: Mapping[State, frozenset[State]]
+    labels: Mapping[State, str]
+    active_states: frozenset[State] = field(default_factory=frozenset)
+    terminal_states: frozenset[State] = field(default_factory=frozenset)
+    failure_states: frozenset[State] = field(default_factory=frozenset)
+    retryable_states: frozenset[State] = field(default_factory=frozenset)
+    ordered_states: tuple[State, ...] = ()
+    recovery: Mapping[State, State | str] = field(default_factory=dict)
+    groups: Mapping[str, frozenset[State] | tuple[State, ...]] = field(default_factory=dict)
+
+    def normalize(self, state: State | StrEnum) -> State:
+        return state.value if isinstance(state, StrEnum) else state
+
+    def validate_state(self, state: State | StrEnum) -> State:
+        normalized = self.normalize(state)
+        if normalized not in self.states:
+            allowed = ", ".join("null" if item is None else item for item in self.ordered_states or self.states)
+            raise InvalidStateTransition(f"Unknown {self.name} state {normalized!r}; expected one of: {allowed}.")
+        return normalized
+
+    def transition(self, current: State | StrEnum, target: State | StrEnum, *, context: str | None = None) -> State:
+        current_value = self.validate_state(current)
+        target_value = self.validate_state(target)
+        if current_value == target_value:
+            return target_value
+        allowed = self.transitions.get(current_value, frozenset())
+        if target_value not in allowed:
+            allowed_text = ", ".join("null" if item is None else item for item in sorted(allowed, key=str)) or "none"
+            location = f" for {context}" if context else ""
+            raise InvalidStateTransition(
+                f"Invalid {self.name} transition{location}: {current_value!r} -> {target_value!r}. "
+                f"Allowed next states: {allowed_text}."
+            )
+        return target_value
+
+    def manifest(self) -> dict[str, Any]:
+        ordered = self.ordered_states or tuple(sorted(self.states, key=lambda value: (value is not None, str(value))))
+
+        def ordered_subset(values: Iterable[State]) -> list[State]:
+            selected = set(values)
+            return [value for value in ordered if value in selected]
+
+        return {
+            "name": self.name,
+            "states": [{"value": value, "label": self.labels[value]} for value in ordered],
+            "active_states": ordered_subset(self.active_states),
+            "terminal_states": ordered_subset(self.terminal_states),
+            "failure_states": ordered_subset(self.failure_states),
+            "retryable_states": ordered_subset(self.retryable_states),
+            "recovery": {"null" if key is None else key: value for key, value in self.recovery.items()},
+            "groups": {
+                name: list(values) if isinstance(values, tuple) else ordered_subset(values)
+                for name, values in self.groups.items()
+            },
+        }
+
+
+def _values(items: Iterable[State | StrEnum]) -> frozenset[State]:
+    return frozenset(item.value if isinstance(item, StrEnum) else item for item in items)
+
+
+def _labels(**labels: str) -> dict[State, str]:
+    return {(None if key == "null" else key): value for key, value in labels.items()}
+
+
+PROCESSING_JOB = StateMachine(
+    name="processing job",
+    states=_values(ProcessingJobStatus),
+    transitions={
+        ProcessingJobStatus.QUEUED: _values(
+            (
+                ProcessingJobStatus.RUNNING,
+                ProcessingJobStatus.COMPLETED,
+                ProcessingJobStatus.ERROR,
+                ProcessingJobStatus.CANCELED,
+            )
+        ),
+        ProcessingJobStatus.RUNNING: _values(
+            (
+                ProcessingJobStatus.QUEUED,
+                ProcessingJobStatus.COMPLETED,
+                ProcessingJobStatus.ERROR,
+                ProcessingJobStatus.CANCELED,
+            )
+        ),
+        ProcessingJobStatus.ERROR: _values((ProcessingJobStatus.QUEUED,)),
+        ProcessingJobStatus.CANCELED: _values((ProcessingJobStatus.QUEUED,)),
+        ProcessingJobStatus.COMPLETED: frozenset(),
+    },
+    labels=_labels(queued="Queued", running="Running", completed="Completed", error="Failed", canceled="Canceled"),
+    active_states=_values((ProcessingJobStatus.QUEUED, ProcessingJobStatus.RUNNING)),
+    terminal_states=_values((ProcessingJobStatus.COMPLETED, ProcessingJobStatus.ERROR, ProcessingJobStatus.CANCELED)),
+    failure_states=_values((ProcessingJobStatus.ERROR,)),
+    retryable_states=_values((ProcessingJobStatus.ERROR, ProcessingJobStatus.CANCELED)),
+    ordered_states=tuple(item.value for item in ProcessingJobStatus),
+    recovery={
+        ProcessingJobStatus.QUEUED: ProcessingJobStatus.QUEUED,
+        ProcessingJobStatus.RUNNING: ProcessingJobStatus.QUEUED,
+    },
+    groups={
+        "running": (ProcessingJobStatus.RUNNING.value,),
+        "waiting": (ProcessingJobStatus.QUEUED.value,),
+    },
+)
+
+WEB_IMPORT = StateMachine(
+    name="web import",
+    states=_values((None, *WebImportStatus)),
+    transitions={
+        None: _values((WebImportStatus.PENDING, WebImportStatus.ERROR)),
+        WebImportStatus.PENDING: _values((None, WebImportStatus.ERROR)),
+        WebImportStatus.ERROR: _values((WebImportStatus.PENDING,)),
+    },
+    labels=_labels(null="Ready", pending="Importing", error="Import failed"),
+    active_states=_values((WebImportStatus.PENDING,)),
+    terminal_states=_values((None, WebImportStatus.ERROR)),
+    failure_states=_values((WebImportStatus.ERROR,)),
+    retryable_states=_values((WebImportStatus.ERROR,)),
+    ordered_states=(None, WebImportStatus.PENDING, WebImportStatus.ERROR),
+    recovery={WebImportStatus.PENDING: WebImportStatus.PENDING},
+)
+
+WEB_REFRESH = StateMachine(
+    name="web refresh",
+    states=_values((None, *WebRefreshStatus)),
+    transitions={
+        None: _values(
+            (
+                WebRefreshStatus.QUEUED,
+                WebRefreshStatus.PROCESSING,
+                WebRefreshStatus.ERROR,
+            )
+        ),
+        WebRefreshStatus.QUEUED: _values((WebRefreshStatus.PROCESSING, None, WebRefreshStatus.ERROR)),
+        WebRefreshStatus.PROCESSING: _values((None, WebRefreshStatus.ERROR, WebRefreshStatus.QUEUED)),
+        WebRefreshStatus.ERROR: _values((WebRefreshStatus.QUEUED, WebRefreshStatus.PROCESSING, None)),
+    },
+    labels=_labels(null="Up to date", queued="Refresh queued", processing="Refreshing", error="Refresh failed"),
+    active_states=_values((WebRefreshStatus.QUEUED, WebRefreshStatus.PROCESSING)),
+    terminal_states=_values((None, WebRefreshStatus.ERROR)),
+    failure_states=_values((WebRefreshStatus.ERROR,)),
+    retryable_states=_values((WebRefreshStatus.ERROR,)),
+    ordered_states=(None, WebRefreshStatus.QUEUED, WebRefreshStatus.PROCESSING, WebRefreshStatus.ERROR),
+    recovery={
+        WebRefreshStatus.QUEUED: WebRefreshStatus.QUEUED,
+        WebRefreshStatus.PROCESSING: WebRefreshStatus.QUEUED,
+    },
+)
+
+UPDATE_TASK = StateMachine(
+    name="library refresh task",
+    states=_values(UpdateTaskStatus),
+    transitions={
+        UpdateTaskStatus.RUNNING: _values((UpdateTaskStatus.COMPLETED, UpdateTaskStatus.FAILED, UpdateTaskStatus.INTERRUPTED)),
+        UpdateTaskStatus.INTERRUPTED: _values((UpdateTaskStatus.RUNNING,)),
+        UpdateTaskStatus.COMPLETED: frozenset(),
+        UpdateTaskStatus.FAILED: frozenset(),
+    },
+    labels=_labels(running="Running", completed="Completed", failed="Failed", interrupted="Interrupted"),
+    active_states=_values((UpdateTaskStatus.RUNNING,)),
+    terminal_states=_values((UpdateTaskStatus.COMPLETED, UpdateTaskStatus.FAILED, UpdateTaskStatus.INTERRUPTED)),
+    failure_states=_values((UpdateTaskStatus.FAILED, UpdateTaskStatus.INTERRUPTED)),
+    ordered_states=tuple(item.value for item in UpdateTaskStatus),
+    recovery={UpdateTaskStatus.RUNNING: UpdateTaskStatus.INTERRUPTED},
+)
+
+METADATA_JOB = StateMachine(
+    name="metadata sync job",
+    states=_values(MetadataJobStatus),
+    transitions={
+        MetadataJobStatus.QUEUED: _values((MetadataJobStatus.RUNNING, MetadataJobStatus.FAILED)),
+        MetadataJobStatus.RUNNING: _values((MetadataJobStatus.QUEUED, MetadataJobStatus.COMPLETED, MetadataJobStatus.FAILED)),
+        MetadataJobStatus.FAILED: _values((MetadataJobStatus.QUEUED,)),
+        MetadataJobStatus.COMPLETED: frozenset(),
+    },
+    labels=_labels(queued="Queued", running="Running", completed="Completed", failed="Failed"),
+    active_states=_values((MetadataJobStatus.QUEUED, MetadataJobStatus.RUNNING)),
+    terminal_states=_values((MetadataJobStatus.COMPLETED, MetadataJobStatus.FAILED)),
+    failure_states=_values((MetadataJobStatus.FAILED,)),
+    retryable_states=_values((MetadataJobStatus.FAILED,)),
+    ordered_states=tuple(item.value for item in MetadataJobStatus),
+    recovery={
+        MetadataJobStatus.QUEUED: MetadataJobStatus.QUEUED,
+        MetadataJobStatus.RUNNING: MetadataJobStatus.QUEUED,
+    },
+)
+
+_pipeline_phases = tuple(
+    item.value
+    for item in (
+        AudiobookPipelineStatus.INGESTING,
+        AudiobookPipelineStatus.ROSTER_GENERATION,
+        AudiobookPipelineStatus.DIARIZING,
+        AudiobookPipelineStatus.AUDIO_GENERATION,
+        AudiobookPipelineStatus.ASSEMBLING,
+    )
+)
+_pipeline_states = _values((None, *AudiobookPipelineStatus))
+_pipeline_restart_targets = _values(
+    (
+        *_pipeline_phases,
+        AudiobookPipelineStatus.PAUSED,
+        AudiobookPipelineStatus.COMPLETE,
+        AudiobookPipelineStatus.ERROR,
+    )
+)
+AUDIOBOOK_PIPELINE = StateMachine(
+    name="generated audiobook pipeline",
+    states=_pipeline_states,
+    transitions={
+        None: _pipeline_restart_targets,
+        **{
+            phase: _values(
+                (
+                    None,
+                    *_pipeline_phases,
+                    AudiobookPipelineStatus.PAUSED,
+                    AudiobookPipelineStatus.COMPLETE,
+                    AudiobookPipelineStatus.ERROR,
+                )
+            )
+            for phase in _pipeline_phases
+        },
+        AudiobookPipelineStatus.PAUSED: _pipeline_restart_targets,
+        AudiobookPipelineStatus.ERROR: _pipeline_restart_targets,
+        AudiobookPipelineStatus.COMPLETE: _values((AudiobookPipelineStatus.PAUSED, *_pipeline_phases)),
+    },
+    labels=_labels(
+        null="Not started",
+        ingesting="Ingesting",
+        roster_gen="Roster",
+        diarizing="Diarizing",
+        audio_gen="TTS",
+        assembling="Assembly",
+        paused="Paused",
+        complete="Complete",
+        error="Error",
+    ),
+    active_states=_values(_pipeline_phases),
+    terminal_states=_values(
+        (None, AudiobookPipelineStatus.PAUSED, AudiobookPipelineStatus.COMPLETE, AudiobookPipelineStatus.ERROR)
+    ),
+    failure_states=_values((AudiobookPipelineStatus.ERROR,)),
+    retryable_states=_values((AudiobookPipelineStatus.ERROR, AudiobookPipelineStatus.PAUSED)),
+    ordered_states=(None, *_pipeline_phases, "paused", "complete", "error"),
+    recovery={phase: phase for phase in _pipeline_phases},
+    groups={
+        "progress_steps": (*_pipeline_phases, AudiobookPipelineStatus.COMPLETE.value),
+        "batchable": (
+            AudiobookPipelineStatus.DIARIZING.value,
+            AudiobookPipelineStatus.AUDIO_GENERATION.value,
+            AudiobookPipelineStatus.ASSEMBLING.value,
+        ),
+        "concurrent_analysis": (AudiobookPipelineStatus.DIARIZING.value,),
+        "ready": (AudiobookPipelineStatus.COMPLETE.value,),
+        "paused": (AudiobookPipelineStatus.PAUSED.value,),
+    },
+)
+
+AUDIOBOOK_PUBLICATION = StateMachine(
+    name="audiobook publication",
+    states=_values((None, *AudiobookPublicationStatus)),
+    transitions={state: _values(AudiobookPublicationStatus) for state in (None, *AudiobookPublicationStatus)},
+    labels=_labels(
+        null="Unavailable", processing="Processing", partial="Partial", complete="Complete", stale="Stale", error="Error"
+    ),
+    active_states=_values((AudiobookPublicationStatus.PROCESSING,)),
+    terminal_states=_values(
+        (
+            None,
+            AudiobookPublicationStatus.PARTIAL,
+            AudiobookPublicationStatus.COMPLETE,
+            AudiobookPublicationStatus.STALE,
+            AudiobookPublicationStatus.ERROR,
+        )
+    ),
+    failure_states=_values((AudiobookPublicationStatus.ERROR, AudiobookPublicationStatus.STALE)),
+    ordered_states=(None, *tuple(item.value for item in AudiobookPublicationStatus)),
+    recovery={AudiobookPublicationStatus.PROCESSING: AudiobookPublicationStatus.STALE},
+)
+
+CHAPTER_PREVIEW = StateMachine(
+    name="chapter preview",
+    states=_values((None, *ChapterPreviewStatus)),
+    transitions={
+        None: _values((ChapterPreviewStatus.QUEUED,)),
+        ChapterPreviewStatus.QUEUED: _values((ChapterPreviewStatus.GENERATING, ChapterPreviewStatus.ERROR, None)),
+        ChapterPreviewStatus.GENERATING: _values(
+            (ChapterPreviewStatus.READY, ChapterPreviewStatus.ERROR, ChapterPreviewStatus.QUEUED, None)
+        ),
+        ChapterPreviewStatus.READY: _values((ChapterPreviewStatus.QUEUED, None)),
+        ChapterPreviewStatus.ERROR: _values((ChapterPreviewStatus.QUEUED, None)),
+    },
+    labels=_labels(null="Not generated", queued="Queued", generating="Generating", ready="Ready", error="Error"),
+    active_states=_values((ChapterPreviewStatus.QUEUED, ChapterPreviewStatus.GENERATING)),
+    terminal_states=_values((None, ChapterPreviewStatus.READY, ChapterPreviewStatus.ERROR)),
+    failure_states=_values((ChapterPreviewStatus.ERROR,)),
+    retryable_states=_values((ChapterPreviewStatus.ERROR,)),
+    ordered_states=(None, *tuple(item.value for item in ChapterPreviewStatus)),
+    recovery={
+        ChapterPreviewStatus.QUEUED: ChapterPreviewStatus.QUEUED,
+        ChapterPreviewStatus.GENERATING: ChapterPreviewStatus.QUEUED,
+    },
+    groups={
+        "waiting": (ChapterPreviewStatus.QUEUED.value,),
+        "working": (ChapterPreviewStatus.GENERATING.value,),
+    },
+)
+
+CHAPTER_GENERATION = StateMachine(
+    name="published audiobook chapter",
+    states=_values(ChapterGenerationStatus),
+    transitions={
+        ChapterGenerationStatus.PENDING: _values(
+            (ChapterGenerationStatus.PROCESSING, ChapterGenerationStatus.READY, ChapterGenerationStatus.ERROR)
+        ),
+        ChapterGenerationStatus.PROCESSING: _values(
+            (ChapterGenerationStatus.PENDING, ChapterGenerationStatus.READY, ChapterGenerationStatus.ERROR)
+        ),
+        ChapterGenerationStatus.READY: _values(
+            (ChapterGenerationStatus.PENDING, ChapterGenerationStatus.PROCESSING, ChapterGenerationStatus.ERROR)
+        ),
+        ChapterGenerationStatus.ERROR: _values((ChapterGenerationStatus.PENDING, ChapterGenerationStatus.PROCESSING)),
+    },
+    labels=_labels(pending="Pending", processing="Processing", ready="Ready", error="Error"),
+    active_states=_values((ChapterGenerationStatus.PENDING, ChapterGenerationStatus.PROCESSING)),
+    terminal_states=_values((ChapterGenerationStatus.READY, ChapterGenerationStatus.ERROR)),
+    failure_states=_values((ChapterGenerationStatus.ERROR,)),
+    retryable_states=_values((ChapterGenerationStatus.ERROR,)),
+    ordered_states=tuple(item.value for item in ChapterGenerationStatus),
+    recovery={
+        ChapterGenerationStatus.PENDING: ChapterGenerationStatus.PENDING,
+        ChapterGenerationStatus.PROCESSING: ChapterGenerationStatus.PENDING,
+    },
+)
+
+SENTENCE = StateMachine(
+    name="audiobook sentence",
+    states=_values(SentenceStatus),
+    transitions={
+        SentenceStatus.PENDING_DIARIZATION: _values((SentenceStatus.READY_FOR_AUDIO, SentenceStatus.ERROR)),
+        SentenceStatus.READY_FOR_AUDIO: _values(
+            (
+                SentenceStatus.AUDIO_QUEUED,
+                SentenceStatus.AUDIO_GENERATING,
+                SentenceStatus.AUDIO_GENERATED,
+                SentenceStatus.ERROR,
+                SentenceStatus.PENDING_DIARIZATION,
+            )
+        ),
+        SentenceStatus.AUDIO_QUEUED: _values(
+            (SentenceStatus.AUDIO_GENERATING, SentenceStatus.READY_FOR_AUDIO, SentenceStatus.ERROR)
+        ),
+        SentenceStatus.AUDIO_GENERATING: _values(
+            (SentenceStatus.AUDIO_GENERATED, SentenceStatus.READY_FOR_AUDIO, SentenceStatus.ERROR)
+        ),
+        SentenceStatus.AUDIO_GENERATED: _values(
+            (SentenceStatus.READY_FOR_AUDIO, SentenceStatus.PENDING_DIARIZATION, SentenceStatus.ERROR)
+        ),
+        SentenceStatus.ERROR: _values(
+            (
+                SentenceStatus.READY_FOR_AUDIO,
+                SentenceStatus.AUDIO_QUEUED,
+                SentenceStatus.AUDIO_GENERATING,
+                SentenceStatus.PENDING_DIARIZATION,
+            )
+        ),
+    },
+    labels=_labels(
+        pending_diarization="Pending diarization",
+        ready_for_audio="Ready for audio",
+        audio_queued="Audio queued",
+        audio_generating="Generating audio",
+        audio_generated="Audio generated",
+        error="Error",
+    ),
+    active_states=_values((SentenceStatus.PENDING_DIARIZATION, SentenceStatus.AUDIO_QUEUED, SentenceStatus.AUDIO_GENERATING)),
+    terminal_states=_values((SentenceStatus.READY_FOR_AUDIO, SentenceStatus.AUDIO_GENERATED, SentenceStatus.ERROR)),
+    failure_states=_values((SentenceStatus.ERROR,)),
+    retryable_states=_values((SentenceStatus.ERROR,)),
+    ordered_states=tuple(item.value for item in SentenceStatus),
+    recovery={
+        SentenceStatus.PENDING_DIARIZATION: SentenceStatus.PENDING_DIARIZATION,
+        SentenceStatus.AUDIO_QUEUED: SentenceStatus.READY_FOR_AUDIO,
+        SentenceStatus.AUDIO_GENERATING: SentenceStatus.READY_FOR_AUDIO,
+    },
+    groups={
+        "audio_in_progress": (
+            SentenceStatus.AUDIO_QUEUED.value,
+            SentenceStatus.AUDIO_GENERATING.value,
+        ),
+        "audio_ready": (SentenceStatus.READY_FOR_AUDIO.value,),
+        "audio_waiting": (SentenceStatus.AUDIO_QUEUED.value,),
+        "audio_working": (SentenceStatus.AUDIO_GENERATING.value,),
+        "audio_playable": (SentenceStatus.AUDIO_GENERATED.value,),
+    },
+)
+
+IMPORTED_AUDIOBOOK = StateMachine(
+    name="imported audiobook",
+    states=_values(ImportedAudiobookStatus),
+    transitions={
+        ImportedAudiobookStatus.QUEUED: _values(
+            (ImportedAudiobookStatus.IMPORTING, ImportedAudiobookStatus.STALE, ImportedAudiobookStatus.ERROR)
+        ),
+        ImportedAudiobookStatus.IMPORTING: _values(
+            (
+                ImportedAudiobookStatus.READY,
+                ImportedAudiobookStatus.STALE,
+                ImportedAudiobookStatus.ERROR,
+                ImportedAudiobookStatus.QUEUED,
+            )
+        ),
+        ImportedAudiobookStatus.READY: _values(
+            (ImportedAudiobookStatus.ALIGNING, ImportedAudiobookStatus.STALE, ImportedAudiobookStatus.IMPORTING)
+        ),
+        ImportedAudiobookStatus.ALIGNING: _values(
+            (ImportedAudiobookStatus.READY, ImportedAudiobookStatus.STALE, ImportedAudiobookStatus.ERROR)
+        ),
+        ImportedAudiobookStatus.STALE: _values(
+            (ImportedAudiobookStatus.IMPORTING, ImportedAudiobookStatus.READY, ImportedAudiobookStatus.ALIGNING)
+        ),
+        ImportedAudiobookStatus.ERROR: _values(
+            (ImportedAudiobookStatus.QUEUED, ImportedAudiobookStatus.IMPORTING, ImportedAudiobookStatus.STALE)
+        ),
+    },
+    labels=_labels(queued="Queued", importing="Importing", ready="Ready", aligning="Aligning", stale="Stale", error="Error"),
+    active_states=_values(
+        (
+            ImportedAudiobookStatus.QUEUED,
+            ImportedAudiobookStatus.IMPORTING,
+            ImportedAudiobookStatus.ALIGNING,
+            ImportedAudiobookStatus.STALE,
+        )
+    ),
+    terminal_states=_values((ImportedAudiobookStatus.READY, ImportedAudiobookStatus.ERROR)),
+    failure_states=_values((ImportedAudiobookStatus.ERROR, ImportedAudiobookStatus.STALE)),
+    retryable_states=_values((ImportedAudiobookStatus.ERROR, ImportedAudiobookStatus.STALE)),
+    ordered_states=tuple(item.value for item in ImportedAudiobookStatus),
+    recovery={
+        ImportedAudiobookStatus.QUEUED: ImportedAudiobookStatus.QUEUED,
+        ImportedAudiobookStatus.IMPORTING: ImportedAudiobookStatus.QUEUED,
+        ImportedAudiobookStatus.ALIGNING: ImportedAudiobookStatus.READY,
+        ImportedAudiobookStatus.STALE: ImportedAudiobookStatus.STALE,
+    },
+)
+
+ALIGNMENT_METHOD = StateMachine(
+    name="audiobook alignment method",
+    states=_values((None, *AlignmentMethod)),
+    transitions={state: _values((None, *AlignmentMethod)) for state in (None, *AlignmentMethod)},
+    labels=_labels(null="Not aligned", estimated="Estimated", transcribed="Transcribed", hybrid="Hybrid"),
+    terminal_states=_values((None, *AlignmentMethod)),
+    ordered_states=(None, *tuple(item.value for item in AlignmentMethod)),
+)
+
+LIFECYCLES: Mapping[str, StateMachine] = {
+    "processing_job": PROCESSING_JOB,
+    "web_import": WEB_IMPORT,
+    "web_refresh": WEB_REFRESH,
+    "update_task": UPDATE_TASK,
+    "metadata_job": METADATA_JOB,
+    "audiobook_pipeline": AUDIOBOOK_PIPELINE,
+    "audiobook_publication": AUDIOBOOK_PUBLICATION,
+    "chapter_preview": CHAPTER_PREVIEW,
+    "chapter_generation": CHAPTER_GENERATION,
+    "sentence": SENTENCE,
+    "imported_audiobook": IMPORTED_AUDIOBOOK,
+    "alignment_method": ALIGNMENT_METHOD,
+}
+
+
+def transition_state(
+    record: Any,
+    attribute: str,
+    machine: StateMachine,
+    target: State | StrEnum,
+    *,
+    context: str | None = None,
+) -> State:
+    """Validate and assign one ORM-backed lifecycle field."""
+    current = getattr(record, attribute)
+    value = machine.transition(current, target, context=context or f"{type(record).__name__}.{attribute}")
+    setattr(record, attribute, value)
+    return value
+
+
+def lifecycle_manifest() -> dict[str, dict[str, Any]]:
+    """Return the documented vocabulary consumed by frontend labels/groupings."""
+    return {name: machine.manifest() for name, machine in LIFECYCLES.items()}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -28,6 +28,7 @@ from .routers import (
     cleaning,
     covers,
     dashboard,
+    lifecycles,
     metadata,
     processing,
     reader,
@@ -115,6 +116,7 @@ app.include_router(web_novels.router)
 app.include_router(cleaning.router)
 app.include_router(covers.router)
 app.include_router(dashboard.router)
+app.include_router(lifecycles.router)
 app.include_router(scheduler.router)
 app.include_router(storage.router)
 app.include_router(api_keys.router)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,6 +1,7 @@
 from sqlalchemy import (
     BigInteger,
     Boolean,
+    CheckConstraint,
     Column,
     Integer,
     String,
@@ -18,7 +19,33 @@ from sqlalchemy import (
 )
 from sqlalchemy.sql import func
 from .database import Base
+from .lifecycle import (
+    ALIGNMENT_METHOD,
+    AUDIOBOOK_PIPELINE,
+    AUDIOBOOK_PUBLICATION,
+    CHAPTER_GENERATION,
+    CHAPTER_PREVIEW,
+    IMPORTED_AUDIOBOOK,
+    METADATA_JOB,
+    PROCESSING_JOB,
+    SENTENCE,
+    UPDATE_TASK,
+    WEB_IMPORT,
+    WEB_REFRESH,
+    ChapterGenerationStatus,
+    ImportedAudiobookStatus,
+    MetadataJobStatus,
+    ProcessingJobStatus,
+    SentenceStatus,
+    StateMachine,
+    UpdateTaskStatus,
+)
 import enum
+
+
+def _state_check(column_name: str, machine: StateMachine, name: str) -> CheckConstraint:
+    values = ", ".join(f"'{value}'" for value in sorted(value for value in machine.states if value is not None))
+    return CheckConstraint(f"{column_name} IN ({values})", name=name)
 
 
 class SourceType(enum.Enum):
@@ -28,6 +55,16 @@ class SourceType(enum.Enum):
 
 class Book(Base):
     __tablename__ = "books"
+    __table_args__ = (
+        _state_check("download_status", WEB_IMPORT, "ck_books_download_status"),
+        _state_check("refresh_status", WEB_REFRESH, "ck_books_refresh_status"),
+        _state_check("audiobook_pipeline_status", AUDIOBOOK_PIPELINE, "ck_books_audiobook_pipeline_status"),
+        _state_check(
+            "audiobook_publication_state",
+            AUDIOBOOK_PUBLICATION,
+            "ck_books_audiobook_publication_state",
+        ),
+    )
 
     id = Column(Integer, primary_key=True, index=True)
     title = Column(String, index=True)
@@ -135,7 +172,13 @@ class ProcessingJob(Base):
 
     id = Column(Integer, primary_key=True)
     job_type = Column(String, nullable=False, index=True)
-    status = Column(String, nullable=False, default="queued", server_default="queued", index=True)
+    status = Column(
+        String,
+        nullable=False,
+        default=ProcessingJobStatus.QUEUED.value,
+        server_default=ProcessingJobStatus.QUEUED.value,
+        index=True,
+    )
     resource_lane = Column(String, nullable=False, default="maintenance", server_default="maintenance", index=True)
     book_id = Column(Integer, ForeignKey("books.id", ondelete="CASCADE"), nullable=True, index=True)
     target_type = Column(String, nullable=True)
@@ -161,6 +204,7 @@ class ProcessingJob(Base):
     updated_at = Column(DateTime(timezone=True), onupdate=func.now(), nullable=True)
 
     __table_args__ = (
+        _state_check("status", PROCESSING_JOB, "ck_processing_jobs_status"),
         Index(
             "uq_processing_jobs_active_dedupe",
             "dedupe_key",
@@ -195,21 +239,23 @@ class BookLog(Base):
 
 class UpdateTask(Base):
     __tablename__ = "update_tasks"
+    __table_args__ = (_state_check("status", UPDATE_TASK, "ck_update_tasks_status"),)
 
     id = Column(Integer, primary_key=True, index=True)
     total_books = Column(Integer, nullable=False)
     completed_books = Column(Integer, nullable=False, default=0)
-    status = Column(String, nullable=False, default="running")
+    status = Column(String, nullable=False, default=UpdateTaskStatus.RUNNING.value)
     started_at = Column(DateTime(timezone=True), server_default=func.now())
     completed_at = Column(DateTime(timezone=True), nullable=True)
 
 
 class MetadataSyncJob(Base):
     __tablename__ = "metadata_sync_jobs"
+    __table_args__ = (_state_check("status", METADATA_JOB, "ck_metadata_sync_jobs_status"),)
 
     id = Column(Integer, primary_key=True, index=True)
     trigger = Column(String, nullable=False)
-    status = Column(String, nullable=False, default="queued")
+    status = Column(String, nullable=False, default=MetadataJobStatus.QUEUED.value)
     total_books = Column(Integer, nullable=False, default=0)
     processed_books = Column(Integer, nullable=False, default=0)
     matched_books = Column(Integer, nullable=False, default=0)
@@ -345,7 +391,11 @@ class AiEndpointRequestMetric(Base):
 
 class AudiobookChapter(Base):
     __tablename__ = "audiobook_chapters"
-    __table_args__ = (UniqueConstraint("book_id", "stable_chapter_key", name="uq_audiobook_chapter_stable_key"),)
+    __table_args__ = (
+        UniqueConstraint("book_id", "stable_chapter_key", name="uq_audiobook_chapter_stable_key"),
+        _state_check("preview_status", CHAPTER_PREVIEW, "ck_audiobook_chapters_preview_status"),
+        _state_check("generation_state", CHAPTER_GENERATION, "ck_audiobook_chapters_generation_state"),
+    )
 
     id = Column(Integer, primary_key=True, index=True)
     book_id = Column(Integer, ForeignKey("books.id", ondelete="CASCADE"), nullable=False, index=True)
@@ -365,7 +415,12 @@ class AudiobookChapter(Base):
     source_content_hash = Column(String(64), nullable=True)
     title = Column(String, nullable=True)
     spine_order = Column(Integer, nullable=True)
-    generation_state = Column(String, nullable=False, default="pending", server_default="pending")
+    generation_state = Column(
+        String,
+        nullable=False,
+        default=ChapterGenerationStatus.PENDING.value,
+        server_default=ChapterGenerationStatus.PENDING.value,
+    )
     audio_revision = Column(Integer, nullable=False, default=0, server_default="0")
     reader_audio_file_path = Column(String, nullable=True)
     reader_smil_file_path = Column(String, nullable=True)
@@ -418,6 +473,7 @@ class AudiobookCharacter(Base):
 
 class AudiobookSentence(Base):
     __tablename__ = "audiobook_sentences"
+    __table_args__ = (_state_check("status", SENTENCE, "ck_audiobook_sentences_status"),)
 
     id = Column(Integer, primary_key=True, index=True)
     chapter_id = Column(Integer, ForeignKey("audiobook_chapters.id", ondelete="CASCADE"), nullable=False, index=True)
@@ -430,22 +486,32 @@ class AudiobookSentence(Base):
     audio_duration_ms = Column(Integer, nullable=True)
     speaker_confidence = Column(Float, nullable=True)
     speaker_reason = Column(Text, nullable=True)
-    # Status values: pending_diarization, ready_for_audio, audio_generated, error
-    status = Column(String, nullable=False, server_default="pending_diarization")
+    # Values and transitions are defined by lifecycle.SENTENCE.
+    status = Column(String, nullable=False, server_default=SentenceStatus.PENDING_DIARIZATION.value)
 
 
 class ImportedAudiobook(Base):
     """A human-narrated audiobook edition attached to a library book."""
 
     __tablename__ = "imported_audiobooks"
+    __table_args__ = (
+        _state_check("status", IMPORTED_AUDIOBOOK, "ck_imported_audiobooks_status"),
+        _state_check("alignment_method", ALIGNMENT_METHOD, "ck_imported_audiobooks_alignment_method"),
+    )
 
     id = Column(Integer, primary_key=True, index=True)
     book_id = Column(Integer, ForeignKey("books.id", ondelete="CASCADE"), nullable=False, index=True)
     name = Column(String, nullable=False)
     source_type = Column(String, nullable=False, default="upload", server_default="upload")
     asin = Column(String, nullable=True, index=True)
-    # Values: queued, importing, ready, aligning, error.
-    status = Column(String, nullable=False, default="queued", server_default="queued", index=True)
+    # Values and transitions are defined by lifecycle.IMPORTED_AUDIOBOOK.
+    status = Column(
+        String,
+        nullable=False,
+        default=ImportedAudiobookStatus.QUEUED.value,
+        server_default=ImportedAudiobookStatus.QUEUED.value,
+        index=True,
+    )
     alignment_method = Column(String, nullable=True)
     original_filenames = Column(JSON, nullable=True)
     duration_ms = Column(BigInteger, nullable=True)

--- a/backend/app/routers/audiobook.py
+++ b/backend/app/routers/audiobook.py
@@ -19,6 +19,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from .. import crud
 from ..config import LIBRARY_PATH
 from ..database import get_db
+from ..lifecycle import IMPORTED_AUDIOBOOK, ImportedAudiobookStatus, transition_state
 from ..models import (
     AudiobookChapter,
     AudiobookCharacter,
@@ -734,7 +735,13 @@ async def upload_imported_audiobook(
         )
         await _notify_legacy_queue(get_audiobook_import_queue, "enqueue", edition.id)
     except Exception as exc:
-        edition.status = "error"
+        transition_state(
+            edition,
+            "status",
+            IMPORTED_AUDIOBOOK,
+            ImportedAudiobookStatus.ERROR,
+            context=f"imported audiobook {edition.id}",
+        )
         edition.error = str(exc)
         edition.progress_detail = "Upload failed"
         await db.commit()
@@ -756,7 +763,13 @@ async def retry_imported_audiobook(
     await _get_book_or_404(edition.book_id, db)
     if edition.status not in ("error", "queued"):
         raise HTTPException(status_code=409, detail=f"Audiobook import is {edition.status}, not retryable")
-    edition.status = "queued"
+    transition_state(
+        edition,
+        "status",
+        IMPORTED_AUDIOBOOK,
+        ImportedAudiobookStatus.QUEUED,
+        context=f"imported audiobook {edition.id}",
+    )
     edition.error = None
     edition.progress_detail = "Queued for retry"
     await db.commit()
@@ -800,7 +813,13 @@ async def align_imported_audiobook(
     )
     if not matched_count:
         raise HTTPException(status_code=409, detail="Match at least one audio track to a book chapter first.")
-    edition.status = "aligning"
+    transition_state(
+        edition,
+        "status",
+        IMPORTED_AUDIOBOOK,
+        ImportedAudiobookStatus.ALIGNING,
+        context=f"imported audiobook {edition.id}",
+    )
     edition.alignment_error = None
     edition.progress_current = 0
     edition.progress_total = matched_count
@@ -844,7 +863,13 @@ async def rematch_imported_audiobook(
         raise HTTPException(status_code=409, detail="This audiobook has no imported audio tracks")
 
     realign = edition.alignment_method in {"transcribed", "hybrid"}
-    edition.status = "stale"
+    transition_state(
+        edition,
+        "status",
+        IMPORTED_AUDIOBOOK,
+        ImportedAudiobookStatus.STALE,
+        context=f"imported audiobook {edition.id}",
+    )
     edition.alignment_error = None
     edition.progress_current = 0
     edition.progress_total = track_count

--- a/backend/app/routers/lifecycles.py
+++ b/backend/app/routers/lifecycles.py
@@ -1,0 +1,12 @@
+"""Read-only lifecycle vocabulary shared with the frontend."""
+
+from fastapi import APIRouter
+
+from ..lifecycle import lifecycle_manifest
+
+router = APIRouter()
+
+
+@router.get("/api/lifecycles")
+async def get_lifecycle_definitions() -> dict:
+    return lifecycle_manifest()

--- a/backend/app/routers/web_novels.py
+++ b/backend/app/routers/web_novels.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import crud, models, schemas
 from ..database import get_db
+from ..lifecycle import WEB_REFRESH, WebRefreshStatus, transition_state
 from ..services.processing_queue import queue_processing_job
 from ..services.refresh_queue import RefreshQueue, get_refresh_queue
 
@@ -111,7 +112,7 @@ async def refresh_book(
     # no-op rather than doubling it up — return the current status so the client
     # can begin polling.
     if db_book.refresh_status not in ("queued", "processing"):
-        db_book.refresh_status = "queued"
+        transition_state(db_book, "refresh_status", WEB_REFRESH, WebRefreshStatus.QUEUED, context=f"book {db_book.id}")
         await db.commit()
         await db.refresh(db_book)
 

--- a/backend/app/services/audiobook_alignment.py
+++ b/backend/app/services/audiobook_alignment.py
@@ -18,6 +18,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import crud
 from ..config import LIBRARY_PATH
+from ..lifecycle import (
+    ALIGNMENT_METHOD,
+    IMPORTED_AUDIOBOOK,
+    AlignmentMethod,
+    ImportedAudiobookStatus,
+    transition_state,
+)
 from ..models import (
     AudiobookSentence,
     ImportedAudiobook,
@@ -474,7 +481,13 @@ async def process_alignment(edition_id: int, db: AsyncSession) -> None:
     settings = await crud.audiobook.get_audiobook_settings(db)
     provider = transcription_provider_name(settings)
     if settings is None or provider == "none":
-        edition.status = "ready"
+        transition_state(
+            edition,
+            "status",
+            IMPORTED_AUDIOBOOK,
+            ImportedAudiobookStatus.READY,
+            context=f"imported audiobook {edition.id}",
+        )
         edition.alignment_error = "Configure a transcription provider in Audio Settings first."
         edition.progress_detail = "Timestamp alignment not configured"
         await db.commit()
@@ -489,7 +502,13 @@ async def process_alignment(edition_id: int, db: AsyncSession) -> None:
         .order_by(ImportedAudiobookTrack.sequence_order)
     )
     tracks = list(result.scalars().all())
-    edition.status = "aligning"
+    transition_state(
+        edition,
+        "status",
+        IMPORTED_AUDIOBOOK,
+        ImportedAudiobookStatus.ALIGNING,
+        context=f"imported audiobook {edition.id}",
+    )
     edition.alignment_error = None
     edition.progress_current = 0
     edition.progress_total = len(tracks)
@@ -559,8 +578,20 @@ async def process_alignment(edition_id: int, db: AsyncSession) -> None:
             await db.commit()
 
         average_score = sum(scores) / max(1, len(scores))
-        edition.status = "ready"
-        edition.alignment_method = "transcribed" if average_score >= 0.65 else "hybrid"
+        transition_state(
+            edition,
+            "status",
+            IMPORTED_AUDIOBOOK,
+            ImportedAudiobookStatus.READY,
+            context=f"imported audiobook {edition.id}",
+        )
+        transition_state(
+            edition,
+            "alignment_method",
+            ALIGNMENT_METHOD,
+            AlignmentMethod.TRANSCRIBED if average_score >= 0.65 else AlignmentMethod.HYBRID,
+            context=f"imported audiobook {edition.id}",
+        )
         edition.progress_current = len(tracks)
         edition.progress_total = len(tracks)
         edition.progress_detail = f"Timestamp alignment ready ({average_score:.0%} confidence)"
@@ -572,7 +603,13 @@ async def process_alignment(edition_id: int, db: AsyncSession) -> None:
         await db.rollback()
         edition = await db.get(ImportedAudiobook, edition_id)
         if edition is not None:
-            edition.status = "ready"
+            transition_state(
+                edition,
+                "status",
+                IMPORTED_AUDIOBOOK,
+                ImportedAudiobookStatus.READY,
+                context=f"imported audiobook {edition.id}",
+            )
             edition.alignment_error = str(exc)
             edition.progress_detail = "Timestamp alignment failed; estimated cues retained where available"
             await db.commit()

--- a/backend/app/services/audiobook_import.py
+++ b/backend/app/services/audiobook_import.py
@@ -17,6 +17,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import crud
 from ..config import LIBRARY_PATH
+from ..lifecycle import (
+    ALIGNMENT_METHOD,
+    AUDIOBOOK_PIPELINE,
+    IMPORTED_AUDIOBOOK,
+    AlignmentMethod,
+    ImportedAudiobookStatus,
+    transition_state,
+)
 from ..models import (
     AudiobookChapter,
     AudiobookSentence,
@@ -472,7 +480,13 @@ async def ensure_span_anchored_text(book: Book, db: AsyncSession) -> list[Audiob
     await db.refresh(book)
     # Importing narration must not silently opt the user into an unattended AI
     # generation run. The generated pipeline remains exactly where it was.
-    book.audiobook_pipeline_status = prior_status
+    transition_state(
+        book,
+        "audiobook_pipeline_status",
+        AUDIOBOOK_PIPELINE,
+        prior_status,
+        context=f"book {book.id} after narration import preparation",
+    )
     await db.commit()
     return await crud.audiobook.get_chapters_for_book(db, book.id)
 
@@ -481,7 +495,13 @@ async def process_import(edition_id: int, db: AsyncSession) -> None:
     edition = await db.get(ImportedAudiobook, edition_id)
     if edition is None:
         return
-    edition.status = "importing"
+    transition_state(
+        edition,
+        "status",
+        IMPORTED_AUDIOBOOK,
+        ImportedAudiobookStatus.IMPORTING,
+        context=f"imported audiobook {edition.id}",
+    )
     edition.error = None
     edition.progress_detail = "Inspecting uploaded files"
     await db.commit()
@@ -523,8 +543,20 @@ async def process_import(edition_id: int, db: AsyncSession) -> None:
             await db.commit()
 
         matched_count = sum(1 for spec in specs if _chapter_match(spec, chapters))
-        edition.status = "ready"
-        edition.alignment_method = "estimated"
+        transition_state(
+            edition,
+            "status",
+            IMPORTED_AUDIOBOOK,
+            ImportedAudiobookStatus.READY,
+            context=f"imported audiobook {edition.id}",
+        )
+        transition_state(
+            edition,
+            "alignment_method",
+            ALIGNMENT_METHOD,
+            AlignmentMethod.ESTIMATED,
+            context=f"imported audiobook {edition.id}",
+        )
         edition.matched_content_version = book.content_version or 1
         edition.progress_current = len(specs)
         edition.progress_total = len(specs)
@@ -537,7 +569,13 @@ async def process_import(edition_id: int, db: AsyncSession) -> None:
         await db.rollback()
         edition = await db.get(ImportedAudiobook, edition_id)
         if edition is not None:
-            edition.status = "error"
+            transition_state(
+                edition,
+                "status",
+                IMPORTED_AUDIOBOOK,
+                ImportedAudiobookStatus.ERROR,
+                context=f"imported audiobook {edition.id}",
+            )
             edition.error = str(exc)
             edition.progress_detail = "Import failed"
             await db.commit()
@@ -552,7 +590,13 @@ async def rematch_imported_audiobook(edition_id: int, db: AsyncSession) -> int:
     if book is None:
         raise ValueError("The selected library book no longer exists.")
 
-    edition.status = "importing"
+    transition_state(
+        edition,
+        "status",
+        IMPORTED_AUDIOBOOK,
+        ImportedAudiobookStatus.IMPORTING,
+        context=f"imported audiobook {edition.id}",
+    )
     edition.alignment_error = None
     edition.progress_current = 0
     edition.progress_detail = "Preparing current cleaned book text"
@@ -587,8 +631,20 @@ async def rematch_imported_audiobook(edition_id: int, db: AsyncSession) -> int:
         edition.progress_detail = f"Rematched track {index} of {len(tracks)}"
         await db.commit()
 
-    edition.status = "ready"
-    edition.alignment_method = "estimated"
+    transition_state(
+        edition,
+        "status",
+        IMPORTED_AUDIOBOOK,
+        ImportedAudiobookStatus.READY,
+        context=f"imported audiobook {edition.id}",
+    )
+    transition_state(
+        edition,
+        "alignment_method",
+        ALIGNMENT_METHOD,
+        AlignmentMethod.ESTIMATED,
+        context=f"imported audiobook {edition.id}",
+    )
     edition.matched_content_version = book.content_version or 1
     edition.progress_detail = f"Ready: {matched_count} of {len(tracks)} tracks matched"
     edition.error = None
@@ -610,7 +666,13 @@ async def rematch_track(
     track.alignment_score = None
     edition = await db.get(ImportedAudiobook, track.imported_audiobook_id)
     if edition is not None:
-        edition.alignment_method = "estimated"
+        transition_state(
+            edition,
+            "alignment_method",
+            ALIGNMENT_METHOD,
+            AlignmentMethod.ESTIMATED,
+            context=f"imported audiobook {edition.id}",
+        )
         edition.alignment_error = None
     await db.commit()
     await db.refresh(track)

--- a/backend/app/services/audiobook_ingestion.py
+++ b/backend/app/services/audiobook_ingestion.py
@@ -17,6 +17,15 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from .. import crud
 from ..config import LIBRARY_PATH
 from ..models import AudiobookChapter, AudiobookSentence, Book
+from ..lifecycle import (
+    AUDIOBOOK_PIPELINE,
+    AUDIOBOOK_PUBLICATION,
+    CHAPTER_GENERATION,
+    AudiobookPipelineStatus,
+    AudiobookPublicationStatus,
+    ChapterGenerationStatus,
+    transition_state,
+)
 from .audiobook_publication import (
     normalize_resource_href,
     stable_chapter_key,
@@ -416,7 +425,13 @@ async def ingest_epub(book_id: int, db: AsyncSession) -> None:
             chapter.smil_sha256 = None
             chapter.duration_ms = None
             chapter.needs_reassembly = True
-            chapter.generation_state = "pending"
+            transition_state(
+                chapter,
+                "generation_state",
+                CHAPTER_GENERATION,
+                ChapterGenerationStatus.PENDING,
+                context=f"audiobook chapter {chapter.id}",
+            )
             chapter.summary = None
             chapter.summary_updated_at = None
             db.add_all([AudiobookSentence(chapter_id=chapter.id, **sentence) for sentence in chapter_sentences])
@@ -466,9 +481,21 @@ async def ingest_epub(book_id: int, db: AsyncSession) -> None:
     book.audiobook_text_file_path = text_path
     book.audiobook_text_size_bytes = text_size
     book.audiobook_text_sha256 = text_sha
-    book.audiobook_publication_state = "partial" if ready_count else "processing"
+    transition_state(
+        book,
+        "audiobook_publication_state",
+        AUDIOBOOK_PUBLICATION,
+        AudiobookPublicationStatus.PARTIAL if ready_count else AudiobookPublicationStatus.PROCESSING,
+        context=f"book {book.id}",
+    )
     book.audiobook_publication_error = None
-    book.audiobook_pipeline_status = "diarizing" if characters else "roster_gen"
+    transition_state(
+        book,
+        "audiobook_pipeline_status",
+        AUDIOBOOK_PIPELINE,
+        AudiobookPipelineStatus.DIARIZING if characters else AudiobookPipelineStatus.ROSTER_GENERATION,
+        context=f"book {book.id}",
+    )
     book.audiobook_progress_current = persisted_chapters
     book.audiobook_progress_total = persisted_chapters
     book.audiobook_progress_detail = (

--- a/backend/app/services/audiobook_publication.py
+++ b/backend/app/services/audiobook_publication.py
@@ -14,6 +14,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from .. import crud
 from ..config import LIBRARY_PATH
 from ..models import AudiobookChapter, Book
+from ..lifecycle import (
+    AUDIOBOOK_PUBLICATION,
+    CHAPTER_GENERATION,
+    AudiobookPublicationStatus,
+    ChapterGenerationStatus,
+    transition_state,
+)
 
 
 def normalize_resource_href(raw: str | None, chapter_number: int = 0) -> str:
@@ -147,7 +154,13 @@ async def publish_reader_audiobook(db: AsyncSession, book_id: int) -> None:
         source_audio = _resolved(chapter.audio_file_path)
         source_smil = _resolved(chapter.smil_file_path)
         if source_audio is None or source_smil is None or not source_audio.is_file() or not source_smil.is_file():
-            chapter.generation_state = "pending"
+            transition_state(
+                chapter,
+                "generation_state",
+                CHAPTER_GENERATION,
+                ChapterGenerationStatus.PENDING,
+                context=f"audiobook chapter {chapter.id}",
+            )
             continue
 
         href = normalize_resource_href(chapter.source_href or chapter.content_file_name, chapter.chapter_number)
@@ -176,7 +189,13 @@ async def publish_reader_audiobook(db: AsyncSession, book_id: int) -> None:
         chapter.smil_size_bytes = len(smil_content)
         chapter.smil_sha256 = smil_sha
         chapter.duration_ms = sum(sentence.audio_duration_ms or 0 for sentence in sentences)
-        chapter.generation_state = "ready"
+        transition_state(
+            chapter,
+            "generation_state",
+            CHAPTER_GENERATION,
+            ChapterGenerationStatus.READY,
+            context=f"audiobook chapter {chapter.id}",
+        )
         ready_count += 1
 
     book.audiobook_revision = (book.audiobook_revision or 0) + 1
@@ -187,8 +206,16 @@ async def publish_reader_audiobook(db: AsyncSession, book_id: int) -> None:
     book.audiobook_source_content_version = content_version
     book.audiobook_text_content_version = content_version
     book.audiobook_pending_content_version = pending_content_version or None
-    book.audiobook_publication_state = (
-        "complete" if chapters and ready_count == len(chapters) and not pending_content_version else "partial"
+    transition_state(
+        book,
+        "audiobook_publication_state",
+        AUDIOBOOK_PUBLICATION,
+        (
+            AudiobookPublicationStatus.COMPLETE
+            if chapters and ready_count == len(chapters) and not pending_content_version
+            else AudiobookPublicationStatus.PARTIAL
+        ),
+        context=f"book {book.id}",
     )
     book.audiobook_text_file_path = _relative(text_target)
     book.audiobook_text_size_bytes = text_size

--- a/backend/app/services/audiobook_queue.py
+++ b/backend/app/services/audiobook_queue.py
@@ -10,6 +10,7 @@ from typing import Optional
 
 from .. import crud
 from ..database import SessionLocal
+from ..lifecycle import AUDIOBOOK_PIPELINE, AudiobookPipelineStatus, transition_state
 from .audiobook_ingestion import ingest_epub
 from .audiobook_llm import generate_character_roster, diarize_sentences
 from .audiobook_tts import (
@@ -329,7 +330,13 @@ class AudiobookQueue:
                 and book.audiobook_pending_content_version <= book.audiobook_source_content_version
             ):
                 return False
-            book.audiobook_pipeline_status = "ingesting"
+            transition_state(
+                book,
+                "audiobook_pipeline_status",
+                AUDIOBOOK_PIPELINE,
+                AudiobookPipelineStatus.INGESTING,
+                context=f"book {book.id}",
+            )
             await db.commit()
             return True
 

--- a/backend/app/services/processing_queue.py
+++ b/backend/app/services/processing_queue.py
@@ -14,6 +14,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import crud
 from ..database import SessionLocal
+from ..lifecycle import (
+    AUDIOBOOK_PUBLICATION,
+    IMPORTED_AUDIOBOOK,
+    AudiobookPublicationStatus,
+    ImportedAudiobookStatus,
+    transition_state,
+)
 from ..models import Book, ImportedAudiobook, ImportedAudiobookTrack, ProcessingJob
 from .audiobook_alignment import process_alignment
 from .audiobook_import import process_import, rematch_imported_audiobook
@@ -674,7 +681,13 @@ async def queue_audio_reconciliation(book: Book, db: AsyncSession, parent_job_id
     content_version = book.content_version or 1
     queued: list[ProcessingJob] = []
     if book.audiobook_enabled:
-        book.audiobook_publication_state = "stale"
+        transition_state(
+            book,
+            "audiobook_publication_state",
+            AUDIOBOOK_PUBLICATION,
+            AudiobookPublicationStatus.STALE,
+            context=f"book {book.id}",
+        )
         await db.commit()
 
     result = await db.execute(select(ImportedAudiobook).where(ImportedAudiobook.book_id == book.id))
@@ -682,7 +695,13 @@ async def queue_audio_reconciliation(book: Book, db: AsyncSession, parent_job_id
         if edition.matched_content_version == content_version and edition.status != "stale":
             continue
         realign = edition.alignment_method in {"transcribed", "hybrid"}
-        edition.status = "stale"
+        transition_state(
+            edition,
+            "status",
+            IMPORTED_AUDIOBOOK,
+            ImportedAudiobookStatus.STALE,
+            context=f"imported audiobook {edition.id}",
+        )
         edition.progress_detail = "Book content changed; rematch queued"
         edition.alignment_error = None
         await db.commit()

--- a/backend/app/services/web_novel.py
+++ b/backend/app/services/web_novel.py
@@ -18,6 +18,15 @@ from lxml import etree
 from .. import crud, epub_editor, models, schemas
 from ..config import LIBRARY_PATH
 from ..database import SessionLocal
+from ..lifecycle import (
+    AUDIOBOOK_PIPELINE,
+    WEB_IMPORT,
+    WEB_REFRESH,
+    AudiobookPipelineStatus,
+    WebImportStatus,
+    WebRefreshStatus,
+    transition_state,
+)
 from .cover_collectors import collect_cover
 from .epub_utils import (
     get_and_save_epub_cover,
@@ -330,7 +339,13 @@ async def _enqueue_audiobook_refresh(book: models.Book, db) -> None:
         )
         active_statuses = {"ingesting", "roster_gen", "diarizing", "audio_gen", "assembling"}
         if book.audiobook_pipeline_status not in active_statuses:
-            book.audiobook_pipeline_status = "ingesting"
+            transition_state(
+                book,
+                "audiobook_pipeline_status",
+                AUDIOBOOK_PIPELINE,
+                AudiobookPipelineStatus.INGESTING,
+                context=f"book {book.id}",
+            )
         await db.commit()
 
         from .audiobook_queue import AudiobookQueue, get_audiobook_queue
@@ -565,7 +580,7 @@ async def finish_web_novel_download(book_id: int, source_url: str) -> None:
         try:
             result = await download_web_novel(source_url)
             if result is None:
-                db_book.download_status = "error"
+                transition_state(db_book, "download_status", WEB_IMPORT, WebImportStatus.ERROR, context=f"book {book_id}")
                 db_book.title = "Error: FFF produced no epub for new URL"
                 await db.commit()
                 return
@@ -574,7 +589,7 @@ async def finish_web_novel_download(book_id: int, source_url: str) -> None:
             existing = await crud.get_book_by_title_and_author(db, title=metadata["title"], author=metadata["author"])
             if existing and existing.id != book_id and existing.source_type == models.SourceType.web:
                 new_epub_path.unlink(missing_ok=True)
-                db_book.download_status = "error"
+                transition_state(db_book, "download_status", WEB_IMPORT, WebImportStatus.ERROR, context=f"book {book_id}")
                 db_book.title = f"Conflict: '{metadata['title']}' already exists"
                 await db.commit()
                 return
@@ -603,14 +618,14 @@ async def finish_web_novel_download(book_id: int, source_url: str) -> None:
             if cover_path:
                 db_book.cover_path = str(cover_path.relative_to(LIBRARY_PATH.parent))
 
-            db_book.download_status = None
+            transition_state(db_book, "download_status", WEB_IMPORT, None, context=f"book {book_id}")
             await db.commit()
             await db.refresh(db_book)
 
         except Exception as e:
             logger.error(f"Background download failed for book {book_id}: {e}\n{traceback.format_exc()}")
             try:
-                db_book.download_status = "error"
+                transition_state(db_book, "download_status", WEB_IMPORT, WebImportStatus.ERROR, context=f"book {book_id}")
                 db_book.title = "Download failed"
                 await db.commit()
             except Exception:
@@ -647,11 +662,17 @@ async def run_book_refresh(book_id: int) -> None:
             return
         if not db_book.source_url:
             logger.warning("Refresh worker: book %s has no source_url.", book_id)
-            db_book.refresh_status = "error"
+            transition_state(db_book, "refresh_status", WEB_REFRESH, WebRefreshStatus.ERROR, context=f"book {book_id}")
             await db.commit()
             return
 
-        db_book.refresh_status = "processing"
+        transition_state(
+            db_book,
+            "refresh_status",
+            WEB_REFRESH,
+            WebRefreshStatus.PROCESSING,
+            context=f"book {book_id}",
+        )
         await db.commit()
         await db.refresh(db_book)
 
@@ -674,7 +695,7 @@ async def run_book_refresh(book_id: int) -> None:
                 updated_book.current_word_count = new_word_count
                 updated_book.immutable_path = str(immutable_path.relative_to(LIBRARY_PATH.parent))
                 updated_book.current_path = str(current_path.relative_to(LIBRARY_PATH.parent))
-                updated_book.download_status = None
+                transition_state(updated_book, "download_status", WEB_IMPORT, None, context=f"book {book_id}")
                 await crud.touch_book_content(db, updated_book)
                 await db.commit()
                 await db.refresh(updated_book)
@@ -691,7 +712,7 @@ async def run_book_refresh(book_id: int) -> None:
                 await _enqueue_audiobook_refresh(updated_book, db)
                 await queue_metadata_sync_job(db, trigger="book_update", book_ids=[updated_book.id])
 
-                updated_book.refresh_status = None
+                transition_state(updated_book, "refresh_status", WEB_REFRESH, None, context=f"book {book_id}")
                 await db.commit()
                 return
 
@@ -740,7 +761,7 @@ async def run_book_refresh(book_id: int) -> None:
             await _enqueue_audiobook_refresh(updated_book, db)
             await queue_metadata_sync_job(db, trigger="book_update", book_ids=[updated_book.id])
 
-            updated_book.refresh_status = None
+            transition_state(updated_book, "refresh_status", WEB_REFRESH, None, context=f"book {book_id}")
             await db.commit()
         except Exception as exc:
             logger.error(
@@ -750,7 +771,7 @@ async def run_book_refresh(book_id: int) -> None:
                 traceback.format_exc(),
             )
             try:
-                db_book.refresh_status = "error"
+                transition_state(db_book, "refresh_status", WEB_REFRESH, WebRefreshStatus.ERROR, context=f"book {book_id}")
                 await db.commit()
             except Exception:
                 logger.exception("Failed to mark refresh_status=error for book %s", book_id)

--- a/backend/tests/test_crud_modules.py
+++ b/backend/tests/test_crud_modules.py
@@ -54,7 +54,7 @@ class TestBooksCrud:
     async def test_detach_book_source(self, db):
         book = await _create_book(db, "Web Book", "Author", source_url="http://example.com/story")
         book.source_type = models.SourceType.web
-        book.download_status = "complete"
+        book.download_status = "pending"
         await db.commit()
         detached = await crud.detach_book_source(db, book)
         assert detached.source_url is None

--- a/backend/tests/test_lifecycle.py
+++ b/backend/tests/test_lifecycle.py
@@ -1,0 +1,83 @@
+"""Tests for centralized lifecycle definitions and transition enforcement."""
+
+from dataclasses import dataclass
+
+import pytest
+
+from backend.app.lifecycle import (
+    LIFECYCLES,
+    PROCESSING_JOB,
+    InvalidStateTransition,
+    ProcessingJobStatus,
+    lifecycle_manifest,
+    transition_state,
+)
+
+
+@dataclass
+class Record:
+    status: str | None
+
+
+def test_every_lifecycle_definition_is_internally_consistent():
+    manifest = lifecycle_manifest()
+
+    assert manifest.keys() == LIFECYCLES.keys()
+    for key, machine in LIFECYCLES.items():
+        assert set(machine.labels) == machine.states, key
+        assert set(machine.transitions) == machine.states, key
+        assert machine.active_states <= machine.states, key
+        assert machine.terminal_states <= machine.states, key
+        assert machine.failure_states <= machine.states, key
+        assert machine.retryable_states <= machine.states, key
+        assert set(machine.recovery) == machine.active_states, key
+        assert all(target in machine.states for targets in machine.transitions.values() for target in targets), key
+        assert all(target in machine.states or isinstance(target, str) for target in machine.recovery.values()), key
+        assert {item["value"] for item in manifest[key]["states"]} == machine.states
+
+
+def test_transition_helper_assigns_valid_state():
+    record = Record(status=ProcessingJobStatus.QUEUED.value)
+
+    value = transition_state(record, "status", PROCESSING_JOB, ProcessingJobStatus.RUNNING)
+
+    assert value == ProcessingJobStatus.RUNNING.value
+    assert record.status == ProcessingJobStatus.RUNNING.value
+
+
+def test_invalid_transition_explains_context_and_allowed_targets():
+    record = Record(status=ProcessingJobStatus.COMPLETED.value)
+
+    with pytest.raises(InvalidStateTransition) as error:
+        transition_state(
+            record,
+            "status",
+            PROCESSING_JOB,
+            ProcessingJobStatus.RUNNING,
+            context="job 42",
+        )
+
+    assert "job 42" in str(error.value)
+    assert "'completed' -> 'running'" in str(error.value)
+    assert "Allowed next states: none" in str(error.value)
+    assert record.status == ProcessingJobStatus.COMPLETED.value
+
+
+def test_unknown_persisted_state_is_actionable():
+    record = Record(status="mystery")
+
+    with pytest.raises(InvalidStateTransition, match="Unknown processing job state 'mystery'"):
+        transition_state(record, "status", PROCESSING_JOB, ProcessingJobStatus.ERROR)
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_manifest_endpoint(app_client):
+    response = app_client.get("/api/lifecycles")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["processing_job"]["groups"]["running"] == ["running"]
+    assert body["sentence"]["groups"]["audio_in_progress"] == [
+        "audio_queued",
+        "audio_generating",
+    ]

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1695,7 +1695,7 @@ async def test_detach_book_source(db_session):
                 immutable_path="library/imported/original.epub",
                 current_path="library/imported/current.epub",
                 source_type=models.SourceType.web,
-                download_status="complete",
+                download_status="pending",
             ),
         )
 
@@ -1722,7 +1722,7 @@ async def test_detach_book_source_allows_missing_source_url_for_web_books(db_ses
                 immutable_path="library/imported/original.epub",
                 current_path="library/imported/current.epub",
                 source_type=models.SourceType.web,
-                download_status="complete",
+                download_status="pending",
             ),
         )
 
@@ -3811,7 +3811,7 @@ async def test_reader_series_api_and_opds_feeds(db_session):
                 immutable_path="library/immutable_hidden.epub",
                 current_path="library/hidden.epub",
                 source_type=models.SourceType.epub,
-                download_status="processing",
+                download_status="pending",
             ),
         )
         await crud.create_book(
@@ -3949,7 +3949,7 @@ async def test_reader_books_all_returns_only_reader_eligible_books(db_session):
                 immutable_path="library/immutable_background.epub",
                 current_path="library/background.epub",
                 source_type=models.SourceType.epub,
-                download_status="processing",
+                download_status="pending",
             ),
         )
         await crud.create_book(

--- a/docs/AUDIOBOOK_PIPELINE.md
+++ b/docs/AUDIOBOOK_PIPELINE.md
@@ -58,7 +58,7 @@ for deployment and configuration.
 
 ## Overview
 
-This pipeline converts any stored EPUB into an EPUB 3 Media Overlay audiobook. The system is a **sentence-level state machine**: each sentence in the book is independently tracked through diarization → TTS → assembly, enabling surgical regeneration of specific audio snippets without full rebuilds.
+This pipeline converts any stored EPUB into an EPUB 3 Media Overlay audiobook. The system is a **sentence-level state machine**: each sentence in the book is independently tracked through diarization → TTS → assembly, enabling surgical regeneration of specific audio snippets without full rebuilds. The authoritative pipeline, publication, preview, chapter, sentence, import, and alignment vocabularies live in `backend/app/lifecycle.py`; recovery behavior is documented in [Application lifecycles](LIFECYCLES.md).
 
 The five pipeline phases are:
 1. **Ingestion** — parse EPUB, inject sentence `<span>` IDs, seed the database

--- a/docs/IMPROVEMENT_ROADMAP.md
+++ b/docs/IMPROVEMENT_ROADMAP.md
@@ -108,7 +108,7 @@ Search should use PostgreSQL indexes suited to title, author, series, and tag lo
 
 ## 6. Consolidated background execution
 
-**Status:** In progress
+**Status:** Complete
 
 Complete the transition from specialized in-memory queues to the durable processing-job ledger. The API process should enqueue work, while a unified worker claims and executes jobs using explicit resource lanes.
 
@@ -125,9 +125,11 @@ The first deployment can retain a single-container experience, but job ownership
 
 ## 7. Centralized state-machine definitions
 
-**Status:** Planned
+**Status:** In progress
 
 Replace scattered lifecycle strings and implicit transitions with centralized state definitions for processing jobs, web imports and refreshes, metadata jobs, generated audiobooks, imported audiobooks, alignment, and publication.
+
+The lifecycle vocabulary and recovery contract are documented in [Application lifecycles](LIFECYCLES.md).
 
 State machines should define valid transitions, terminal states, retry behavior, and how parent and child operations interact. Database constraints should reject impossible values.
 

--- a/docs/LIFECYCLES.md
+++ b/docs/LIFECYCLES.md
@@ -1,0 +1,57 @@
+# Application lifecycles
+
+Story Manager's persisted lifecycle vocabulary is defined in `backend/app/lifecycle.py`. That module owns allowed values, transitions, labels, active and terminal groupings, retryability, and recovery targets. The `GET /api/lifecycles` endpoint exposes the same manifest to the frontend; UI code must not maintain a second list of lifecycle labels or groupings.
+
+Database check constraints reject unknown persisted values. They deliberately validate values rather than transition edges: application helpers enforce edges while migrations and recovery routines can safely repair rows in bulk.
+
+## Transition rules
+
+Services should call `transition_state(record, attribute, machine, target)` for ORM-backed changes and use the lifecycle enums for bulk updates. Invalid edges raise `InvalidStateTransition` with the lifecycle name, current and requested values, context, and allowed targets.
+
+Assigning the current value again is allowed. This makes idempotent retries safe without weakening the set of possible next states.
+
+## Recovery contract
+
+| Lifecycle | Non-terminal state | Recovery behavior |
+| --- | --- | --- |
+| Processing job | `queued` | Remains available until a worker for its resource lane claims it. |
+| Processing job | `running` | An expired lease is atomically reclaimed and returned to `queued`, subject to the attempt limit. |
+| Web import | `pending` | The durable import processing job is resumed or retried; the placeholder remains visible. |
+| Web refresh | `queued` | The durable refresh processing job remains claimable. |
+| Web refresh | `processing` | The processing-job lease is reclaimed; refresh returns to `queued` before retry. |
+| Library refresh task | `running` | Startup reconciliation marks the historical task `interrupted`; incomplete book refresh jobs remain independently recoverable. |
+| Metadata job | `queued` | Remains claimable by the metadata resource lane. |
+| Metadata job | `running` | Reconciliation returns it to `queued` when its processing job is reclaimed. |
+| Generated audiobook pipeline | Any phase from `ingesting` through `assembling` | The durable processing job resumes from the persisted phase and artifacts. The phase is not guessed from process memory. |
+| Audiobook publication | `processing` | Interrupted packaging is marked `stale`; reconciliation rebuilds from durable chapter artifacts. |
+| Chapter preview | `queued` | Remains claimable as a processing job. |
+| Chapter preview | `generating` | Recovery returns it to `queued`. |
+| Published chapter | `pending` | Packaging reconciliation processes it. |
+| Published chapter | `processing` | Recovery returns it to `pending`. |
+| Sentence | `pending_diarization` | The next diarization pass resumes it. |
+| Sentence | `audio_queued` or `audio_generating` | Recovery returns it to `ready_for_audio`; a full run, preview, or explicit sentence request can queue it again. |
+| Imported audiobook | `queued` | Remains claimable by the import resource lane. |
+| Imported audiobook | `importing` | Recovery returns it to `queued`. |
+| Imported audiobook | `aligning` | Recovery returns it to `ready`; the existing edition remains usable and alignment can be requested again. |
+| Imported audiobook | `stale` | Reconciliation reimports or rematches it from its retained source files. |
+
+The manifest's `recovery` field is the machine-readable summary of these targets. Some waiting states recover to themselves because their durable job is the recovery mechanism.
+
+## Parent and child jobs
+
+A processing job may enqueue child jobs by setting `parent_job_id`. Parent and child records have independent leases, attempts, cancellation flags, progress, and terminal states:
+
+- A parent may complete after dispatching children; completion does not imply that every child succeeded.
+- A child failure is visible and retryable on its own. It does not rewrite a completed parent.
+- Retrying or canceling a parent does not implicitly cascade to children. A workflow that needs cascading behavior must request it explicitly and transition every affected job.
+- Dedupe keys and target content versions prevent a recovered parent from creating duplicate current-version children.
+
+This separation keeps fan-out work observable and recoverable without pretending it is one in-memory transaction.
+
+## Adding or changing a lifecycle
+
+1. Add or update the enum and `StateMachine` in `backend/app/lifecycle.py`.
+2. Route service changes through `transition_state` or enum-backed bulk updates.
+3. Add a safe Alembic migration for persisted values and constraints; normalize existing data before adding a constraint.
+4. Use `/api/lifecycles` for frontend labels and behavioral groupings.
+5. Add transition, recovery, populated-database migration, and affected workflow tests.

--- a/frontend/src/api/lifecycles.js
+++ b/frontend/src/api/lifecycles.js
@@ -1,0 +1,5 @@
+import { getJson } from "./client";
+
+export function getLifecycleDefinitions() {
+  return getJson("/api/lifecycles", "Failed to fetch lifecycle definitions");
+}

--- a/frontend/src/components/AudiobookPipeline.jsx
+++ b/frontend/src/components/AudiobookPipeline.jsx
@@ -20,30 +20,13 @@ import AudiobookReader from "./audiobook/AudiobookReader";
 import ProgressDashboard from "./audiobook/ProgressDashboard";
 import AudiobookSources from "./audiobook/AudiobookSources";
 import { AUDIOBOOK_TABS } from "../lib/navigation";
+import useLifecycleDefinitions from "../hooks/useLifecycleDefinitions";
 
-const PIPELINE_STEPS = [
-  { status: "ingesting", label: "Ingesting" },
-  { status: "roster_gen", label: "Roster" },
-  { status: "diarizing", label: "Diarizing" },
-  { status: "audio_gen", label: "TTS" },
-  { status: "assembling", label: "Assembly" },
-  { status: "complete", label: "Complete" },
-];
-
-const ACTIVE_STATUSES = new Set([
-  "ingesting",
-  "roster_gen",
-  "diarizing",
-  "audio_gen",
-  "assembling",
-]);
-const BATCHABLE_STATUSES = new Set(["diarizing", "audio_gen", "assembling"]);
-
-function PipelineProgress({ status }) {
-  const currentIdx = PIPELINE_STEPS.findIndex((s) => s.status === status);
+function PipelineProgress({ status, steps }) {
+  const currentIdx = steps.findIndex((step) => step.status === status);
   return (
     <div className="pipeline-progress">
-      {PIPELINE_STEPS.map((step, idx) => {
+      {steps.map((step, idx) => {
         let cls = "pipeline-step";
         if (idx < currentIdx) cls += " pipeline-step--done";
         else if (idx === currentIdx) cls += " pipeline-step--active";
@@ -128,6 +111,36 @@ function AudiobookPipeline({
   audiobookTab,
   onAudiobookTabChange,
 }) {
+  const { data: lifecycleDefinitions } = useLifecycleDefinitions();
+  const pipelineLifecycle = lifecycleDefinitions?.audiobook_pipeline;
+  const importedLifecycle = lifecycleDefinitions?.imported_audiobook;
+  const previewLifecycle = lifecycleDefinitions?.chapter_preview;
+  const sentenceLifecycle = lifecycleDefinitions?.sentence;
+  const stateLabels = Object.fromEntries(
+    (pipelineLifecycle?.states ?? []).map((state) => [
+      state.value,
+      state.label,
+    ]),
+  );
+  const pipelineSteps = (pipelineLifecycle?.groups?.progress_steps ?? []).map(
+    (status) => ({
+      status,
+      label: stateLabels[status] ?? status,
+    }),
+  );
+  const activeStatuses = new Set(pipelineLifecycle?.active_states ?? []);
+  const batchableStatuses = new Set(pipelineLifecycle?.groups?.batchable ?? []);
+  const failedPipelineStatuses = new Set(
+    pipelineLifecycle?.failure_states ?? [],
+  );
+  const readyPipelineStatuses = new Set(pipelineLifecycle?.groups?.ready ?? []);
+  const pausedPipelineStatuses = new Set(
+    pipelineLifecycle?.groups?.paused ?? [],
+  );
+  const activeImportStatuses = new Set(importedLifecycle?.active_states ?? []);
+  const activePreviewStatuses = new Set(previewLifecycle?.active_states ?? []);
+  const playableSentenceStatuses =
+    sentenceLifecycle?.groups?.audio_playable ?? [];
   const bookId = book.id;
   const aiEnabled = book.audiobook_enabled !== false;
   const queryClient = useQueryClient();
@@ -137,7 +150,7 @@ function AudiobookPipeline({
   const [confirmRebuild, setConfirmRebuild] = useState(false);
   const [lastQueuedJob, setLastQueuedJob] = useState(null);
 
-  const isActive = (status) => ACTIVE_STATUSES.has(status);
+  const isActive = (status) => activeStatuses.has(status);
 
   const { data: statusData } = useQuery({
     queryKey: ["audiobook-status", bookId],
@@ -162,9 +175,7 @@ function AudiobookPipeline({
     queryFn: () => getImportedAudiobooks(bookId),
     refetchInterval: ({ state }) =>
       Array.isArray(state.data) &&
-      state.data.some((edition) =>
-        ["stale", "queued", "importing", "aligning"].includes(edition.status),
-      )
+      state.data.some((edition) => activeImportStatuses.has(edition.status))
         ? 1000
         : false,
   });
@@ -176,7 +187,7 @@ function AudiobookPipeline({
     refetchInterval: ({ state }) => {
       const s = statusData?.pipeline_status;
       const previewActive = state.data?.some((chapter) =>
-        ["queued", "generating"].includes(chapter.preview_status),
+        activePreviewStatuses.has(chapter.preview_status),
       );
       const audioStillFinishing =
         (statusData?.sentence_counts?.audio_generating ?? 0) > 0;
@@ -236,18 +247,20 @@ function AudiobookPipeline({
   const nextPhase = statusData?.next_phase ?? "ingesting";
   const pauseRequested = statusData?.pause_requested ?? false;
   const progressStatus =
-    isActive(pipelineStatus) || pipelineStatus === "complete"
+    isActive(pipelineStatus) || readyPipelineStatuses.has(pipelineStatus)
       ? pipelineStatus
       : nextPhase;
   const nextPhaseLabel =
-    PIPELINE_STEPS.find((step) => step.status === nextPhase)?.label ??
-    nextPhase;
+    pipelineSteps.find((step) => step.status === nextPhase)?.label ?? nextPhase;
   const sentenceCounts = statusData?.sentence_counts ?? {};
   const totalSentences = Object.values(sentenceCounts).reduce(
     (a, b) => a + b,
     0,
   );
-  const doneCount = sentenceCounts["audio_generated"] ?? 0;
+  const doneCount = playableSentenceStatuses.reduce(
+    (count, status) => count + (sentenceCounts[status] ?? 0),
+    0,
+  );
 
   // A fast local/stub phase can finish before the slower data queries poll.
   // Refresh editor data whenever the durable pipeline state advances so the
@@ -279,7 +292,7 @@ function AudiobookPipeline({
     <div className="audiobook-pipeline">
       {aiEnabled && (
         <div className="pipeline-header">
-          <PipelineProgress status={progressStatus} />
+          <PipelineProgress status={progressStatus} steps={pipelineSteps} />
 
           <div className="pipeline-meta">
             {totalSentences > 0 && (
@@ -287,10 +300,10 @@ function AudiobookPipeline({
                 {doneCount} / {totalSentences} sentences with audio
               </span>
             )}
-            {pipelineStatus === "error" && (
+            {failedPipelineStatuses.has(pipelineStatus) && (
               <span className="badge badge--error">Pipeline error</span>
             )}
-            {pipelineStatus === "paused" && (
+            {pausedPipelineStatuses.has(pipelineStatus) && (
               <span className="badge badge--warning">
                 Paused — next: {nextPhaseLabel}
               </span>
@@ -313,7 +326,7 @@ function AudiobookPipeline({
           />
 
           <div className="pipeline-controls">
-            {pipelineStatus === "complete" && (
+            {readyPipelineStatuses.has(pipelineStatus) && (
               <a
                 className="btn btn-primary"
                 href={getAudiobookDownloadUrl(bookId)}
@@ -322,9 +335,10 @@ function AudiobookPipeline({
                 Download Audiobook EPUB
               </a>
             )}
-            {pipelineStatus !== "complete" && !isActive(pipelineStatus) && (
+            {!readyPipelineStatuses.has(pipelineStatus) &&
+              !isActive(pipelineStatus) && (
               <>
-                {BATCHABLE_STATUSES.has(nextPhase) && (
+                  {batchableStatuses.has(nextPhase) && (
                   <button
                     onClick={() => batchMutation.mutate()}
                     disabled={

--- a/frontend/src/components/AudiobookPipeline.test.jsx
+++ b/frontend/src/components/AudiobookPipeline.test.jsx
@@ -4,6 +4,79 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import AudiobookPipeline from "./AudiobookPipeline";
 import { renderWithClient } from "../test-utils";
 
+vi.mock("../hooks/useLifecycleDefinitions", () => ({
+  default: () => ({
+    data: {
+      audiobook_pipeline: {
+        states: [
+          { value: null, label: "Not started" },
+          { value: "ingesting", label: "Ingesting" },
+          { value: "roster_gen", label: "Roster" },
+          { value: "diarizing", label: "Diarizing" },
+          { value: "audio_gen", label: "TTS" },
+          { value: "assembling", label: "Assembly" },
+          { value: "complete", label: "Complete" },
+          { value: "error", label: "Error" },
+        ],
+        active_states: [
+          "ingesting",
+          "roster_gen",
+          "diarizing",
+          "audio_gen",
+          "assembling",
+        ],
+        failure_states: ["error"],
+        groups: {
+          progress_steps: [
+            "ingesting",
+            "roster_gen",
+            "diarizing",
+            "audio_gen",
+            "assembling",
+            "complete",
+          ],
+          batchable: ["diarizing", "audio_gen", "assembling"],
+          concurrent_analysis: ["diarizing"],
+          ready: ["complete"],
+          paused: ["paused"],
+        },
+      },
+      imported_audiobook: {
+        active_states: ["stale", "queued", "importing", "aligning"],
+      },
+      chapter_preview: {
+        states: [
+          { value: null, label: "Not generated" },
+          { value: "queued", label: "Queued" },
+          { value: "generating", label: "Generating" },
+          { value: "ready", label: "Ready" },
+          { value: "error", label: "Error" },
+        ],
+        active_states: ["queued", "generating"],
+        failure_states: ["error"],
+      },
+      sentence: {
+        states: [
+          { value: "pending_diarization", label: "Pending diarization" },
+          { value: "ready_for_audio", label: "Ready for audio" },
+          { value: "audio_queued", label: "Audio queued" },
+          { value: "audio_generating", label: "Generating audio" },
+          { value: "audio_generated", label: "Audio generated" },
+          { value: "error", label: "Error" },
+        ],
+        failure_states: ["error"],
+        groups: {
+          audio_in_progress: ["audio_queued", "audio_generating"],
+          audio_ready: ["ready_for_audio"],
+          audio_waiting: ["audio_queued"],
+          audio_working: ["audio_generating"],
+          audio_playable: ["audio_generated"],
+        },
+      },
+    },
+  }),
+}));
+
 describe("AudiobookPipeline", () => {
   beforeEach(() => {
     vi.restoreAllMocks();

--- a/frontend/src/components/ProcessingJobs.jsx
+++ b/frontend/src/components/ProcessingJobs.jsx
@@ -2,14 +2,13 @@ import { useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { getBookCatalog } from "../api/books";
 import useDebouncedValue from "../hooks/useDebouncedValue";
+import useLifecycleDefinitions from "../hooks/useLifecycleDefinitions";
 import {
   cancelProcessingJob,
   getProcessingJobs,
   queueProcessingJobs,
   retryProcessingJob,
 } from "../api/processing";
-
-const ACTIVE = new Set(["queued", "running"]);
 
 const JOB_LABELS = {
   clean_book: "Clean book",
@@ -36,19 +35,26 @@ function formatDate(value) {
   return value ? new Date(value).toLocaleString() : "—";
 }
 
-function JobProgress({ job }) {
+function JobProgress({ job, runningState }) {
   const measured = job.progress_total > 0;
-  if (!measured && job.status !== "running") return null;
+  if (!measured && job.status !== runningState) return null;
 
   const percent = measured
-    ? Math.min(100, Math.round((job.progress_current * 100) / job.progress_total))
+    ? Math.min(
+        100,
+        Math.round((job.progress_current * 100) / job.progress_total),
+      )
     : null;
 
   return (
-    <div className={`processing-job-progress${measured ? "" : " processing-job-progress--indeterminate"}`}>
+    <div
+      className={`processing-job-progress${measured ? "" : " processing-job-progress--indeterminate"}`}
+    >
       <progress
         aria-label={`${JOB_LABELS[job.job_type] || job.job_type} progress`}
-        {...(measured ? { value: job.progress_current, max: job.progress_total } : {})}
+        {...(measured
+          ? { value: job.progress_current, max: job.progress_total }
+          : {})}
       />
       <span>
         {measured
@@ -61,11 +67,29 @@ function JobProgress({ job }) {
 
 function ProcessingJobs() {
   const queryClient = useQueryClient();
+  const { data: lifecycleDefinitions } = useLifecycleDefinitions();
+  const processingLifecycle = lifecycleDefinitions?.processing_job;
+  const activeStatuses = useMemo(
+    () => new Set(processingLifecycle?.active_states ?? []),
+    [processingLifecycle],
+  );
+  const retryableStatuses = useMemo(
+    () => new Set(processingLifecycle?.retryable_states ?? []),
+    [processingLifecycle],
+  );
+  const statusLabels = useMemo(
+    () =>
+      Object.fromEntries(
+        (processingLifecycle?.states ?? []).map((state) => [
+          state.value,
+          state.label,
+        ]),
+      ),
+    [processingLifecycle],
+  );
   const [statusFilter, setStatusFilter] = useState(() => {
     const requested = new URLSearchParams(window.location.search).get("status");
-    return ["active", "all", "error", "completed", "canceled"].includes(requested)
-      ? requested
-      : "active";
+    return requested || "active";
   });
   const [operation, setOperation] = useState("clean_book");
   const [bookSearch, setBookSearch] = useState("");
@@ -73,13 +97,22 @@ function ProcessingJobs() {
   const [selectedIds, setSelectedIds] = useState([]);
   const [queueNotice, setQueueNotice] = useState("");
   const statuses =
-    statusFilter === "active" ? "queued,running" : statusFilter === "all" ? "" : statusFilter;
+    statusFilter === "active"
+      ? (processingLifecycle?.active_states ?? []).join(",")
+      : statusFilter === "all"
+        ? ""
+        : statusFilter;
 
-  const { data: jobs = [], isLoading, error } = useQuery({
+  const {
+    data: jobs = [],
+    isLoading,
+    error,
+  } = useQuery({
     queryKey: ["processing-jobs", statuses],
     queryFn: () => getProcessingJobs({ statuses, limit: 200 }),
+    enabled: Boolean(processingLifecycle),
     refetchInterval: ({ state }) =>
-      state.data?.some((job) => ACTIVE.has(job.status)) ? 1500 : 5000,
+      state.data?.some((job) => activeStatuses.has(job.status)) ? 1500 : 5000,
   });
   const { data: catalogPage } = useQuery({
     queryKey: ["processing-book-catalog", operation, debouncedBookSearch],
@@ -98,9 +131,14 @@ function ProcessingJobs() {
   const eligibleBooks = useMemo(() => {
     const query = debouncedBookSearch.toLocaleLowerCase();
     return catalog.filter((book) => {
-      if (operation === "refresh_book" && book.source_type !== "web") return false;
-      if (operation === "audiobook_pipeline" && !book.audiobook_enabled) return false;
-      return !query || `${book.title} ${book.author}`.toLocaleLowerCase().includes(query);
+      if (operation === "refresh_book" && book.source_type !== "web")
+        return false;
+      if (operation === "audiobook_pipeline" && !book.audiobook_enabled)
+        return false;
+      return (
+        !query ||
+        `${book.title} ${book.author}`.toLocaleLowerCase().includes(query)
+      );
     });
   }, [catalog, debouncedBookSearch, operation]);
 
@@ -109,29 +147,43 @@ function ProcessingJobs() {
     queryClient.invalidateQueries({ queryKey: ["active-processing-jobs"] });
   };
   const queueMutation = useMutation({
-    mutationFn: ({ jobType, bookIds, payload }) => queueProcessingJobs(jobType, bookIds, payload),
+    mutationFn: ({ jobType, bookIds, payload }) =>
+      queueProcessingJobs(jobType, bookIds, payload),
     onSuccess: (data) => {
       const count = data.jobs?.length || 0;
-      setQueueNotice(`${count} processing job${count === 1 ? "" : "s"} queued.`);
+      setQueueNotice(
+        `${count} processing job${count === 1 ? "" : "s"} queued.`,
+      );
       setSelectedIds([]);
       refresh();
     },
   });
-  const retryMutation = useMutation({ mutationFn: retryProcessingJob, onSuccess: refresh });
-  const cancelMutation = useMutation({ mutationFn: cancelProcessingJob, onSuccess: refresh });
+  const retryMutation = useMutation({
+    mutationFn: retryProcessingJob,
+    onSuccess: refresh,
+  });
+  const cancelMutation = useMutation({
+    mutationFn: cancelProcessingJob,
+    onSuccess: refresh,
+  });
 
   const toggleBook = (bookId) => {
     setSelectedIds((current) =>
-      current.includes(bookId) ? current.filter((id) => id !== bookId) : [...current, bookId],
+      current.includes(bookId)
+        ? current.filter((id) => id !== bookId)
+        : [...current, bookId],
     );
   };
   const queueSelected = () => {
-    const payload = operation === "audiobook_pipeline" ? { mode: "reconcile" } : {};
+    const payload =
+      operation === "audiobook_pipeline" ? { mode: "reconcile" } : {};
     queueMutation.mutate({ jobType: operation, bookIds: selectedIds, payload });
   };
 
-  const runningCount = jobs.filter((job) => job.status === "running").length;
-  const queuedCount = jobs.filter((job) => job.status === "queued").length;
+  const runningState = processingLifecycle?.groups?.running?.[0];
+  const queuedState = processingLifecycle?.groups?.waiting?.[0];
+  const runningCount = jobs.filter((job) => job.status === runningState).length;
+  const queuedCount = jobs.filter((job) => job.status === queuedState).length;
 
   return (
     <div className="processing-page">
@@ -142,9 +194,19 @@ function ProcessingJobs() {
         </div>
         <p>Durable work queue · automatic recovery enabled</p>
       </header>
-      <div className="processing-health-strip" aria-label="Processing system status">
-        <div><span className="processing-health-dot" /><strong>Queue online</strong><small>Workers available</small></div>
-        <div><strong>{runningCount} running</strong><small>{queuedCount} waiting</small></div>
+      <div
+        className="processing-health-strip"
+        aria-label="Processing system status"
+      >
+        <div>
+          <span className="processing-health-dot" />
+          <strong>Queue online</strong>
+          <small>Workers available</small>
+        </div>
+        <div>
+          <strong>{runningCount} running</strong>
+          <small>{queuedCount} waiting</small>
+        </div>
       </div>
       <details className="settings-section processing-queue-panel">
         <summary className="processing-queue-summary">
@@ -153,12 +215,19 @@ function ProcessingJobs() {
             <span className="processing-queue-title">Queue work</span>
           </span>
           <span className="hint">
-            Queue cleaning, source refreshes, or audiobook regeneration for one or more books.
+            Queue cleaning, source refreshes, or audiobook regeneration for one
+            or more books.
           </span>
         </summary>
         <div className="processing-quick-actions">
           <button
-            onClick={() => queueMutation.mutate({ jobType: "clean_all", bookIds: [], payload: {} })}
+            onClick={() =>
+              queueMutation.mutate({
+                jobType: "clean_all",
+                bookIds: [],
+                payload: {},
+              })
+            }
             disabled={queueMutation.isPending}
           >
             Clean entire library
@@ -187,7 +256,9 @@ function ProcessingJobs() {
               }}
             >
               {QUEUE_OPERATIONS.map((item) => (
-                <option key={item.value} value={item.value}>{item.label}</option>
+                <option key={item.value} value={item.value}>
+                  {item.label}
+                </option>
               ))}
             </select>
           </label>
@@ -202,16 +273,26 @@ function ProcessingJobs() {
           <div className="processing-picker-actions">
             <button
               className="btn-text"
-              onClick={() => setSelectedIds(eligibleBooks.map((book) => book.id))}
+              onClick={() =>
+                setSelectedIds(eligibleBooks.map((book) => book.id))
+              }
               disabled={!eligibleBooks.length}
             >
               Select visible
             </button>
-            <button className="btn-text" onClick={() => setSelectedIds([])} disabled={!selectedIds.length}>
+            <button
+              className="btn-text"
+              onClick={() => setSelectedIds([])}
+              disabled={!selectedIds.length}
+            >
               Clear
             </button>
           </div>
-          <div className="processing-book-options" role="group" aria-label="Books to process">
+          <div
+            className="processing-book-options"
+            role="group"
+            aria-label="Books to process"
+          >
             {eligibleBooks.slice(0, 100).map((book) => (
               <label key={book.id}>
                 <input
@@ -219,10 +300,15 @@ function ProcessingJobs() {
                   checked={selectedIds.includes(book.id)}
                   onChange={() => toggleBook(book.id)}
                 />
-                <span><strong>{book.title}</strong><small>{book.author}</small></span>
+                <span>
+                  <strong>{book.title}</strong>
+                  <small>{book.author}</small>
+                </span>
               </label>
             ))}
-            {!eligibleBooks.length && <p className="hint">No eligible books match.</p>}
+            {!eligibleBooks.length && (
+              <p className="hint">No eligible books match.</p>
+            )}
           </div>
           <button
             className="btn-primary"
@@ -237,7 +323,9 @@ function ProcessingJobs() {
           </button>
         </div>
         {queueNotice && <p className="job-queued-notice">{queueNotice}</p>}
-        {queueMutation.isError && <p className="error">{queueMutation.error.message}</p>}
+        {queueMutation.isError && (
+          <p className="error">{queueMutation.error.message}</p>
+        )}
       </details>
 
       <section className="settings-section">
@@ -245,40 +333,66 @@ function ProcessingJobs() {
           <div>
             <span className="processing-section-code">02 / JOB LEDGER</span>
             <h2>Processing jobs</h2>
-            <p className="hint">Durable work survives application restarts and can be retried here.</p>
+            <p className="hint">
+              Durable work survives application restarts and can be retried
+              here.
+            </p>
           </div>
           <label>
             Status
-            <select value={statusFilter} onChange={(event) => setStatusFilter(event.target.value)}>
+            <select
+              value={statusFilter}
+              onChange={(event) => setStatusFilter(event.target.value)}
+            >
               <option value="active">Active</option>
               <option value="all">All</option>
-              <option value="error">Failed</option>
-              <option value="completed">Completed</option>
-              <option value="canceled">Canceled</option>
+              {(processingLifecycle?.terminal_states ?? []).map((value) => (
+                <option key={value} value={value}>
+                  {statusLabels[value] ?? value}
+                </option>
+              ))}
             </select>
           </label>
         </div>
         {isLoading && <p>Loading jobs…</p>}
         {error && <p className="error">{error.message}</p>}
-        {!isLoading && !jobs.length && <p className="hint">No processing jobs in this view.</p>}
+        {!isLoading && !jobs.length && (
+          <p className="hint">No processing jobs in this view.</p>
+        )}
         <div className="processing-job-list">
           {jobs.map((job) => (
-            <article key={job.id} className={`processing-job processing-job--${job.status}`}>
+            <article
+              key={job.id}
+              className={`processing-job processing-job--${job.status}`}
+            >
               <div className="processing-job-main">
                 <div>
-                  <span className={`badge processing-status processing-status--${job.status}`}>{job.status}</span>
-                  <strong>{JOB_LABELS[job.job_type] || job.job_type.replaceAll("_", " ")}</strong>
+                  <span
+                    className={`badge processing-status processing-status--${job.status}`}
+                  >
+                    {statusLabels[job.status] ?? job.status}
+                  </span>
+                  <strong>
+                    {JOB_LABELS[job.job_type] ||
+                      job.job_type.replaceAll("_", " ")}
+                  </strong>
                   {job.book_id && (
-                    <a href={`/books/${job.book_id}`}>{job.book_title || `Book ${job.book_id}`}</a>
+                    <a href={`/books/${job.book_id}`}>
+                      {job.book_title || `Book ${job.book_id}`}
+                    </a>
                   )}
                 </div>
-                <small>#{job.id} · {formatDate(job.created_at)}</small>
+                <small>
+                  #{job.id} · {formatDate(job.created_at)}
+                </small>
               </div>
               <p>{job.progress_detail || "Waiting"}</p>
-              <JobProgress job={job} />
-              {job.error && <pre className="processing-job-error">{job.error}</pre>}
+              <JobProgress job={job} runningState={runningState} />
+              {job.error && (
+                <pre className="processing-job-error">{job.error}</pre>
+              )}
               <div className="processing-job-actions">
-                {ACTIVE.has(job.status) && (
+                {activeStatuses.has(job.status) && (
                   <button
                     className="btn-text"
                     onClick={() => cancelMutation.mutate(job.id)}
@@ -287,8 +401,11 @@ function ProcessingJobs() {
                     {job.cancel_requested ? "Cancellation requested" : "Cancel"}
                   </button>
                 )}
-                {["error", "canceled"].includes(job.status) && (
-                  <button onClick={() => retryMutation.mutate(job.id)} disabled={retryMutation.isPending}>
+                {retryableStatuses.has(job.status) && (
+                  <button
+                    onClick={() => retryMutation.mutate(job.id)}
+                    disabled={retryMutation.isPending}
+                  >
                     Retry
                   </button>
                 )}

--- a/frontend/src/components/ProcessingJobs.test.jsx
+++ b/frontend/src/components/ProcessingJobs.test.jsx
@@ -3,8 +3,30 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import ProcessingJobs from "./ProcessingJobs";
 
+vi.mock("../hooks/useLifecycleDefinitions", () => ({
+  default: () => ({
+    data: {
+      processing_job: {
+        states: [
+          { value: "queued", label: "Queued" },
+          { value: "running", label: "Running" },
+          { value: "completed", label: "Completed" },
+          { value: "error", label: "Failed" },
+          { value: "canceled", label: "Canceled" },
+        ],
+        active_states: ["queued", "running"],
+        terminal_states: ["completed", "error", "canceled"],
+        retryable_states: ["error", "canceled"],
+        groups: { running: ["running"], waiting: ["queued"] },
+      },
+    },
+  }),
+}));
+
 function renderPage() {
-  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
   return render(
     <QueryClientProvider client={client}>
       <ProcessingJobs />
@@ -64,7 +86,9 @@ describe("ProcessingJobs", () => {
 
   it("shows active durable jobs and their progress", async () => {
     renderPage();
-    expect(await screen.findByRole("link", { name: "Queued Story" })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("link", { name: "Queued Story" }),
+    ).toBeInTheDocument();
     expect(screen.getByText("Cleaning chapters")).toBeInTheDocument();
     expect(screen.getByText("33% · 1 / 3")).toBeInTheDocument();
     expect(screen.getByRole("progressbar")).toHaveValue(1);

--- a/frontend/src/components/audiobook/ChapterAssembly.jsx
+++ b/frontend/src/components/audiobook/ChapterAssembly.jsx
@@ -4,9 +4,17 @@ import {
   getChapterAudioUrl,
 } from "../../api/audiobook";
 import { chapterLabel } from "../../lib/audiobook";
+import useLifecycleDefinitions from "../../hooks/useLifecycleDefinitions";
 
 function ChapterAssembly({ chapters, bookId, pipelineActive = false }) {
   const queryClient = useQueryClient();
+  const { data: lifecycleDefinitions } = useLifecycleDefinitions();
+  const previewLifecycle = lifecycleDefinitions?.chapter_preview;
+  const previewLabels = Object.fromEntries(
+    (previewLifecycle?.states ?? []).map((state) => [state.value, state.label]),
+  );
+  const activePreviewStatuses = new Set(previewLifecycle?.active_states ?? []);
+  const failedPreviewStatuses = new Set(previewLifecycle?.failure_states ?? []);
   const previewMutation = useMutation({
     mutationFn: (chapterId) => generateChapterPreview(bookId, chapterId),
     onSuccess: () => {
@@ -41,7 +49,7 @@ function ChapterAssembly({ chapters, bookId, pipelineActive = false }) {
             const analyzed =
               chapter.sentence_count > 0 &&
               chapter.processed_sentence_count === chapter.sentence_count;
-            const previewBusy = ["queued", "generating"].includes(
+            const previewBusy = activePreviewStatuses.has(
               chapter.preview_status,
             );
             const previewReady =
@@ -52,12 +60,11 @@ function ChapterAssembly({ chapters, bookId, pipelineActive = false }) {
                 <td>
                   {previewBusy ? (
                     <span className="badge badge--warning">
-                      {chapter.preview_status === "queued"
-                        ? "Queued"
-                        : "Generating"}{" "}
+                      {previewLabels[chapter.preview_status] ??
+                        chapter.preview_status}{" "}
                       · {chapter.audio_generated_count}/{chapter.sentence_count}
                     </span>
-                  ) : chapter.preview_status === "error" ? (
+                  ) : failedPreviewStatuses.has(chapter.preview_status) ? (
                     <span className="badge badge--error">Preview failed</span>
                   ) : chapter.needs_reassembly ? (
                     <span className="badge badge--warning">

--- a/frontend/src/components/audiobook/CharacterRoster.jsx
+++ b/frontend/src/components/audiobook/CharacterRoster.jsx
@@ -7,14 +7,7 @@ import {
   shareCharacterRosterWithSeries,
   updateCharacter,
 } from "../../api/audiobook";
-
-const ACTIVE_STATUSES = new Set([
-  "ingesting",
-  "roster_gen",
-  "diarizing",
-  "audio_gen",
-  "assembling",
-]);
+import useLifecycleDefinitions from "../../hooks/useLifecycleDefinitions";
 
 function CharacterCard({ character, bookId, pipelineActive, ttsProvider }) {
   const queryClient = useQueryClient();
@@ -204,6 +197,11 @@ function CharacterRoster({
   ttsProvider,
 }) {
   const queryClient = useQueryClient();
+  const { data: lifecycleDefinitions } = useLifecycleDefinitions();
+  const activeStatuses = new Set(
+    lifecycleDefinitions?.audiobook_pipeline?.active_states ?? [],
+  );
+  const pipelineActive = activeStatuses.has(pipelineStatus);
   const [confirmRegenerate, setConfirmRegenerate] = useState(false);
   const regenerateMutation = useMutation({
     mutationFn: () => rebuildCharacterRoster(bookId),
@@ -247,9 +245,7 @@ function CharacterRoster({
         {series && (
           <button
             onClick={() => shareMutation.mutate()}
-            disabled={
-              shareMutation.isPending || ACTIVE_STATUSES.has(pipelineStatus)
-            }
+            disabled={shareMutation.isPending || pipelineActive}
           >
             {shareMutation.isPending ? "Syncing series…" : "Sync Series Roster"}
           </button>
@@ -257,7 +253,7 @@ function CharacterRoster({
         {!confirmRegenerate ? (
           <button
             onClick={() => setConfirmRegenerate(true)}
-            disabled={ACTIVE_STATUSES.has(pipelineStatus)}
+            disabled={pipelineActive}
           >
             Regenerate Character Roster
           </button>
@@ -305,7 +301,7 @@ function CharacterRoster({
             key={char.id}
             character={char}
             bookId={bookId}
-            pipelineActive={ACTIVE_STATUSES.has(pipelineStatus)}
+            pipelineActive={pipelineActive}
             ttsProvider={ttsProvider}
           />
         ))}

--- a/frontend/src/components/audiobook/ProgressDashboard.jsx
+++ b/frontend/src/components/audiobook/ProgressDashboard.jsx
@@ -1,13 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { chapterLabel } from "../../lib/audiobook";
-
-const ACTIVE_STATUSES = new Set([
-  "ingesting",
-  "roster_gen",
-  "diarizing",
-  "audio_gen",
-  "assembling",
-]);
+import useLifecycleDefinitions from "../../hooks/useLifecycleDefinitions";
 
 function percent(current, total) {
   return total ? Math.round((current * 1000) / total) / 10 : 0;
@@ -65,6 +58,19 @@ function ProgressMetric({ label, current, total, detail }) {
 }
 
 function ProgressDashboard({ status, chapters = [] }) {
+  const { data: lifecycleDefinitions } = useLifecycleDefinitions();
+  const pipelineLifecycle = lifecycleDefinitions?.audiobook_pipeline;
+  const stateLabels = Object.fromEntries(
+    (pipelineLifecycle?.states ?? []).map((state) => [
+      state.value,
+      state.label,
+    ]),
+  );
+  const activeStatuses = new Set(pipelineLifecycle?.active_states ?? []);
+  const failureStatuses = new Set(pipelineLifecycle?.failure_states ?? []);
+  const concurrentAnalysisStatuses = new Set(
+    pipelineLifecycle?.groups?.concurrent_analysis ?? [],
+  );
   const counts = status?.sentence_counts ?? {};
   const totalSentences = Object.values(counts).reduce(
     (sum, count) => sum + count,
@@ -86,7 +92,9 @@ function ProgressDashboard({ status, chapters = [] }) {
       chapter.audio_file_path &&
       chapter.smil_file_path,
   ).length;
-  const active = ACTIVE_STATUSES.has(status?.pipeline_status);
+  const pipelineStatus = status?.pipeline_status ?? null;
+  const pipelineLabel = stateLabels[pipelineStatus] ?? "Not started";
+  const active = activeStatuses.has(pipelineStatus);
   const rates = useProgressRates(analyzedSentences, generatedAudio);
   const receiving = status?.progress_detail?.includes("receiving ");
   const startedAt = status?.pipeline_started_at
@@ -103,7 +111,7 @@ function ProgressDashboard({ status, chapters = [] }) {
           <div>
             <span className="metric-label">Current activity</span>
             <h3>
-              {status?.pipeline_status || "Not started"}
+              {pipelineLabel}
               {active && (
                 <span className="progress-live-pulse" aria-label="working" />
               )}
@@ -111,16 +119,14 @@ function ProgressDashboard({ status, chapters = [] }) {
           </div>
           <span
             className={`badge ${
-              status?.pipeline_status === "error"
+              failureStatuses.has(pipelineStatus)
                 ? "badge--error"
                 : active
                   ? "badge--success"
                   : "badge--neutral"
             }`}
           >
-            {receiving
-              ? "Streaming model response"
-              : status?.pipeline_status || "idle"}
+            {receiving ? "Streaming model response" : pipelineLabel}
           </span>
         </div>
         <p className="progress-live-detail">
@@ -136,7 +142,7 @@ function ProgressDashboard({ status, chapters = [] }) {
             Audio: {formatRate(rates.audio)} ·{" "}
             {formatEta(totalSentences - generatedAudio, rates.audio)}
           </span>
-          {status?.pipeline_status === "diarizing" && (
+          {concurrentAnalysisStatuses.has(pipelineStatus) && (
             <span>Analysis and speech lanes are running concurrently</span>
           )}
           {startedAt && <span>Started {startedAt.toLocaleString()}</span>}

--- a/frontend/src/components/audiobook/ScriptEditor.jsx
+++ b/frontend/src/components/audiobook/ScriptEditor.jsx
@@ -7,17 +7,25 @@ import {
   getSentenceAudioUrl,
 } from "../../api/audiobook";
 import { chapterLabel } from "../../lib/audiobook";
+import useLifecycleDefinitions from "../../hooks/useLifecycleDefinitions";
 
 const STATUS_ICONS = {
-  pending_diarization: { icon: "⏳", label: "Pending diarization" },
-  ready_for_audio: { icon: "🎙", label: "Ready for audio" },
-  audio_queued: { icon: "⏱", label: "Audio queued" },
-  audio_generating: { icon: "🔊", label: "Generating audio" },
-  audio_generated: { icon: "✅", label: "Audio generated" },
-  error: { icon: "❌", label: "Error" },
+  pending_diarization: "⏳",
+  ready_for_audio: "🎙",
+  audio_queued: "⏱",
+  audio_generating: "🔊",
+  audio_generated: "✅",
+  error: "❌",
 };
 
-function SentenceRow({ sentence, characters, bookId, pipelineActive }) {
+function SentenceRow({
+  sentence,
+  characters,
+  bookId,
+  pipelineActive,
+  statusLabels,
+  statusGroups,
+}) {
   const queryClient = useQueryClient();
   const [tags, setTags] = useState(
     sentence.tagged_text || sentence.original_text,
@@ -56,12 +64,11 @@ function SentenceRow({ sentence, characters, bookId, pipelineActive }) {
     });
   };
 
-  const statusInfo = STATUS_ICONS[sentence.status] || {
-    icon: "?",
-    label: sentence.status,
+  const statusInfo = {
+    icon: STATUS_ICONS[sentence.status] || "?",
+    label: statusLabels[sentence.status] || sentence.status,
   };
-  const audioUrl =
-    sentence.status === "audio_generated"
+  const audioUrl = statusGroups.playable.has(sentence.status)
       ? getSentenceAudioUrl(sentence.id)
       : null;
 
@@ -127,8 +134,8 @@ function SentenceRow({ sentence, characters, bookId, pipelineActive }) {
             preload="none"
             style={{ height: "24px" }}
           />
-        ) : sentence.status === "ready_for_audio" ||
-          sentence.status === "error" ? (
+        ) : statusGroups.ready.has(sentence.status) ||
+          statusGroups.failed.has(sentence.status) ? (
           <button
             type="button"
             className="btn-small"
@@ -151,13 +158,15 @@ function SentenceRow({ sentence, characters, bookId, pipelineActive }) {
           >
             {audioMutation.isPending
               ? "Queueing…"
-              : sentence.status === "error"
+              : statusGroups.failed.has(sentence.status)
                 ? "Retry audio"
                 : "Generate audio"}
           </button>
-        ) : ["audio_queued", "audio_generating"].includes(sentence.status) ? (
+        ) : statusGroups.inProgress.has(sentence.status) ? (
           <span className="sentence-audio-progress">
-            {sentence.status === "audio_queued" ? "Waiting…" : "Working…"}
+            {statusGroups.waiting.has(sentence.status)
+              ? "Waiting…"
+              : "Working…"}
           </span>
         ) : null}
         {audioMutation.isError && (
@@ -202,6 +211,38 @@ function ScriptEditor({
   chapters = [],
   pipelineActive = false,
 }) {
+  const { data: lifecycleDefinitions } = useLifecycleDefinitions();
+  const sentenceLifecycle = lifecycleDefinitions?.sentence;
+  const statusLabels = Object.fromEntries(
+    (sentenceLifecycle?.states ?? []).map((state) => [
+      state.value,
+      state.label,
+    ]),
+  );
+  const audioInProgressStatuses = new Set(
+    sentenceLifecycle?.groups?.audio_in_progress ?? [],
+  );
+  const audioReadyStatuses = new Set(
+    sentenceLifecycle?.groups?.audio_ready ?? [],
+  );
+  const audioWaitingStatuses = new Set(
+    sentenceLifecycle?.groups?.audio_waiting ?? [],
+  );
+  const audioWorkingStatuses = new Set(
+    sentenceLifecycle?.groups?.audio_working ?? [],
+  );
+  const audioPlayableStatuses = new Set(
+    sentenceLifecycle?.groups?.audio_playable ?? [],
+  );
+  const failedStatuses = new Set(sentenceLifecycle?.failure_states ?? []);
+  const statusGroups = {
+    inProgress: audioInProgressStatuses,
+    ready: audioReadyStatuses,
+    waiting: audioWaitingStatuses,
+    working: audioWorkingStatuses,
+    playable: audioPlayableStatuses,
+    failed: failedStatuses,
+  };
   const [page, setPage] = useState(1);
   const [chapterFilter, setChapterFilter] = useState("");
   const [reviewOnly, setReviewOnly] = useState(false);
@@ -219,7 +260,7 @@ function ScriptEditor({
     keepPreviousData: true,
     refetchInterval: ({ state }) =>
       state.data?.items?.some((sentence) =>
-        ["audio_queued", "audio_generating"].includes(sentence.status),
+        audioInProgressStatuses.has(sentence.status),
       )
         ? 1500
         : false,
@@ -313,6 +354,8 @@ function ScriptEditor({
                   characters={characters}
                   bookId={bookId}
                   pipelineActive={pipelineActive}
+                  statusLabels={statusLabels}
+                  statusGroups={statusGroups}
                 />
               ))}
             </tbody>

--- a/frontend/src/hooks/useLifecycleDefinitions.js
+++ b/frontend/src/hooks/useLifecycleDefinitions.js
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+import { getLifecycleDefinitions } from "../api/lifecycles";
+
+export default function useLifecycleDefinitions() {
+  return useQuery({
+    queryKey: ["lifecycle-definitions"],
+    queryFn: getLifecycleDefinitions,
+    staleTime: Infinity,
+  });
+}

--- a/scripts/migration-lifecycle-setup.sql
+++ b/scripts/migration-lifecycle-setup.sql
@@ -1,0 +1,29 @@
+UPDATE books
+SET download_status = 'complete',
+    refresh_status = 'unknown-refresh',
+    audiobook_pipeline_status = 'unknown-pipeline',
+    audiobook_publication_state = 'unknown-publication'
+WHERE title = 'Migration Test';
+
+UPDATE audiobook_chapters
+SET preview_status = 'unknown-preview',
+    generation_state = 'unknown-generation'
+WHERE content_file_name = 'Text/existing.xhtml';
+
+UPDATE audiobook_sentences
+SET status = 'unknown-sentence'
+WHERE html_element_id = 'existing-sentence';
+
+UPDATE imported_audiobooks
+SET status = 'unknown-import',
+    alignment_method = 'unknown-alignment'
+WHERE name = 'Pre-existing imported edition';
+
+INSERT INTO processing_jobs (job_type, status, resource_lane)
+VALUES ('migration_lifecycle_test', 'unknown-job', 'maintenance');
+
+INSERT INTO update_tasks (total_books, completed_books, status)
+VALUES (1, 0, 'unknown-task');
+
+INSERT INTO metadata_sync_jobs (trigger, status, total_books)
+VALUES ('migration-test', 'unknown-metadata', 1);

--- a/scripts/migration-lifecycle-verify.sql
+++ b/scripts/migration-lifecycle-verify.sql
@@ -1,0 +1,61 @@
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM books
+        WHERE title = 'Migration Test'
+          AND download_status IS NULL
+          AND refresh_status = 'error'
+          AND audiobook_pipeline_status = 'error'
+          AND audiobook_publication_state = 'error'
+          AND audiobook_publication_error IS NOT NULL
+    ) THEN
+        RAISE EXCEPTION 'book lifecycle values were not normalized';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM audiobook_chapters
+        WHERE content_file_name = 'Text/existing.xhtml'
+          AND preview_status = 'error'
+          AND preview_error IS NOT NULL
+          AND generation_state = 'error'
+    ) THEN
+        RAISE EXCEPTION 'chapter lifecycle values were not normalized';
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM audiobook_sentences WHERE html_element_id = 'existing-sentence' AND status = 'error')
+       OR NOT EXISTS (SELECT 1 FROM imported_audiobooks WHERE name = 'Pre-existing imported edition' AND status = 'error' AND alignment_method IS NULL AND alignment_error IS NOT NULL)
+       OR NOT EXISTS (SELECT 1 FROM processing_jobs WHERE job_type = 'migration_lifecycle_test' AND status = 'error')
+       OR NOT EXISTS (SELECT 1 FROM update_tasks WHERE status = 'interrupted')
+       OR NOT EXISTS (SELECT 1 FROM metadata_sync_jobs WHERE trigger = 'migration-test' AND status = 'failed') THEN
+        RAISE EXCEPTION 'one or more lifecycle values were not normalized';
+    END IF;
+
+    IF (
+        SELECT count(*)
+        FROM pg_constraint
+        WHERE contype = 'c'
+          AND conname IN (
+                 'ck_books_download_status',
+                 'ck_books_refresh_status',
+                 'ck_books_audiobook_pipeline_status',
+                 'ck_books_audiobook_publication_state',
+                 'ck_processing_jobs_status',
+                 'ck_update_tasks_status',
+                 'ck_metadata_sync_jobs_status',
+                 'ck_audiobook_chapters_preview_status',
+                 'ck_audiobook_chapters_generation_state',
+                 'ck_audiobook_sentences_status',
+                 'ck_imported_audiobooks_status',
+                 'ck_imported_audiobooks_alignment_method'
+             )
+    ) < 12 THEN
+        RAISE EXCEPTION 'expected lifecycle check constraints were not created';
+    END IF;
+
+    BEGIN
+        UPDATE books SET refresh_status = 'still-invalid' WHERE title = 'Migration Test';
+        RAISE EXCEPTION 'invalid lifecycle value unexpectedly satisfied the check constraint';
+    EXCEPTION
+        WHEN check_violation THEN NULL;
+    END;
+END $$;


### PR DESCRIPTION
## Summary

- define authoritative state machines, enums, transitions, terminal/retry/recovery groupings, and actionable invalid-transition errors for 12 persisted lifecycles
- route processing, web, metadata, generated-audio, imported-audio, alignment, preview, sentence, and publication changes through shared lifecycle helpers
- expose the shared manifest at `GET /api/lifecycles` and derive frontend labels and behavioral groupings from it
- normalize legacy/invalid populated data in migration 0033 before adding database check constraints
- document recovery for every non-terminal state plus parent/child processing-job behavior

## Validation

- `make pr-check`
- `make test` (377 backend, 72 frontend)
- `make test-migrations` (clean PostgreSQL, populated invalid-data repair, constraint rejection, downgrade)
- `make e2e` (4 Playwright tests)
- local PostgreSQL migrated to 0033; API on port 8000 serves the lifecycle manifest