### PR TITLE
Add backup and disaster recovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,6 +192,7 @@ backend.log
 # where the books are stored
 library
 config
+/backups/
 
 # Mac specific files
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,7 @@ run-ui:
 
 run-api:
 	$(MAKE) migrate
+	STORY_MANAGER_PG_DUMP_CONTAINER=story-manager-db \
 	PYTHONPATH=backend .venv/bin/uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
 
 run-db: ensure-db

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ In the Unraid web UI, open **Docker**, choose **Add Container**, switch to **Adv
 | WebUI | `http://[IP]:[PORT:8889]`                                                 |
 | Port | Host `8889` -> Container `8000`                                           |
 | Library path | `/mnt/user/appdata/story-manager/library` -> `/app/library` (read/write)  |
+| Backup path | `/mnt/user/appdata/story-manager/backups` -> `/app/backups` (read/write)  |
 | Database path | `/mnt/user/appdata/story-manager/pgdata` -> `/tmp/pgdata` (read/write)    |
 | FanFicFare config | `/mnt/user/appdata/story-manager/fanficfare` -> `/app/config` (read-only) |
 
@@ -61,13 +62,14 @@ can be tuned per resource lane; see `docs/deployment.md`.
 For a terminal-based installation, the equivalent command is:
 
 ```bash
-mkdir -p /mnt/user/appdata/story-manager/{library,pgdata,fanficfare}
+mkdir -p /mnt/user/appdata/story-manager/{library,backups,pgdata,fanficfare}
 
 docker run -d \
   --name story-manager \
   --restart unless-stopped \
   -p 8889:8000 \
   -v /mnt/user/appdata/story-manager/library:/app/library \
+  -v /mnt/user/appdata/story-manager/backups:/app/backups \
   -v /mnt/user/appdata/story-manager/pgdata:/tmp/pgdata \
   -v /mnt/user/appdata/story-manager/fanficfare:/app/config:ro \
   ghcr.io/jalbertcory/story-manager:latest

--- a/backend/app/backup_cli.py
+++ b/backend/app/backup_cli.py
@@ -1,0 +1,72 @@
+"""Offline verification and restore commands for Story Manager backups."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from .config import LIBRARY_PATH
+from .database import DATABASE_URL
+from .services.backups import BackupError, restore_backup_archive, verify_backup_archive
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Verify or restore a Story Manager backup.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    verify = subparsers.add_parser("verify", help="Verify the manifest and every file checksum.")
+    verify.add_argument("archive", type=Path)
+
+    restore = subparsers.add_parser("restore", help="Replace the database and library from a verified backup.")
+    restore.add_argument("archive", type=Path)
+    restore.add_argument("--library-path", type=Path, default=LIBRARY_PATH)
+    restore.add_argument("--database-url", default=DATABASE_URL)
+    restore.add_argument(
+        "--confirm-replace",
+        action="store_true",
+        help="Required acknowledgement that the current database and library will be replaced.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        if args.command == "verify":
+            manifest = verify_backup_archive(args.archive.resolve())
+            library = manifest.get("library", {})
+            print(
+                json.dumps(
+                    {
+                        "status": "verified",
+                        "created_at": manifest.get("created_at"),
+                        "library_file_count": library.get("file_count", 0),
+                        "library_size_bytes": library.get("size_bytes", 0),
+                    },
+                    indent=2,
+                )
+            )
+            return 0
+
+        if not args.confirm_replace:
+            print(
+                "Restore refused: pass --confirm-replace after stopping Story Manager to replace the current data.",
+                file=sys.stderr,
+            )
+            return 2
+        restore_backup_archive(
+            archive_path=args.archive.resolve(),
+            database_url=args.database_url,
+            library_path=args.library_path.resolve(),
+        )
+        print("Backup restored. Run database migrations before starting Story Manager.")
+        return 0
+    except BackupError as exc:
+        print(f"Backup operation failed: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/app/backup_middleware.py
+++ b/backend/app/backup_middleware.py
@@ -1,0 +1,24 @@
+"""Temporarily reject new API mutations while a consistent backup is made."""
+
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+from .services.backup_barrier import BackupInProgressError, backup_barrier
+
+_SAFE_METHODS = {"GET", "HEAD", "OPTIONS"}
+
+
+class BackupWriteBarrierMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        if request.method in _SAFE_METHODS or not request.url.path.startswith("/api/"):
+            return await call_next(request)
+        try:
+            async with backup_barrier.mutation():
+                return await call_next(request)
+        except BackupInProgressError as exc:
+            return JSONResponse(
+                status_code=503,
+                headers={"Retry-After": "5"},
+                content={"detail": str(exc)},
+            )

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -7,6 +7,12 @@ APP_DIR = Path(__file__).parent.resolve()
 # Absolute path to the library/ directory at the project root
 LIBRARY_PATH = (APP_DIR / ".." / ".." / "library").resolve()
 
+# Backups live outside the library tree so a backup never recursively includes
+# older archives. Production mounts this directory as a separate persistent
+# volume; local development can override it in the same way.
+BACKUP_PATH = Path(os.getenv("STORY_MANAGER_BACKUP_DIR", str(LIBRARY_PATH.parent / "backups"))).resolve()
+BACKUP_RETENTION_COUNT = max(0, int(os.getenv("STORY_MANAGER_BACKUP_RETENTION_COUNT", "10")))
+
 # Application logs survive ordinary restarts and rotate in a bounded directory.
 LOG_DIR = Path(os.getenv("STORY_MANAGER_LOG_DIR", str(LIBRARY_PATH.parent / "logs"))).resolve()
 LOG_MAX_BYTES = max(64 * 1024, int(os.getenv("STORY_MANAGER_LOG_MAX_BYTES", str(5 * 1024 * 1024))))

--- a/backend/app/crud/processing.py
+++ b/backend/app/crud/processing.py
@@ -182,6 +182,22 @@ async def heartbeat_processing_job(
     return bool(result.rowcount)
 
 
+async def defer_processing_job_for_backup(db: AsyncSession, job_id: int, *, lease_owner: str) -> bool:
+    """Return a just-claimed job to the queue when the backup barrier won the race."""
+    job = await db.get(ProcessingJob, job_id)
+    if job is None or job.status != ProcessingJobStatus.RUNNING.value or job.lease_owner != lease_owner:
+        return False
+    transition_state(job, "status", PROCESSING_JOB, ProcessingJobStatus.QUEUED, context=f"processing job {job.id}")
+    job.attempt_count = max(0, (job.attempt_count or 0) - 1)
+    job.started_at = None
+    job.lease_owner = None
+    job.lease_expires_at = None
+    job.heartbeat_at = None
+    job.progress_detail = "Waiting for library backup to finish"
+    await db.commit()
+    return True
+
+
 async def recover_abandoned_processing_jobs(db: AsyncSession) -> tuple[int, int]:
     """Cancel or exhaust expired leases; claimable jobs remain available to workers."""
     now = datetime.now(timezone.utc)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from . import crud
 from .admin_auth_middleware import AdminAuthMiddleware
+from .backup_middleware import BackupWriteBarrierMiddleware
 from .auth import validate_admin_auth_configuration
 from .config import LIBRARY_PATH
 from .errors import install_error_handlers
@@ -24,6 +25,7 @@ from .routers import (
     api_keys,
     auth,
     audiobook,
+    backups,
     books,
     cleaning,
     covers,
@@ -96,6 +98,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="Story Manager", lifespan=lifespan)
 install_error_handlers(app)
+app.add_middleware(BackupWriteBarrierMiddleware)
 app.add_middleware(AdminAuthMiddleware)
 app.add_middleware(RequestIdMiddleware)
 app.mount(
@@ -112,6 +115,7 @@ app.mount(
 )
 
 app.include_router(audiobook.router)
+app.include_router(backups.router)
 app.include_router(processing.router)
 app.include_router(observability.router)
 app.include_router(books.router)

--- a/backend/app/routers/backups.py
+++ b/backend/app/routers/backups.py
@@ -1,0 +1,79 @@
+"""Backup creation, inventory, verification, download, and deletion API."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi.responses import FileResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import schemas
+from ..config import BACKUP_PATH, BACKUP_RETENTION_COUNT
+from ..database import get_db
+from ..services.backups import BackupError, list_backups, resolve_backup
+from ..services.processing_queue import queue_processing_job
+
+router = APIRouter()
+
+
+def _job_response(job) -> schemas.ProcessingJob:
+    return schemas.ProcessingJob.model_validate(job)
+
+
+@router.get("/api/backups", response_model=schemas.BackupInventory)
+async def get_backups() -> dict[str, object]:
+    return {"retention_count": BACKUP_RETENTION_COUNT, "backups": list_backups(BACKUP_PATH)}
+
+
+@router.post("/api/backups", response_model=schemas.ProcessingJob, status_code=status.HTTP_202_ACCEPTED)
+async def create_backup(db: AsyncSession = Depends(get_db)) -> schemas.ProcessingJob:
+    job = await queue_processing_job(
+        db=db,
+        job_type="create_backup",
+        dedupe_key="create_backup",
+        progress_detail="Queued to create a verified backup",
+    )
+    return _job_response(job)
+
+
+@router.post(
+    "/api/backups/{filename}/verify",
+    response_model=schemas.ProcessingJob,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def verify_backup(filename: str, db: AsyncSession = Depends(get_db)) -> schemas.ProcessingJob:
+    try:
+        resolve_backup(BACKUP_PATH, filename)
+    except BackupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    job = await queue_processing_job(
+        db=db,
+        job_type="verify_backup",
+        payload={"filename": filename},
+        dedupe_key=f"verify_backup:{filename}",
+        progress_detail=f"Queued to verify {filename}",
+    )
+    return _job_response(job)
+
+
+@router.get("/api/backups/{filename}/download")
+async def download_backup(filename: str) -> FileResponse:
+    try:
+        archive = resolve_backup(BACKUP_PATH, filename)
+    except BackupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return FileResponse(
+        archive,
+        filename=archive.name,
+        media_type="application/zip",
+        headers={"X-Content-Type-Options": "nosniff"},
+    )
+
+
+@router.delete("/api/backups/{filename}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_backup(filename: str) -> Response:
+    try:
+        archive = resolve_backup(BACKUP_PATH, filename)
+    except BackupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    archive.unlink()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -376,6 +376,8 @@ PROCESSING_JOB_TYPES = Literal[
     "generate_sentence_audio",
     "generate_chapter_preview",
     "retry_cover",
+    "create_backup",
+    "verify_backup",
 ]
 
 
@@ -418,6 +420,23 @@ class ProcessingJob(BaseModel):
 
 class ProcessingJobsCreated(BaseModel):
     jobs: List[ProcessingJob] = Field(default_factory=list)
+
+
+class BackupArchive(BaseModel):
+    filename: str
+    created_at: datetime
+    size_bytes: int
+    library_file_count: int
+    library_size_bytes: int
+    valid_manifest: bool
+    verified_at_creation: bool
+    error: Optional[str] = None
+    download_url: str
+
+
+class BackupInventory(BaseModel):
+    retention_count: int
+    backups: List[BackupArchive] = Field(default_factory=list)
 
 
 class AttentionBookItem(BaseModel):

--- a/backend/app/services/backup_barrier.py
+++ b/backend/app/services/backup_barrier.py
@@ -1,0 +1,57 @@
+"""Coordinate consistent backups with API writes and processing workers."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+
+
+class BackupInProgressError(RuntimeError):
+    """Raised when a new mutation arrives while a snapshot is being made."""
+
+
+class BackupBarrier:
+    """A process-local write barrier for the supported single-worker deployment."""
+
+    def __init__(self) -> None:
+        self._condition = asyncio.Condition()
+        self._backup_active = False
+        self._active_mutations = 0
+
+    @property
+    def backup_active(self) -> bool:
+        return self._backup_active
+
+    @asynccontextmanager
+    async def mutation(self):
+        async with self._condition:
+            if self._backup_active:
+                raise BackupInProgressError("A library backup is being created. Try again shortly.")
+            self._active_mutations += 1
+        try:
+            yield
+        finally:
+            async with self._condition:
+                self._active_mutations -= 1
+                self._condition.notify_all()
+
+    @asynccontextmanager
+    async def backup(self):
+        async with self._condition:
+            if self._backup_active:
+                raise BackupInProgressError("A library backup is already being created.")
+            self._backup_active = True
+            await self._condition.wait_for(lambda: self._active_mutations == 0)
+        try:
+            yield
+        finally:
+            async with self._condition:
+                self._backup_active = False
+                self._condition.notify_all()
+
+    async def wait_until_writes_allowed(self) -> None:
+        async with self._condition:
+            await self._condition.wait_for(lambda: not self._backup_active)
+
+
+backup_barrier = BackupBarrier()

--- a/backend/app/services/backups.py
+++ b/backend/app/services/backups.py
@@ -1,0 +1,408 @@
+"""Create, inspect, verify, and restore portable Story Manager backups."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
+from typing import BinaryIO
+from uuid import uuid4
+
+from sqlalchemy.engine import URL, make_url
+
+BACKUP_FORMAT = "story-manager-backup"
+BACKUP_FORMAT_VERSION = 1
+MANIFEST_NAME = "manifest.json"
+DATABASE_DUMP_NAME = "database.dump"
+BACKUP_SUFFIX = ".story-manager.zip"
+_COPY_CHUNK_SIZE = 1024 * 1024
+
+
+class BackupError(RuntimeError):
+    """A safe, user-facing backup or restore failure."""
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _find_postgres_tool(name: str, configured_path: str | None = None) -> str:
+    if configured_path:
+        candidate = Path(configured_path).expanduser()
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return str(candidate)
+        raise BackupError(f"Configured {name} executable was not found: {candidate}")
+
+    discovered = shutil.which(name)
+    if discovered:
+        return discovered
+
+    candidates = sorted(Path("/usr/lib/postgresql").glob(f"*/bin/{name}"), reverse=True)
+    if candidates:
+        return str(candidates[0])
+    raise BackupError(f"{name} is required but was not found. Install PostgreSQL client tools and try again.")
+
+
+def _postgres_connection(database_url: str) -> tuple[URL, dict[str, str]]:
+    url = make_url(database_url)
+    if url.get_backend_name() != "postgresql" or not url.database:
+        raise BackupError("Backup and restore require a PostgreSQL DATABASE_URL.")
+    env = os.environ.copy()
+    if url.password:
+        env["PGPASSWORD"] = url.password
+    return url, env
+
+
+def _connection_args(url: URL) -> list[str]:
+    args: list[str] = []
+    if url.host:
+        args.extend(("--host", url.host))
+    if url.port:
+        args.extend(("--port", str(url.port)))
+    if url.username:
+        args.extend(("--username", url.username))
+    args.extend(("--dbname", url.database or ""))
+    return args
+
+
+def _run_postgres_tool(args: list[str], env: dict[str, str], operation: str) -> None:
+    result = subprocess.run(args, env=env, capture_output=True, text=True, check=False)
+    if result.returncode == 0:
+        return
+    detail = (result.stderr or result.stdout or "unknown PostgreSQL error").strip()
+    raise BackupError(f"{operation} failed: {detail}")
+
+
+def _dump_database(database_url: str, destination: Path, pg_dump_path: str | None = None) -> None:
+    url, env = _postgres_connection(database_url)
+    try:
+        executable = _find_postgres_tool("pg_dump", pg_dump_path or os.getenv("STORY_MANAGER_PG_DUMP_PATH"))
+    except BackupError:
+        container = os.getenv("STORY_MANAGER_PG_DUMP_CONTAINER")
+        if not container:
+            raise
+        _dump_database_from_container(url, destination, container)
+        return
+    args = [
+        executable,
+        "--format=custom",
+        "--no-owner",
+        "--no-privileges",
+        "--file",
+        str(destination),
+        *_connection_args(url),
+    ]
+    _run_postgres_tool(args, env, "Database backup")
+
+
+def _dump_database_from_container(url: URL, destination: Path, container: str) -> None:
+    """Use the project's development PostgreSQL container when client tools are absent."""
+    docker = shutil.which("docker")
+    if not docker:
+        raise BackupError("Docker is required to use the configured PostgreSQL dump container.")
+    args = [docker, "exec", "-i", container, "pg_dump", "--format=custom", "--no-owner", "--no-privileges"]
+    if url.username:
+        args.extend(("--username", url.username))
+    args.extend(("--dbname", url.database or ""))
+    with destination.open("wb") as output:
+        result = subprocess.run(args, stdout=output, stderr=subprocess.PIPE, check=False)
+    if result.returncode != 0:
+        destination.unlink(missing_ok=True)
+        detail = (result.stderr or b"unknown PostgreSQL error").decode("utf-8", errors="replace").strip()
+        raise BackupError(f"Database backup failed: {detail}")
+
+
+def _sha256_stream(source: BinaryIO) -> str:
+    digest = hashlib.sha256()
+    while chunk := source.read(_COPY_CHUNK_SIZE):
+        digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _write_file(archive: zipfile.ZipFile, source: Path, archive_name: str) -> dict[str, object]:
+    digest = hashlib.sha256()
+    size = 0
+    with source.open("rb") as input_file, archive.open(archive_name, "w", force_zip64=True) as output_file:
+        while chunk := input_file.read(_COPY_CHUNK_SIZE):
+            output_file.write(chunk)
+            digest.update(chunk)
+            size += len(chunk)
+    return {"path": archive_name, "size_bytes": size, "sha256": digest.hexdigest()}
+
+
+def _library_files(library_path: Path) -> list[Path]:
+    if not library_path.exists():
+        return []
+    files: list[Path] = []
+    for candidate in library_path.rglob("*"):
+        if candidate.is_symlink():
+            raise BackupError(f"Library backups do not follow symbolic links: {candidate}")
+        if candidate.is_file():
+            files.append(candidate)
+    return sorted(files, key=lambda item: item.relative_to(library_path).as_posix())
+
+
+def create_backup_archive(
+    *,
+    database_url: str,
+    library_path: Path,
+    backup_path: Path,
+    pg_dump_path: str | None = None,
+    retention_count: int = 10,
+) -> dict[str, object]:
+    """Create and verify an archive, publishing it atomically when complete."""
+    created_at = _utc_now()
+    if backup_path.resolve().is_relative_to(library_path.resolve()):
+        raise BackupError("The backup directory must be outside the library directory.")
+    backup_path.mkdir(parents=True, exist_ok=True)
+    filename = f"story-manager-{created_at.strftime('%Y%m%dT%H%M%SZ')}-{uuid4().hex[:8]}{BACKUP_SUFFIX}"
+    destination = backup_path / filename
+
+    with tempfile.TemporaryDirectory(prefix="story-manager-backup-", dir=backup_path) as temp_name:
+        temp_dir = Path(temp_name)
+        database_dump = temp_dir / DATABASE_DUMP_NAME
+        archive_path = temp_dir / filename
+        _dump_database(database_url, database_dump, pg_dump_path)
+
+        file_entries: list[dict[str, object]] = []
+        with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_STORED, allowZip64=True) as archive:
+            file_entries.append(_write_file(archive, database_dump, DATABASE_DUMP_NAME))
+            for source in _library_files(library_path):
+                relative = source.relative_to(library_path).as_posix()
+                file_entries.append(_write_file(archive, source, f"library/{relative}"))
+
+            library_entries = [entry for entry in file_entries if str(entry["path"]).startswith("library/")]
+            manifest = {
+                "format": BACKUP_FORMAT,
+                "format_version": BACKUP_FORMAT_VERSION,
+                "created_at": created_at.isoformat(),
+                "integrity": {"algorithm": "sha256", "verified_at_creation": True},
+                "database": {"path": DATABASE_DUMP_NAME, "format": "postgresql-custom"},
+                "library": {
+                    "path": "library/",
+                    "file_count": len(library_entries),
+                    "size_bytes": sum(int(entry["size_bytes"]) for entry in library_entries),
+                },
+                "files": file_entries,
+            }
+            archive.writestr(MANIFEST_NAME, json.dumps(manifest, indent=2, sort_keys=True).encode("utf-8"))
+
+        verify_backup_archive(archive_path)
+        os.chmod(archive_path, 0o600)
+        os.replace(archive_path, destination)
+
+    prune_backups(backup_path, retention_count=retention_count)
+    return backup_summary(destination)
+
+
+def _safe_archive_name(name: str) -> bool:
+    path = PurePosixPath(name)
+    return bool(name) and not path.is_absolute() and ".." not in path.parts and "\\" not in name
+
+
+def _load_manifest(archive: zipfile.ZipFile) -> dict[str, object]:
+    try:
+        info = archive.getinfo(MANIFEST_NAME)
+    except KeyError as exc:
+        raise BackupError("Backup manifest is missing.") from exc
+    if info.file_size > 64 * 1024 * 1024:
+        raise BackupError("Backup manifest is unexpectedly large.")
+    try:
+        manifest = json.loads(archive.read(info))
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise BackupError("Backup manifest is invalid.") from exc
+    if manifest.get("format") != BACKUP_FORMAT or manifest.get("format_version") != BACKUP_FORMAT_VERSION:
+        raise BackupError("This backup format is not supported by this Story Manager version.")
+    return manifest
+
+
+def verify_backup_archive(archive_path: Path) -> dict[str, object]:
+    """Validate archive layout, declared sizes, and every SHA-256 checksum."""
+    if not archive_path.is_file():
+        raise BackupError(f"Backup archive was not found: {archive_path}")
+    try:
+        with zipfile.ZipFile(archive_path, "r") as archive:
+            infos = archive.infolist()
+            names = [info.filename for info in infos]
+            if len(names) != len(set(names)) or any(not _safe_archive_name(name) for name in names):
+                raise BackupError("Backup contains duplicate or unsafe paths.")
+            if any(info.compress_type != zipfile.ZIP_STORED for info in infos):
+                raise BackupError("Backup uses an unsupported compression method.")
+            manifest = _load_manifest(archive)
+            raw_entries = manifest.get("files")
+            if not isinstance(raw_entries, list):
+                raise BackupError("Backup manifest has no file inventory.")
+
+            expected_names = {MANIFEST_NAME}
+            for entry in raw_entries:
+                if not isinstance(entry, dict):
+                    raise BackupError("Backup manifest contains an invalid file entry.")
+                name = entry.get("path")
+                size = entry.get("size_bytes")
+                expected_hash = entry.get("sha256")
+                if not isinstance(name, str) or not _safe_archive_name(name):
+                    raise BackupError("Backup manifest contains an unsafe path.")
+                if not isinstance(size, int) or size < 0 or not isinstance(expected_hash, str):
+                    raise BackupError(f"Backup manifest metadata is invalid for {name}.")
+                try:
+                    info = archive.getinfo(name)
+                except KeyError as exc:
+                    raise BackupError(f"Backup is missing {name}.") from exc
+                if info.file_size != size:
+                    raise BackupError(f"Backup size check failed for {name}.")
+                with archive.open(info, "r") as source:
+                    actual_hash = _sha256_stream(source)
+                if actual_hash != expected_hash:
+                    raise BackupError(f"Backup checksum failed for {name}.")
+                expected_names.add(name)
+            if set(names) != expected_names:
+                raise BackupError("Backup contains files that are not declared in its manifest.")
+            if DATABASE_DUMP_NAME not in expected_names:
+                raise BackupError("Backup database dump is missing.")
+            return manifest
+    except zipfile.BadZipFile as exc:
+        raise BackupError("Backup archive is not a readable ZIP file.") from exc
+
+
+def backup_summary(archive_path: Path) -> dict[str, object]:
+    stat = archive_path.stat()
+    summary: dict[str, object] = {
+        "filename": archive_path.name,
+        "created_at": datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc),
+        "size_bytes": stat.st_size,
+        "library_file_count": 0,
+        "library_size_bytes": 0,
+        "valid_manifest": False,
+        "verified_at_creation": False,
+        "error": None,
+        "download_url": f"/api/backups/{archive_path.name}/download",
+    }
+    try:
+        with zipfile.ZipFile(archive_path, "r") as archive:
+            manifest = _load_manifest(archive)
+        library = manifest.get("library") if isinstance(manifest.get("library"), dict) else {}
+        integrity = manifest.get("integrity") if isinstance(manifest.get("integrity"), dict) else {}
+        created_at = datetime.fromisoformat(str(manifest["created_at"]))
+        if created_at.tzinfo is None:
+            created_at = created_at.replace(tzinfo=timezone.utc)
+        summary.update(
+            {
+                "created_at": created_at,
+                "library_file_count": int(library.get("file_count", 0)),
+                "library_size_bytes": int(library.get("size_bytes", 0)),
+                "valid_manifest": True,
+                "verified_at_creation": bool(integrity.get("verified_at_creation")),
+            }
+        )
+    except (BackupError, KeyError, TypeError, ValueError, zipfile.BadZipFile) as exc:
+        summary["error"] = str(exc)
+    return summary
+
+
+def list_backups(backup_path: Path) -> list[dict[str, object]]:
+    if not backup_path.exists():
+        return []
+    archives = [item for item in backup_path.iterdir() if item.is_file() and item.name.endswith(BACKUP_SUFFIX)]
+    return sorted((backup_summary(item) for item in archives), key=lambda item: item["created_at"], reverse=True)
+
+
+def prune_backups(backup_path: Path, *, retention_count: int) -> list[Path]:
+    """Delete oldest managed archives beyond the configured count; zero keeps all."""
+    if retention_count <= 0 or not backup_path.exists():
+        return []
+    archives = sorted(
+        (item for item in backup_path.iterdir() if item.is_file() and item.name.endswith(BACKUP_SUFFIX)),
+        key=lambda item: (item.stat().st_mtime_ns, item.name),
+        reverse=True,
+    )
+    removed = archives[retention_count:]
+    for archive in removed:
+        archive.unlink()
+    return removed
+
+
+def resolve_backup(backup_path: Path, filename: str) -> Path:
+    if Path(filename).name != filename or not filename.endswith(BACKUP_SUFFIX):
+        raise BackupError("Invalid backup filename.")
+    resolved_root = backup_path.resolve()
+    candidate = (resolved_root / filename).resolve()
+    if not candidate.is_relative_to(resolved_root) or not candidate.is_file():
+        raise BackupError("Backup archive was not found.")
+    return candidate
+
+
+def restore_backup_archive(
+    *,
+    archive_path: Path,
+    database_url: str,
+    library_path: Path,
+    pg_restore_path: str | None = None,
+) -> None:
+    """Restore verified files and the database, rolling files back if PostgreSQL fails."""
+    manifest = verify_backup_archive(archive_path)
+    url, env = _postgres_connection(database_url)
+    executable = _find_postgres_tool("pg_restore", pg_restore_path or os.getenv("STORY_MANAGER_PG_RESTORE_PATH"))
+    library_path.mkdir(parents=True, exist_ok=True)
+
+    # The production library is a bind mount, so its mount point cannot be
+    # renamed. Stage and roll back entries inside that same filesystem.
+    with tempfile.TemporaryDirectory(prefix=".story-manager-restore-", dir=library_path) as temp_name:
+        temp_dir = Path(temp_name)
+        staged_library = temp_dir / "library"
+        staged_library.mkdir()
+        previous_library = temp_dir / "previous-library"
+        previous_library.mkdir()
+        database_dump = temp_dir / DATABASE_DUMP_NAME
+        with zipfile.ZipFile(archive_path, "r") as archive:
+            for entry in manifest["files"]:
+                name = str(entry["path"])
+                if name == DATABASE_DUMP_NAME:
+                    destination = database_dump
+                elif name.startswith("library/"):
+                    destination = staged_library / PurePosixPath(name).relative_to("library")
+                else:
+                    raise BackupError(f"Backup contains an unsupported entry: {name}")
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                with archive.open(name) as source, destination.open("wb") as output:
+                    shutil.copyfileobj(source, output, length=_COPY_CHUNK_SIZE)
+
+        previous_entries = [entry for entry in library_path.iterdir() if entry != temp_dir]
+        restored_entries: list[Path] = []
+
+        def roll_back_library() -> None:
+            for entry in reversed(restored_entries):
+                if entry.is_dir() and not entry.is_symlink():
+                    shutil.rmtree(entry)
+                else:
+                    entry.unlink(missing_ok=True)
+            for entry in previous_library.iterdir():
+                entry.rename(library_path / entry.name)
+
+        try:
+            for entry in previous_entries:
+                entry.rename(previous_library / entry.name)
+            for entry in list(staged_library.iterdir()):
+                destination = library_path / entry.name
+                entry.rename(destination)
+                restored_entries.append(destination)
+            args = [
+                executable,
+                "--exit-on-error",
+                "--single-transaction",
+                "--clean",
+                "--if-exists",
+                "--no-owner",
+                "--no-privileges",
+                *_connection_args(url),
+                str(database_dump),
+            ]
+            _run_postgres_tool(args, env, "Database restore")
+        except Exception:
+            roll_back_library()
+            raise

--- a/backend/app/services/processing_queue.py
+++ b/backend/app/services/processing_queue.py
@@ -13,12 +13,14 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import crud
-from ..database import SessionLocal
+from ..config import BACKUP_PATH, BACKUP_RETENTION_COUNT, LIBRARY_PATH
+from ..database import DATABASE_URL, SessionLocal
 from ..lifecycle import (
     AUDIOBOOK_PUBLICATION,
     IMPORTED_AUDIOBOOK,
     AudiobookPublicationStatus,
     ImportedAudiobookStatus,
+    ProcessingJobStatus,
     transition_state,
 )
 from ..models import Book, ImportedAudiobook, ImportedAudiobookTrack, ProcessingJob
@@ -30,6 +32,8 @@ from .audiobook_queue import get_audiobook_queue
 from .audiobook_tts import generate_audio_for_sentence
 from .audiobook_assembly import assemble_chapter_preview
 from .audiobook_tts import generate_audio_for_chapter_preview
+from .backup_barrier import backup_barrier
+from .backups import create_backup_archive, resolve_backup, verify_backup_archive
 from .cover_processing import reextract_book_cover
 from .metadata_jobs import process_metadata_sync_job
 from .transcription_providers import transcription_provider_name
@@ -56,6 +60,8 @@ JOB_POLICIES: dict[str, tuple[str, int]] = {
     "import_audiobook": ("cpu", 3),
     "rematch_imported_audiobook": ("cpu", 3),
     "align_imported_audiobook": ("transcription", 3),
+    "create_backup": ("maintenance", 1),
+    "verify_backup": ("maintenance", 1),
 }
 
 
@@ -164,6 +170,7 @@ class ProcessingQueue:
         lease_owner = f"{self._instance_id}:{lane}:{worker_number}"
         while True:
             try:
+                await backup_barrier.wait_until_writes_allowed()
                 async with SessionLocal() as db:
                     await crud.recover_abandoned_processing_jobs(db)
                     job = await crud.claim_processing_job(
@@ -184,6 +191,13 @@ class ProcessingQueue:
                     await asyncio.wait_for(self._wake.wait(), timeout=self._poll_seconds)
                 except asyncio.TimeoutError:
                     pass
+                continue
+
+            if backup_barrier.backup_active and job.job_type != "create_backup":
+                async with SessionLocal() as db:
+                    await crud.defer_processing_job_for_backup(db, job.id, lease_owner=lease_owner)
+                await backup_barrier.wait_until_writes_allowed()
+                self._wake.set()
                 continue
 
             with correlation_context(request_id=job.request_id, job_id=job.id):
@@ -250,6 +264,37 @@ class ProcessingQueue:
 
     async def _execute(self, job: ProcessingJob) -> str:
         payload = job.payload or {}
+        if job.job_type == "create_backup":
+            async with backup_barrier.backup():
+                async with SessionLocal() as db:
+                    running_jobs = await db.scalar(
+                        select(func.count(ProcessingJob.id)).where(
+                            ProcessingJob.status == ProcessingJobStatus.RUNNING.value,
+                            ProcessingJob.id != job.id,
+                        )
+                    )
+                if running_jobs:
+                    raise RuntimeError(
+                        f"Backup paused because {running_jobs} other processing job(s) are still running. "
+                        "Try again when Activity is idle."
+                    )
+                await self._update_progress(job.id, 0, 2, "Creating database and library snapshot")
+                summary = await asyncio.to_thread(
+                    create_backup_archive,
+                    database_url=DATABASE_URL,
+                    library_path=LIBRARY_PATH,
+                    backup_path=BACKUP_PATH,
+                    retention_count=BACKUP_RETENTION_COUNT,
+                )
+                await self._update_progress(job.id, 2, 2, f"Verified {summary['filename']}")
+                return f"Backup created and verified: {summary['filename']}"
+        if job.job_type == "verify_backup":
+            filename = str(payload.get("filename") or "")
+            archive = resolve_backup(BACKUP_PATH, filename)
+            await self._update_progress(job.id, 0, 1, f"Verifying {filename}")
+            await asyncio.to_thread(verify_backup_archive, archive)
+            await self._update_progress(job.id, 1, 1, f"Verified {filename}")
+            return f"Backup verified: {filename}"
         if job.job_type == "clean_book":
             return await self._clean_book(job.id, job.book_id)
         if job.job_type == "clean_all":

--- a/backend/tests/test_backups.py
+++ b/backend/tests/test_backups.py
@@ -1,0 +1,235 @@
+"""Backup archive, restore safety, and API coverage."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from backend.app import backup_cli
+from backend.app.routers import backups as backups_router
+from backend.app.services import backups
+from backend.app.services.backup_barrier import BackupBarrier, BackupInProgressError
+
+
+def _fake_database_dump(_database_url: str, destination: Path, _pg_dump_path: str | None = None) -> None:
+    destination.write_bytes(b"PGDMP-test-database")
+
+
+def _create_archive(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> tuple[Path, Path]:
+    library = tmp_path / "library"
+    library.mkdir()
+    (library / "book.epub").write_bytes(b"epub data")
+    (library / "audiobooks").mkdir()
+    (library / "audiobooks" / "chapter.mp3").write_bytes(b"audio data")
+    backup_dir = tmp_path / "backups"
+    monkeypatch.setattr(backups, "_dump_database", _fake_database_dump)
+    summary = backups.create_backup_archive(
+        database_url="postgresql+psycopg://storyuser:secret@localhost/story_manager",
+        library_path=library,
+        backup_path=backup_dir,
+    )
+    return backup_dir / str(summary["filename"]), library
+
+
+def test_create_and_verify_backup_archive(monkeypatch, tmp_path):
+    archive, _library = _create_archive(monkeypatch, tmp_path)
+
+    manifest = backups.verify_backup_archive(archive)
+    summary = backups.backup_summary(archive)
+
+    assert manifest["format"] == backups.BACKUP_FORMAT
+    assert manifest["library"] == {"path": "library/", "file_count": 2, "size_bytes": 19}
+    assert summary["valid_manifest"] is True
+    assert summary["verified_at_creation"] is True
+    assert summary["library_file_count"] == 2
+    assert archive.stat().st_mode & 0o777 == 0o600
+
+
+def test_verification_rejects_changed_file(monkeypatch, tmp_path):
+    archive, _library = _create_archive(monkeypatch, tmp_path)
+    changed = tmp_path / "changed.story-manager.zip"
+    with zipfile.ZipFile(archive, "r") as source, zipfile.ZipFile(changed, "w") as destination:
+        for info in source.infolist():
+            data = source.read(info)
+            if info.filename == "library/book.epub":
+                data += b"tampered"
+            destination.writestr(info.filename, data)
+
+    with pytest.raises(backups.BackupError, match="size check failed"):
+        backups.verify_backup_archive(changed)
+
+
+def test_verification_rejects_unsafe_or_undeclared_paths(monkeypatch, tmp_path):
+    archive, _library = _create_archive(monkeypatch, tmp_path)
+    changed = tmp_path / "unsafe.story-manager.zip"
+    shutil.copyfile(archive, changed)
+    with zipfile.ZipFile(changed, "a") as destination:
+        destination.writestr("../outside.txt", b"unsafe")
+
+    with pytest.raises(backups.BackupError, match="unsafe paths"):
+        backups.verify_backup_archive(changed)
+
+
+def test_backup_directory_must_not_be_inside_library(monkeypatch, tmp_path):
+    library = tmp_path / "library"
+    library.mkdir()
+    monkeypatch.setattr(backups, "_dump_database", _fake_database_dump)
+    with pytest.raises(backups.BackupError, match="outside the library"):
+        backups.create_backup_archive(
+            database_url="postgresql+psycopg://storyuser:secret@localhost/story_manager",
+            library_path=library,
+            backup_path=library / "backups",
+        )
+
+
+def test_database_dump_can_use_development_postgres_container(monkeypatch, tmp_path):
+    destination = tmp_path / "database.dump"
+    monkeypatch.setenv("STORY_MANAGER_PG_DUMP_CONTAINER", "story-manager-db")
+    monkeypatch.setattr(backups, "_find_postgres_tool", lambda *_args: (_ for _ in ()).throw(backups.BackupError()))
+    monkeypatch.setattr(backups.shutil, "which", lambda name: "/usr/bin/docker" if name == "docker" else None)
+
+    def run(args, *, stdout, stderr, check):
+        assert args[:5] == ["/usr/bin/docker", "exec", "-i", "story-manager-db", "pg_dump"]
+        assert "secret" not in args
+        stdout.write(b"PGDMP-container")
+        return subprocess.CompletedProcess(args, 0, stderr=b"")
+
+    monkeypatch.setattr(backups.subprocess, "run", run)
+    backups._dump_database(
+        "postgresql+psycopg://storyuser:secret@localhost/story_manager",
+        destination,
+    )
+
+    assert destination.read_bytes() == b"PGDMP-container"
+
+
+def test_retention_prunes_only_oldest_managed_archives(tmp_path):
+    archives = []
+    for index in range(3):
+        archive = tmp_path / f"backup-{index}.story-manager.zip"
+        archive.write_bytes(b"backup")
+        os.utime(archive, ns=(index + 1, index + 1))
+        archives.append(archive)
+    unrelated = tmp_path / "notes.txt"
+    unrelated.write_text("keep")
+
+    removed = backups.prune_backups(tmp_path, retention_count=2)
+
+    assert removed == [archives[0]]
+    assert not archives[0].exists()
+    assert archives[1].exists() and archives[2].exists()
+    assert unrelated.exists()
+
+
+def test_restore_replaces_library_after_database_restore(monkeypatch, tmp_path):
+    archive, source_library = _create_archive(monkeypatch, tmp_path)
+    source_library.rename(tmp_path / "source-library")
+    library = tmp_path / "library"
+    library.mkdir()
+    (library / "old.epub").write_bytes(b"old")
+    monkeypatch.setattr(backups, "_run_postgres_tool", lambda *_args: None)
+
+    backups.restore_backup_archive(
+        archive_path=archive,
+        database_url="postgresql+psycopg://storyuser:secret@localhost/story_manager",
+        library_path=library,
+        pg_restore_path=shutil.which("true"),
+    )
+
+    assert (library / "book.epub").read_bytes() == b"epub data"
+    assert (library / "audiobooks" / "chapter.mp3").read_bytes() == b"audio data"
+    assert not (library / "old.epub").exists()
+
+
+def test_restore_rolls_library_back_when_database_restore_fails(monkeypatch, tmp_path):
+    archive, source_library = _create_archive(monkeypatch, tmp_path)
+    source_library.rename(tmp_path / "source-library")
+    library = tmp_path / "library"
+    library.mkdir()
+    (library / "old.epub").write_bytes(b"old")
+
+    def fail_restore(*_args):
+        raise backups.BackupError("database restore failed")
+
+    monkeypatch.setattr(backups, "_run_postgres_tool", fail_restore)
+    with pytest.raises(backups.BackupError, match="database restore failed"):
+        backups.restore_backup_archive(
+            archive_path=archive,
+            database_url="postgresql+psycopg://storyuser:secret@localhost/story_manager",
+            library_path=library,
+            pg_restore_path=shutil.which("true"),
+        )
+
+    assert (library / "old.epub").read_bytes() == b"old"
+    assert not (library / "book.epub").exists()
+
+
+@pytest.mark.asyncio
+async def test_backup_barrier_blocks_new_mutations_and_waits_for_existing_one():
+    barrier = BackupBarrier()
+    mutation = barrier.mutation()
+    await mutation.__aenter__()
+    entered = False
+
+    async def enter_backup():
+        nonlocal entered
+        async with barrier.backup():
+            entered = True
+
+    import asyncio
+
+    task = asyncio.create_task(enter_backup())
+    await asyncio.sleep(0)
+    assert barrier.backup_active is True
+    assert entered is False
+    with pytest.raises(BackupInProgressError):
+        async with barrier.mutation():
+            pass
+    await mutation.__aexit__(None, None, None)
+    await task
+    assert entered is True
+    assert barrier.backup_active is False
+
+
+def test_backup_api_lists_downloads_queues_and_deletes(app_client, monkeypatch, tmp_path):
+    archive, _library = _create_archive(monkeypatch, tmp_path)
+    monkeypatch.setattr(backups_router, "BACKUP_PATH", archive.parent)
+
+    listed = app_client.get("/api/backups")
+    assert listed.status_code == 200
+    assert listed.json()["retention_count"] == 10
+    assert listed.json()["backups"][0]["filename"] == archive.name
+
+    create_response = app_client.post("/api/backups")
+    assert create_response.status_code == 202
+    assert create_response.json()["job_type"] == "create_backup"
+
+    verify_response = app_client.post(f"/api/backups/{archive.name}/verify")
+    assert verify_response.status_code == 202
+    assert verify_response.json()["job_type"] == "verify_backup"
+    assert verify_response.json()["payload"] == {"filename": archive.name}
+
+    download = app_client.get(f"/api/backups/{archive.name}/download")
+    assert download.status_code == 200
+    assert download.content == archive.read_bytes()
+
+    deleted = app_client.delete(f"/api/backups/{archive.name}")
+    assert deleted.status_code == 204
+    assert not archive.exists()
+
+
+def test_backup_api_rejects_path_traversal(app_client, monkeypatch, tmp_path):
+    monkeypatch.setattr(backups_router, "BACKUP_PATH", tmp_path)
+    response = app_client.get("/api/backups/not-a-backup/download")
+    assert response.status_code == 404
+
+
+def test_restore_cli_requires_explicit_confirmation(capsys, tmp_path):
+    result = backup_cli.main(["restore", str(tmp_path / "backup.story-manager.zip")])
+    assert result == 2
+    assert "--confirm-replace" in capsys.readouterr().err

--- a/backend/tests/test_processing_jobs.py
+++ b/backend/tests/test_processing_jobs.py
@@ -39,6 +39,45 @@ async def test_processing_jobs_use_explicit_resource_policies(sqlite_sessionmake
             assert job.resource_lane == lane
             assert job.max_attempts == 3
 
+    async with sqlite_sessionmaker() as db:
+        backup = await queue_processing_job(db=db, job_type="create_backup", dedupe_key="backup-lane-test")
+        assert backup.resource_lane == "maintenance"
+        assert backup.max_attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_processing_queue_creates_backup_under_write_barrier(sqlite_sessionmaker, monkeypatch, tmp_path):
+    async with sqlite_sessionmaker() as db:
+        job, _created = await crud.create_processing_job(
+            db,
+            job_type="create_backup",
+            resource_lane="maintenance",
+            max_attempts=1,
+        )
+        job.status = "running"
+        await db.commit()
+        await db.refresh(job)
+
+    observed = {}
+
+    def create_backup(**kwargs):
+        observed.update(kwargs)
+        assert processing_queue_module.backup_barrier.backup_active is True
+        return {"filename": "test.story-manager.zip"}
+
+    monkeypatch.setattr(processing_queue_module, "SessionLocal", sqlite_sessionmaker)
+    monkeypatch.setattr(processing_queue_module, "create_backup_archive", create_backup)
+    monkeypatch.setattr(processing_queue_module, "LIBRARY_PATH", tmp_path / "library")
+    monkeypatch.setattr(processing_queue_module, "BACKUP_PATH", tmp_path / "backups")
+    monkeypatch.setattr(processing_queue_module, "DATABASE_URL", "postgresql+psycopg://localhost/test")
+
+    detail = await ProcessingQueue()._execute(job)
+
+    assert detail == "Backup created and verified: test.story-manager.zip"
+    assert observed["library_path"] == tmp_path / "library"
+    assert observed["backup_path"] == tmp_path / "backups"
+    assert processing_queue_module.backup_barrier.backup_active is False
+
 
 @pytest.mark.asyncio
 async def test_processing_job_claim_is_exclusive_and_heartbeated(sqlite_sessionmaker):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,9 @@ services:
       - "8000:8000"  # UI + API
     volumes:
       - ./config/library:/app/library
+      - ./config/backups:/app/backups
       - ./config/fanficfare:/app/config:ro
       - ./config/pgdata:/tmp/pgdata
+    environment:
+      STORY_MANAGER_BACKUP_DIR: /app/backups
     restart: unless-stopped

--- a/docs/IMPROVEMENT_ROADMAP.md
+++ b/docs/IMPROVEMENT_ROADMAP.md
@@ -20,6 +20,7 @@ This roadmap captures the next major product and technical improvements for Stor
 6. [Consolidated background execution](#6-consolidated-background-execution)
 7. [Centralized state-machine definitions](#7-centralized-state-machine-definitions)
 8. [Stronger observability](#8-stronger-observability)
+9. [Backup and disaster recovery](#9-backup-and-disaster-recovery)
 
 ## 1. Needs Attention dashboard
 
@@ -144,7 +145,7 @@ State machines should define valid transitions, terminal states, retry behavior,
 
 ## 8. Stronger observability
 
-**Status:** In progress
+**Status:** Complete
 
 Make failures diagnosable without reading raw container output. Connect request IDs to log records, expose worker and dependency health, measure job behavior, and provide a user-downloadable diagnostic bundle with secrets removed.
 
@@ -158,3 +159,24 @@ Observability should remain useful for a small self-hosted deployment and should
 - Logs required for recent diagnostics survive ordinary application restarts.
 - Users can download a redacted diagnostic bundle from the UI.
 - Metrics and logs never expose API keys, session secrets, book contents, or generated audio.
+
+## 9. Backup and disaster recovery
+
+**Status:** In progress
+
+Protect a self-hosted library from database loss, disk failure, and failed host migrations. Backups should be
+portable, independently verifiable, and stored outside the library tree so one archive never includes another.
+Restores must be an explicit offline operation rather than a browser action against a running service.
+
+### Acceptance criteria
+
+- Users can queue a complete database-and-library backup from Library Tools and follow its durable job progress.
+- New writes pause during snapshot creation, and a backup refuses to run alongside active processing work.
+- Every archive contains a versioned manifest, full file inventory, sizes, and SHA-256 checksums.
+- An archive is checksum-verified before it appears in backup history or becomes downloadable.
+- Backup history enforces a configurable retention count, with zero available for manual retention.
+- Existing backups can be downloaded, re-verified, and deliberately deleted from the UI.
+- The bundled offline restore command validates the archive before replacing data and rolls library files back if
+  PostgreSQL restore fails.
+- Docker Compose persists backups separately from both the library and PostgreSQL data directories.
+- Tests cover archive tampering, unsafe paths, API behavior, successful restore, and restore rollback.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -13,6 +13,7 @@ The production container serves the built frontend and API from `http://localhos
 The default `docker-compose.yml` stores persistent data under `./config`:
 
 - `config/library`: uploaded EPUBs and downloaded web novels
+- `config/backups`: verified database-and-library backup archives
 - `config/fanficfare`: optional FanFicFare user configuration
 - `config/pgdata`: PostgreSQL data
 
@@ -43,6 +44,72 @@ queued or running job with that key, while terminal history is retained. Handler
 metadata, and audiobook state, so a worker can safely reclaim an expired lease instead of depending on an in-memory
 queue notification. Claims use row locks with `SKIP LOCKED`; only the current lease owner may heartbeat or finish a
 job.
+
+## Backups and disaster recovery
+
+Open **Settings → Library Tools → Backup & Restore** to create a portable backup. Backup creation is a durable
+maintenance job, so its status remains visible after navigation or reload. Story Manager briefly rejects new write
+requests and prevents queued workers from starting while it snapshots the database and library. If another job is
+already running, backup creation stops with an actionable error instead of capturing partial output.
+
+Each `.story-manager.zip` archive contains:
+
+- a PostgreSQL custom-format dump;
+- every file under `/app/library`, including EPUBs, covers, and audiobook files;
+- a versioned JSON manifest with sizes and SHA-256 checksums.
+
+The archive is written to a temporary path and checksum-verified before it is atomically published under
+`config/backups`. API keys and authentication settings come from environment variables and are not included. Keep a
+copy of important backups on another disk or host; a backup stored beside a failed disk is not disaster recovery.
+
+Story Manager keeps the newest 10 backups by default and prunes older managed archives after a new backup succeeds.
+Set `STORY_MANAGER_BACKUP_RETENTION_COUNT` to another count, or `0` to keep every backup until it is manually
+deleted. Off-host copies are not affected by this policy.
+
+Set `STORY_MANAGER_BACKUP_DIR` to use a different backup directory. The production image also accepts
+`STORY_MANAGER_PG_DUMP_PATH` and `STORY_MANAGER_PG_RESTORE_PATH` when PostgreSQL client tools are installed outside
+their normal locations.
+
+Local development through `make run-api` automatically runs `pg_dump` inside the `story-manager-db` development
+container when PostgreSQL client tools are not installed on the host. Set `STORY_MANAGER_PG_DUMP_CONTAINER` if that
+container has a different name.
+
+### Verify a downloaded backup
+
+The UI verifies archives when they are created and can queue a fresh verification later. To verify from the
+container without changing application data:
+
+```bash
+docker compose run --rm story-manager \
+  ./run-container.sh verify /app/backups/<filename>.story-manager.zip
+```
+
+### Restore a backup
+
+A restore replaces the current PostgreSQL database and library. It is intentionally unavailable through the web UI
+and refuses to run without the explicit confirmation flag.
+
+From the directory containing `docker-compose.yml`:
+
+```bash
+docker compose stop story-manager
+
+docker compose run --rm story-manager \
+  ./run-container.sh restore \
+  /app/backups/<filename>.story-manager.zip \
+  --confirm-replace
+
+docker compose up -d story-manager
+```
+
+The restore command verifies all paths, sizes, and checksums before changing anything. It stages the restored
+library on the same filesystem, swaps it into place, and invokes `pg_restore` in a single transaction. If the
+database restore fails, the prior library directory is put back. After a successful restore, migrations are applied
+before the recovery container exits.
+
+Do not start the normal Story Manager container until the restore command succeeds. A host using an external
+PostgreSQL service should stop every application instance, set `DATABASE_URL` for the recovery container, and run
+the Python command directly if its Compose topology differs.
 
 ## Admin Authentication
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -544,6 +544,67 @@
   gap: 0.5rem;
 }
 
+.backup-restore-warning {
+  display: grid;
+  gap: 0.25rem;
+  margin: 1rem 0;
+  padding: 0.75rem;
+  border: 1px solid var(--warning, #d97706);
+  border-radius: var(--radius);
+  background: color-mix(in srgb, var(--warning, #d97706) 10%, transparent);
+}
+
+.backup-restore-details {
+  margin-bottom: 1.25rem;
+}
+
+.backup-restore-details summary {
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.backup-restore-details code {
+  display: block;
+  overflow-x: auto;
+  margin: 0.5rem 0;
+  padding: 0.65rem;
+  border-radius: var(--radius);
+  background: var(--surface-2);
+  white-space: nowrap;
+}
+
+.backup-list {
+  display: grid;
+  gap: 0.65rem;
+  padding: 0;
+  list-style: none;
+}
+
+.backup-list-item {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.backup-list-item p {
+  margin: 0.2rem 0 0;
+}
+
+.backup-status-ok {
+  color: var(--success, #22c55e);
+}
+
+.backup-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
 .btn-text {
   background: none;
   border-color: transparent;
@@ -5259,5 +5320,13 @@ body {
     padding: 0 0 0.65rem;
     border-right: 0;
     border-bottom: 1px solid var(--border-strong);
+  }
+
+  .backup-list-item {
+    flex-direction: column;
+  }
+
+  .backup-actions {
+    justify-content: flex-start;
   }
 }

--- a/frontend/src/api/backups.js
+++ b/frontend/src/api/backups.js
@@ -1,0 +1,27 @@
+import { getJson, sendWithoutBody } from "./client";
+
+export function getBackups() {
+  return getJson("/api/backups", "Failed to load backups");
+}
+
+export function createBackup() {
+  return sendWithoutBody("/api/backups", {
+    fallbackMessage: "Failed to queue backup",
+  });
+}
+
+export function verifyBackup(filename) {
+  return sendWithoutBody(
+    `/api/backups/${encodeURIComponent(filename)}/verify`,
+    {
+      fallbackMessage: "Failed to queue backup verification",
+    },
+  );
+}
+
+export function deleteBackup(filename) {
+  return sendWithoutBody(`/api/backups/${encodeURIComponent(filename)}`, {
+    method: "DELETE",
+    fallbackMessage: "Failed to delete backup",
+  });
+}

--- a/frontend/src/components/ProcessingJobs.jsx
+++ b/frontend/src/components/ProcessingJobs.jsx
@@ -23,6 +23,8 @@ const JOB_LABELS = {
   generate_sentence_audio: "Generate sentence audio",
   generate_chapter_preview: "Generate chapter preview",
   retry_cover: "Re-extract book cover",
+  create_backup: "Create library backup",
+  verify_backup: "Verify library backup",
 };
 
 const QUEUE_OPERATIONS = [

--- a/frontend/src/components/Utilities.jsx
+++ b/frontend/src/components/Utilities.jsx
@@ -15,6 +15,8 @@ import {
   permanentlyDeleteRecycledBook,
   restoreRecycledBook,
 } from "../api/books";
+import { createBackup, deleteBackup, getBackups, verifyBackup } from "../api/backups";
+import { getProcessingJobs } from "../api/processing";
 
 const utilityTabs = [
   { key: "audit", label: "Audit" },
@@ -23,6 +25,7 @@ const utilityTabs = [
   { key: "audiobooks", label: "Audiobooks" },
   { key: "recycle-bin", label: "Recycle Bin" },
   { key: "storage", label: "Storage" },
+  { key: "backups", label: "Backup & Restore" },
   { key: "reader-access", label: "Reader Access" },
 ];
 
@@ -35,7 +38,8 @@ function formatBytes(bytes) {
   if (bytes === 0) return "0 B";
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
 }
 
 async function runCleanup(dryRun) {
@@ -111,6 +115,7 @@ function Utilities({ onBack }) {
   const [detectState, setDetectState] = useState(null); // null | "pending" | { updated, series_detected, error? }
   const [selectedMatchIds, setSelectedMatchIds] = useState({});
   const [permanentDeleteTarget, setPermanentDeleteTarget] = useState(null);
+  const [backupDeleteTarget, setBackupDeleteTarget] = useState(null);
 
   useEffect(() => {
     const onPopState = () => setActiveTab(getRequestedUtilityTab());
@@ -219,6 +224,47 @@ function Utilities({ onBack }) {
     onSuccess: () => {
       setPermanentDeleteTarget(null);
       queryClient.invalidateQueries({ queryKey: ["recycle-bin"] });
+    },
+  });
+
+  const { data: backupJobs = [] } = useQuery({
+    queryKey: ["backup-jobs"],
+    queryFn: () => getProcessingJobs({ limit: 100 }),
+    enabled: activeTab === "backups",
+    select: (jobs) => jobs.filter((job) => ["create_backup", "verify_backup"].includes(job.job_type)),
+    refetchInterval: ({ state }) =>
+      (state.data || []).some((job) => ["queued", "running"].includes(job.status)) ? 3000 : false,
+  });
+  const activeBackupJob = backupJobs.find((job) => ["queued", "running"].includes(job.status));
+  const latestBackupJob = backupJobs[0];
+
+  const { data: backupInventory, isLoading: backupsLoading } = useQuery({
+    queryKey: ["backups"],
+    queryFn: getBackups,
+    enabled: activeTab === "backups",
+    refetchInterval: activeBackupJob ? 3000 : false,
+  });
+  const backups = backupInventory?.backups || [];
+
+  useEffect(() => {
+    if (latestBackupJob?.completed_at) queryClient.invalidateQueries({ queryKey: ["backups"] });
+  }, [latestBackupJob?.completed_at, queryClient]);
+
+  const createBackupMutation = useMutation({
+    mutationFn: createBackup,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["backup-jobs"] }),
+  });
+
+  const verifyBackupMutation = useMutation({
+    mutationFn: verifyBackup,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["backup-jobs"] }),
+  });
+
+  const deleteBackupMutation = useMutation({
+    mutationFn: deleteBackup,
+    onSuccess: () => {
+      setBackupDeleteTarget(null);
+      queryClient.invalidateQueries({ queryKey: ["backups"] });
     },
   });
 
@@ -713,6 +759,109 @@ function Utilities({ onBack }) {
           </section>
         )}
 
+        {activeTab === "backups" && (
+          <section className="settings-section">
+            <h3>Backup & Restore</h3>
+            <p className="hint">
+              Create a portable snapshot of the PostgreSQL catalog and every library file. Story Manager briefly
+              pauses changes, verifies every file checksum, and only then publishes the backup for download.
+            </p>
+            <div className="settings-actions">
+              <button
+                type="button"
+                onClick={() => createBackupMutation.mutate()}
+                disabled={Boolean(activeBackupJob) || createBackupMutation.isPending}
+              >
+                {activeBackupJob?.job_type === "create_backup"
+                  ? activeBackupJob.progress_detail || "Creating backup…"
+                  : "Create backup"}
+              </button>
+            </div>
+
+            {latestBackupJob?.status === "error" && (
+              <p className="error">{latestBackupJob.error || latestBackupJob.progress_detail}</p>
+            )}
+            {activeBackupJob && (
+              <p className="hint" aria-live="polite">{activeBackupJob.progress_detail || "Backup work is running…"}</p>
+            )}
+            {(createBackupMutation.isError || verifyBackupMutation.isError || deleteBackupMutation.isError) && (
+              <p className="error">
+                {(createBackupMutation.error || verifyBackupMutation.error || deleteBackupMutation.error)?.message}
+              </p>
+            )}
+
+            <div className="backup-restore-warning">
+              <strong>Restore is intentionally offline.</strong>
+              <span>
+                Stop Story Manager and use the documented restore command. This prevents a running worker or browser
+                request from changing data during recovery.
+              </span>
+            </div>
+            <details className="backup-restore-details">
+              <summary>Show restore command</summary>
+              <p className="hint">Run this from the directory containing your Docker Compose file:</p>
+              <code>docker compose stop story-manager</code>
+              <code>
+                docker compose run --rm story-manager ./run-container.sh restore /app/backups/&lt;filename&gt; --confirm-replace
+              </code>
+              <p className="hint">Start Story Manager again only after the restore command succeeds.</p>
+            </details>
+
+            <h4>Available backups</h4>
+            {backupInventory && (
+              <p className="hint">
+                {backupInventory.retention_count === 0
+                  ? "Backups are kept until you delete them."
+                  : `The newest ${backupInventory.retention_count} backup${backupInventory.retention_count === 1 ? " is" : "s are"} kept automatically.`}
+              </p>
+            )}
+            {backupsLoading ? (
+              <p className="hint">Loading backups…</p>
+            ) : backups.length === 0 ? (
+              <p className="hint">No backups have been created yet.</p>
+            ) : (
+              <ul className="backup-list">
+                {backups.map((backup) => (
+                  <li className="backup-list-item" key={backup.filename}>
+                    <div>
+                      <strong>{new Date(backup.created_at).toLocaleString()}</strong>
+                      <p className="hint">
+                        {formatBytes(backup.size_bytes)} · {backup.library_file_count} library file
+                        {backup.library_file_count === 1 ? "" : "s"} · {formatBytes(backup.library_size_bytes)} of library data
+                      </p>
+                      <p className={backup.valid_manifest ? "backup-status-ok" : "error"}>
+                        {backup.valid_manifest && backup.verified_at_creation
+                          ? "✓ Checksums verified when created"
+                          : backup.error || "Manifest could not be validated"}
+                      </p>
+                    </div>
+                    <div className="backup-actions">
+                      <a className="btn btn-secondary" href={backup.download_url} download>
+                        Download
+                      </a>
+                      <button
+                        type="button"
+                        onClick={() => verifyBackupMutation.mutate(backup.filename)}
+                        disabled={Boolean(activeBackupJob) || verifyBackupMutation.isPending}
+                      >
+                        Verify now
+                      </button>
+                      <button
+                        type="button"
+                        className="btn-danger"
+                        onClick={() => setBackupDeleteTarget(backup)}
+                        disabled={Boolean(activeBackupJob) || deleteBackupMutation.isPending}
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        )}
+
         {activeTab === "reader-access" && <ReaderKeys />}
       </div>
 
@@ -728,6 +877,19 @@ function Utilities({ onBack }) {
       >
         <p>This removes the database record, EPUBs, cover, audiobook files, and saved revision history.</p>
         <p><strong>This cannot be undone.</strong></p>
+      </ConfirmActionDialog>
+      <ConfirmActionDialog
+        open={Boolean(backupDeleteTarget)}
+        title="Delete this backup?"
+        confirmLabel="Delete backup"
+        busyLabel="Deleting…"
+        danger
+        isPending={deleteBackupMutation.isPending}
+        onCancel={() => setBackupDeleteTarget(null)}
+        onConfirm={() => deleteBackupMutation.mutate(backupDeleteTarget.filename)}
+      >
+        <p>{backupDeleteTarget?.filename}</p>
+        <p><strong>This removes the only copy of this backup from Story Manager and cannot be undone.</strong></p>
       </ConfirmActionDialog>
     </div>
   );

--- a/frontend/src/components/Utilities.test.jsx
+++ b/frontend/src/components/Utilities.test.jsx
@@ -30,6 +30,7 @@ describe("Utilities", () => {
     expect(screen.getByRole("tab", { name: "Audiobooks" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Recycle Bin" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Storage" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Backup & Restore" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Reader Access" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Library Audit" })).toBeInTheDocument();
 
@@ -54,6 +55,55 @@ describe("Utilities", () => {
         "aria-selected",
         "true",
       );
+    });
+  });
+
+  it("creates, downloads, verifies, and deliberately deletes backups", async () => {
+    const filename = "story-manager-20260809T120000Z-abcd1234.story-manager.zip";
+    const backup = {
+      filename,
+      created_at: "2026-08-09T12:00:00Z",
+      size_bytes: 2048,
+      library_file_count: 2,
+      library_size_bytes: 1024,
+      valid_manifest: true,
+      verified_at_creation: true,
+      error: null,
+      download_url: `/api/backups/${filename}/download`,
+    };
+    globalThis.fetch = vi.fn((url, options) => {
+      if (url === "/api/metadata/jobs/latest") return Promise.resolve({ ok: true, json: () => Promise.resolve(null) });
+      if (url === "/api/metadata/inbox") return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+      if (String(url).startsWith("/api/processing/jobs?")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+      }
+      if (url === "/api/backups" && !options) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ retention_count: 10, backups: [backup] }) });
+      }
+      if (url === `/api/backups/${filename}` && options?.method === "DELETE") {
+        return Promise.resolve({ ok: true, status: 204, json: () => Promise.resolve(null) });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ status: "queued" }) });
+    });
+
+    renderWithClient(<Utilities onBack={() => {}} />);
+    fireEvent.click(screen.getByRole("tab", { name: "Backup & Restore" }));
+
+    expect(await screen.findByText("✓ Checksums verified when created")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Download" })).toHaveAttribute("href", backup.download_url);
+
+    fireEvent.click(screen.getByRole("button", { name: "Create backup" }));
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith("/api/backups", { method: "POST" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Verify now" }));
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith(`/api/backups/${filename}/verify`, { method: "POST" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    const dialog = screen.getByRole("dialog");
+    expect(within(dialog).getByText(/cannot be undone/i)).toBeInTheDocument();
+    fireEvent.click(within(dialog).getByRole("button", { name: "Delete backup" }));
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(`/api/backups/${filename}`, { method: "DELETE" });
     });
   });
 

--- a/run-container.sh
+++ b/run-container.sh
@@ -35,14 +35,60 @@ until su postgres -c "$PG_BIN/pg_isready -h localhost" >/dev/null 2>&1; do
 done
 echo "--- PostgreSQL started ---"
 
+APP_PID=""
+cleanup() {
+  echo "--- Shutting down processes ---"
+  if [ -n "$APP_PID" ]; then
+    kill "$APP_PID" 2>/dev/null || true
+  fi
+  su postgres -c "$PG_BIN/pg_ctl -D $PGDATA -m fast stop" >/dev/null 2>&1 || true
+  echo "--- Processes shut down ---"
+}
+trap cleanup EXIT
+
 # Ensure the application database exists
 echo "--- Ensuring database exists ---"
 su postgres -c "$PG_BIN/psql -h localhost -tc \"SELECT 1 FROM pg_database WHERE datname='story_manager'\" | grep -q 1 || $PG_BIN/psql -h localhost -c \"CREATE DATABASE story_manager\"" >/dev/null
 echo "--- Database ensured ---"
 
-# Set DATABASE_URL and run migrations
-echo "--- Running database migrations ---"
+# Set DATABASE_URL before serving or running an offline recovery command.
 export DATABASE_URL="postgresql+psycopg://postgres@localhost:5432/story_manager?client_encoding=utf8"
+MODE="${1:-serve}"
+
+if [ "$MODE" = "verify" ]; then
+  if [ -z "${2:-}" ]; then
+    echo "Usage: ./run-container.sh verify /app/backups/<filename>" >&2
+    exit 2
+  fi
+  PYTHONPATH=/app python -m backend.app.backup_cli verify "$2"
+  exit
+fi
+
+if [ "$MODE" = "restore" ]; then
+  if [ -z "${2:-}" ]; then
+    echo "Usage: ./run-container.sh restore /app/backups/<filename> --confirm-replace" >&2
+    exit 2
+  fi
+  ARCHIVE_PATH="$2"
+  shift 2
+  PYTHONPATH=/app python -m backend.app.backup_cli restore \
+    "$ARCHIVE_PATH" \
+    --library-path /app/library \
+    --database-url "$DATABASE_URL" \
+    "$@"
+  echo "--- Upgrading restored database ---"
+  PYTHONPATH=/app alembic -c backend/alembic.ini upgrade head
+  echo "--- Restore complete ---"
+  exit
+fi
+
+if [ "$MODE" != "serve" ]; then
+  echo "Unknown mode: $MODE (expected serve, verify, or restore)" >&2
+  exit 2
+fi
+
+# Run migrations for the normal application startup path.
+echo "--- Running database migrations ---"
 PYTHONPATH=/app alembic -c backend/alembic.ini upgrade head
 echo "--- Database migrations complete ---"
 
@@ -53,9 +99,6 @@ PYTHONPATH=/app uvicorn backend.app.main:app --host 0.0.0.0 --port 8000 --worker
 APP_PID=$!
 
 echo "--- Application started (PID: $APP_PID) ---"
-
-# Ensure all processes are cleaned up, including PostgreSQL
-trap "echo '--- Shutting down processes ---'; kill $APP_PID; su postgres -c \"$PG_BIN/pg_ctl -D $PGDATA -m fast stop\"; echo '--- Processes shut down ---'" EXIT
 
 wait
 


### PR DESCRIPTION
## What changed

- adds a Backup & Restore section to Library Tools with durable creation and verification jobs
- creates portable PostgreSQL-and-library archives with versioned manifests, SHA-256 checksums, atomic publication, download/delete actions, and configurable retention
- pauses API mutations during snapshots and refuses to overlap a backup with active processing work
- adds a guarded offline verification/restore command with library rollback when PostgreSQL restore fails
- persists backups in a separate Docker Compose volume and documents Docker, Unraid, local-development, and recovery workflows
- marks observability complete and adds backup/disaster recovery as roadmap item 9

## Why

Recoverable edits protect against user mistakes, but not database loss, disk failure, or host migration problems. This gives self-hosted installations a complete backup format plus a tested recovery path without exposing destructive restore through the running web app.

## Validation

- `make test`: 401 backend tests and 73 frontend tests passed
- `make pr-check`: Black, unused-import checks, Flake8, and frontend ESLint passed
- production Docker image built successfully
- disposable production-image drill created a real PostgreSQL/library backup, changed both sources, restored offline, and verified both returned to the backed-up values
