### PR TITLE
Improve Libation audiobook matching and review

### DIFF
--- a/backend/app/routers/audiobook.py
+++ b/backend/app/routers/audiobook.py
@@ -6,6 +6,7 @@ import logging
 import re
 import shutil
 from datetime import datetime
+from difflib import get_close_matches
 from pathlib import Path
 from typing import Any, Optional
 from xml.etree import ElementTree as ET
@@ -49,7 +50,7 @@ from ..services.transcription_providers import (
 )
 from ..services.endpoint_pool import configured_endpoints, primary_provider
 from ..services.endpoint_metrics import endpoint_summaries
-from ..services.metadata.scoring import normalize_text
+from ..services.metadata.scoring import normalize_text, title_similarity
 from ..services.tts_providers import (
     TTSRequest,
     design_omnivoice_voice,
@@ -384,6 +385,14 @@ class LibationBackupPreviewRequest(BaseModel):
     source_paths: list[str] = Field(min_length=1, max_length=50_000)
 
 
+class LibationBookOptionResponse(BaseModel):
+    book_id: int
+    book_title: str
+    book_author: Optional[str] = None
+    book_series: Optional[str] = None
+    match_score: Optional[float] = None
+
+
 class LibationBackupMatchResponse(BaseModel):
     source_key: str
     folder_name: str
@@ -397,6 +406,7 @@ class LibationBackupMatchResponse(BaseModel):
     book_author: Optional[str] = None
     existing_edition_id: Optional[int] = None
     detail: Optional[str] = None
+    candidates: list[LibationBookOptionResponse] = Field(default_factory=list)
 
 
 class LibationBackupPreviewResponse(BaseModel):
@@ -406,6 +416,7 @@ class LibationBackupPreviewResponse(BaseModel):
     ambiguous_count: int
     already_imported_count: int
     ignored_file_count: int
+    library_books: list[LibationBookOptionResponse] = Field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
@@ -545,13 +556,32 @@ def _normalized_identifier(value: Any) -> str:
     return re.sub(r"[^0-9a-z]", "", str(value).casefold())
 
 
+def _identifier_match_keys(value: Any) -> set[str]:
+    normalized = _normalized_identifier(value)
+    keys = {normalized} if normalized else set()
+    if len(normalized) == 10 and re.fullmatch(r"\d{9}[\dx]", normalized):
+        digits = [*(int(character) for character in normalized[:9]), 10 if normalized[-1] == "x" else int(normalized[-1])]
+        if sum((10 - index) * digit for index, digit in enumerate(digits)) % 11 == 0:
+            isbn13_base = f"978{normalized[:9]}"
+            check_digit = (
+                10 - sum((1 if index % 2 == 0 else 3) * int(digit) for index, digit in enumerate(isbn13_base)) % 10
+            ) % 10
+            keys.add(f"{isbn13_base}{check_digit}")
+    elif len(normalized) == 13 and normalized.startswith("978") and normalized.isdigit():
+        if sum((1 if index % 2 == 0 else 3) * int(digit) for index, digit in enumerate(normalized)) % 10 == 0:
+            isbn10_base = normalized[3:12]
+            check_value = (-sum((10 - index) * int(digit) for index, digit in enumerate(isbn10_base))) % 11
+            keys.add(f"{isbn10_base}{'x' if check_value == 10 else check_value}")
+    return keys
+
+
 def _book_identifier_values(book: Book) -> set[str]:
     values: set[str] = set()
     for value in (book.metadata_remote_ids or {}).values():
         candidates = value if isinstance(value, list) else [value]
         for candidate in candidates:
-            if isinstance(candidate, (str, int)) and (normalized := _normalized_identifier(candidate)):
-                values.add(normalized)
+            if isinstance(candidate, (str, int)):
+                values.update(_identifier_match_keys(candidate))
     return values
 
 
@@ -560,6 +590,77 @@ def _single_book_match(candidates: list[Book]) -> tuple[Book | None, bool]:
     if len(unique) == 1:
         return next(iter(unique.values())), False
     return None, len(unique) > 1
+
+
+_TRAILING_TITLE_QUALIFIER_RE = re.compile(r"\s*[\[(].*[\])]\s*$")
+_TRAILING_EDITION_RE = re.compile(
+    r"(?:\s*,?\s+)(?:movie\s+tie[ -]in|revised|unabridged|abridged|dramatized)" r"(?:\s+(?:edition|adaptation))$",
+    re.IGNORECASE,
+)
+
+
+def _libation_title_keys(value: str) -> set[str]:
+    """Return conservative aliases for store and EPUB title decorations."""
+    pending = [(value or "").strip()]
+    aliases: set[str] = set()
+    while pending:
+        candidate = pending.pop()
+        normalized = normalize_text(candidate)
+        if not normalized or normalized in aliases:
+            continue
+        aliases.add(normalized)
+
+        without_qualifier = _TRAILING_TITLE_QUALIFIER_RE.sub("", candidate).strip()
+        if without_qualifier and without_qualifier != candidate:
+            pending.append(without_qualifier)
+
+        without_edition = _TRAILING_EDITION_RE.sub("", candidate).strip()
+        if without_edition and without_edition != candidate:
+            pending.append(without_edition)
+
+        # EPUB metadata commonly appends a series, volume, or edition label
+        # after a colon while Libation uses only the work title.
+        if ":" in candidate:
+            pending.append(candidate.split(":", 1)[0].strip())
+
+    for alias in tuple(aliases):
+        words = alias.split()
+        if len(words) > 2 and words[0] in {"a", "an", "the"}:
+            aliases.add(" ".join(words[1:]))
+    return aliases
+
+
+def _book_option(book: Book, *, match_score: float | None = None) -> LibationBookOptionResponse:
+    return LibationBookOptionResponse(
+        book_id=book.id,
+        book_title=book.title or "Untitled book",
+        book_author=book.author,
+        book_series=book.series,
+        match_score=round(match_score, 3) if match_score is not None else None,
+    )
+
+
+def _suggested_libation_books(
+    source_title: str,
+    books_by_title_variant: dict[str, list[Book]],
+    library_title_keys: tuple[str, ...],
+) -> list[LibationBookOptionResponse]:
+    scores_by_book: dict[int, tuple[float, Book]] = {}
+    for source_key in _libation_title_keys(source_title):
+        for library_key in get_close_matches(source_key, library_title_keys, n=10, cutoff=0.6):
+            score = title_similarity(source_key, library_key)
+            for book in books_by_title_variant[library_key]:
+                previous = scores_by_book.get(book.id)
+                if previous is None or score > previous[0]:
+                    scores_by_book[book.id] = (score, book)
+    scored = sorted(
+        scores_by_book.values(),
+        key=lambda item: (-item[0], (item[1].title or "").casefold(), item[1].id),
+    )
+    if not scored or scored[0][0] < 0.6:
+        return []
+    minimum = max(0.6, scored[0][0] - 0.12)
+    return [_book_option(book, match_score=score) for score, book in scored[:3] if score >= minimum]
 
 
 # ---------------------------------------------------------------------------
@@ -577,30 +678,50 @@ async def preview_libation_backup(
 ) -> LibationBackupPreviewResponse:
     """Match a path-only Libation backup manifest before any audio is uploaded."""
     groups, ignored_file_count = libation_backup_groups(request.source_paths)
-    books = list((await db.execute(select(Book).order_by(Book.title, Book.id))).scalars().all())
+    books = list(
+        (await db.execute(select(Book).where(Book.deleted_at.is_(None)).order_by(Book.title, Book.id))).scalars().all()
+    )
     imports = list((await db.execute(select(ImportedAudiobook))).scalars().all())
     imports_by_book_and_id = {
-        (edition.book_id, _normalized_identifier(edition.asin)): edition for edition in imports if edition.asin
+        (edition.book_id, identifier): edition
+        for edition in imports
+        if edition.asin
+        for identifier in _identifier_match_keys(edition.asin)
     }
     books_by_identifier: dict[str, list[Book]] = {}
     books_by_title: dict[str, list[Book]] = {}
+    books_by_title_variant: dict[str, list[Book]] = {}
     for book in books:
         for identifier in _book_identifier_values(book):
             books_by_identifier.setdefault(identifier, []).append(book)
         books_by_title.setdefault(normalize_text(book.title or ""), []).append(book)
+        for title_key in _libation_title_keys(book.title or ""):
+            books_by_title_variant.setdefault(title_key, []).append(book)
+    library_title_keys = tuple(books_by_title_variant)
 
     matches: list[LibationBackupMatchResponse] = []
     for group in groups:
-        normalized_id = _normalized_identifier(group.product_id)
-        identifier_candidates = books_by_identifier.get(normalized_id, [])
+        title_candidates: list[Book] = []
+        variant_candidates: list[Book] = []
+        identifier_keys = _identifier_match_keys(group.product_id)
+        identifier_candidates = [book for identifier in identifier_keys for book in books_by_identifier.get(identifier, [])]
         matched_book, ambiguous = _single_book_match(identifier_candidates)
         match_method = "identifier" if matched_book else None
         if not identifier_candidates:
             title_candidates = books_by_title.get(normalize_text(group.title), [])
             matched_book, ambiguous = _single_book_match(title_candidates)
             match_method = "title" if matched_book else None
+            if not title_candidates:
+                variant_candidates = [
+                    book
+                    for title_key in _libation_title_keys(group.title)
+                    for book in books_by_title_variant.get(title_key, [])
+                ]
+                matched_book, ambiguous = _single_book_match(variant_candidates)
+                match_method = "title_variant" if matched_book else None
 
         if ambiguous:
+            ambiguous_candidates = identifier_candidates or title_candidates or variant_candidates
             matches.append(
                 LibationBackupMatchResponse(
                     source_key=group.source_key,
@@ -610,6 +731,10 @@ async def preview_libation_backup(
                     file_count=len(group.source_paths),
                     status="ambiguous",
                     detail="More than one library book has this identifier or title.",
+                    candidates=[
+                        _book_option(book, match_score=1.0)
+                        for book in {book.id: book for book in ambiguous_candidates}.values()
+                    ],
                 )
             )
             continue
@@ -622,12 +747,24 @@ async def preview_libation_backup(
                     product_id=group.product_id,
                     file_count=len(group.source_paths),
                     status="unmatched",
-                    detail="No library book has the same identifier or title.",
+                    detail="No confident automatic match. Review the suggestions or search the library.",
+                    candidates=_suggested_libation_books(
+                        group.title,
+                        books_by_title_variant,
+                        library_title_keys,
+                    ),
                 )
             )
             continue
 
-        existing = imports_by_book_and_id.get((matched_book.id, normalized_id))
+        existing = next(
+            (
+                imports_by_book_and_id[(matched_book.id, identifier)]
+                for identifier in identifier_keys
+                if (matched_book.id, identifier) in imports_by_book_and_id
+            ),
+            None,
+        )
         status = "already_imported" if existing else "matched"
         matches.append(
             LibationBackupMatchResponse(
@@ -653,6 +790,7 @@ async def preview_libation_backup(
         ambiguous_count=sum(match.status == "ambiguous" for match in matches),
         already_imported_count=sum(match.status == "already_imported" for match in matches),
         ignored_file_count=ignored_file_count,
+        library_books=[_book_option(book) for book in books],
     )
 
 

--- a/backend/tests/test_audiobook_import.py
+++ b/backend/tests/test_audiobook_import.py
@@ -273,7 +273,7 @@ async def test_libation_backup_preview_matches_identifiers_titles_and_skips_exis
             author="Author One",
             immutable_path="library/identifier-immutable.epub",
             current_path="library/identifier.epub",
-            metadata_remote_ids={"isbn_10": "1980085722"},
+            metadata_remote_ids={"isbn_13": "9781980085720"},
         )
         title_book = Book(
             title="Title Match",
@@ -281,13 +281,19 @@ async def test_libation_backup_preview_matches_identifiers_titles_and_skips_exis
             immutable_path="library/title-immutable.epub",
             current_path="library/title.epub",
         )
+        title_variant_book = Book(
+            title="Rhythm of War (The Stormlight Archive)",
+            author="Brandon Sanderson",
+            immutable_path="library/rhythm-immutable.epub",
+            current_path="library/rhythm.epub",
+        )
         existing_book = Book(
             title="Already Here",
             author="Author Three",
             immutable_path="library/existing-immutable.epub",
             current_path="library/existing.epub",
         )
-        db.add_all([identifier_book, title_book, existing_book])
+        db.add_all([identifier_book, title_book, title_variant_book, existing_book])
         await db.flush()
         existing = ImportedAudiobook(
             book_id=existing_book.id,
@@ -304,6 +310,7 @@ async def test_libation_backup_preview_matches_identifiers_titles_and_skips_exis
             "source_paths": [
                 "Backup/Store Name [1980085722]/book.m4b",
                 "Backup/Title Match [B012345678]/book.m4b",
+                "Backup/Rhythm of War [1250759781]/book.m4b",
                 "Backup/Already Here [B111111111]/book.m4b",
                 "Backup/Not In Library [B222222222]/book.m4b",
                 "Backup/Not In Library [B222222222]/cover.jpg",
@@ -313,7 +320,7 @@ async def test_libation_backup_preview_matches_identifiers_titles_and_skips_exis
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["matched_count"] == 2
+    assert payload["matched_count"] == 3
     assert payload["unmatched_count"] == 1
     assert payload["already_imported_count"] == 1
     assert payload["ignored_file_count"] == 1
@@ -321,9 +328,54 @@ async def test_libation_backup_preview_matches_identifiers_titles_and_skips_exis
     assert matches["1980085722"]["match_method"] == "identifier"
     assert matches["1980085722"]["book_title"] == "Different Store Title"
     assert matches["B012345678"]["match_method"] == "title"
+    assert matches["1250759781"]["match_method"] == "title_variant"
+    assert matches["1250759781"]["book_title"] == "Rhythm of War (The Stormlight Archive)"
     assert matches["B111111111"]["status"] == "already_imported"
     assert matches["B111111111"]["existing_edition_id"] is not None
     assert matches["B222222222"]["status"] == "unmatched"
+    assert {book["book_title"] for book in payload["library_books"]} >= {
+        "Different Store Title",
+        "Rhythm of War (The Stormlight Archive)",
+    }
+
+
+@pytest.mark.asyncio
+async def test_libation_backup_preview_requires_review_for_ambiguous_title_variants(
+    app_client,
+    sqlite_sessionmaker,
+):
+    async with sqlite_sessionmaker() as db:
+        db.add_all(
+            [
+                Book(
+                    title="Shared Title (Series One)",
+                    author="Author One",
+                    immutable_path="library/shared-one-immutable.epub",
+                    current_path="library/shared-one.epub",
+                ),
+                Book(
+                    title="Shared Title: Anniversary Edition",
+                    author="Author Two",
+                    immutable_path="library/shared-two-immutable.epub",
+                    current_path="library/shared-two.epub",
+                ),
+            ]
+        )
+        await db.commit()
+
+    response = app_client.post(
+        "/api/audiobook/libation-backup/preview",
+        json={"source_paths": ["Backup/Shared Title [B012345678]/book.m4b"]},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ambiguous_count"] == 1
+    assert payload["matched_count"] == 0
+    assert {candidate["book_author"] for candidate in payload["groups"][0]["candidates"]} == {
+        "Author One",
+        "Author Two",
+    }
 
 
 @pytest.mark.asyncio

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2179,6 +2179,21 @@
   overflow: auto;
 }
 
+.libation-review-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.libation-review-toolbar label {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
 .libation-match {
   display: flex;
   justify-content: space-between;
@@ -2192,6 +2207,43 @@
 
 .libation-match--matched {
   border-color: color-mix(in srgb, var(--success) 35%, var(--border));
+}
+
+.libation-match-copy {
+  display: grid;
+  flex: 1;
+  gap: 0.45rem;
+  min-width: 0;
+}
+
+.libation-book-search {
+  display: grid;
+  gap: 0.3rem;
+  max-width: 44rem;
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.libation-book-search input {
+  width: 100%;
+}
+
+.libation-suggestions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem 0.6rem;
+}
+
+.libation-suggestions .btn-text {
+  padding: 0;
+  font-size: 0.8rem;
+}
+
+.libation-include-match {
+  color: var(--text-muted);
+  font-size: 0.8rem;
 }
 
 .libation-match-status {
@@ -2213,6 +2265,10 @@
 
 @media (max-width: 640px) {
   .libation-match {
+    display: grid;
+  }
+
+  .libation-review-toolbar {
     display: grid;
   }
 }

--- a/frontend/src/components/LibationBackupImport.jsx
+++ b/frontend/src/components/LibationBackupImport.jsx
@@ -69,7 +69,9 @@ function statusLabel(group) {
     case "matched":
       return group.match_method === "identifier"
         ? "Matched by identifier"
-        : "Matched by title";
+        : group.match_method === "title_variant"
+          ? "Matched by title variant"
+          : "Matched by title";
     case "already_imported":
       return "Already imported";
     case "ambiguous":
@@ -77,6 +79,11 @@ function statusLabel(group) {
     default:
       return "No library match";
   }
+}
+
+function bookOptionLabel(book) {
+  if (!book?.book_id) return "";
+  return `${book.book_title}${book.book_author ? ` — ${book.book_author}` : ""} (#${book.book_id})`;
 }
 
 function LibationBackupImport() {
@@ -88,6 +95,8 @@ function LibationBackupImport() {
   const [previewing, setPreviewing] = useState(false);
   const [autoAlign, setAutoAlign] = useState(true);
   const [importState, setImportState] = useState(null);
+  const [review, setReview] = useState({});
+  const [matchFilter, setMatchFilter] = useState("all");
 
   const inspectFiles = async (selectedFiles) => {
     const selected = Array.from(selectedFiles || []);
@@ -100,6 +109,19 @@ function LibationBackupImport() {
     try {
       const result = await previewLibationBackup(selected.map(sourcePath));
       setPreview(result);
+      setReview(
+        Object.fromEntries(
+          (result.groups || []).map((group) => [
+            group.source_key,
+            {
+              bookId: group.book_id || null,
+              included: group.status === "matched",
+              input: group.book_id ? bookOptionLabel(group) : "",
+            },
+          ]),
+        ),
+      );
+      setMatchFilter("all");
     } catch (error) {
       setPreviewError(error.message);
     } finally {
@@ -108,9 +130,15 @@ function LibationBackupImport() {
   };
 
   const importMatches = async () => {
-    const matches = (preview?.groups || []).filter(
-      (group) => group.status === "matched",
-    );
+    const matches = (preview?.groups || [])
+      .filter((group) => {
+        const selection = review[group.source_key];
+        return selection?.included && selection.bookId;
+      })
+      .map((group) => ({
+        ...group,
+        book_id: review[group.source_key].bookId,
+      }));
     const groupedFiles = filesBySourceKey(files);
     const results = [];
     setImportState({ current: 0, total: matches.length, results, done: false });
@@ -148,7 +176,34 @@ function LibationBackupImport() {
     setPreview(null);
     setPreviewError("");
     setImportState(null);
+    setReview({});
+    setMatchFilter("all");
     if (inputRef.current) inputRef.current.value = "";
+  };
+
+  const updateBookMatch = (group, input) => {
+    const option = (preview?.library_books || []).find(
+      (book) => bookOptionLabel(book) === input,
+    );
+    setReview((current) => ({
+      ...current,
+      [group.source_key]: {
+        bookId: option?.book_id || null,
+        included: Boolean(option),
+        input,
+      },
+    }));
+  };
+
+  const chooseCandidate = (group, candidate) => {
+    setReview((current) => ({
+      ...current,
+      [group.source_key]: {
+        bookId: candidate.book_id,
+        included: true,
+        input: bookOptionLabel(candidate),
+      },
+    }));
   };
 
   const queuedCount =
@@ -157,15 +212,39 @@ function LibationBackupImport() {
   const failedCount =
     importState?.results.filter((result) => result.result === "failed")
       .length || 0;
+  const selectedCount = (preview?.groups || []).filter((group) => {
+    const selection = review[group.source_key];
+    return selection?.included && selection.bookId;
+  }).length;
+  const needsReviewCount = (preview?.groups || []).filter((group) => {
+    const selection = review[group.source_key];
+    return (
+      group.status !== "already_imported" &&
+      !(selection?.included && selection.bookId)
+    );
+  }).length;
+  const optionById = new Map(
+    (preview?.library_books || []).map((book) => [book.book_id, book]),
+  );
+  const visibleGroups = (preview?.groups || []).filter((group) => {
+    const selection = review[group.source_key];
+    const isSelected = Boolean(selection?.included && selection.bookId);
+    if (matchFilter === "ready") return isSelected;
+    if (matchFilter === "review") {
+      return group.status !== "already_imported" && !isSelected;
+    }
+    if (matchFilter === "imported") return group.status === "already_imported";
+    return true;
+  });
 
   return (
     <section className="settings-section libation-backup-import">
       <h3>Import a Libation Backup</h3>
       <p className="hint">
         Choose the directory that contains all of your Libation book folders.
-        Story Manager previews identifier and exact-title matches before any
-        audio is transferred, skips books that are not in this library, and
-        queues each matched book separately.
+        Story Manager compares identifiers and title variants before any audio
+        is transferred. Review or change every match, skip anything you do not
+        want, and then queue the selected books together.
       </p>
       <label className="libation-directory-picker">
         Libation backup directory
@@ -189,11 +268,8 @@ function LibationBackupImport() {
       {preview && (
         <>
           <p className="libation-preview-summary" role="status">
-            <strong>{preview.matched_count} ready to import</strong>
-            {` · ${preview.already_imported_count} already imported · ${preview.unmatched_count} unmatched`}
-            {preview.ambiguous_count
-              ? ` · ${preview.ambiguous_count} ambiguous`
-              : ""}
+            <strong>{selectedCount} selected to import</strong>
+            {` · ${needsReviewCount} need review · ${preview.already_imported_count} already imported`}
           </p>
           {preview.ignored_file_count > 0 && (
             <p className="hint">
@@ -203,30 +279,112 @@ function LibationBackupImport() {
               ignored.
             </p>
           )}
-          <div className="libation-match-list">
-            {preview.groups.map((group) => (
-              <div
-                className={`libation-match libation-match--${group.status}`}
-                key={group.source_key}
+          <div className="libation-review-toolbar">
+            <label>
+              Show{" "}
+              <select
+                value={matchFilter}
+                disabled={Boolean(importState)}
+                onChange={(event) => setMatchFilter(event.target.value)}
               >
-                <div>
-                  <strong>{group.source_title}</strong>
-                  <span className="hint"> · {group.product_id}</span>
-                  {group.book_title && (
-                    <p className="hint">
-                      Library: {group.book_title}
-                      {group.book_author ? ` by ${group.book_author}` : ""}
-                    </p>
-                  )}
-                  {!group.book_title && group.detail && (
-                    <p className="hint">{group.detail}</p>
-                  )}
-                </div>
-                <span className="libation-match-status">
-                  {statusLabel(group)}
-                </span>
-              </div>
+                <option value="all">All {preview.groups.length}</option>
+                <option value="review">Needs review {needsReviewCount}</option>
+                <option value="ready">Selected {selectedCount}</option>
+                <option value="imported">
+                  Already imported {preview.already_imported_count}
+                </option>
+              </select>
+            </label>
+            <span className="hint">
+              Title variants include series, volume, and edition suffixes.
+            </span>
+          </div>
+          <datalist id="libation-library-books">
+            {(preview.library_books || []).map((book) => (
+              <option value={bookOptionLabel(book)} key={book.book_id} />
             ))}
+          </datalist>
+          <div className="libation-match-list">
+            {visibleGroups.map((group) => {
+              const selection = review[group.source_key] || {};
+              const selectedBook = optionById.get(selection.bookId);
+              const canImport = group.status !== "already_imported";
+              return (
+                <div
+                  className={`libation-match libation-match--${group.status}`}
+                  key={group.source_key}
+                >
+                  <div className="libation-match-copy">
+                    <div>
+                      <strong>{group.source_title}</strong>
+                      <span className="hint"> · {group.product_id}</span>
+                    </div>
+                    {group.detail && !group.book_title && (
+                      <p className="hint">{group.detail}</p>
+                    )}
+                    {canImport && (
+                      <label className="libation-book-search">
+                        Library match
+                        <input
+                          type="text"
+                          list="libation-library-books"
+                          value={selection.input || ""}
+                          placeholder="Type a title or author…"
+                          disabled={Boolean(importState)}
+                          aria-label={`Library match for ${group.source_title}`}
+                          onChange={(event) =>
+                            updateBookMatch(group, event.target.value)
+                          }
+                        />
+                      </label>
+                    )}
+                    {!selection.bookId && group.candidates?.length > 0 && (
+                      <div className="libation-suggestions">
+                        <span className="hint">Possible matches:</span>
+                        {group.candidates.map((candidate) => (
+                          <button
+                            type="button"
+                            className="btn-text"
+                            key={candidate.book_id}
+                            disabled={Boolean(importState)}
+                            onClick={() => chooseCandidate(group, candidate)}
+                          >
+                            {candidate.book_title}
+                            {candidate.book_author
+                              ? ` by ${candidate.book_author}`
+                              : ""}
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                    {selectedBook && (
+                      <label className="libation-include-match">
+                        <input
+                          type="checkbox"
+                          checked={Boolean(selection.included)}
+                          disabled={Boolean(importState)}
+                          onChange={(event) =>
+                            setReview((current) => ({
+                              ...current,
+                              [group.source_key]: {
+                                ...current[group.source_key],
+                                included: event.target.checked,
+                              },
+                            }))
+                          }
+                        />{" "}
+                        Include this audiobook in the import
+                      </label>
+                    )}
+                  </div>
+                  <span className="libation-match-status">
+                    {selection.bookId && group.status !== "matched"
+                      ? "Match reviewed"
+                      : statusLabel(group)}
+                  </span>
+                </div>
+              );
+            })}
           </div>
           <label>
             <input
@@ -243,14 +401,12 @@ function LibationBackupImport() {
               type="button"
               className="btn-primary"
               disabled={
-                preview.matched_count === 0 ||
-                Boolean(importState) ||
-                previewing
+                selectedCount === 0 || Boolean(importState) || previewing
               }
               onClick={importMatches}
             >
-              Import {preview.matched_count} Matched{" "}
-              {preview.matched_count === 1 ? "Book" : "Books"}
+              Import {selectedCount} Selected{" "}
+              {selectedCount === 1 ? "Book" : "Books"}
             </button>
             <button
               type="button"
@@ -282,8 +438,9 @@ function LibationBackupImport() {
         </div>
       )}
       <p className="hint">
-        Unmatched books are not uploaded. Add their EPUBs to Story Manager and
-        select this backup again later; already imported books will be skipped.
+        Books left unchecked or without a library match are not uploaded. Add
+        missing EPUBs and select this backup again later; already imported books
+        are skipped.
       </p>
     </section>
   );

--- a/frontend/src/components/LibationBackupImport.test.jsx
+++ b/frontend/src/components/LibationBackupImport.test.jsx
@@ -93,10 +93,10 @@ describe("LibationBackupImport", () => {
       target: { files: [matchedM4b, duplicateMp3, unmatchedM4b] },
     });
 
-    expect(await screen.findByText("1 ready to import")).toBeInTheDocument();
+    expect(await screen.findByText("1 selected to import")).toBeInTheDocument();
     expect(screen.getByText("No library match")).toBeInTheDocument();
     fireEvent.click(
-      screen.getByRole("button", { name: "Import 1 Matched Book" }),
+      screen.getByRole("button", { name: "Import 1 Selected Book" }),
     );
 
     await waitFor(() => {
@@ -105,5 +105,80 @@ describe("LibationBackupImport", () => {
       ).toBeInTheDocument();
     });
     expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("lets the user review a suggestion before including an unmatched book", async () => {
+    const audiobook = backupFile(
+      "Rhythm.m4b",
+      "Backup/Rhythm of War [1250759781]/Rhythm.m4b",
+    );
+
+    globalThis.fetch = vi.fn((url) => {
+      if (url === "/api/audiobook/libation-backup/preview") {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              matched_count: 0,
+              unmatched_count: 1,
+              ambiguous_count: 0,
+              already_imported_count: 0,
+              ignored_file_count: 0,
+              library_books: [
+                {
+                  book_id: 9,
+                  book_title: "Rhythm of War (The Stormlight Archive)",
+                  book_author: "Brandon Sanderson",
+                },
+              ],
+              groups: [
+                {
+                  source_key: "Backup/Rhythm of War [1250759781]",
+                  source_title: "Rhythm of War",
+                  product_id: "1250759781",
+                  status: "unmatched",
+                  candidates: [
+                    {
+                      book_id: 9,
+                      book_title: "Rhythm of War (The Stormlight Archive)",
+                      book_author: "Brandon Sanderson",
+                      match_score: 0.98,
+                    },
+                  ],
+                },
+              ],
+            }),
+        });
+      }
+      if (url === "/api/books/9/audiobook/imports") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ id: 20 }),
+        });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+
+    renderWithClient(<LibationBackupImport />);
+    fireEvent.change(screen.getByLabelText("Libation backup directory"), {
+      target: { files: [audiobook] },
+    });
+
+    expect(await screen.findByText("0 selected to import")).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Rhythm of War (The Stormlight Archive) by Brandon Sanderson",
+      }),
+    );
+    expect(screen.getByText("1 selected to import")).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Import 1 Selected Book" }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Queued 1 of 1 matched books."),
+      ).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
## Summary

- match Libation folders using equivalent ISBN-10/ISBN-13 values and conservative title aliases
- recognize common EPUB/store differences such as parenthetical series names, volume suffixes, edition labels, and colon subtitles
- keep ambiguous or fuzzy matches in review instead of automatically attaching them
- add full-library search, suggested matches, include/exclude controls, and review filters to the Libation preview

## Why

The preview previously required either the same stored identifier or an exact normalized title. This caused avoidable misses such as `Rhythm of War [1250759781]` versus `Rhythm of War (The Stormlight Archive)`, while the review screen offered no way to correct misses before uploading.

Against the supplied 214-title Libation list and the current 925-book library, title matching improves from 29 exact matches to 87 unique matches. The live preview reports 85 ready to import, 2 already imported, and 127 remaining for review or absent from the library. Candidate indexing keeps the full preview around 1.1 seconds locally.

## User impact

Users can review every proposed import, accept a suggestion, search any library book, uncheck unwanted matches, and filter the list before starting uploads. Uncertain matches remain opt-in.

## Validation

- `make pr-check`
- `.venv/bin/python3 -m pytest backend/tests/test_audiobook_import.py -q` (11 passed)
- `npm test -- --run src/components/LibationBackupImport.test.jsx` (2 passed)
- full supplied Libation manifest previewed against the local PostgreSQL library
