### PR TITLE
Add stronger observability and diagnostic bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -196,3 +196,5 @@ config
 # Mac specific files
 .DS_Store
 .DS_Store?
+# Persistent local application logs
+/logs/

--- a/Makefile
+++ b/Makefile
@@ -227,9 +227,18 @@ test-migrations:
 	docker exec -i story-manager-migration-test psql -v ON_ERROR_STOP=1 -U postgres -d story_manager \
 		< scripts/migration-lifecycle-verify.sql; \
 	DATABASE_URL="postgresql+psycopg://postgres:postgres@localhost:5433/story_manager" \
+	PYTHONPATH=. .venv/bin/alembic -c backend/alembic.ini downgrade 0032; \
+	docker exec story-manager-migration-test psql -v ON_ERROR_STOP=1 -U postgres -d story_manager \
+		-c "UPDATE books SET refresh_status = 'constraint-removed' WHERE title = 'Migration Test';" \
+		-c "INSERT INTO processing_jobs (job_type) VALUES ('clean_all');"; \
+	DATABASE_URL="postgresql+psycopg://postgres:postgres@localhost:5433/story_manager" \
+	PYTHONPATH=. .venv/bin/alembic -c backend/alembic.ini upgrade head; \
+	docker exec story-manager-migration-test psql -v ON_ERROR_STOP=1 -U postgres -d story_manager \
+		-c "DO \$$\$$ BEGIN IF NOT EXISTS (SELECT 1 FROM processing_jobs WHERE request_id LIKE 'legacy-%') THEN RAISE EXCEPTION 'processing request id was not backfilled'; END IF; IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE tablename = 'processing_jobs' AND indexname = 'ix_processing_jobs_request_id') THEN RAISE EXCEPTION 'processing request id index was not created'; END IF; END \$$\$$;"; \
+	DATABASE_URL="postgresql+psycopg://postgres:postgres@localhost:5433/story_manager" \
 	PYTHONPATH=. .venv/bin/alembic -c backend/alembic.ini downgrade -1; \
 	docker exec story-manager-migration-test psql -v ON_ERROR_STOP=1 -U postgres -d story_manager \
-		-c "UPDATE books SET refresh_status = 'constraint-removed' WHERE title = 'Migration Test';"
+		-c "DO \$$\$$ BEGIN IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'processing_jobs' AND column_name = 'request_id') THEN RAISE EXCEPTION 'processing request id column survived downgrade'; END IF; END \$$\$$;"
 
 e2e:
 	docker rm -f $(E2E_DB_CONTAINER) >/dev/null 2>&1 || true

--- a/backend/alembic/versions/0034_processing_job_request_ids.py
+++ b/backend/alembic/versions/0034_processing_job_request_ids.py
@@ -1,0 +1,60 @@
+"""add processing job request correlation
+
+Revision ID: 0034
+Revises: 0033
+Create Date: 2026-08-09 00:00:00
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0034"
+down_revision = "0033"
+branch_labels = None
+depends_on = None
+
+TABLE_NAME = "processing_jobs"
+COLUMN_NAME = "request_id"
+INDEX_NAME = "ix_processing_jobs_request_id"
+
+
+def upgrade():
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    if not inspector.has_table(TABLE_NAME):
+        return
+
+    columns = {column["name"] for column in inspector.get_columns(TABLE_NAME)}
+    if COLUMN_NAME not in columns:
+        op.add_column(TABLE_NAME, sa.Column(COLUMN_NAME, sa.String(length=64), nullable=True))
+
+    jobs = sa.table(
+        TABLE_NAME,
+        sa.column("id", sa.Integer),
+        sa.column(COLUMN_NAME, sa.String(length=64)),
+    )
+    conn.execute(
+        jobs.update()
+        .where(jobs.c.request_id.is_(None))
+        .values(request_id=sa.literal("legacy-") + sa.cast(jobs.c.id, sa.String()))
+    )
+    op.alter_column(TABLE_NAME, COLUMN_NAME, existing_type=sa.String(length=64), nullable=False)
+
+    indexes = {index["name"] for index in sa.inspect(conn).get_indexes(TABLE_NAME)}
+    if INDEX_NAME not in indexes:
+        op.create_index(INDEX_NAME, TABLE_NAME, [COLUMN_NAME])
+
+
+def downgrade():
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    if not inspector.has_table(TABLE_NAME):
+        return
+    indexes = {index["name"] for index in inspector.get_indexes(TABLE_NAME)}
+    if INDEX_NAME in indexes:
+        op.drop_index(INDEX_NAME, table_name=TABLE_NAME)
+    columns = {column["name"] for column in sa.inspect(conn).get_columns(TABLE_NAME)}
+    if COLUMN_NAME in columns:
+        op.drop_column(TABLE_NAME, COLUMN_NAME)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -7,6 +7,11 @@ APP_DIR = Path(__file__).parent.resolve()
 # Absolute path to the library/ directory at the project root
 LIBRARY_PATH = (APP_DIR / ".." / ".." / "library").resolve()
 
+# Application logs survive ordinary restarts and rotate in a bounded directory.
+LOG_DIR = Path(os.getenv("STORY_MANAGER_LOG_DIR", str(LIBRARY_PATH.parent / "logs"))).resolve()
+LOG_MAX_BYTES = max(64 * 1024, int(os.getenv("STORY_MANAGER_LOG_MAX_BYTES", str(5 * 1024 * 1024))))
+LOG_BACKUP_COUNT = max(1, int(os.getenv("STORY_MANAGER_LOG_BACKUP_COUNT", "3")))
+
 # Rename this marker whenever chapter concatenation semantics change. A
 # missing marker makes existing packages resumable at assembly without a
 # database migration or destructive audio regeneration.

--- a/backend/app/crud/processing.py
+++ b/backend/app/crud/processing.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 from typing import Iterable
+from uuid import uuid4
 
 from sqlalchemy import and_, desc, or_, select, update
 from sqlalchemy.exc import IntegrityError
@@ -11,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..lifecycle import PROCESSING_JOB, ProcessingJobStatus, transition_state
 from ..models import Book, ProcessingJob
+from ..observability_context import request_id_var
 
 ACTIVE_PROCESSING_STATUSES = tuple(PROCESSING_JOB.active_states)
 
@@ -52,6 +54,7 @@ async def create_processing_job(
         target_id=target_id,
         target_content_version=target_content_version,
         parent_job_id=parent_job_id,
+        request_id=request_id_var.get() or uuid4().hex[:12],
         payload=payload or {},
         dedupe_key=dedupe_key,
         resource_lane=resource_lane,

--- a/backend/app/errors.py
+++ b/backend/app/errors.py
@@ -1,11 +1,14 @@
 """Structured error responses and global exception handlers."""
 
 import logging
-import traceback
 
 from fastapi import FastAPI, HTTPException, Request, status
+from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
+
+from .logging_config import redact_value
+from .observability_context import request_id_var
 
 logger = logging.getLogger(__name__)
 
@@ -14,6 +17,28 @@ class ErrorResponse(BaseModel):
     error: str
     detail: str
     status_code: int
+    request_id: str
+
+
+def _request_id(request: Request) -> str:
+    return getattr(request.state, "request_id", None) or request_id_var.get()
+
+
+def _error_response(request: Request, status_code: int, detail, *, headers=None) -> JSONResponse:
+    request_id = _request_id(request)
+    response_headers = dict(headers or {})
+    if request_id:
+        response_headers["X-Request-ID"] = request_id
+    return JSONResponse(
+        status_code=status_code,
+        content={
+            "error": _status_to_error_code(status_code),
+            "detail": redact_value(detail),
+            "status_code": status_code,
+            "request_id": request_id,
+        },
+        headers=response_headers,
+    )
 
 
 def install_error_handlers(app: FastAPI) -> None:
@@ -21,32 +46,24 @@ def install_error_handlers(app: FastAPI) -> None:
 
     @app.exception_handler(HTTPException)
     async def http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:
-        return JSONResponse(
-            status_code=exc.status_code,
-            content={
-                "error": _status_to_error_code(exc.status_code),
-                "detail": exc.detail,
-                "status_code": exc.status_code,
-            },
-            headers=getattr(exc, "headers", None),
-        )
+        return _error_response(request, exc.status_code, exc.detail, headers=getattr(exc, "headers", None))
+
+    @app.exception_handler(RequestValidationError)
+    async def validation_exception_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
+        return _error_response(request, 422, exc.errors())
 
     @app.exception_handler(Exception)
     async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse:
-        logger.error(
-            "Unhandled exception on %s %s: %s\n%s",
+        logger.exception(
+            "Unhandled exception on %s %s: %s",
             request.method,
             request.url.path,
             exc,
-            traceback.format_exc(),
         )
-        return JSONResponse(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            content={
-                "error": "internal_error",
-                "detail": "An unexpected error occurred.",
-                "status_code": 500,
-            },
+        return _error_response(
+            request,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            "An unexpected error occurred.",
         )
 
 

--- a/backend/app/logging_config.py
+++ b/backend/app/logging_config.py
@@ -18,6 +18,18 @@ from .observability_context import job_id_var, request_id_var
 
 _LOG_BUFFER: collections.deque = collections.deque(maxlen=1000)
 _LOG_FILE = LOG_DIR / "story-manager.jsonl"
+QUIET_SUCCESS_PATHS = frozenset(
+    {
+        "/api/dashboard/attention",
+        "/api/logs",
+        "/api/observability/health",
+        "/api/observability/job-metrics",
+        "/api/processing/jobs",
+        "/health",
+        "/health/live",
+        "/health/ready",
+    }
+)
 
 _REDACTION_PATTERNS = (
     (re.compile(r"(?i)\b(Bearer)\s+[A-Za-z0-9._~+/=-]+"), r"\1 [REDACTED]"),
@@ -65,6 +77,14 @@ def redact_value(value: Any) -> Any:
     if isinstance(value, str):
         return redact_text(value)
     return value
+
+
+def is_quiet_successful_access_entry(entry: dict[str, Any]) -> bool:
+    """Identify historical successful polling access records for UI filtering."""
+    if entry.get("logger") != "story_manager.access":
+        return False
+    message = str(entry.get("message") or "")
+    return any(re.match(rf"^GET {re.escape(path)} completed with [23]\d\d\b", message) for path in QUIET_SUCCESS_PATHS)
 
 
 class _CorrelationFilter(logging.Filter):

--- a/backend/app/logging_config.py
+++ b/backend/app/logging_config.py
@@ -1,63 +1,187 @@
+"""Structured, correlated, persistent, and redacted application logging."""
+
+from __future__ import annotations
+
 import collections
 import json
 import logging
 import os
+import re
 import sys
 from datetime import datetime, timezone
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from typing import Any
 
-# In-memory log buffer (most-recent 1000 records)
+from .config import LOG_BACKUP_COUNT, LOG_DIR, LOG_MAX_BYTES
+from .observability_context import job_id_var, request_id_var
+
 _LOG_BUFFER: collections.deque = collections.deque(maxlen=1000)
+_LOG_FILE = LOG_DIR / "story-manager.jsonl"
+
+_REDACTION_PATTERNS = (
+    (re.compile(r"(?i)\b(Bearer)\s+[A-Za-z0-9._~+/=-]+"), r"\1 [REDACTED]"),
+    (
+        re.compile(r"(?i)\b(authorization|cookie|set-cookie)\s*:\s*[^\r\n]+"),
+        r"\1: [REDACTED]",
+    ),
+    (
+        re.compile(
+            r"""(?ix)(["']?(?:api[_-]?key|password|secret|token|session(?:_id)?|story_manager_admin)"""
+            r"""["']?\s*[=:]\s*)["']?[^"',;\s}]+"""
+        ),
+        r"\1[REDACTED]",
+    ),
+    (re.compile(r"(?i)\b(postgres(?:ql)?(?:\+\w+)?://)[^@\s]+@"), r"\1[REDACTED]@"),
+)
+
+
+def redact_text(value: str) -> str:
+    """Remove common credential forms from operator-visible diagnostics."""
+    redacted = value
+    for pattern, replacement in _REDACTION_PATTERNS:
+        redacted = pattern.sub(replacement, redacted)
+    return redacted
+
+
+def redact_value(value: Any) -> Any:
+    """Recursively redact mappings without changing their diagnostic shape."""
+    if isinstance(value, dict):
+        return {
+            key: (
+                "[REDACTED]"
+                if any(
+                    marker in str(key).lower()
+                    for marker in ("api_key", "authorization", "cookie", "password", "secret", "session", "token")
+                )
+                else redact_value(item)
+            )
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [redact_value(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(redact_value(item) for item in value)
+    if isinstance(value, str):
+        return redact_text(value)
+    return value
+
+
+class _CorrelationFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        if not getattr(record, "request_id", None):
+            record.request_id = request_id_var.get()
+        if getattr(record, "job_id", None) is None:
+            record.job_id = job_id_var.get()
+        return True
+
+
+def _record_entry(record: logging.LogRecord, formatter: logging.Formatter) -> dict[str, Any]:
+    entry: dict[str, Any] = {
+        "timestamp": datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat(),
+        "level": record.levelname,
+        "logger": record.name,
+        "message": redact_text(record.getMessage()),
+    }
+    if record.exc_info and record.exc_info[1]:
+        entry["exception"] = redact_text(formatter.formatException(record.exc_info))
+    if request_id := getattr(record, "request_id", None):
+        entry["request_id"] = request_id
+    if (job_id := getattr(record, "job_id", None)) is not None:
+        entry["job_id"] = job_id
+    return entry
 
 
 class _StructuredFormatter(logging.Formatter):
-    """JSON-lines formatter for structured logging in container environments."""
+    """JSON-lines formatter for both containers and persistent log files."""
 
     def format(self, record: logging.LogRecord) -> str:
-        log_entry = {
-            "timestamp": datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat(),
-            "level": record.levelname,
-            "logger": record.name,
-            "message": record.getMessage(),
-        }
-        if record.exc_info and record.exc_info[1]:
-            log_entry["exception"] = self.formatException(record.exc_info)
-        # Include request_id if attached to the log record
-        request_id = getattr(record, "request_id", None)
-        if request_id:
-            log_entry["request_id"] = request_id
-        return json.dumps(log_entry, default=str)
+        return json.dumps(_record_entry(record, self), default=str)
+
+
+class _RedactedTextFormatter(logging.Formatter):
+    """Apply the same credential redaction to human-readable console output."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        original_message, original_args = record.msg, record.args
+        try:
+            record.msg = redact_text(record.getMessage())
+            record.args = ()
+            return super().format(record)
+        finally:
+            record.msg, record.args = original_message, original_args
+
+    def formatException(self, exc_info) -> str:
+        return redact_text(super().formatException(exc_info))
 
 
 class _MemoryLogHandler(logging.Handler):
     def emit(self, record: logging.LogRecord) -> None:
-        entry = {
-            "timestamp": datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat(),
-            "level": record.levelname,
-            "logger": record.name,
-            "message": self.format(record),
-        }
-        request_id = getattr(record, "request_id", None)
-        if request_id:
-            entry["request_id"] = request_id
-        _LOG_BUFFER.append(entry)
+        try:
+            _LOG_BUFFER.append(_record_entry(record, self.formatter or logging.Formatter()))
+        except Exception:
+            self.handleError(record)
 
 
-def setup_logging() -> tuple[logging.StreamHandler, _MemoryLogHandler]:
+def setup_logging() -> tuple[logging.StreamHandler, _MemoryLogHandler, RotatingFileHandler]:
     use_json = os.getenv("LOG_FORMAT", "").lower() == "json"
-
+    correlation_filter = _CorrelationFilter()
     root_logger = logging.getLogger()
     root_logger.setLevel(logging.INFO)
 
-    # Console handler
     console_handler = logging.StreamHandler(sys.stderr)
+    console_handler.addFilter(correlation_filter)
     if use_json:
         console_handler.setFormatter(_StructuredFormatter())
     else:
-        console_handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s"))
+        console_handler.setFormatter(
+            _RedactedTextFormatter(
+                "%(asctime)s %(levelname)s %(name)s " "[request_id=%(request_id)s job_id=%(job_id)s]: %(message)s"
+            )
+        )
     root_logger.addHandler(console_handler)
 
-    # Memory handler (always uses plain message format for the API endpoint)
     mem_handler = _MemoryLogHandler()
-    mem_handler.setFormatter(logging.Formatter("%(message)s"))
+    mem_handler.addFilter(correlation_filter)
     root_logger.addHandler(mem_handler)
-    return console_handler, mem_handler
+
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    file_handler = RotatingFileHandler(
+        _LOG_FILE,
+        maxBytes=LOG_MAX_BYTES,
+        backupCount=LOG_BACKUP_COUNT,
+        encoding="utf-8",
+    )
+    file_handler.addFilter(correlation_filter)
+    file_handler.setFormatter(_StructuredFormatter())
+    root_logger.addHandler(file_handler)
+    return console_handler, mem_handler, file_handler
+
+
+def read_persisted_logs(*, limit: int = 500, level: str | None = None, log_file: Path | None = None) -> list[dict]:
+    """Read the newest structured entries across the bounded rotated files."""
+    target = log_file or _LOG_FILE
+    candidates = [target.with_name(f"{target.name}.{index}") for index in range(LOG_BACKUP_COUNT, 0, -1)]
+    candidates.append(target)
+    entries: collections.deque = collections.deque(maxlen=max(1, limit))
+    for candidate in candidates:
+        if not candidate.is_file():
+            continue
+        try:
+            with candidate.open("r", encoding="utf-8", errors="replace") as handle:
+                for line in handle:
+                    try:
+                        entry = redact_value(json.loads(line))
+                    except (json.JSONDecodeError, TypeError):
+                        continue
+                    if level and entry.get("level") != level.upper():
+                        continue
+                    entries.append(entry)
+        except OSError:
+            continue
+    if entries:
+        return list(entries)
+    memory = [redact_value(entry) for entry in _LOG_BUFFER]
+    if level:
+        memory = [entry for entry in memory if entry.get("level") == level.upper()]
+    return memory[-limit:]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -31,6 +31,7 @@ from .routers import (
     lifecycles,
     metadata,
     processing,
+    observability,
     reader,
     scheduler,
     storage,
@@ -57,7 +58,7 @@ class RasterCoverStaticFiles(StaticFiles):
         return response
 
 
-_console_handler, _mem_handler = setup_logging()
+_console_handler, _mem_handler, _file_handler = setup_logging()
 _scheduler = get_scheduler()
 _processing_queue = get_processing_queue()
 
@@ -72,6 +73,8 @@ async def lifespan(app: FastAPI):
         root_logger.addHandler(_console_handler)
     if _mem_handler not in root_logger.handlers:
         root_logger.addHandler(_mem_handler)
+    if _file_handler not in root_logger.handlers:
+        root_logger.addHandler(_file_handler)
     logger.info("Starting up Story Manager services.")
     async with SessionLocal() as db:
         await crud.reset_stuck_update_tasks(db)
@@ -93,8 +96,8 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="Story Manager", lifespan=lifespan)
 install_error_handlers(app)
-app.add_middleware(RequestIdMiddleware)
 app.add_middleware(AdminAuthMiddleware)
+app.add_middleware(RequestIdMiddleware)
 app.mount(
     "/library/covers",
     RasterCoverStaticFiles(directory=str((LIBRARY_PATH / "covers").resolve()), check_dir=False),
@@ -110,6 +113,7 @@ app.mount(
 
 app.include_router(audiobook.router)
 app.include_router(processing.router)
+app.include_router(observability.router)
 app.include_router(books.router)
 app.include_router(upload.router)
 app.include_router(web_novels.router)
@@ -137,6 +141,21 @@ async def health_check(db: AsyncSession = Depends(get_db)):
             status_code=503,
             content={"status": "unhealthy", "database": "unavailable"},
         )
+
+
+@app.get("/health/live")
+async def liveness_check():
+    """Process-only health check that never depends on external services."""
+    return {"status": "alive"}
+
+
+@app.get("/health/ready")
+async def readiness_check(db: AsyncSession = Depends(get_db)):
+    """Required-dependency readiness check for container orchestration."""
+    from .services.observability import health_report
+
+    report = await health_report(db, _processing_queue)
+    return JSONResponse(status_code=200 if report["status"] == "healthy" else 503, content=report)
 
 
 # Serve the Vite-built frontend in production. The build output lives at

--- a/backend/app/middleware.py
+++ b/backend/app/middleware.py
@@ -1,22 +1,42 @@
-"""Request middleware: request ID injection for tracing."""
+"""Request middleware: correlation IDs and access logging."""
 
+import logging
+import re
+import time
 import uuid
-from contextvars import ContextVar
 
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.requests import Request
 from starlette.responses import Response
 
-# Context variable accessible from any async code in the request lifecycle
-request_id_var: ContextVar[str] = ContextVar("request_id", default="")
+from .observability_context import request_id_var
+
+logger = logging.getLogger("story_manager.access")
+_SAFE_REQUEST_ID = re.compile(r"^[A-Za-z0-9._:-]{1,64}$")
 
 
 class RequestIdMiddleware(BaseHTTPMiddleware):
     """Assigns a unique request ID to each incoming request and includes it in the response."""
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
-        rid = request.headers.get("X-Request-ID") or uuid.uuid4().hex[:12]
-        request_id_var.set(rid)
-        response = await call_next(request)
-        response.headers["X-Request-ID"] = rid
-        return response
+        supplied = request.headers.get("X-Request-ID", "")
+        rid = supplied if _SAFE_REQUEST_ID.fullmatch(supplied) else uuid.uuid4().hex[:12]
+        request.state.request_id = rid
+        token = request_id_var.set(rid)
+        started = time.perf_counter()
+        response: Response | None = None
+        try:
+            response = await call_next(request)
+            response.headers["X-Request-ID"] = rid
+            return response
+        finally:
+            duration_ms = round((time.perf_counter() - started) * 1000, 1)
+            status_code = response.status_code if response is not None else 500
+            logger.info(
+                "%s %s completed with %s in %sms",
+                request.method,
+                request.url.path,
+                status_code,
+                duration_ms,
+            )
+            request_id_var.reset(token)

--- a/backend/app/middleware.py
+++ b/backend/app/middleware.py
@@ -9,22 +9,11 @@ from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoin
 from starlette.requests import Request
 from starlette.responses import Response
 
+from .logging_config import QUIET_SUCCESS_PATHS
 from .observability_context import request_id_var
 
 logger = logging.getLogger("story_manager.access")
 _SAFE_REQUEST_ID = re.compile(r"^[A-Za-z0-9._:-]{1,64}$")
-_QUIET_SUCCESS_PATHS = frozenset(
-    {
-        "/api/dashboard/attention",
-        "/api/logs",
-        "/api/observability/health",
-        "/api/observability/job-metrics",
-        "/api/processing/jobs",
-        "/health",
-        "/health/live",
-        "/health/ready",
-    }
-)
 
 
 class RequestIdMiddleware(BaseHTTPMiddleware):
@@ -46,7 +35,7 @@ class RequestIdMiddleware(BaseHTTPMiddleware):
             status_code = response.status_code if response is not None else 500
             log = (
                 logger.debug
-                if request.method == "GET" and status_code < 400 and request.url.path in _QUIET_SUCCESS_PATHS
+                if request.method == "GET" and status_code < 400 and request.url.path in QUIET_SUCCESS_PATHS
                 else logger.info
             )
             log(

--- a/backend/app/middleware.py
+++ b/backend/app/middleware.py
@@ -13,6 +13,18 @@ from .observability_context import request_id_var
 
 logger = logging.getLogger("story_manager.access")
 _SAFE_REQUEST_ID = re.compile(r"^[A-Za-z0-9._:-]{1,64}$")
+_QUIET_SUCCESS_PATHS = frozenset(
+    {
+        "/api/dashboard/attention",
+        "/api/logs",
+        "/api/observability/health",
+        "/api/observability/job-metrics",
+        "/api/processing/jobs",
+        "/health",
+        "/health/live",
+        "/health/ready",
+    }
+)
 
 
 class RequestIdMiddleware(BaseHTTPMiddleware):
@@ -32,7 +44,12 @@ class RequestIdMiddleware(BaseHTTPMiddleware):
         finally:
             duration_ms = round((time.perf_counter() - started) * 1000, 1)
             status_code = response.status_code if response is not None else 500
-            logger.info(
+            log = (
+                logger.debug
+                if request.method == "GET" and status_code < 400 and request.url.path in _QUIET_SUCCESS_PATHS
+                else logger.info
+            )
+            log(
                 "%s %s completed with %s in %sms",
                 request.method,
                 request.url.path,

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -41,6 +41,7 @@ from .lifecycle import (
     UpdateTaskStatus,
 )
 import enum
+from uuid import uuid4
 
 
 def _state_check(column_name: str, machine: StateMachine, name: str) -> CheckConstraint:
@@ -185,6 +186,7 @@ class ProcessingJob(Base):
     target_id = Column(Integer, nullable=True)
     target_content_version = Column(Integer, nullable=True)
     parent_job_id = Column(Integer, ForeignKey("processing_jobs.id", ondelete="SET NULL"), nullable=True)
+    request_id = Column(String(64), nullable=False, default=lambda: uuid4().hex[:12], index=True)
     payload = Column(JSON, nullable=True)
     dedupe_key = Column(String, nullable=True, index=True)
     progress_current = Column(Integer, nullable=False, default=0, server_default="0")

--- a/backend/app/observability_context.py
+++ b/backend/app/observability_context.py
@@ -1,0 +1,22 @@
+"""Correlation context shared by HTTP requests, workers, and log handlers."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Iterator
+
+request_id_var: ContextVar[str] = ContextVar("request_id", default="")
+job_id_var: ContextVar[int | None] = ContextVar("job_id", default=None)
+
+
+@contextmanager
+def correlation_context(*, request_id: str = "", job_id: int | None = None) -> Iterator[None]:
+    """Temporarily attach correlation identifiers to all logs in this context."""
+    request_token = request_id_var.set(request_id)
+    job_token = job_id_var.set(job_id)
+    try:
+        yield
+    finally:
+        job_id_var.reset(job_token)
+        request_id_var.reset(request_token)

--- a/backend/app/routers/observability.py
+++ b/backend/app/routers/observability.py
@@ -1,0 +1,71 @@
+"""Operator-facing health, metrics, and safe diagnostic endpoints."""
+
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import JSONResponse, StreamingResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..database import get_db
+from ..logging_config import redact_value
+from ..services.observability import (
+    diagnostic_configuration,
+    diagnostic_logs,
+    health_report,
+    processing_job_metrics,
+)
+from ..services.processing_queue import get_processing_queue
+
+router = APIRouter(prefix="/api/observability", tags=["observability"])
+
+
+@router.get("/health")
+async def get_health(db: AsyncSession = Depends(get_db)):
+    return await health_report(db, get_processing_queue())
+
+
+@router.get("/ready")
+async def get_readiness(db: AsyncSession = Depends(get_db)):
+    report = await health_report(db, get_processing_queue())
+    return JSONResponse(status_code=200 if report["status"] == "healthy" else 503, content=report)
+
+
+@router.get("/job-metrics")
+async def get_job_metrics(
+    window_hours: int = Query(default=24, ge=1, le=24 * 90),
+    db: AsyncSession = Depends(get_db),
+):
+    return await processing_job_metrics(db, window_hours=window_hours)
+
+
+@router.get("/diagnostics")
+async def download_diagnostics(db: AsyncSession = Depends(get_db)):
+    """Download a redacted bundle with no library files, audio, or secret configuration."""
+    queue = get_processing_queue()
+    files = {
+        "health.json": await health_report(db, queue),
+        "job-metrics.json": await processing_job_metrics(db, window_hours=24),
+        "logs.json": diagnostic_logs(),
+        "configuration.json": diagnostic_configuration(),
+        "manifest.json": {
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "redacted": True,
+            "contents": ["health", "job metrics", "recent application logs", "configuration allowlist"],
+        },
+    }
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for filename, payload in files.items():
+            archive.writestr(filename, json.dumps(redact_value(payload), indent=2, default=str))
+    output.seek(0)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    return StreamingResponse(
+        output,
+        media_type="application/zip",
+        headers={"Content-Disposition": f'attachment; filename="story-manager-diagnostics-{timestamp}.zip"'},
+    )

--- a/backend/app/routers/storage.py
+++ b/backend/app/routers/storage.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from .. import crud
 from ..config import LIBRARY_PATH
 from ..database import get_db
-from ..logging_config import read_persisted_logs
+from ..logging_config import is_quiet_successful_access_entry, read_persisted_logs
 from ..services.library_health import inspect_library_files, is_failed_web_import_placeholder
 
 logger = logging.getLogger(__name__)
@@ -42,8 +42,11 @@ async def get_logs(
     level: Optional[str] = None,
     request_id: Optional[str] = None,
     job_id: Optional[int] = None,
+    include_polling: bool = False,
 ):
     entries = read_persisted_logs(limit=1000, level=level)
+    if not include_polling:
+        entries = [entry for entry in entries if not is_quiet_successful_access_entry(entry)]
     if request_id:
         entries = [entry for entry in entries if entry.get("request_id") == request_id]
     if job_id is not None:

--- a/backend/app/routers/storage.py
+++ b/backend/app/routers/storage.py
@@ -1,16 +1,16 @@
-"""Storage cleanup and in-memory log endpoints."""
+"""Storage cleanup and persistent log endpoints."""
 
 import logging
 from typing import Optional
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import crud
 from ..config import LIBRARY_PATH
 from ..database import get_db
-from ..logging_config import _LOG_BUFFER
+from ..logging_config import read_persisted_logs
 from ..services.library_health import inspect_library_files, is_failed_web_import_placeholder
 
 logger = logging.getLogger(__name__)
@@ -37,11 +37,17 @@ async def post_client_log(entry: ClientLogEntry):
 
 
 @router.get("/api/logs")
-async def get_logs(limit: int = 200, level: Optional[str] = None):
-    entries = list(_LOG_BUFFER)
-    if level:
-        upper = level.upper()
-        entries = [e for e in entries if e["level"] == upper]
+async def get_logs(
+    limit: int = Query(default=200, ge=1, le=1000),
+    level: Optional[str] = None,
+    request_id: Optional[str] = None,
+    job_id: Optional[int] = None,
+):
+    entries = read_persisted_logs(limit=1000, level=level)
+    if request_id:
+        entries = [entry for entry in entries if entry.get("request_id") == request_id]
+    if job_id is not None:
+        entries = [entry for entry in entries if entry.get("job_id") == job_id]
     return entries[-limit:]
 
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -399,6 +399,7 @@ class ProcessingJob(BaseModel):
     target_id: Optional[int] = None
     target_content_version: Optional[int] = None
     parent_job_id: Optional[int] = None
+    request_id: str
     payload: dict = Field(default_factory=dict)
     progress_current: int
     progress_total: int

--- a/backend/app/services/observability.py
+++ b/backend/app/services/observability.py
@@ -1,0 +1,180 @@
+"""Sanitized health reports, processing metrics, and diagnostic exports."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import crud
+from ..config import LIBRARY_PATH
+from ..logging_config import read_persisted_logs, redact_value
+from ..models import ProcessingJob
+from .endpoint_pool import configured_endpoints
+from .processing_queue import ProcessingQueue
+
+
+def _aware(value: datetime | None) -> datetime | None:
+    if value is None or value.tzinfo is not None:
+        return value
+    return value.replace(tzinfo=timezone.utc)
+
+
+def _average(values: list[float]) -> float | None:
+    return round(sum(values) / len(values), 1) if values else None
+
+
+async def processing_job_metrics(db: AsyncSession, *, window_hours: int = 24) -> dict[str, Any]:
+    """Summarize queue delay, runtime, retries, cancellation, and failures."""
+    now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(hours=window_hours)
+    jobs = list(
+        (
+            await db.scalars(
+                select(ProcessingJob).where(ProcessingJob.created_at >= cutoff).order_by(ProcessingJob.created_at.desc())
+            )
+        ).all()
+    )
+    grouped: dict[str, list[ProcessingJob]] = defaultdict(list)
+    for job in jobs:
+        grouped[job.job_type].append(job)
+
+    def summarize(rows: list[ProcessingJob]) -> dict[str, Any]:
+        queue_delays = [
+            max(0.0, ((_aware(row.started_at) - _aware(row.created_at)).total_seconds() * 1000))
+            for row in rows
+            if row.started_at and row.created_at
+        ]
+        durations = [
+            max(0.0, ((_aware(row.completed_at) - _aware(row.started_at)).total_seconds() * 1000))
+            for row in rows
+            if row.completed_at and row.started_at
+        ]
+        statuses = defaultdict(int)
+        for row in rows:
+            statuses[row.status] += 1
+        return {
+            "total": len(rows),
+            "queued": statuses["queued"],
+            "running": statuses["running"],
+            "completed": statuses["completed"],
+            "failed": statuses["error"],
+            "canceled": statuses["canceled"],
+            "retries": sum(max(0, row.attempt_count - 1) for row in rows),
+            "average_queue_delay_ms": _average(queue_delays),
+            "average_duration_ms": _average(durations),
+        }
+
+    return {
+        "generated_at": now.isoformat(),
+        "window_hours": window_hours,
+        "aggregate": summarize(jobs),
+        "by_job_type": {job_type: summarize(rows) for job_type, rows in sorted(grouped.items())},
+    }
+
+
+def storage_health(path: Path = LIBRARY_PATH) -> dict[str, Any]:
+    """Report capacity and writability without exposing the host path."""
+    target = path if path.exists() else path.parent
+    try:
+        usage = shutil.disk_usage(target)
+        percent_free = round((usage.free / usage.total) * 100, 1) if usage.total else 0.0
+        minimum_bytes = max(0, int(os.getenv("STORY_MANAGER_MIN_FREE_BYTES", str(1024**3))))
+        writable = os.access(target, os.W_OK)
+        low_capacity = usage.free < minimum_bytes or percent_free < 5
+        return {
+            "status": "available" if writable and not low_capacity else "unavailable",
+            "writable": writable,
+            "total_bytes": usage.total,
+            "free_bytes": usage.free,
+            "percent_free": percent_free,
+            "minimum_free_bytes": minimum_bytes,
+        }
+    except OSError:
+        return {"status": "unavailable", "writable": False}
+
+
+async def provider_health(db: AsyncSession) -> list[dict[str, Any]]:
+    """Describe optional provider configuration without returning secrets or URLs."""
+    settings = await crud.audiobook.get_audiobook_settings(db)
+    providers = []
+    for capability in ("llm", "tts", "transcription"):
+        endpoints = configured_endpoints(settings, capability) if settings else []
+        enabled = [
+            endpoint
+            for endpoint in endpoints
+            if str(endpoint.get("provider") or "").strip().lower() not in {"", "disabled", "none"}
+        ]
+        providers.append(
+            {
+                "capability": capability,
+                "status": "configured" if enabled else "disabled",
+                "configured_endpoints": len(enabled),
+            }
+        )
+    return providers
+
+
+def _unknown_providers() -> list[dict[str, Any]]:
+    return [
+        {"capability": capability, "status": "unknown", "configured_endpoints": 0}
+        for capability in ("llm", "tts", "transcription")
+    ]
+
+
+async def health_report(db: AsyncSession, queue: ProcessingQueue) -> dict[str, Any]:
+    database = {"status": "available"}
+    try:
+        await db.execute(text("SELECT 1"))
+    except Exception:
+        database = {"status": "unavailable"}
+    providers = _unknown_providers()
+    if database["status"] == "available":
+        try:
+            providers = await provider_health(db)
+        except Exception:
+            providers = _unknown_providers()
+    workers = queue.health_snapshot()
+    storage = storage_health()
+    required = (database["status"], workers["status"], storage["status"])
+    return {
+        "status": "healthy" if all(status == "available" for status in required) else "unhealthy",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "liveness": {"status": "alive"},
+        "database": database,
+        "workers": workers,
+        "storage": storage,
+        "providers": providers,
+    }
+
+
+def diagnostic_configuration() -> dict[str, Any]:
+    """Return an explicit allowlist of non-secret runtime configuration."""
+    names = (
+        "LOG_FORMAT",
+        "STORY_MANAGER_LOG_MAX_BYTES",
+        "STORY_MANAGER_LOG_BACKUP_COUNT",
+        "STORY_MANAGER_MIN_FREE_BYTES",
+        "RECYCLE_BIN_RETENTION_DAYS",
+        "PROCESSING_LEASE_SECONDS",
+        "PROCESSING_HEARTBEAT_SECONDS",
+        "PROCESSING_POLL_SECONDS",
+        "PROCESSING_RETRY_BACKOFF_SECONDS",
+        "PROCESSING_CPU_CONCURRENCY",
+        "PROCESSING_MAINTENANCE_CONCURRENCY",
+        "PROCESSING_LLM_CONCURRENCY",
+        "PROCESSING_TTS_CONCURRENCY",
+        "PROCESSING_TRANSCRIPTION_CONCURRENCY",
+    )
+    return redact_value({name: os.getenv(name, "default") for name in names})
+
+
+def diagnostic_logs(limit: int = 500) -> list[dict[str, Any]]:
+    """Read the bounded, already-redacted recent application log history."""
+    return read_persisted_logs(limit=limit)

--- a/backend/app/services/processing_queue.py
+++ b/backend/app/services/processing_queue.py
@@ -22,6 +22,8 @@ from ..lifecycle import (
     transition_state,
 )
 from ..models import Book, ImportedAudiobook, ImportedAudiobookTrack, ProcessingJob
+from ..logging_config import redact_text
+from ..observability_context import correlation_context
 from .audiobook_alignment import process_alignment
 from .audiobook_import import process_import, rematch_imported_audiobook
 from .audiobook_queue import get_audiobook_queue
@@ -90,22 +92,51 @@ class ProcessingQueue:
 
     async def start(self) -> None:
         if self._worker_tasks:
-            return
+            if all(not task.done() for task in self._worker_tasks):
+                return
+            await self.stop()
         for lane in RESOURCE_LANES:
             count = _positive_int_env(f"PROCESSING_{lane.upper()}_CONCURRENCY", 1)
             for index in range(count):
-                self._worker_tasks.append(
-                    asyncio.create_task(
-                        self._run(lane, index + 1),
-                        name=f"processing-{lane}-worker-{index + 1}",
-                    )
+                task = asyncio.create_task(
+                    self._run(lane, index + 1),
+                    name=f"processing-{lane}-worker-{index + 1}",
                 )
+                task.add_done_callback(self._worker_finished)
+                self._worker_tasks.append(task)
         await get_audiobook_queue().start_background_audio()
         self._wake.set()
 
     @property
     def is_running(self) -> bool:
-        return bool(self._worker_tasks)
+        return bool(self._worker_tasks) and all(not task.done() for task in self._worker_tasks)
+
+    @staticmethod
+    def _worker_finished(task: asyncio.Task[None]) -> None:
+        if task.cancelled():
+            return
+        error = task.exception()
+        if error is not None:
+            logger.error(
+                "Background worker %s stopped unexpectedly: %s",
+                task.get_name(),
+                error,
+                exc_info=(type(error), error, error.__traceback__),
+            )
+
+    def health_snapshot(self) -> dict:
+        """Return a public, credential-free view of worker availability."""
+        configured = {lane: _positive_int_env(f"PROCESSING_{lane.upper()}_CONCURRENCY", 1) for lane in RESOURCE_LANES}
+        alive = [task for task in self._worker_tasks if not task.done()]
+        dead = [task for task in self._worker_tasks if task.done()]
+        return {
+            "status": "available" if self.is_running and not dead else "unavailable",
+            "running": self.is_running,
+            "configured_workers": sum(configured.values()),
+            "active_workers": len(alive),
+            "failed_workers": len(dead),
+            "lanes": configured,
+        }
 
     async def stop(self) -> None:
         if not self._worker_tasks:
@@ -132,14 +163,21 @@ class ProcessingQueue:
     async def _run(self, lane: str, worker_number: int) -> None:
         lease_owner = f"{self._instance_id}:{lane}:{worker_number}"
         while True:
-            async with SessionLocal() as db:
-                await crud.recover_abandoned_processing_jobs(db)
-                job = await crud.claim_processing_job(
-                    db,
-                    resource_lane=lane,
-                    lease_owner=lease_owner,
-                    lease_seconds=self._lease_seconds,
-                )
+            try:
+                async with SessionLocal() as db:
+                    await crud.recover_abandoned_processing_jobs(db)
+                    job = await crud.claim_processing_job(
+                        db,
+                        resource_lane=lane,
+                        lease_owner=lease_owner,
+                        lease_seconds=self._lease_seconds,
+                    )
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("Processing %s worker could not poll the durable queue.", lane)
+                await asyncio.sleep(self._poll_seconds)
+                continue
             if job is None:
                 self._wake.clear()
                 try:
@@ -148,27 +186,28 @@ class ProcessingQueue:
                     pass
                 continue
 
-            try:
-                detail = await self._execute_with_heartbeat(job, lease_owner)
-                async with SessionLocal() as db:
-                    if await crud.is_processing_job_cancel_requested(db, job.id):
-                        await crud.mark_processing_job_canceled(db, job.id)
-                    else:
-                        await crud.complete_processing_job(db, job.id, detail, lease_owner=lease_owner)
-            except asyncio.CancelledError:
-                raise
-            except Exception as exc:
-                logger.exception("Processing job %s (%s) failed.", job.id, job.job_type)
-                async with SessionLocal() as db:
-                    status = await crud.fail_processing_job(
-                        db,
-                        job.id,
-                        str(exc),
-                        lease_owner=lease_owner,
-                        retry_backoff_seconds=self._retry_backoff_seconds,
-                    )
-                if status == "queued":
-                    self._wake.set()
+            with correlation_context(request_id=job.request_id, job_id=job.id):
+                try:
+                    detail = await self._execute_with_heartbeat(job, lease_owner)
+                    async with SessionLocal() as db:
+                        if await crud.is_processing_job_cancel_requested(db, job.id):
+                            await crud.mark_processing_job_canceled(db, job.id)
+                        else:
+                            await crud.complete_processing_job(db, job.id, detail, lease_owner=lease_owner)
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    logger.exception("Processing job %s (%s) failed.", job.id, job.job_type)
+                    async with SessionLocal() as db:
+                        status = await crud.fail_processing_job(
+                            db,
+                            job.id,
+                            redact_text(str(exc)),
+                            lease_owner=lease_owner,
+                            retry_backoff_seconds=self._retry_backoff_seconds,
+                        )
+                    if status == "queued":
+                        self._wake.set()
 
     async def _execute_with_heartbeat(self, job: ProcessingJob, lease_owner: str) -> str:
         operation = asyncio.create_task(self._execute(job), name=f"processing-operation-{job.id}")

--- a/backend/tests/test_errors_and_health.py
+++ b/backend/tests/test_errors_and_health.py
@@ -16,6 +16,7 @@ class TestStructuredErrors:
         assert data["error"] == "not_found"
         assert "detail" in data
         assert data["status_code"] == 404
+        assert data["request_id"] == response.headers["X-Request-ID"]
 
     @pytest.mark.asyncio
     async def test_400_returns_structured_error(self, app_client):
@@ -56,6 +57,7 @@ class TestAdminApiAuth:
 
         unauthorized = app_client.get("/api/books")
         assert unauthorized.status_code == 401
+        assert unauthorized.headers["X-Request-ID"]
 
         bad_login = app_client.post("/api/auth/login", json={"password": "wrong"})
         assert bad_login.status_code == 401

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -130,6 +130,19 @@ def test_request_ids_are_returned_and_can_be_supplied(app_client):
     assert unsafe.headers["X-Request-ID"] != "secret value\ninvalid"
 
 
+def test_successful_polling_access_logs_are_debug_but_failures_remain_visible(app_client, caplog):
+    caplog.set_level(logging.DEBUG, logger="story_manager.access")
+
+    successful = app_client.get("/api/logs?limit=1")
+    invalid = app_client.get("/api/logs?limit=0")
+
+    assert successful.status_code == 200
+    assert invalid.status_code == 422
+    access_records = [record for record in caplog.records if record.name == "story_manager.access"]
+    assert any(record.levelno == logging.DEBUG and "completed with 200" in record.message for record in access_records)
+    assert any(record.levelno == logging.INFO and "completed with 422" in record.message for record in access_records)
+
+
 @pytest.mark.asyncio
 async def test_health_report_survives_database_outage():
     db = AsyncMock()

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -1,0 +1,204 @@
+"""Regression tests for health, metrics, correlation, and safe diagnostics."""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import zipfile
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from unittest.mock import AsyncMock, Mock
+
+from backend.app.logging_config import _RedactedTextFormatter, read_persisted_logs, redact_text
+from backend.app.models import ProcessingJob
+from backend.app.services.observability import health_report, processing_job_metrics
+
+
+def test_redact_text_removes_common_secret_forms():
+    message = (
+        "Authorization: Bearer private-token\n"
+        "api_key=sk-secret postgresql+psycopg://story:password@database/story "
+        '{"session_id": "browser-secret"}'
+    )
+
+    redacted = redact_text(message)
+
+    assert "private-token" not in redacted
+    assert "sk-secret" not in redacted
+    assert "story:password" not in redacted
+    assert "browser-secret" not in redacted
+    assert redacted.count("[REDACTED]") >= 3
+
+
+def test_persisted_logs_can_be_read_after_memory_is_gone(tmp_path):
+    log_file = tmp_path / "story-manager.jsonl"
+    entries = [
+        {"timestamp": "2026-08-09T01:00:00+00:00", "level": "INFO", "message": "before restart"},
+        {
+            "timestamp": "2026-08-09T01:01:00+00:00",
+            "level": "ERROR",
+            "message": "api_key=do-not-show",
+            "request_id": "request-123",
+        },
+    ]
+    log_file.write_text("\n".join(json.dumps(entry) for entry in entries), encoding="utf-8")
+
+    restored = read_persisted_logs(log_file=log_file)
+
+    assert [entry["level"] for entry in restored] == ["INFO", "ERROR"]
+    assert restored[0]["message"] == "before restart"
+    assert "do-not-show" not in restored[1]["message"]
+    assert restored[1]["request_id"] == "request-123"
+
+
+def test_plain_console_formatter_redacts_interpolated_secrets():
+    record = logging.LogRecord(
+        name="test",
+        level=logging.ERROR,
+        pathname=__file__,
+        lineno=1,
+        msg="request failed with api_key=%s",
+        args=("console-secret",),
+        exc_info=None,
+    )
+
+    output = _RedactedTextFormatter("%(message)s").format(record)
+
+    assert "console-secret" not in output
+    assert output == "request failed with api_key=[REDACTED]"
+
+
+@pytest.mark.asyncio
+async def test_processing_metrics_are_grouped_by_job_type(db):
+    now = datetime.now(timezone.utc)
+    db.add_all(
+        [
+            ProcessingJob(
+                job_type="clean_book",
+                status="completed",
+                request_id="metric-1",
+                attempt_count=2,
+                created_at=now - timedelta(minutes=3),
+                started_at=now - timedelta(minutes=2),
+                completed_at=now - timedelta(minutes=1),
+            ),
+            ProcessingJob(
+                job_type="clean_book",
+                status="error",
+                request_id="metric-2",
+                attempt_count=3,
+                created_at=now - timedelta(minutes=4),
+                started_at=now - timedelta(minutes=3),
+                completed_at=now - timedelta(minutes=2),
+            ),
+            ProcessingJob(
+                job_type="refresh_book",
+                status="canceled",
+                request_id="metric-3",
+                created_at=now - timedelta(minutes=5),
+            ),
+        ]
+    )
+    await db.commit()
+
+    result = await processing_job_metrics(db, window_hours=24)
+
+    cleaning = result["by_job_type"]["clean_book"]
+    assert cleaning == {
+        "total": 2,
+        "queued": 0,
+        "running": 0,
+        "completed": 1,
+        "failed": 1,
+        "canceled": 0,
+        "retries": 3,
+        "average_queue_delay_ms": 60000.0,
+        "average_duration_ms": 60000.0,
+    }
+    assert result["by_job_type"]["refresh_book"]["canceled"] == 1
+
+
+def test_request_ids_are_returned_and_can_be_supplied(app_client):
+    generated = app_client.get("/health/live")
+    supplied = app_client.get("/health/live", headers={"X-Request-ID": "browser-check-42"})
+    unsafe = app_client.get("/health/live", headers={"X-Request-ID": "secret value\ninvalid"})
+
+    assert len(generated.headers["X-Request-ID"]) == 12
+    assert supplied.headers["X-Request-ID"] == "browser-check-42"
+    assert unsafe.headers["X-Request-ID"] != "secret value\ninvalid"
+
+
+@pytest.mark.asyncio
+async def test_health_report_survives_database_outage():
+    db = AsyncMock()
+    db.execute.side_effect = RuntimeError("database unavailable")
+    queue = Mock()
+    queue.health_snapshot.return_value = {
+        "status": "available",
+        "running": True,
+        "configured_workers": 1,
+        "active_workers": 1,
+        "failed_workers": 0,
+        "lanes": {"maintenance": 1},
+    }
+
+    report = await health_report(db, queue)
+
+    assert report["status"] == "unhealthy"
+    assert report["database"] == {"status": "unavailable"}
+    assert {provider["status"] for provider in report["providers"]} == {"unknown"}
+
+
+def test_failure_details_include_request_id(app_client):
+    response = app_client.get("/api/books/99999", headers={"X-Request-ID": "missing-book-7"})
+
+    assert response.status_code == 404
+    assert response.headers["X-Request-ID"] == "missing-book-7"
+    assert response.json()["request_id"] == "missing-book-7"
+
+
+def test_health_metrics_and_redacted_diagnostics_are_available(app_client, monkeypatch):
+    monkeypatch.setenv("STORY_MANAGER_AUTH_MODE", "disabled")
+    monkeypatch.setenv("STORY_MANAGER_ADMIN_PASSWORD", "never-export-this")
+    app_client.post(
+        "/api/logs/client",
+        headers={"X-Request-ID": "diagnostic-log-9"},
+        json={"level": "ERROR", "message": "api_key=never-export-this", "source": "test"},
+    )
+
+    health = app_client.get("/api/observability/health")
+    metrics = app_client.get("/api/observability/job-metrics")
+    bundle = app_client.get("/api/observability/diagnostics")
+
+    assert health.status_code == 200
+    assert {"database", "workers", "storage", "providers"} <= health.json().keys()
+    assert metrics.status_code == 200
+    assert {"aggregate", "by_job_type", "window_hours"} <= metrics.json().keys()
+    assert bundle.status_code == 200
+    assert bundle.headers["content-type"] == "application/zip"
+
+    with zipfile.ZipFile(io.BytesIO(bundle.content)) as archive:
+        assert set(archive.namelist()) == {
+            "health.json",
+            "job-metrics.json",
+            "logs.json",
+            "configuration.json",
+            "manifest.json",
+        }
+        combined = b"".join(archive.read(name) for name in archive.namelist())
+    assert b"never-export-this" not in combined
+    assert b"STORY_MANAGER_ADMIN_PASSWORD" not in combined
+
+
+def test_application_logs_support_correlation_filtering(app_client):
+    logging.getLogger("observability-test").error(
+        "correlated test entry",
+        extra={"request_id": "filter-me", "job_id": 481},
+    )
+
+    response = app_client.get("/api/logs?request_id=filter-me&job_id=481")
+
+    assert response.status_code == 200
+    assert any(entry["message"] == "correlated test entry" for entry in response.json())

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -11,7 +11,12 @@ from datetime import datetime, timedelta, timezone
 import pytest
 from unittest.mock import AsyncMock, Mock
 
-from backend.app.logging_config import _RedactedTextFormatter, read_persisted_logs, redact_text
+from backend.app.logging_config import (
+    _RedactedTextFormatter,
+    is_quiet_successful_access_entry,
+    read_persisted_logs,
+    redact_text,
+)
 from backend.app.models import ProcessingJob
 from backend.app.services.observability import health_report, processing_job_metrics
 
@@ -68,6 +73,30 @@ def test_plain_console_formatter_redacts_interpolated_secrets():
 
     assert "console-secret" not in output
     assert output == "request failed with api_key=[REDACTED]"
+
+
+def test_historical_successful_polling_entries_can_be_hidden():
+    assert is_quiet_successful_access_entry(
+        {
+            "logger": "story_manager.access",
+            "level": "INFO",
+            "message": "GET /api/logs completed with 200 in 61.9ms",
+        }
+    )
+    assert not is_quiet_successful_access_entry(
+        {
+            "logger": "story_manager.access",
+            "level": "INFO",
+            "message": "GET /api/logs completed with 500 in 61.9ms",
+        }
+    )
+    assert not is_quiet_successful_access_entry(
+        {
+            "logger": "story_manager.access",
+            "level": "INFO",
+            "message": "POST /api/processing/jobs completed with 202 in 12.0ms",
+        }
+    )
 
 
 @pytest.mark.asyncio

--- a/docs/IMPROVEMENT_ROADMAP.md
+++ b/docs/IMPROVEMENT_ROADMAP.md
@@ -125,7 +125,7 @@ The first deployment can retain a single-container experience, but job ownership
 
 ## 7. Centralized state-machine definitions
 
-**Status:** In progress
+**Status:** Complete
 
 Replace scattered lifecycle strings and implicit transitions with centralized state definitions for processing jobs, web imports and refreshes, metadata jobs, generated audiobooks, imported audiobooks, alignment, and publication.
 
@@ -144,7 +144,7 @@ State machines should define valid transitions, terminal states, retry behavior,
 
 ## 8. Stronger observability
 
-**Status:** Planned
+**Status:** In progress
 
 Make failures diagnosable without reading raw container output. Connect request IDs to log records, expose worker and dependency health, measure job behavior, and provide a user-downloadable diagnostic bundle with secrets removed.
 

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -1,0 +1,35 @@
+# Observability
+
+Story Manager includes local diagnostics designed for a small self-hosted installation. No external monitoring service is required.
+
+## Health endpoints
+
+- `GET /health/live` checks only that the API process can respond.
+- `GET /health/ready` checks the database, processing workers, and writable storage capacity. It returns `503` when a required dependency is unavailable.
+- `GET /api/observability/health` returns the complete operator view, including optional LLM, text-to-speech, and transcription configuration status.
+- `GET /health` remains available for compatibility with existing database-only health checks.
+
+The storage check is considered unavailable below 5 percent free space or 1 GiB free, whichever is reached first. Set `STORY_MANAGER_MIN_FREE_BYTES` to change the byte threshold.
+
+## Correlation and logs
+
+Every API response includes `X-Request-ID`. A caller may provide a safe identifier with the same header; otherwise Story Manager generates one. Processing jobs retain the request ID that created them, so their API details and worker logs can be correlated later.
+
+Application logs are stored as redacted JSON lines in `logs/story-manager.jsonl` by default. They rotate at 5 MiB with three backups and survive normal restarts. These settings are configurable:
+
+- `STORY_MANAGER_LOG_DIR`
+- `STORY_MANAGER_LOG_MAX_BYTES`
+- `STORY_MANAGER_LOG_BACKUP_COUNT`
+- `LOG_FORMAT=json` for structured container output
+
+The Logs screen and `GET /api/logs` read this persisted history. The API accepts `level`, `request_id`, `job_id`, and `limit` filters.
+
+## Job metrics
+
+`GET /api/observability/job-metrics?window_hours=24` groups processing outcomes by job type. It reports queue delay, execution duration, retries, failures, and cancellations. The window can range from one hour to 90 days.
+
+## Diagnostic bundle
+
+The Logs screen can download a ZIP bundle containing health, job metrics, recent redacted logs, and an explicit allowlist of non-secret configuration. The export never includes environment dumps, API keys, session secrets, library files, book contents, or generated audio.
+
+Redaction is defense in depth: application code should still avoid logging credentials, request bodies, book contents, or audio data in the first place.

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -22,7 +22,7 @@ Application logs are stored as redacted JSON lines in `logs/story-manager.jsonl`
 - `STORY_MANAGER_LOG_BACKUP_COUNT`
 - `LOG_FORMAT=json` for structured container output
 
-The Logs screen and `GET /api/logs` read this persisted history. The API accepts `level`, `request_id`, `job_id`, and `limit` filters.
+The Logs screen and `GET /api/logs` read this persisted history. Successful high-frequency polling requests are hidden by default so they do not overwhelm useful records; pass `include_polling=true` to include them. The API also accepts `level`, `request_id`, `job_id`, and `limit` filters.
 
 ## Job metrics
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -28,6 +28,124 @@
   margin-right: auto;
 }
 
+/* ─── Observability ─────────────────────────────────────── */
+.observability-heading,
+.observability-controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.observability-heading h3,
+.observability-heading p {
+  margin: 0;
+}
+
+.observability-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  gap: 0.65rem;
+  margin-top: 1rem;
+}
+
+.observability-card {
+  display: grid;
+  gap: 0.2rem;
+  border: 1px solid var(--border);
+  padding: 0.75rem;
+}
+
+.observability-card span,
+.observability-card small {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+}
+
+.observability-card--healthy strong {
+  color: var(--success);
+}
+
+.observability-card--muted strong {
+  color: var(--text-muted);
+}
+
+.observability-metrics {
+  margin-top: 1.25rem;
+}
+
+.observability-table-wrap {
+  overflow-x: auto;
+}
+
+.observability-table-wrap table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.78rem;
+}
+
+.observability-table-wrap th,
+.observability-table-wrap td {
+  border-bottom: 1px solid var(--border);
+  padding: 0.45rem;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.observability-controls {
+  justify-content: flex-start;
+  margin-bottom: 0.75rem;
+}
+
+.observability-controls label {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.875rem;
+}
+
+.observability-logs {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  max-height: 70vh;
+  overflow-y: auto;
+  padding: 0.5rem;
+  border-radius: 6px;
+  background: var(--surface, #1a1a2e);
+  font-family: monospace;
+  font-size: 0.78rem;
+}
+
+.observability-log-row {
+  display: grid;
+  grid-template-columns: 90px 56px minmax(0, 1fr);
+  gap: 0.5rem;
+  padding: 2px 4px;
+  line-height: 1.4;
+}
+
+.observability-time {
+  color: #6b7280;
+  white-space: nowrap;
+}
+
+.observability-level {
+  font-weight: 600;
+  text-align: right;
+}
+
+.observability-message {
+  color: #e2e8f0;
+  word-break: break-word;
+}
+
+.observability-message small {
+  display: block;
+  color: #94a3b8;
+}
+
 /* ─── Needs Attention dashboard ─────────────────────────── */
 .attention-page {
   display: grid;

--- a/frontend/src/components/Logs.jsx
+++ b/frontend/src/components/Logs.jsx
@@ -10,22 +10,61 @@ const LEVEL_COLORS = {
   DEBUG: "#9ca3af",
 };
 
+async function fetchJson(path, message) {
+  const response = await fetch(path);
+  if (!response.ok) throw new Error(message);
+  return response.json();
+}
+
+function HealthCard({ label, status, detail }) {
+  const healthy = ["alive", "available", "configured"].includes(status);
+  return (
+    <div className={`observability-card observability-card--${healthy ? "healthy" : "muted"}`}>
+      <span>{label}</span>
+      <strong>{status || "unknown"}</strong>
+      {detail && <small>{detail}</small>}
+    </div>
+  );
+}
+
+function formatDuration(value) {
+  if (value == null) return "—";
+  if (value < 1000) return `${Math.round(value)} ms`;
+  return `${(value / 1000).toFixed(1)} s`;
+}
+
 function Logs({ onBack }) {
   const [level, setLevel] = useState("ALL");
   const [autoRefresh, setAutoRefresh] = useState(true);
 
-  const { data: logs = [], isLoading, dataUpdatedAt, refetch } = useQuery({
+  const logsQuery = useQuery({
     queryKey: ["logs", level],
-    queryFn: async () => {
+    queryFn: () => {
       const param = level !== "ALL" ? `&level=${level}` : "";
-      const res = await fetch(`/api/logs?limit=500${param}`);
-      if (!res.ok) throw new Error("Failed to fetch logs");
-      return res.json();
+      return fetchJson(`/api/logs?limit=500${param}`, "Failed to fetch logs");
     },
     refetchInterval: autoRefresh ? 3000 : false,
   });
+  const healthQuery = useQuery({
+    queryKey: ["observability-health"],
+    queryFn: () => fetchJson("/api/observability/health", "Failed to fetch system health"),
+    refetchInterval: autoRefresh ? 10000 : false,
+  });
+  const metricsQuery = useQuery({
+    queryKey: ["observability-job-metrics"],
+    queryFn: () => fetchJson("/api/observability/job-metrics?window_hours=24", "Failed to fetch job metrics"),
+    refetchInterval: autoRefresh ? 10000 : false,
+  });
 
+  const logs = logsQuery.data || [];
+  const health = healthQuery.data;
+  const metrics = metricsQuery.data;
   const reversed = [...logs].reverse();
+  const refreshAll = () => {
+    logsQuery.refetch();
+    healthQuery.refetch();
+    metricsQuery.refetch();
+  };
 
   return (
     <div className={onBack ? "book-settings" : undefined}>
@@ -38,87 +77,127 @@ function Logs({ onBack }) {
         <h2>Application Logs</h2>
       </div>
 
+      <section className="settings-section observability-overview">
+        <div className="observability-heading">
+          <div>
+            <h3>System health</h3>
+            <p className="hint">Required services and optional AI providers, without exposing credentials.</p>
+          </div>
+          <a className="btn-secondary" href="/api/observability/diagnostics" download>
+            Download diagnostic bundle
+          </a>
+        </div>
+        {healthQuery.isLoading && <p>Loading health…</p>}
+        {health && (
+          <div className="observability-grid">
+            <HealthCard label="Database" status={health.database.status} />
+            <HealthCard
+              label="Workers"
+              status={health.workers.status}
+              detail={`${health.workers.active_workers}/${health.workers.configured_workers} active`}
+            />
+            <HealthCard
+              label="Storage"
+              status={health.storage.status}
+              detail={health.storage.percent_free != null ? `${health.storage.percent_free}% free` : undefined}
+            />
+            {health.providers.map((provider) => (
+              <HealthCard
+                key={provider.capability}
+                label={provider.capability.toUpperCase()}
+                status={provider.status}
+                detail={provider.configured_endpoints ? `${provider.configured_endpoints} endpoint(s)` : "Optional"}
+              />
+            ))}
+          </div>
+        )}
+
+        {metrics && (
+          <div className="observability-metrics">
+            <h3>Background jobs · last 24 hours</h3>
+            {Object.keys(metrics.by_job_type).length === 0 ? (
+              <p className="hint">No background jobs during this window.</p>
+            ) : (
+              <div className="observability-table-wrap">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Job type</th>
+                      <th>Total</th>
+                      <th>Failed</th>
+                      <th>Canceled</th>
+                      <th>Retries</th>
+                      <th>Queue delay</th>
+                      <th>Duration</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {Object.entries(metrics.by_job_type).map(([jobType, values]) => (
+                      <tr key={jobType}>
+                        <td>{jobType.replaceAll("_", " ")}</td>
+                        <td>{values.total}</td>
+                        <td>{values.failed}</td>
+                        <td>{values.canceled}</td>
+                        <td>{values.retries}</td>
+                        <td>{formatDuration(values.average_queue_delay_ms)}</td>
+                        <td>{formatDuration(values.average_duration_ms)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        )}
+      </section>
+
       <section className="settings-section">
-        <div style={{ display: "flex", gap: "0.75rem", alignItems: "center", flexWrap: "wrap", marginBottom: "0.75rem" }}>
-          <select value={level} onChange={(e) => setLevel(e.target.value)}>
-            {LEVELS.map((l) => (
-              <option key={l} value={l}>{l}</option>
+        <div className="observability-controls">
+          <select aria-label="Log level" value={level} onChange={(event) => setLevel(event.target.value)}>
+            {LEVELS.map((item) => (
+              <option key={item} value={item}>{item}</option>
             ))}
           </select>
-          <label style={{ display: "flex", alignItems: "center", gap: "0.4rem", fontSize: "0.875rem" }}>
-            <input
-              type="checkbox"
-              checked={autoRefresh}
-              onChange={(e) => setAutoRefresh(e.target.checked)}
-            />
+          <label>
+            <input type="checkbox" checked={autoRefresh} onChange={(event) => setAutoRefresh(event.target.checked)} />
             Auto-refresh
           </label>
-          <button onClick={() => refetch()} style={{ marginLeft: "auto" }}>
-            Refresh
-          </button>
-          {dataUpdatedAt > 0 && (
-            <span className="hint" style={{ fontSize: "0.75rem" }}>
-              Updated {new Date(dataUpdatedAt).toLocaleTimeString()}
-            </span>
+          <button onClick={refreshAll} style={{ marginLeft: "auto" }}>Refresh</button>
+          {logsQuery.dataUpdatedAt > 0 && (
+            <span className="hint">Updated {new Date(logsQuery.dataUpdatedAt).toLocaleTimeString()}</span>
           )}
         </div>
 
-        {isLoading && <p>Loading...</p>}
-        {!isLoading && reversed.length === 0 && (
-          <p className="hint">No log entries.</p>
-        )}
+        {logsQuery.isLoading && <p>Loading…</p>}
+        {!logsQuery.isLoading && reversed.length === 0 && <p className="hint">No log entries.</p>}
 
-        <div
-          style={{
-            fontFamily: "monospace",
-            fontSize: "0.78rem",
-            overflowY: "auto",
-            maxHeight: "70vh",
-            background: "var(--surface, #1a1a2e)",
-            borderRadius: "6px",
-            padding: "0.5rem",
-            display: "flex",
-            flexDirection: "column",
-            gap: "1px",
-          }}
-        >
-          {reversed.map((entry, i) => (
-            <div
-              key={i}
-              style={{
-                display: "grid",
-                gridTemplateColumns: "160px 56px 1fr",
-                gap: "0.5rem",
-                padding: "2px 4px",
-                borderRadius: "3px",
-                lineHeight: "1.4",
-              }}
-            >
-              <span style={{ color: "#6b7280", whiteSpace: "nowrap" }}>
+        <div className="observability-logs">
+          {reversed.map((entry, index) => (
+            <div className="observability-log-row" key={`${entry.timestamp}-${index}`}>
+              <span className="observability-time">
                 {new Date(entry.timestamp).toLocaleTimeString([], {
                   hour: "2-digit",
                   minute: "2-digit",
                   second: "2-digit",
                 })}
               </span>
-              <span
-                style={{
-                  color: LEVEL_COLORS[entry.level] ?? "#9ca3af",
-                  fontWeight: "600",
-                  textAlign: "right",
-                }}
-              >
+              <span className="observability-level" style={{ color: LEVEL_COLORS[entry.level] ?? "#9ca3af" }}>
                 {entry.level}
               </span>
-              <span style={{ color: "#e2e8f0", wordBreak: "break-all" }}>
+              <span className="observability-message">
                 {entry.message}
+                {(entry.request_id || entry.job_id != null) && (
+                  <small>
+                    {entry.request_id && `request ${entry.request_id}`}
+                    {entry.request_id && entry.job_id != null && " · "}
+                    {entry.job_id != null && `job ${entry.job_id}`}
+                  </small>
+                )}
               </span>
             </div>
           ))}
         </div>
-        <p className="hint" style={{ marginTop: "0.5rem" }}>
-          Showing {reversed.length} entries (last 500, most recent first). Buffer holds up to 1000.
-        </p>
+        <p className="hint">Showing {reversed.length} entries (last 500, most recent first). Recent logs survive restarts.</p>
       </section>
     </div>
   );

--- a/frontend/src/components/ProcessingJobs.jsx
+++ b/frontend/src/components/ProcessingJobs.jsx
@@ -384,6 +384,7 @@ function ProcessingJobs() {
                 </div>
                 <small>
                   #{job.id} · {formatDate(job.created_at)}
+                  {job.request_id && ` · Request ${job.request_id}`}
                 </small>
               </div>
               <p>{job.progress_detail || "Waiting"}</p>

--- a/frontend/src/components/ProcessingJobs.test.jsx
+++ b/frontend/src/components/ProcessingJobs.test.jsx
@@ -64,6 +64,7 @@ describe("ProcessingJobs", () => {
             target_id: 7,
             target_content_version: 2,
             parent_job_id: null,
+            request_id: "request-42",
             payload: {},
             progress_current: 1,
             progress_total: 3,
@@ -92,6 +93,7 @@ describe("ProcessingJobs", () => {
     expect(screen.getByText("Cleaning chapters")).toBeInTheDocument();
     expect(screen.getByText("33% · 1 / 3")).toBeInTheDocument();
     expect(screen.getByRole("progressbar")).toHaveValue(1);
+    expect(screen.getByText(/Request request-42/)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary

- correlate API responses, structured/persistent logs, processing jobs, and failure details with request IDs
- add liveness/readiness and detailed database, worker, storage, and optional-provider health surfaces
- add per-job-type queue delay, duration, retry, cancellation, and failure metrics
- persist bounded JSONL logs with credential/session redaction and add a downloadable redacted diagnostic ZIP
- upgrade the Logs screen with health cards, job metrics, correlation details, and diagnostic download
- make processing workers survive transient queue/database polling failures
- add migration 0034 to backfill request IDs on existing processing jobs

## Validation

- `make pr-check`
- `make test` — 384 backend + 72 frontend tests
- `make test-migrations` — clean PostgreSQL, existing-data backfill/index, downgrade
- `make e2e` — 4 Playwright tests
- live local UI verification, including diagnostic download and console-error check