### PR TITLE
Expose aligned text for human audiobooks

### DIFF
--- a/backend/app/routers/reader.py
+++ b/backend/app/routers/reader.py
@@ -124,7 +124,7 @@ def _reader_book_payload(
     has_human_audiobook: bool = False,
 ) -> dict:
     base_url = str(request.base_url).rstrip("/")
-    generated_audiobook = _reader_audiobook_capability(book, audiobook_chapters or [])
+    audiobook = _reader_audiobook_capability(book, audiobook_chapters or [])
     return {
         "id": book.id,
         "title": book.title,
@@ -139,9 +139,9 @@ def _reader_book_payload(
         "effective_genre_tags": _effective_genre_tags(book, series_user_genre_tags),
         "download_url": f"{base_url}/reader/books/{book.id}/download",
         "cover_url": f"{base_url}/reader/covers/{book.id}" if book.cover_path else None,
-        "audiobook": generated_audiobook,
+        "audiobook": audiobook,
         "audiobook_types": [
-            *(["ai_generated"] if generated_audiobook is not None else []),
+            *(["ai_generated"] if book.audiobook_enabled and audiobook is not None else []),
             *(["human_narrated"] if has_human_audiobook else []),
         ],
     }
@@ -161,9 +161,10 @@ def _reader_audiobook_capability(
     book: models.Book,
     chapters: list[models.AudiobookChapter],
 ) -> dict | None:
-    if not book.audiobook_enabled:
+    has_current_text = _has_current_audiobook_text(book)
+    if not book.audiobook_enabled and not has_current_text:
         return None
-    if not book.audiobook_pipeline_status and not book.audiobook_revision and not chapters:
+    if not has_current_text and not book.audiobook_pipeline_status and not book.audiobook_revision and not chapters:
         return None
     ready_chapters = [
         chapter
@@ -189,6 +190,11 @@ def _reader_audiobook_capability(
         "ready_audio_bytes": ready_bytes,
         "manifest_url": f"/reader/books/{book.id}/audiobook/manifest",
     }
+
+
+def _has_current_audiobook_text(book: models.Book) -> bool:
+    content_version = book.content_version or 1
+    return book.audiobook_text_content_version == content_version and text_reader_path(book) is not None
 
 
 @router.get("/reader/opds")
@@ -416,8 +422,11 @@ async def get_reader_updates(
 
 async def _reader_audiobook_book(book_id: int, db: AsyncSession) -> models.Book:
     book = await crud.get_reader_book(db, book_id)
-    if not book.audiobook_enabled or (not book.audiobook_pipeline_status and not book.audiobook_revision):
-        raise HTTPException(status_code=404, detail="Generated audiobook is not available")
+    has_generated_audiobook = book.audiobook_enabled and (
+        bool(book.audiobook_pipeline_status) or bool(book.audiobook_revision)
+    )
+    if not has_generated_audiobook and not _has_current_audiobook_text(book):
+        raise HTTPException(status_code=404, detail="Synchronized audiobook text is not available")
     return book
 
 

--- a/backend/tests/test_reader_audiobook.py
+++ b/backend/tests/test_reader_audiobook.py
@@ -443,8 +443,12 @@ async def test_human_only_audiobook_exposes_cues_and_downloads_anchored_text(
             current_path=_relative(library, current_path),
             content_version=1,
             audiobook_enabled=False,
+            audiobook_revision=4,
+            audiobook_source_content_version=1,
             audiobook_text_content_version=1,
             audiobook_text_file_path=_relative(library, reader_path),
+            audiobook_text_size_bytes=reader_path.stat().st_size,
+            audiobook_text_sha256=hashlib.sha256(reader_path.read_bytes()).hexdigest(),
         )
         chapter = models.AudiobookChapter(
             id=801,
@@ -509,6 +513,24 @@ async def test_human_only_audiobook_exposes_cues_and_downloads_anchored_text(
 
     key_response = app_client.post("/api/reader-keys", json={"label": "Human Audio Reader"})
     auth = ("reader", key_response.json()["token"])
+    reader_book = app_client.get("/reader/books/841", auth=auth).json()
+    assert reader_book["audiobook_types"] == ["human_narrated"]
+    assert reader_book["audiobook"] == {
+        "status": "processing",
+        "revision": 4,
+        "source_content_version": 1,
+        "text_content_version": 1,
+        "ready_chapter_count": 0,
+        "total_chapter_count": 1,
+        "ready_audio_bytes": 0,
+        "manifest_url": "/reader/books/841/audiobook/manifest",
+    }
+    manifest = app_client.get(reader_book["audiobook"]["manifest_url"], auth=auth)
+    assert manifest.status_code == 200
+    assert manifest.json()["revision"] == 4
+    assert manifest.json()["text"]["content_version"] == 1
+    assert app_client.get(manifest.json()["text"]["url"], auth=auth).content == reader_path.read_bytes()
+
     download = app_client.get("/reader/books/841/download", auth=auth)
     assert download.status_code == 200
     assert download.content == reader_path.read_bytes()


### PR DESCRIPTION
## What changed

- expose the audiobook manifest capability when a human-only audiobook has a current span-anchored EPUB
- continue advertising `ai_generated` only when AI audiobook generation is enabled
- allow reader clients to fetch the synchronized text manifest without enabling synthetic narration
- cover the human-only reader metadata, manifest, and aligned-text download flow

## Why

Story Reader relies on the audiobook capability and manifest to discover and install a Whisper-aligned EPUB. Human audiobook imports disable AI generation, so Story Manager previously returned a null capability even when a current aligned rendition existed. Books downloaded before alignment therefore kept using their original, unanchored EPUB.

The new capability is exposed only when its text content version matches the current book and the rendition exists on disk, preserving the stale-content fallback.

## Validation

- `PYTHONPATH=. uv run pytest backend/tests/test_reader_audiobook.py -q` (5 passed)
- `make pr-check`