### PR TITLE
Show existing audio during Libation import review

### DIFF
--- a/backend/app/routers/audiobook.py
+++ b/backend/app/routers/audiobook.py
@@ -385,12 +385,21 @@ class LibationBackupPreviewRequest(BaseModel):
     source_paths: list[str] = Field(min_length=1, max_length=50_000)
 
 
+class LibationExistingAudioResponse(BaseModel):
+    edition_id: int
+    name: str
+    status: str
+    source_type: str
+    product_id: Optional[str] = None
+
+
 class LibationBookOptionResponse(BaseModel):
     book_id: int
     book_title: str
     book_author: Optional[str] = None
     book_series: Optional[str] = None
     match_score: Optional[float] = None
+    existing_audiobooks: list[LibationExistingAudioResponse] = Field(default_factory=list)
 
 
 class LibationBackupMatchResponse(BaseModel):
@@ -407,6 +416,7 @@ class LibationBackupMatchResponse(BaseModel):
     existing_edition_id: Optional[int] = None
     detail: Optional[str] = None
     candidates: list[LibationBookOptionResponse] = Field(default_factory=list)
+    existing_audiobooks: list[LibationExistingAudioResponse] = Field(default_factory=list)
 
 
 class LibationBackupPreviewResponse(BaseModel):
@@ -415,6 +425,7 @@ class LibationBackupPreviewResponse(BaseModel):
     unmatched_count: int
     ambiguous_count: int
     already_imported_count: int
+    existing_audio_match_count: int
     ignored_file_count: int
     library_books: list[LibationBookOptionResponse] = Field(default_factory=list)
 
@@ -630,13 +641,32 @@ def _libation_title_keys(value: str) -> set[str]:
     return aliases
 
 
-def _book_option(book: Book, *, match_score: float | None = None) -> LibationBookOptionResponse:
+def _existing_audio_options(editions: list[ImportedAudiobook]) -> list[LibationExistingAudioResponse]:
+    return [
+        LibationExistingAudioResponse(
+            edition_id=edition.id,
+            name=edition.name,
+            status=edition.status,
+            source_type=edition.source_type,
+            product_id=edition.asin,
+        )
+        for edition in editions
+    ]
+
+
+def _book_option(
+    book: Book,
+    *,
+    match_score: float | None = None,
+    existing_editions: list[ImportedAudiobook] | None = None,
+) -> LibationBookOptionResponse:
     return LibationBookOptionResponse(
         book_id=book.id,
         book_title=book.title or "Untitled book",
         book_author=book.author,
         book_series=book.series,
         match_score=round(match_score, 3) if match_score is not None else None,
+        existing_audiobooks=_existing_audio_options(existing_editions or []),
     )
 
 
@@ -644,6 +674,7 @@ def _suggested_libation_books(
     source_title: str,
     books_by_title_variant: dict[str, list[Book]],
     library_title_keys: tuple[str, ...],
+    imports_by_book: dict[int, list[ImportedAudiobook]],
 ) -> list[LibationBookOptionResponse]:
     scores_by_book: dict[int, tuple[float, Book]] = {}
     for source_key in _libation_title_keys(source_title):
@@ -660,7 +691,15 @@ def _suggested_libation_books(
     if not scored or scored[0][0] < 0.6:
         return []
     minimum = max(0.6, scored[0][0] - 0.12)
-    return [_book_option(book, match_score=score) for score, book in scored[:3] if score >= minimum]
+    return [
+        _book_option(
+            book,
+            match_score=score,
+            existing_editions=imports_by_book.get(book.id, []),
+        )
+        for score, book in scored[:3]
+        if score >= minimum
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -681,7 +720,21 @@ async def preview_libation_backup(
     books = list(
         (await db.execute(select(Book).where(Book.deleted_at.is_(None)).order_by(Book.title, Book.id))).scalars().all()
     )
-    imports = list((await db.execute(select(ImportedAudiobook))).scalars().all())
+    imports = list(
+        (
+            await db.execute(
+                select(ImportedAudiobook).order_by(
+                    ImportedAudiobook.created_at.desc(),
+                    ImportedAudiobook.id.desc(),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    imports_by_book: dict[int, list[ImportedAudiobook]] = {}
+    for edition in imports:
+        imports_by_book.setdefault(edition.book_id, []).append(edition)
     imports_by_book_and_id = {
         (edition.book_id, identifier): edition
         for edition in imports
@@ -732,7 +785,11 @@ async def preview_libation_backup(
                     status="ambiguous",
                     detail="More than one library book has this identifier or title.",
                     candidates=[
-                        _book_option(book, match_score=1.0)
+                        _book_option(
+                            book,
+                            match_score=1.0,
+                            existing_editions=imports_by_book.get(book.id, []),
+                        )
                         for book in {book.id: book for book in ambiguous_candidates}.values()
                     ],
                 )
@@ -752,6 +809,7 @@ async def preview_libation_backup(
                         group.title,
                         books_by_title_variant,
                         library_title_keys,
+                        imports_by_book,
                     ),
                 )
             )
@@ -765,6 +823,7 @@ async def preview_libation_backup(
             ),
             None,
         )
+        existing_editions = imports_by_book.get(matched_book.id, [])
         status = "already_imported" if existing else "matched"
         matches.append(
             LibationBackupMatchResponse(
@@ -780,6 +839,7 @@ async def preview_libation_backup(
                 book_author=matched_book.author,
                 existing_edition_id=existing.id if existing else None,
                 detail=(f"Already attached as {existing.name} ({existing.status})." if existing else None),
+                existing_audiobooks=_existing_audio_options(existing_editions),
             )
         )
 
@@ -789,8 +849,9 @@ async def preview_libation_backup(
         unmatched_count=sum(match.status == "unmatched" for match in matches),
         ambiguous_count=sum(match.status == "ambiguous" for match in matches),
         already_imported_count=sum(match.status == "already_imported" for match in matches),
+        existing_audio_match_count=sum(bool(match.existing_audiobooks) for match in matches),
         ignored_file_count=ignored_file_count,
-        library_books=[_book_option(book) for book in books],
+        library_books=[_book_option(book, existing_editions=imports_by_book.get(book.id, [])) for book in books],
     )
 
 

--- a/backend/tests/test_audiobook_import.py
+++ b/backend/tests/test_audiobook_import.py
@@ -301,7 +301,13 @@ async def test_libation_backup_preview_matches_identifiers_titles_and_skips_exis
             asin="B111111111",
             status="ready",
         )
-        db.add(existing)
+        other_edition = ImportedAudiobook(
+            book_id=title_book.id,
+            name="Uploaded narration",
+            asin="B999999999",
+            status="ready",
+        )
+        db.add_all([existing, other_edition])
         await db.commit()
 
     response = app_client.post(
@@ -323,20 +329,34 @@ async def test_libation_backup_preview_matches_identifiers_titles_and_skips_exis
     assert payload["matched_count"] == 3
     assert payload["unmatched_count"] == 1
     assert payload["already_imported_count"] == 1
+    assert payload["existing_audio_match_count"] == 2
     assert payload["ignored_file_count"] == 1
     matches = {group["product_id"]: group for group in payload["groups"]}
     assert matches["1980085722"]["match_method"] == "identifier"
     assert matches["1980085722"]["book_title"] == "Different Store Title"
     assert matches["B012345678"]["match_method"] == "title"
+    assert matches["B012345678"]["status"] == "matched"
+    assert matches["B012345678"]["existing_audiobooks"] == [
+        {
+            "edition_id": other_edition.id,
+            "name": "Uploaded narration",
+            "status": "ready",
+            "source_type": "upload",
+            "product_id": "B999999999",
+        }
+    ]
     assert matches["1250759781"]["match_method"] == "title_variant"
     assert matches["1250759781"]["book_title"] == "Rhythm of War (The Stormlight Archive)"
     assert matches["B111111111"]["status"] == "already_imported"
     assert matches["B111111111"]["existing_edition_id"] is not None
+    assert matches["B111111111"]["existing_audiobooks"][0]["name"] == "Prior Libation import"
     assert matches["B222222222"]["status"] == "unmatched"
     assert {book["book_title"] for book in payload["library_books"]} >= {
         "Different Store Title",
         "Rhythm of War (The Stormlight Archive)",
     }
+    title_option = next(book for book in payload["library_books"] if book["book_title"] == "Title Match")
+    assert title_option["existing_audiobooks"][0]["name"] == "Uploaded narration"
 
 
 @pytest.mark.asyncio

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2159,6 +2159,11 @@
   border-color: color-mix(in srgb, var(--success) 35%, var(--border));
 }
 
+.libation-match--has-audio {
+  border-color: color-mix(in srgb, var(--warning) 55%, var(--border));
+  background: color-mix(in srgb, var(--warning) 5%, var(--surface));
+}
+
 .libation-match-copy {
   display: grid;
   flex: 1;
@@ -2177,6 +2182,29 @@
 
 .libation-book-search input {
   width: 100%;
+}
+
+.libation-existing-audio {
+  display: grid;
+  gap: 0.3rem;
+  max-width: 44rem;
+  padding: 0.65rem 0.75rem;
+  border-left: 0.25rem solid var(--warning);
+  border-radius: var(--radius);
+  background: color-mix(in srgb, var(--warning) 12%, var(--surface));
+  color: var(--text);
+  font-size: 0.82rem;
+}
+
+.libation-existing-audio ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: var(--text-muted);
+}
+
+.libation-existing-audio a {
+  width: fit-content;
+  font-weight: 600;
 }
 
 .libation-suggestions {

--- a/frontend/src/components/LibationBackupImport.jsx
+++ b/frontend/src/components/LibationBackupImport.jsx
@@ -64,16 +64,17 @@ function filesBySourceKey(files) {
   return groups;
 }
 
-function statusLabel(group) {
+function statusLabel(group, existingAudioCount = 0) {
   switch (group.status) {
     case "matched":
+      if (existingAudioCount) return "Already has audio — skipped";
       return group.match_method === "identifier"
         ? "Matched by identifier"
         : group.match_method === "title_variant"
           ? "Matched by title variant"
           : "Matched by title";
     case "already_imported":
-      return "Already imported";
+      return "Exact edition already imported";
     case "ambiguous":
       return "Needs a unique match";
     default:
@@ -83,7 +84,14 @@ function statusLabel(group) {
 
 function bookOptionLabel(book) {
   if (!book?.book_id) return "";
-  return `${book.book_title}${book.book_author ? ` — ${book.book_author}` : ""} (#${book.book_id})`;
+  const audioLabel = book.existing_audiobooks?.length
+    ? " — AUDIO ALREADY ATTACHED"
+    : "";
+  return `${book.book_title}${book.book_author ? ` — ${book.book_author}` : ""}${audioLabel} (#${book.book_id})`;
+}
+
+function audioStatusLabel(status) {
+  return (status || "unknown").replaceAll("_", " ");
 }
 
 function LibationBackupImport() {
@@ -115,7 +123,9 @@ function LibationBackupImport() {
             group.source_key,
             {
               bookId: group.book_id || null,
-              included: group.status === "matched",
+              included:
+                group.status === "matched" &&
+                !group.existing_audiobooks?.length,
               input: group.book_id ? bookOptionLabel(group) : "",
             },
           ]),
@@ -189,7 +199,7 @@ function LibationBackupImport() {
       ...current,
       [group.source_key]: {
         bookId: option?.book_id || null,
-        included: Boolean(option),
+        included: Boolean(option) && !option.existing_audiobooks?.length,
         input,
       },
     }));
@@ -200,7 +210,7 @@ function LibationBackupImport() {
       ...current,
       [group.source_key]: {
         bookId: candidate.book_id,
-        included: true,
+        included: !candidate.existing_audiobooks?.length,
         input: bookOptionLabel(candidate),
       },
     }));
@@ -212,6 +222,17 @@ function LibationBackupImport() {
   const failedCount =
     importState?.results.filter((result) => result.result === "failed")
       .length || 0;
+  const optionById = new Map(
+    (preview?.library_books || []).map((book) => [book.book_id, book]),
+  );
+  const existingAudioCount = (preview?.groups || []).filter((group) => {
+    const selection = review[group.source_key];
+    if (!selection?.bookId) return false;
+    const selectedBook = optionById.get(selection.bookId);
+    return Boolean(
+      (selectedBook?.existing_audiobooks ?? group.existing_audiobooks)?.length,
+    );
+  }).length;
   const selectedCount = (preview?.groups || []).filter((group) => {
     const selection = review[group.source_key];
     return selection?.included && selection.bookId;
@@ -223,9 +244,6 @@ function LibationBackupImport() {
       !(selection?.included && selection.bookId)
     );
   }).length;
-  const optionById = new Map(
-    (preview?.library_books || []).map((book) => [book.book_id, book]),
-  );
   const visibleGroups = (preview?.groups || []).filter((group) => {
     const selection = review[group.source_key];
     const isSelected = Boolean(selection?.included && selection.bookId);
@@ -233,7 +251,13 @@ function LibationBackupImport() {
     if (matchFilter === "review") {
       return group.status !== "already_imported" && !isSelected;
     }
-    if (matchFilter === "imported") return group.status === "already_imported";
+    if (matchFilter === "audio") {
+      const selectedBook = optionById.get(selection?.bookId);
+      return Boolean(
+        (selectedBook?.existing_audiobooks ?? group.existing_audiobooks)
+          ?.length,
+      );
+    }
     return true;
   });
 
@@ -269,7 +293,10 @@ function LibationBackupImport() {
         <>
           <p className="libation-preview-summary" role="status">
             <strong>{selectedCount} selected to import</strong>
-            {` · ${needsReviewCount} need review · ${preview.already_imported_count} already imported`}
+            {` · ${needsReviewCount} need review · ${existingAudioCount} already have human audio`}
+            {preview.already_imported_count
+              ? ` · ${preview.already_imported_count} exact ${preview.already_imported_count === 1 ? "edition" : "editions"} already imported`
+              : ""}
           </p>
           {preview.ignored_file_count > 0 && (
             <p className="hint">
@@ -290,8 +317,8 @@ function LibationBackupImport() {
                 <option value="all">All {preview.groups.length}</option>
                 <option value="review">Needs review {needsReviewCount}</option>
                 <option value="ready">Selected {selectedCount}</option>
-                <option value="imported">
-                  Already imported {preview.already_imported_count}
+                <option value="audio">
+                  Already has audio {existingAudioCount}
                 </option>
               </select>
             </label>
@@ -309,9 +336,14 @@ function LibationBackupImport() {
               const selection = review[group.source_key] || {};
               const selectedBook = optionById.get(selection.bookId);
               const canImport = group.status !== "already_imported";
+              const existingAudiobooks = selection.bookId
+                ? (selectedBook?.existing_audiobooks ??
+                  group.existing_audiobooks ??
+                  [])
+                : [];
               return (
                 <div
-                  className={`libation-match libation-match--${group.status}`}
+                  className={`libation-match libation-match--${group.status}${existingAudiobooks.length ? " libation-match--has-audio" : ""}`}
                   key={group.source_key}
                 >
                   <div className="libation-match-copy">
@@ -321,6 +353,31 @@ function LibationBackupImport() {
                     </div>
                     {group.detail && !group.book_title && (
                       <p className="hint">{group.detail}</p>
+                    )}
+                    {existingAudiobooks.length > 0 && (
+                      <div className="libation-existing-audio">
+                        <strong>
+                          {group.status === "already_imported"
+                            ? "This exact Libation edition is already attached."
+                            : "This library book already has human audio."}
+                        </strong>
+                        <ul>
+                          {existingAudiobooks.map((edition) => (
+                            <li key={edition.edition_id}>
+                              {edition.name} ·{" "}
+                              {audioStatusLabel(edition.status)}
+                              {edition.product_id
+                                ? ` · ${edition.product_id}`
+                                : ""}
+                            </li>
+                          ))}
+                        </ul>
+                        <a
+                          href={`/books/${selection.bookId}/audiobooks?tab=sources`}
+                        >
+                          Open existing audio
+                        </a>
+                      </div>
                     )}
                     {canImport && (
                       <label className="libation-book-search">
@@ -373,14 +430,18 @@ function LibationBackupImport() {
                             }))
                           }
                         />{" "}
-                        Include this audiobook in the import
+                        {existingAudiobooks.length
+                          ? "Import another audio edition anyway"
+                          : "Include this audiobook in the import"}
                       </label>
                     )}
                   </div>
                   <span className="libation-match-status">
-                    {selection.bookId && group.status !== "matched"
+                    {selection.bookId &&
+                    group.status !== "matched" &&
+                    group.status !== "already_imported"
                       ? "Match reviewed"
-                      : statusLabel(group)}
+                      : statusLabel(group, existingAudiobooks.length)}
                   </span>
                 </div>
               );

--- a/frontend/src/components/LibationBackupImport.test.jsx
+++ b/frontend/src/components/LibationBackupImport.test.jsx
@@ -181,4 +181,81 @@ describe("LibationBackupImport", () => {
       ).toBeInTheDocument();
     });
   });
+
+  it("clearly shows existing human audio and skips another edition by default", async () => {
+    const audiobook = backupFile(
+      "Matched.m4b",
+      "Backup/Matched Book [B012345678]/Matched.m4b",
+    );
+    const existingAudio = {
+      edition_id: 22,
+      name: "Existing Libation audio",
+      status: "ready",
+      source_type: "libation",
+      product_id: "B999999999",
+    };
+
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            matched_count: 1,
+            unmatched_count: 0,
+            ambiguous_count: 0,
+            already_imported_count: 0,
+            existing_audio_match_count: 1,
+            ignored_file_count: 0,
+            library_books: [
+              {
+                book_id: 7,
+                book_title: "Matched Book (Series Name)",
+                book_author: "Writer",
+                existing_audiobooks: [existingAudio],
+              },
+            ],
+            groups: [
+              {
+                source_key: "Backup/Matched Book [B012345678]",
+                source_title: "Matched Book",
+                product_id: "B012345678",
+                status: "matched",
+                match_method: "title_variant",
+                book_id: 7,
+                book_title: "Matched Book (Series Name)",
+                book_author: "Writer",
+                existing_audiobooks: [existingAudio],
+              },
+            ],
+          }),
+      }),
+    );
+
+    renderWithClient(<LibationBackupImport />);
+    fireEvent.change(screen.getByLabelText("Libation backup directory"), {
+      target: { files: [audiobook] },
+    });
+
+    expect(await screen.findByText("0 selected to import")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "1 already have human audio",
+    );
+    expect(
+      screen.getByText("This library book already has human audio."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Existing Libation audio · ready · B999999999"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Already has audio — skipped")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Open existing audio" }),
+    ).toHaveAttribute("href", "/books/7/audiobooks?tab=sources");
+
+    fireEvent.click(
+      screen.getByRole("checkbox", {
+        name: "Import another audio edition anyway",
+      }),
+    );
+    expect(screen.getByText("1 selected to import")).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary

- show every existing human-audio edition for the library book selected during Libation review
- distinguish an exact previously imported Libation product from a different existing edition
- highlight affected rows, include edition status and product ID, and link directly to the book's audio sources
- skip books with existing human audio by default while allowing an explicit “Import another audio edition anyway” override
- add an “Already has audio” summary count and review filter
- mark library search options that already have audio attached

## Why

The original import improvement only labeled a book “already imported” when the existing edition had the same product ID. If the book already had human audio from another Libation product or upload, the row looked like a normal selected match and the duplicate risk was easy to miss.

## Validation

- `make pr-check`
- `.venv/bin/python3 -m pytest backend/tests/test_audiobook_import.py -q` (11 passed)
- `npm test -- --run src/components/LibationBackupImport.test.jsx` (3 passed)
