### PR TITLE
Simplify library controls

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1624,26 +1624,6 @@
   );
 }
 
-.library-filters {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-  align-items: end;
-  margin-bottom: 0.6rem;
-}
-.library-filters label {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: 0.5rem;
-  color: var(--text-muted);
-  font-size: 0.75rem;
-}
-.library-filters select {
-  width: auto;
-  min-width: 11rem;
-  min-height: 2.4rem;
-}
 @media (max-width: 720px) {
   .series-header {
     gap: 0.75rem;
@@ -1679,14 +1659,6 @@
     align-items: stretch;
   }
 
-  .library-filters label {
-    width: 100%;
-  }
-
-  .library-filters select {
-    flex: 1;
-  }
-
   .book-row-actions {
     width: 100%;
   }
@@ -1699,28 +1671,6 @@
   .standalone-tag-form input,
   .standalone-tag-form .btn {
     width: 100%;
-  }
-}
-
-@media (max-width: 480px) {
-  .library-view-tabs {
-    display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 0.4rem;
-    overflow: visible;
-  }
-
-  .library-view-tab {
-    min-width: 0;
-    justify-content: center;
-    gap: 0.2rem;
-    padding: 0.5rem 0.3rem;
-    font-size: 0.75rem;
-  }
-
-  .library-view-tab-count {
-    padding: 0.08rem 0.32rem;
-    font-size: 0.72rem;
   }
 }
 
@@ -4415,7 +4365,7 @@ body {
 
 .search-controls {
   gap: 0;
-  margin: 0 0 1.25rem;
+  margin: 1rem 0 1.25rem;
   padding: 0;
   border-top: 1px solid var(--border-strong);
   border-bottom: 1px solid var(--border-strong);
@@ -4438,6 +4388,16 @@ body {
 .sort-controls {
   gap: 0;
   border-left: 1px solid var(--border-strong);
+}
+
+.sort-control-label {
+  padding: 0 0.75rem;
+  color: var(--text-muted);
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 0.68rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  white-space: nowrap;
 }
 
 .sort-controls select {
@@ -4486,70 +4446,50 @@ body {
   background: transparent;
 }
 
-.library-filters {
-  padding: 0.75rem 0;
-  margin: 0;
-  border-top: 1px solid var(--border);
-}
-
-.library-filters label {
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-.library-filters select {
-  min-height: 2.2rem;
-  border: 0;
-  border-bottom: 1px solid var(--border-strong);
-  border-radius: 0;
-  background: transparent;
-  color: var(--text);
-  text-transform: none;
-  letter-spacing: 0;
-}
-
 .library-view-tabs {
-  gap: 0;
-  margin: 0 0 0.75rem;
+  gap: 1.5rem;
+  margin: 0;
   padding: 0;
-  border-top: 1px solid var(--text);
-  border-bottom: 1px solid var(--text);
+  border-bottom: 1px solid var(--border-strong);
 }
 
 .library-view-tab {
   min-width: 0;
-  padding: 0.75rem 1.1rem;
+  margin-bottom: -1px;
+  padding: 0.7rem 0 0.8rem;
   border: 0;
-  border-right: 1px solid var(--border-strong);
+  border-bottom: 2px solid transparent;
   border-radius: 0;
   background: transparent;
   color: var(--text-muted);
-  font-family: Georgia, "Times New Roman", serif;
-}
-
-.library-view-tab:first-child {
-  border-left: 1px solid var(--border-strong);
+  font-family: inherit;
+  font-size: 0.9rem;
+  font-weight: 600;
 }
 
 .library-view-tab:hover:not(:disabled) {
-  border-color: var(--border-strong);
-  background: var(--surface);
+  border-bottom-color: var(--border-strong);
+  background: transparent;
   color: var(--text);
 }
 
 .library-view-tab--active,
 .library-view-tab--active:hover:not(:disabled) {
-  border-color: var(--text);
-  background: var(--text);
-  color: var(--bg);
+  border-bottom-color: var(--accent);
+  background: transparent;
+  color: var(--text);
 }
 
 .library-view-tab-count {
-  border: 1px solid currentColor;
-  border-radius: 50%;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
   background: transparent;
   color: inherit;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 0.72rem;
+  font-weight: 400;
+  opacity: 0.72;
 }
 
 .series-group {
@@ -5305,11 +5245,31 @@ body {
   }
 
   .library-view-tabs {
-    gap: 0;
+    gap: 1.1rem;
   }
 
   .library-view-tab {
-    padding: 0.6rem 0.35rem;
+    flex: 0 0 auto;
+    padding: 0.65rem 0 0.7rem;
+    font-size: 0.82rem;
+  }
+
+  .search-input-wrap,
+  .sort-controls {
+    flex-basis: 100%;
+  }
+
+  .sort-controls {
+    border-top: 1px solid var(--border);
+    border-left: 0;
+  }
+
+  .sort-controls select {
+    flex: 1;
+  }
+
+  .sort-control-label {
+    display: none;
   }
 
   .pipeline-inspector-grid {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,7 +4,7 @@ import "./App.css";
 import { getAuthStatus, logout } from "./api/auth";
 import { getBook } from "./api/books";
 import AdminLogin from "./components/AdminLogin.jsx";
-import BookList from "./components/BookList";
+import BookList, { LibraryViewTabs } from "./components/BookList";
 import BookSettings from "./components/BookSettings";
 import AddBook from "./components/AddBook.jsx";
 import AudiobookSettings from "./components/AudiobookSettings.jsx";
@@ -37,9 +37,6 @@ function App() {
   const [audiobookTab, setAudiobookTab] = useState("sources");
   const [activeTab, setActiveTab] = useState("library");
   const [libraryView, setLibraryView] = useState("series");
-  const [reviewFilter, setReviewFilter] = useState("");
-  const [audiobookFilter, setAudiobookFilter] = useState("");
-  const [genreFilter, setGenreFilter] = useState("");
   const [pendingImportEntries, setPendingImportEntries] = useState([]);
   const [globalDragging, setGlobalDragging] = useState(false);
   const [authStatus, setAuthStatus] = useState(null);
@@ -175,9 +172,6 @@ function App() {
   } = useLibraryCatalog({
     q: debouncedQuery,
     view: libraryView,
-    review: reviewFilter,
-    audiobook: audiobookFilter,
-    genre: genreFilter,
     sortBy,
     sortOrder,
     enabled: Boolean(authStatus?.authenticated),
@@ -354,6 +348,15 @@ function App() {
                 Add to library
               </button>
             </div>
+            <LibraryViewTabs
+              view={libraryView}
+              onChange={handleLibraryViewChange}
+              counts={{
+                series: catalogSummary?.facets?.series ?? 0,
+                standalone: catalogSummary?.facets?.standalone ?? 0,
+                web: catalogSummary?.facets?.web ?? 0,
+              }}
+            />
             <div className="search-controls">
               <div className="search-input-wrap">
                 <svg
@@ -386,6 +389,7 @@ function App() {
                 )}
               </div>
               <div className="sort-controls">
+                <span className="sort-control-label">Sort by</span>
                 <select
                   aria-label="Sort library by"
                   value={sortBy}
@@ -398,9 +402,12 @@ function App() {
                   <option value="audiobook_enabled">Audiobook Enabled</option>
                 </select>
                 <button
+                  type="button"
                   className="sort-order-btn"
                   onClick={handleToggleSortOrder}
-                  aria-label="Toggle sort order"
+                  aria-label={
+                    sortOrder === "asc" ? "Sort descending" : "Sort ascending"
+                  }
                 >
                   {sortOrder === "asc" ? "↑" : "↓"}
                 </button>
@@ -410,17 +417,9 @@ function App() {
             {error && <p className="error">{error.message}</p>}
             <BookList
               books={catalog}
-              facets={catalogSummary?.facets}
               totalCount={catalogSummary?.total_count ?? 0}
               onEdit={handleEdit}
               libraryView={libraryView}
-              onLibraryViewChange={handleLibraryViewChange}
-              reviewFilter={reviewFilter}
-              onReviewFilterChange={setReviewFilter}
-              audiobookFilter={audiobookFilter}
-              onAudiobookFilterChange={setAudiobookFilter}
-              genreFilter={genreFilter}
-              onGenreFilterChange={setGenreFilter}
               sortBy={sortBy}
               sortOrder={sortOrder}
               fetchNextPage={fetchNextPage}

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -558,7 +558,7 @@ describe("App", () => {
     });
   });
 
-  it("shows and filters AI-generated and human audiobook badges", async () => {
+  it("shows AI-generated and human audiobook badges", async () => {
     const mockBooks = [
       {
         id: 31,
@@ -597,20 +597,13 @@ describe("App", () => {
         url ===
           "/api/books/catalog?sort_by=title&sort_order=asc&view=standalone" ||
         url ===
-          "/api/books/catalog?sort_by=title&sort_order=asc&view=standalone&audiobook=available" ||
-        url ===
-          "/api/books/catalog?sort_by=audiobook_enabled&sort_order=desc&view=standalone&audiobook=available"
+          "/api/books/catalog?sort_by=audiobook_enabled&sort_order=desc&view=standalone"
       ) {
         return Promise.resolve({
           ok: true,
           json: () =>
             Promise.resolve(
-              url.includes("audiobook=available")
-                ? mockBooks.filter(
-                    (book) =>
-                      book.audiobook_enabled || book.audiobook_types?.length,
-                  )
-                : mockBooks,
+              mockBooks,
             ),
         });
       }
@@ -632,19 +625,12 @@ describe("App", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Text Only")).toBeInTheDocument();
 
-    fireEvent.change(screen.getByLabelText("Audiobook"), {
-      target: { value: "available" },
-    });
-    expect(await screen.findByText("Audio Ready")).toBeInTheDocument();
-    expect(screen.getByText("Human Audio")).toBeInTheDocument();
-    expect(screen.queryByText("Text Only")).not.toBeInTheDocument();
-
     fireEvent.change(screen.getByLabelText("Sort library by"), {
       target: { value: "audiobook_enabled" },
     });
     await waitFor(() => {
       expect(globalThis.fetch).toHaveBeenCalledWith(
-        "/api/books/catalog?sort_by=audiobook_enabled&sort_order=desc&view=standalone&audiobook=available",
+        "/api/books/catalog?sort_by=audiobook_enabled&sort_order=desc&view=standalone",
       );
     });
   });

--- a/frontend/src/components/BookList.jsx
+++ b/frontend/src/components/BookList.jsx
@@ -7,7 +7,7 @@ import { buildCatalogGroups } from "../lib/catalogGrouping";
 import { BookRow } from "./book-list/BookCards";
 import SeriesSummaryRow from "./book-list/SeriesSummaryRow";
 
-function LibraryViewTabs({ view, onChange, counts }) {
+export function LibraryViewTabs({ view, onChange, counts }) {
   const tabs = [
     { id: "series", label: "Series", count: counts.series },
     { id: "standalone", label: "Standalone", count: counts.standalone },
@@ -54,58 +54,6 @@ function getWebNovelStatus(book) {
     label: `Library updated ${new Date(book.updated_at).toLocaleDateString()}`,
     tone: "muted",
   };
-}
-
-function LibraryFilters({
-  reviewFilter = "",
-  onReviewFilterChange = () => {},
-  audiobookFilter = "",
-  onAudiobookFilterChange = () => {},
-  genreFilter = "",
-  onGenreFilterChange = () => {},
-  genres,
-}) {
-  return (
-    <div className="library-filters" aria-label="Library filters">
-      <label>
-        Review
-        <select
-          value={reviewFilter}
-          onChange={(event) => onReviewFilterChange(event.target.value)}
-        >
-          <option value="">Everything</option>
-          <option value="missing-series">Missing series</option>
-          <option value="refreshing">Refreshing or queued</option>
-          <option value="refresh-error">Refresh needs attention</option>
-        </select>
-      </label>
-      <label>
-        Audiobook
-        <select
-          value={audiobookFilter}
-          onChange={(event) => onAudiobookFilterChange(event.target.value)}
-        >
-          <option value="">All books</option>
-          <option value="available">Available</option>
-          <option value="none">No audiobook</option>
-        </select>
-      </label>
-      <label>
-        Genre
-        <select
-          value={genreFilter}
-          onChange={(event) => onGenreFilterChange(event.target.value)}
-        >
-          <option value="">All genres</option>
-          {genres.map((genre) => (
-            <option key={genre.name} value={genre.name}>
-              {genre.name} ({genre.count})
-            </option>
-          ))}
-        </select>
-      </label>
-    </div>
-  );
 }
 
 function StandaloneTagAction({ book, seriesOptions }) {
@@ -165,17 +113,9 @@ function StandaloneTagAction({ book, seriesOptions }) {
 
 function BookList({
   books = [],
-  facets,
   totalCount = 0,
   onEdit,
-  libraryView: libraryViewProp,
-  onLibraryViewChange,
-  reviewFilter,
-  onReviewFilterChange,
-  audiobookFilter,
-  onAudiobookFilterChange,
-  genreFilter,
-  onGenreFilterChange,
+  libraryView = "series",
   sortBy = "title",
   sortOrder = "asc",
   fetchNextPage,
@@ -183,8 +123,6 @@ function BookList({
   isFetchingNextPage = false,
 }) {
   const sentinelRef = useRef(null);
-  const [internalView, setInternalView] = useState("series");
-  const libraryView = libraryViewProp ?? internalView;
   const [showStandaloneSeriesEdit, setShowStandaloneSeriesEdit] =
     useState(false);
 
@@ -194,31 +132,11 @@ function BookList({
     staleTime: 60_000,
   });
 
-  const handleTabChange = (tab) => {
-    if (onLibraryViewChange) onLibraryViewChange(tab);
-    else setInternalView(tab);
-  };
-
-  const handleReviewFilterChange = (value) => {
-    onReviewFilterChange(value);
-    if (value === "missing-series") {
-      handleTabChange("standalone");
-    } else if (value === "refreshing" || value === "refresh-error") {
-      handleTabChange("web");
-    }
-  };
-
   const { seriesMap, sortedSeries, standaloneBooks, webBooks } =
     useMemo(
       () => buildCatalogGroups(books, sortBy, sortOrder),
       [books, sortBy, sortOrder],
     );
-  const counts = {
-    series: facets?.series ?? 0,
-    standalone: facets?.standalone ?? 0,
-    web: facets?.web ?? 0,
-  };
-
   useEffect(() => {
     const el = sentinelRef.current;
     if (!el || !hasNextPage || isFetchingNextPage) return;
@@ -236,20 +154,6 @@ function BookList({
 
   return (
     <div className="book-list">
-      <LibraryFilters
-        reviewFilter={reviewFilter}
-        onReviewFilterChange={handleReviewFilterChange}
-        audiobookFilter={audiobookFilter}
-        onAudiobookFilterChange={onAudiobookFilterChange}
-        genreFilter={genreFilter}
-        onGenreFilterChange={onGenreFilterChange}
-        genres={facets?.genres ?? []}
-      />
-      <LibraryViewTabs
-        view={libraryView}
-        onChange={handleTabChange}
-        counts={counts}
-      />
       {libraryView === "series" &&
         (sortedSeries.length ? (
           sortedSeries.map((series) => (


### PR DESCRIPTION
## What changed

- moved Series, Standalone, and Web into primary navigation directly below the Library heading
- removed the Review, Audiobook, and Genre filter row and its frontend state plumbing
- retained search and consolidated sorting into one clearly labeled control
- replaced the heavy segmented-tab treatment with a lighter active underline
- stacked search and sort cleanly on narrow screens
- updated the audiobook badge coverage to reflect the simplified controls

## Why

The library toolbar gave primary views and several low-value filters equal visual weight. This made the section feel crowded, obscured the useful Series / Standalone / Web navigation, and exposed controls that were not helping the normal browsing workflow.

## Impact

The library now has a clearer hierarchy and fewer controls competing for attention. Search, sorting, view counts, audiobook badges, genre metadata, and attention status remain available in their appropriate contexts.

## Validation

- `make pr-check`
- `npm test -- --run` — 73 tests passed
- `npm run lint -- --max-warnings=0`
- `npm run build`