### PR TITLE
Improve human audiobook alignment and rebuild tooling

### DIFF
--- a/backend/alembic/versions/0039_logical_audiobook_chapters.py
+++ b/backend/alembic/versions/0039_logical_audiobook_chapters.py
@@ -1,0 +1,61 @@
+"""group physical EPUB sections into logical audiobook chapters
+
+Revision ID: 0039
+Revises: 0038
+Create Date: 2026-08-27 00:00:00
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0039"
+down_revision = "0038"
+branch_labels = None
+depends_on = None
+
+
+def _column_names(conn, table_name: str) -> set[str]:
+    return {column["name"] for column in sa.inspect(conn).get_columns(table_name)}
+
+
+def _index_names(conn, table_name: str) -> set[str]:
+    return {index["name"] for index in sa.inspect(conn).get_indexes(table_name)}
+
+
+def upgrade():
+    conn = op.get_bind()
+    if not sa.inspect(conn).has_table("audiobook_chapters"):
+        return
+
+    columns = _column_names(conn, "audiobook_chapters")
+    if "logical_chapter_key" not in columns:
+        op.add_column("audiobook_chapters", sa.Column("logical_chapter_key", sa.String(), nullable=True))
+    if "logical_part_order" not in columns:
+        op.add_column("audiobook_chapters", sa.Column("logical_part_order", sa.Integer(), nullable=True))
+
+    index_name = "ix_audiobook_chapters_book_logical_key"
+    if index_name not in _index_names(conn, "audiobook_chapters"):
+        op.create_index(
+            index_name,
+            "audiobook_chapters",
+            ["book_id", "logical_chapter_key"],
+            unique=False,
+        )
+
+
+def downgrade():
+    conn = op.get_bind()
+    if not sa.inspect(conn).has_table("audiobook_chapters"):
+        return
+
+    index_name = "ix_audiobook_chapters_book_logical_key"
+    if index_name in _index_names(conn, "audiobook_chapters"):
+        op.drop_index(index_name, table_name="audiobook_chapters")
+
+    columns = _column_names(conn, "audiobook_chapters")
+    if "logical_part_order" in columns:
+        op.drop_column("audiobook_chapters", "logical_part_order")
+    if "logical_chapter_key" in columns:
+        op.drop_column("audiobook_chapters", "logical_chapter_key")

--- a/backend/alembic/versions/0040_human_audiobook_pipeline_version.py
+++ b/backend/alembic/versions/0040_human_audiobook_pipeline_version.py
@@ -1,0 +1,45 @@
+"""track the human audiobook rebuild pipeline version
+
+Revision ID: 0040
+Revises: 0039
+Create Date: 2026-08-27 00:00:00
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0040"
+down_revision = "0039"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    if inspector.has_table("imported_audiobooks"):
+        columns = {column["name"] for column in inspector.get_columns("imported_audiobooks")}
+        if "pipeline_version" not in columns:
+            op.add_column(
+                "imported_audiobooks",
+                sa.Column("pipeline_version", sa.Integer(), server_default="0", nullable=False),
+            )
+    if inspector.has_table("imported_audiobook_tracks"):
+        columns = {column["name"] for column in inspector.get_columns("imported_audiobook_tracks")}
+        if "match_method" not in columns:
+            op.add_column("imported_audiobook_tracks", sa.Column("match_method", sa.String(), nullable=True))
+
+
+def downgrade():
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    if inspector.has_table("imported_audiobook_tracks"):
+        columns = {column["name"] for column in inspector.get_columns("imported_audiobook_tracks")}
+        if "match_method" in columns:
+            op.drop_column("imported_audiobook_tracks", "match_method")
+    if inspector.has_table("imported_audiobooks"):
+        columns = {column["name"] for column in inspector.get_columns("imported_audiobooks")}
+        if "pipeline_version" in columns:
+            op.drop_column("imported_audiobooks", "pipeline_version")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -407,6 +407,7 @@ class AudiobookChapter(Base):
     __tablename__ = "audiobook_chapters"
     __table_args__ = (
         UniqueConstraint("book_id", "stable_chapter_key", name="uq_audiobook_chapter_stable_key"),
+        Index("ix_audiobook_chapters_book_logical_key", "book_id", "logical_chapter_key"),
         _state_check("preview_status", CHAPTER_PREVIEW, "ck_audiobook_chapters_preview_status"),
         _state_check("generation_state", CHAPTER_GENERATION, "ck_audiobook_chapters_generation_state"),
     )
@@ -425,6 +426,10 @@ class AudiobookChapter(Base):
     preview_status = Column(String, nullable=True)
     preview_error = Column(Text, nullable=True)
     stable_chapter_key = Column(String, nullable=True)
+    # Physical EPUB spine items may be fragments of one reader-visible chapter.
+    # Group them without rewriting the user's EPUB or losing per-file anchors.
+    logical_chapter_key = Column(String, nullable=True)
+    logical_part_order = Column(Integer, nullable=True)
     source_href = Column(String, nullable=True)
     source_content_hash = Column(String(64), nullable=True)
     title = Column(String, nullable=True)
@@ -545,6 +550,8 @@ class ImportedAudiobook(Base):
     source_size_bytes = Column(BigInteger, nullable=True)
     derived_revision = Column(Integer, nullable=False, default=0, server_default="0")
     derived_format_version = Column(Integer, nullable=False, default=0, server_default="0")
+    # Version of the complete human-audiobook rebuild pipeline last applied.
+    pipeline_version = Column(Integer, nullable=False, default=0, server_default="0")
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at = Column(DateTime(timezone=True), onupdate=func.now(), nullable=True)
 
@@ -568,6 +575,8 @@ class ImportedAudiobookTrack(Base):
         nullable=True,
         index=True,
     )
+    # ``None`` means legacy/unknown and is preserved conservatively by rebuilds.
+    match_method = Column(String, nullable=True)
     sequence_order = Column(Integer, nullable=False)
     title = Column(String, nullable=False)
     audio_file_path = Column(String, nullable=False)

--- a/backend/app/routers/audiobook.py
+++ b/backend/app/routers/audiobook.py
@@ -20,7 +20,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from .. import crud
 from ..config import LIBRARY_PATH
 from ..database import get_db
-from ..lifecycle import IMPORTED_AUDIOBOOK, ImportedAudiobookStatus, transition_state
+from ..lifecycle import IMPORTED_AUDIOBOOK, AlignmentMethod, ImportedAudiobookStatus, transition_state
 from ..models import (
     AudiobookChapter,
     AudiobookCharacter,
@@ -32,6 +32,7 @@ from ..models import (
 )
 from ..services.audiobook_import import (
     CURRENT_DERIVED_FORMAT_VERSION,
+    CURRENT_HUMAN_AUDIOBOOK_PIPELINE_VERSION,
     IMPORT_EXTENSIONS,
     MAX_AUDIOBOOK_UPLOAD_BYTES,
     asin_from_names,
@@ -374,6 +375,7 @@ class ImportedTrackResponse(BaseModel):
     title: str
     matched_chapter_id: Optional[int]
     matched_chapter_title: Optional[str]
+    match_method: Optional[str]
     source_start_ms: int
     source_end_ms: int
     duration_ms: int
@@ -400,7 +402,9 @@ class ImportedAudiobookResponse(BaseModel):
     source_manifest_sha256: Optional[str]
     derived_revision: int
     derived_format_version: int
+    pipeline_version: int
     needs_upgrade: bool
+    needs_rebuild: bool
     progress_current: int
     progress_total: int
     progress_detail: Optional[str]
@@ -409,6 +413,15 @@ class ImportedAudiobookResponse(BaseModel):
     created_at: datetime
     is_reader_default: bool = False
     tracks: list[ImportedTrackResponse]
+
+
+class HumanAudiobookRebuildPreview(BaseModel):
+    current_pipeline_version: int
+    total_count: int
+    rebuild_count: int
+    realign_count: int
+    up_to_date_count: int
+    unavailable_count: int
 
 
 class ImportedTrackMatchUpdate(BaseModel):
@@ -537,6 +550,14 @@ async def _imported_audiobook_response(
             .group_by(ImportedAudiobookCue.track_id)
         )
         cue_counts = {track_id: count for track_id, count in cue_result.all()}
+    needs_asset_upgrade = (
+        not edition.source_manifest_sha256 or (edition.derived_format_version or 0) < CURRENT_DERIVED_FORMAT_VERSION
+    )
+    needs_rebuild = (
+        needs_asset_upgrade
+        or (edition.pipeline_version or 0) < CURRENT_HUMAN_AUDIOBOOK_PIPELINE_VERSION
+        or bool(edition.alignment_error)
+    )
     return ImportedAudiobookResponse(
         id=edition.id,
         book_id=edition.book_id,
@@ -552,9 +573,9 @@ async def _imported_audiobook_response(
         source_manifest_sha256=edition.source_manifest_sha256,
         derived_revision=edition.derived_revision or 0,
         derived_format_version=edition.derived_format_version or 0,
-        needs_upgrade=(
-            not edition.source_manifest_sha256 or (edition.derived_format_version or 0) < CURRENT_DERIVED_FORMAT_VERSION
-        ),
+        pipeline_version=edition.pipeline_version or 0,
+        needs_upgrade=needs_asset_upgrade,
+        needs_rebuild=needs_rebuild,
         progress_current=edition.progress_current or 0,
         progress_total=edition.progress_total or 0,
         progress_detail=edition.progress_detail,
@@ -573,6 +594,7 @@ async def _imported_audiobook_response(
                     if track.matched_chapter_id is not None and track.matched_chapter_id in chapters
                     else None
                 ),
+                match_method=track.match_method,
                 source_start_ms=track.source_start_ms,
                 source_end_ms=track.source_end_ms,
                 duration_ms=track.duration_ms,
@@ -1088,6 +1110,98 @@ async def upgrade_all_imported_audiobooks(db: AsyncSession = Depends(get_db)) ->
     return {"queued_count": queued, "skipped_count": skipped}
 
 
+def _needs_human_audiobook_rebuild(edition: ImportedAudiobook) -> bool:
+    return bool(
+        not edition.source_manifest_sha256
+        or (edition.derived_format_version or 0) < CURRENT_DERIVED_FORMAT_VERSION
+        or (edition.pipeline_version or 0) < CURRENT_HUMAN_AUDIOBOOK_PIPELINE_VERSION
+        or edition.alignment_error
+    )
+
+
+async def _human_audiobook_rebuild_inventory(
+    db: AsyncSession,
+) -> tuple[list[ImportedAudiobook], dict[int, int]]:
+    result = await db.execute(select(ImportedAudiobook).order_by(ImportedAudiobook.id))
+    editions = list(result.scalars().all())
+    track_result = await db.execute(
+        select(
+            ImportedAudiobookTrack.imported_audiobook_id,
+            func.count(ImportedAudiobookTrack.id),
+        ).group_by(ImportedAudiobookTrack.imported_audiobook_id)
+    )
+    return editions, {edition_id: count for edition_id, count in track_result.all()}
+
+
+@router.get(
+    "/api/audiobook/imports/rebuild-preview",
+    response_model=HumanAudiobookRebuildPreview,
+)
+async def preview_human_audiobook_rebuilds(
+    db: AsyncSession = Depends(get_db),
+) -> HumanAudiobookRebuildPreview:
+    """Summarize editions that need the current human-audiobook pipeline."""
+    editions, track_counts = await _human_audiobook_rebuild_inventory(db)
+    available = [
+        edition
+        for edition in editions
+        if edition.status == ImportedAudiobookStatus.READY.value and track_counts.get(edition.id, 0) > 0
+    ]
+    rebuild = [edition for edition in available if _needs_human_audiobook_rebuild(edition)]
+    return HumanAudiobookRebuildPreview(
+        current_pipeline_version=CURRENT_HUMAN_AUDIOBOOK_PIPELINE_VERSION,
+        total_count=len(editions),
+        rebuild_count=len(rebuild),
+        realign_count=sum(
+            edition.alignment_method in {AlignmentMethod.TRANSCRIBED.value, AlignmentMethod.HYBRID.value}
+            or bool(edition.alignment_error)
+            for edition in rebuild
+        ),
+        up_to_date_count=len(available) - len(rebuild),
+        unavailable_count=len(editions) - len(available),
+    )
+
+
+@router.post("/api/audiobook/imports/rebuild-all")
+async def rebuild_all_human_audiobooks(
+    force: bool = Query(False),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, int]:
+    """Queue ready editions that are behind the current rebuild pipeline."""
+    editions, track_counts = await _human_audiobook_rebuild_inventory(db)
+    queued = 0
+    skipped = 0
+    for edition in editions:
+        available = edition.status == ImportedAudiobookStatus.READY.value and track_counts.get(edition.id, 0) > 0
+        if not available or (not force and not _needs_human_audiobook_rebuild(edition)):
+            skipped += 1
+            continue
+        await queue_processing_job(
+            db=db,
+            job_type="rebuild_imported_audiobook",
+            book_id=edition.book_id,
+            target_type="imported_audiobook",
+            target_id=edition.id,
+            target_content_version=edition.matched_content_version,
+            payload={
+                "pipeline_version": CURRENT_HUMAN_AUDIOBOOK_PIPELINE_VERSION,
+                "force": force,
+            },
+            dedupe_key=(
+                f"rebuild_imported_audiobook:imported_audiobook:{edition.id}:" f"v{CURRENT_HUMAN_AUDIOBOOK_PIPELINE_VERSION}"
+            ),
+            progress_detail=f"Queued human-audiobook pipeline v{CURRENT_HUMAN_AUDIOBOOK_PIPELINE_VERSION}",
+        )
+        edition.progress_detail = "Human audiobook rebuild queued"
+        queued += 1
+    await db.commit()
+    return {
+        "queued_count": queued,
+        "skipped_count": skipped,
+        "pipeline_version": CURRENT_HUMAN_AUDIOBOOK_PIPELINE_VERSION,
+    }
+
+
 @router.post(
     "/api/imported-audiobooks/{edition_id}/align",
     response_model=ImportedAudiobookResponse,
@@ -1217,20 +1331,22 @@ async def get_imported_track_cues(
     db: AsyncSession = Depends(get_db),
 ) -> list[ImportedCueResponse]:
     edition, track = await _get_imported_track_or_404(edition_id, track_id, db)
-    reading_blocks: dict[str, ReadingBlock] = {}
-    if track.matched_chapter_id is not None:
-        chapter = await db.get(AudiobookChapter, track.matched_chapter_id)
-        # Imported narration is independent of the opt-in AI generation
-        # pipeline. Human-only books still need their synchronized text cues.
-        book = await _get_book_or_404(edition.book_id, db)
-        if chapter is not None:
-            reading_blocks = chapter_reading_blocks(book, chapter)
+    # Imported narration is independent of the opt-in AI generation pipeline.
+    # Human-only books still need synchronized text and block metadata.
+    book = await _get_book_or_404(edition.book_id, db)
     result = await db.execute(
         select(ImportedAudiobookCue, AudiobookSentence)
         .join(AudiobookSentence, AudiobookSentence.id == ImportedAudiobookCue.sentence_id)
         .where(ImportedAudiobookCue.track_id == track.id)
         .order_by(ImportedAudiobookCue.sequence_order)
     )
+    rows = result.all()
+    chapter_ids = {sentence.chapter_id for _cue, sentence in rows}
+    chapters = {}
+    if chapter_ids:
+        chapter_result = await db.execute(select(AudiobookChapter).where(AudiobookChapter.id.in_(chapter_ids)))
+        chapters = {chapter.id: chapter for chapter in chapter_result.scalars().all()}
+    reading_blocks = {chapter_id: chapter_reading_blocks(book, chapter) for chapter_id, chapter in chapters.items()}
     return [
         ImportedCueResponse(
             sentence_id=sentence.id,
@@ -1240,9 +1356,9 @@ async def get_imported_track_cues(
             clip_end_ms=cue.clip_end_ms,
             confidence=cue.confidence,
             method=cue.method,
-            **_reading_block_fields(reading_blocks, sentence.html_element_id),
+            **_reading_block_fields(reading_blocks.get(sentence.chapter_id, {}), sentence.html_element_id),
         )
-        for cue, sentence in result.all()
+        for cue, sentence in rows
     ]
 
 
@@ -1287,7 +1403,9 @@ async def get_imported_track_smil(
     edition, track = await _get_imported_track_or_404(edition_id, track_id, db)
     if track.matched_chapter_id is None:
         raise HTTPException(status_code=404, detail="Track is not matched to book text")
-    chapter = await db.get(AudiobookChapter, track.matched_chapter_id)
+    primary_chapter = await db.get(AudiobookChapter, track.matched_chapter_id)
+    if primary_chapter is None:
+        raise HTTPException(status_code=404, detail="Matched chapter no longer exists")
     canonical_audio_track_id = await _canonical_audio_track_id(track, db)
     result = await db.execute(
         select(ImportedAudiobookCue, AudiobookSentence)
@@ -1295,11 +1413,16 @@ async def get_imported_track_smil(
         .where(ImportedAudiobookCue.track_id == track.id)
         .order_by(ImportedAudiobookCue.sequence_order)
     )
+    rows = result.all()
+    chapter_ids = {sentence.chapter_id for _cue, sentence in rows}
+    chapter_result = await db.execute(select(AudiobookChapter).where(AudiobookChapter.id.in_(chapter_ids)))
+    chapters = {chapter.id: chapter for chapter in chapter_result.scalars().all()}
     root = ET.Element("smil", {"xmlns": "http://www.w3.org/ns/SMIL", "version": "3.0"})
     body = ET.SubElement(root, "body")
     seq = ET.SubElement(body, "seq")
-    chapter_text_href = chapter.content_file_name.replace("\\", "/").rsplit("/", 1)[-1]
-    for cue, sentence in result.all():
+    for cue, sentence in rows:
+        sentence_chapter = chapters.get(sentence.chapter_id, primary_chapter)
+        chapter_text_href = sentence_chapter.content_file_name.replace("\\", "/").rsplit("/", 1)[-1]
         par = ET.SubElement(seq, "par")
         ET.SubElement(
             par,

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -372,6 +372,8 @@ PROCESSING_JOB_TYPES = Literal[
     "refresh_all",
     "audiobook_pipeline",
     "import_audiobook",
+    "upgrade_imported_audiobook",
+    "rebuild_imported_audiobook",
     "rematch_imported_audiobook",
     "align_imported_audiobook",
     "metadata_sync",

--- a/backend/app/services/audiobook_alignment.py
+++ b/backend/app/services/audiobook_alignment.py
@@ -26,12 +26,13 @@ from ..lifecycle import (
     transition_state,
 )
 from ..models import (
+    AudiobookChapter,
     AudiobookSentence,
     ImportedAudiobook,
     ImportedAudiobookCue,
     ImportedAudiobookTrack,
 )
-from .audiobook_import import imported_audiobook_dir, relative_library_path
+from .audiobook_import import imported_audiobook_dir, relative_library_path, sentences_for_logical_chapter
 from .endpoint_pool import configured_endpoints
 from .transcription_providers import (
     TranscriptResult,
@@ -85,6 +86,10 @@ class AlignmentResult:
     score: float
     matched_token_count: int
     canonical_token_count: int
+    matched_transcript_token_count: int
+    transcript_token_count: int
+    first_matched_ms: int | None
+    last_matched_ms: int | None
 
 
 @dataclass(frozen=True)
@@ -314,12 +319,37 @@ def align_transcript_to_sentences(
     score = sum(
         len(indices) * confidence for indices, confidence in zip(sentence_token_indices, confidences, strict=True)
     ) / max(1, len(canonical))
+    matched_transcript_indices = sorted({transcript_index for transcript_index, _similarity in matches.values()})
+    matched_word_indices = [transcript[index].word_index for index in matched_transcript_indices]
     return AlignmentResult(
         cues=cues,
         score=score,
         matched_token_count=len(matches),
         canonical_token_count=len(canonical),
+        matched_transcript_token_count=len(matched_transcript_indices),
+        transcript_token_count=len(transcript),
+        first_matched_ms=(transcript_words[matched_word_indices[0]].start_ms if matched_word_indices else None),
+        last_matched_ms=(transcript_words[matched_word_indices[-1]].end_ms if matched_word_indices else None),
     )
+
+
+def _transcript_coverage(result: AlignmentResult) -> float:
+    return result.matched_transcript_token_count / max(1, result.transcript_token_count)
+
+
+def _continuation_improves_alignment(
+    current: AlignmentResult,
+    candidate: AlignmentResult,
+    duration_ms: int,
+) -> bool:
+    """Accept more canonical text only when it explains a material transcript tail."""
+    if current.transcript_token_count < 20 or _transcript_coverage(current) >= 0.75:
+        return False
+    coverage_gain = _transcript_coverage(candidate) - _transcript_coverage(current)
+    current_tail = current.last_matched_ms or 0
+    candidate_tail = candidate.last_matched_ms or 0
+    tail_gain = (candidate_tail - current_tail) / max(1, duration_ms)
+    return candidate.score >= 0.35 and (coverage_gain >= 0.08 or tail_gain >= 0.10)
 
 
 def _resolve_library_path(relative_path: str | None) -> Path | None:
@@ -465,12 +495,65 @@ def _transcription_cache_config(settings) -> tuple[str, str | None, str | None, 
 
 
 async def _sentences_for_track(track: ImportedAudiobookTrack, db: AsyncSession) -> list[AudiobookSentence]:
-    result = await db.execute(
-        select(AudiobookSentence)
-        .where(AudiobookSentence.chapter_id == track.matched_chapter_id)
-        .order_by(AudiobookSentence.sequence_order)
+    if track.matched_chapter_id is None:
+        return []
+    return await sentences_for_logical_chapter(track.matched_chapter_id, db)
+
+
+async def _continuation_sentence_batches(
+    track: ImportedAudiobookTrack,
+    next_track: ImportedAudiobookTrack | None,
+    db: AsyncSession,
+) -> list[list[AudiobookSentence]]:
+    """Return intervening logical groups before the next matched audio track."""
+    if track.matched_chapter_id is None or next_track is None or next_track.matched_chapter_id is None:
+        return []
+    primary = await db.get(AudiobookChapter, track.matched_chapter_id)
+    boundary = await db.get(AudiobookChapter, next_track.matched_chapter_id)
+    if (
+        primary is None
+        or boundary is None
+        or primary.book_id != boundary.book_id
+        or primary.spine_order is None
+        or boundary.spine_order is None
+        or boundary.spine_order <= primary.spine_order
+    ):
+        return []
+
+    current_group_filter = [AudiobookChapter.id == primary.id]
+    if primary.logical_chapter_key:
+        current_group_filter = [
+            AudiobookChapter.book_id == primary.book_id,
+            AudiobookChapter.logical_chapter_key == primary.logical_chapter_key,
+        ]
+    current_end = await db.scalar(
+        select(AudiobookChapter.spine_order)
+        .where(*current_group_filter)
+        .order_by(AudiobookChapter.spine_order.desc())
+        .limit(1)
     )
-    return list(result.scalars().all())
+    if current_end is None:
+        return []
+    result = await db.execute(
+        select(AudiobookChapter)
+        .where(
+            AudiobookChapter.book_id == primary.book_id,
+            AudiobookChapter.spine_order > current_end,
+            AudiobookChapter.spine_order < boundary.spine_order,
+        )
+        .order_by(AudiobookChapter.spine_order)
+    )
+    batches = []
+    seen_groups: set[str] = set()
+    for chapter in result.scalars().all():
+        group_key = chapter.logical_chapter_key or f"chapter-{chapter.id}"
+        if group_key in seen_groups:
+            continue
+        seen_groups.add(group_key)
+        sentences = await sentences_for_logical_chapter(chapter.id, db)
+        if sentences:
+            batches.append(sentences)
+    return batches
 
 
 async def process_alignment(edition_id: int, db: AsyncSession) -> None:
@@ -557,6 +640,19 @@ async def process_alignment(edition_id: int, db: AsyncSession) -> None:
                 duration_ms=track.duration_ms,
                 source_start_ms=track.source_start_ms,
             )
+            next_track = tracks[index] if index < len(tracks) else None
+            for continuation in await _continuation_sentence_batches(track, next_track, db):
+                candidate_sentences = [*sentences, *continuation]
+                candidate = align_transcript_to_sentences(
+                    [(sentence.id, sentence.original_text) for sentence in candidate_sentences],
+                    transcript.words,
+                    duration_ms=track.duration_ms,
+                    source_start_ms=track.source_start_ms,
+                )
+                if not _continuation_improves_alignment(alignment, candidate, track.duration_ms):
+                    break
+                sentences = candidate_sentences
+                alignment = candidate
             await db.execute(delete(ImportedAudiobookCue).where(ImportedAudiobookCue.track_id == track.id))
             db.add_all(
                 [

--- a/backend/app/services/audiobook_import.py
+++ b/backend/app/services/audiobook_import.py
@@ -43,6 +43,9 @@ logger = logging.getLogger(__name__)
 AUDIO_EXTENSIONS = {".aac", ".flac", ".m4a", ".m4b", ".mp3", ".mp4", ".ogg", ".opus", ".wav"}
 IMPORT_EXTENSIONS = AUDIO_EXTENSIONS | {".cue", ".zip"}
 CURRENT_DERIVED_FORMAT_VERSION = 1
+# Increment when an imported human audiobook must be rebuilt to benefit from
+# changes to text ingestion, chapter matching, cue generation, or alignment.
+CURRENT_HUMAN_AUDIOBOOK_PIPELINE_VERSION = 1
 SOURCE_MANIFEST_FORMAT = "story-manager-audiobook-source"
 SOURCE_MANIFEST_VERSION = 1
 MAX_AUDIOBOOK_UPLOAD_BYTES = 8 * 1024 * 1024 * 1024
@@ -82,6 +85,14 @@ class TrackSpec:
     @property
     def immutable_end_ms(self) -> int:
         return self.end_ms if self.source_end_ms is None else self.source_end_ms
+
+
+@dataclass(frozen=True)
+class HumanAudiobookRebuildResult:
+    matched_track_count: int
+    track_count: int
+    realign: bool
+    derived_revision: int
 
 
 def _chapter_file_suffix(source: Path) -> str:
@@ -367,6 +378,97 @@ async def upgrade_imported_audiobook(edition_id: int, db: AsyncSession) -> int:
     await db.commit()
     cleanup_old_derived_revisions(edition_dir, revision)
     return revision
+
+
+async def rebuild_imported_audiobook(
+    edition_id: int,
+    db: AsyncSession,
+    *,
+    force_assets: bool = False,
+) -> HumanAudiobookRebuildResult:
+    """Bring one human audiobook forward using the current complete pipeline."""
+    edition = await db.get(ImportedAudiobook, edition_id)
+    if edition is None:
+        raise ValueError("Imported audiobook no longer exists.")
+    book = await db.get(Book, edition.book_id)
+    if book is None:
+        raise ValueError("The selected library book no longer exists.")
+    if edition.status != ImportedAudiobookStatus.READY.value:
+        raise ValueError(f"Audiobook is {edition.status}, not ready to rebuild.")
+
+    previous_alignment_method = edition.alignment_method
+    needs_asset_upgrade = (
+        force_assets
+        or not edition.source_manifest_sha256
+        or (edition.derived_format_version or 0) < CURRENT_DERIVED_FORMAT_VERSION
+    )
+    if needs_asset_upgrade:
+        await upgrade_imported_audiobook(edition.id, db)
+        await db.refresh(edition)
+
+    result = await db.execute(
+        select(ImportedAudiobookTrack)
+        .where(ImportedAudiobookTrack.imported_audiobook_id == edition.id)
+        .order_by(ImportedAudiobookTrack.sequence_order)
+    )
+    tracks = list(result.scalars().all())
+    if not tracks:
+        raise ValueError("Imported audiobook has no tracks to rebuild.")
+    should_realign = (
+        previous_alignment_method in {AlignmentMethod.TRANSCRIBED.value, AlignmentMethod.HYBRID.value}
+        or bool(edition.alignment_error)
+        or any(track.transcript_file_path for track in tracks)
+    )
+
+    edition.progress_current = 0
+    edition.progress_total = len(tracks)
+    edition.progress_detail = "Preparing current book text"
+    await db.commit()
+    chapters = await ensure_span_anchored_text(book, db)
+    chapters_by_id = {chapter.id: chapter for chapter in chapters}
+
+    matched_count = 0
+    for index, track in enumerate(tracks, start=1):
+        # Re-run automatic matching while preserving manual and legacy/unknown
+        # corrections whose chapter still exists.
+        if track.match_method == "automatic" or track.matched_chapter_id not in chapters_by_id:
+            spec = TrackSpec(
+                sequence_order=track.sequence_order,
+                title=track.title,
+                audio_path=(LIBRARY_PATH.parent / track.audio_file_path).resolve(),
+                start_ms=track.source_start_ms,
+                end_ms=track.source_end_ms,
+                media_type=track.media_type,
+            )
+            matched = _chapter_match(spec, chapters)
+            track.matched_chapter_id = matched.id if matched else None
+            track.match_method = "automatic"
+        track.alignment_score = None
+        await rebuild_estimated_cues(track, db)
+        matched_count += int(track.matched_chapter_id is not None)
+        edition.progress_current = index
+        edition.progress_detail = f"Rebuilt track {index} of {len(tracks)}"
+        await db.commit()
+
+    transition_state(
+        edition,
+        "alignment_method",
+        ALIGNMENT_METHOD,
+        AlignmentMethod.ESTIMATED,
+        context=f"imported audiobook {edition.id}",
+    )
+    edition.pipeline_version = CURRENT_HUMAN_AUDIOBOOK_PIPELINE_VERSION
+    edition.matched_content_version = book.content_version or 1
+    edition.progress_detail = f"Rebuilt with human-audiobook pipeline v{CURRENT_HUMAN_AUDIOBOOK_PIPELINE_VERSION}"
+    edition.error = None
+    edition.alignment_error = None
+    await db.commit()
+    return HumanAudiobookRebuildResult(
+        matched_track_count=matched_count,
+        track_count=len(tracks),
+        realign=should_realign,
+        derived_revision=edition.derived_revision or 0,
+    )
 
 
 def imported_audiobook_dir(book_id: int, edition_id: int) -> Path:
@@ -730,17 +832,41 @@ def _sentence_weight(text: str) -> int:
     return max(1, len(re.sub(r"\s+", "", text))) + 10
 
 
+async def sentences_for_logical_chapter(
+    chapter_id: int,
+    db: AsyncSession,
+) -> list[AudiobookSentence]:
+    """Return sentences from every physical spine item in one logical chapter."""
+    chapter = await db.get(AudiobookChapter, chapter_id)
+    if chapter is None:
+        return []
+    if chapter.logical_chapter_key:
+        chapter_filter = (
+            AudiobookChapter.book_id == chapter.book_id,
+            AudiobookChapter.logical_chapter_key == chapter.logical_chapter_key,
+        )
+    else:
+        # Pre-migration ingestions remain readable until their next rematch.
+        chapter_filter = (AudiobookChapter.id == chapter.id,)
+    result = await db.execute(
+        select(AudiobookSentence)
+        .join(AudiobookChapter, AudiobookChapter.id == AudiobookSentence.chapter_id)
+        .where(*chapter_filter)
+        .order_by(
+            AudiobookChapter.spine_order,
+            AudiobookChapter.chapter_number,
+            AudiobookSentence.sequence_order,
+        )
+    )
+    return list(result.scalars().all())
+
+
 async def rebuild_estimated_cues(track: ImportedAudiobookTrack, db: AsyncSession) -> int:
     await db.execute(delete(ImportedAudiobookCue).where(ImportedAudiobookCue.track_id == track.id))
     if track.matched_chapter_id is None:
         await db.commit()
         return 0
-    result = await db.execute(
-        select(AudiobookSentence)
-        .where(AudiobookSentence.chapter_id == track.matched_chapter_id)
-        .order_by(AudiobookSentence.sequence_order)
-    )
-    sentences = list(result.scalars().all())
+    sentences = await sentences_for_logical_chapter(track.matched_chapter_id, db)
     if not sentences:
         await db.commit()
         return 0
@@ -778,6 +904,7 @@ async def ensure_span_anchored_text(book: Book, db: AsyncSession) -> list[Audiob
         chapters
         and book.audiobook_source_content_version == content_version
         and book.audiobook_text_content_version == content_version
+        and all(chapter.logical_chapter_key is not None and chapter.logical_part_order is not None for chapter in chapters)
     )
     if chapters_are_current:
         return chapters
@@ -850,6 +977,7 @@ async def process_import(edition_id: int, db: AsyncSession) -> None:
             track = ImportedAudiobookTrack(
                 imported_audiobook_id=edition.id,
                 matched_chapter_id=matched.id if matched else None,
+                match_method="automatic",
                 sequence_order=spec.sequence_order,
                 title=spec.title,
                 audio_file_path=relative_library_path(spec.audio_path),
@@ -886,6 +1014,7 @@ async def process_import(edition_id: int, db: AsyncSession) -> None:
         edition.matched_content_version = book.content_version or 1
         edition.derived_revision = revision
         edition.derived_format_version = CURRENT_DERIVED_FORMAT_VERSION
+        edition.pipeline_version = CURRENT_HUMAN_AUDIOBOOK_PIPELINE_VERSION
         edition.progress_current = len(specs)
         edition.progress_total = len(specs)
         edition.progress_detail = f"Ready: {matched_count} of {len(specs)} tracks matched"
@@ -952,6 +1081,7 @@ async def rematch_imported_audiobook(edition_id: int, db: AsyncSession) -> int:
         )
         matched = _chapter_match(spec, chapters)
         track.matched_chapter_id = matched.id if matched else None
+        track.match_method = "automatic"
         track.alignment_score = None
         await db.commit()
         await rebuild_estimated_cues(track, db)
@@ -975,6 +1105,7 @@ async def rematch_imported_audiobook(edition_id: int, db: AsyncSession) -> int:
         context=f"imported audiobook {edition.id}",
     )
     edition.matched_content_version = book.content_version or 1
+    edition.pipeline_version = CURRENT_HUMAN_AUDIOBOOK_PIPELINE_VERSION
     edition.progress_detail = f"Ready: {matched_count} of {len(tracks)} tracks matched"
     edition.error = None
     await db.commit()
@@ -992,6 +1123,7 @@ async def rematch_track(
         if chapter is None or edition is None or chapter.book_id != edition.book_id:
             raise ValueError("Chapter does not belong to this audiobook's book.")
     track.matched_chapter_id = chapter_id
+    track.match_method = "manual"
     track.alignment_score = None
     edition = await db.get(ImportedAudiobook, track.imported_audiobook_id)
     if edition is not None:

--- a/backend/app/services/audiobook_ingestion.py
+++ b/backend/app/services/audiobook_ingestion.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import re
 import shutil
 import tempfile
 from collections import Counter
@@ -37,6 +38,10 @@ logger = logging.getLogger(__name__)
 
 _NLP = None  # lazy-load spaCy model to avoid startup cost
 _SKIP_TEXT_ANCESTORS = {"script", "style", "head", "title", "svg", "math", "audio", "video"}
+_INDEPENDENT_CHAPTER_TITLE_RE = re.compile(
+    r"^(?:chapter(?:\s+|$)|prologue\b|epilogue\b|foreword\b|afterword\b|introduction\b|appendix\b|\d+\s*$)",
+    re.IGNORECASE,
+)
 
 
 def _get_nlp():
@@ -244,6 +249,11 @@ def _chapter_title(
     return f"Chapter {chapter_number}"
 
 
+def _looks_like_independent_chapter(title: str) -> bool:
+    """Recognize a non-TOC spine item that should start its own logical chapter."""
+    return bool(_INDEPENDENT_CHAPTER_TITLE_RE.search(" ".join(title.split())))
+
+
 def _sentence_texts(soup: BeautifulSoup) -> list[str]:
     texts: list[str] = []
     quote_state: str | None = None
@@ -322,11 +332,28 @@ async def ingest_epub(book_id: int, db: AsyncSession) -> None:
     changed_chapter_ids: set[int] = set()
     new_chapter_count = 0
     obsolete_paths: set[Path] = set()
+    logical_chapter_key: str | None = None
+    logical_part_order = 0
+    logical_group_started_from_toc = False
 
     for chapter_num, item in enumerate(spine_items, start=1):
         content = item.get_content()
         soup = BeautifulSoup(content, "html.parser")
         href = normalize_resource_href(item.get_name(), chapter_num)
+        chapter_title = _chapter_title(item, soup, chapter_num, toc_titles)
+        starts_toc_chapter = href.casefold() in toc_titles
+        continues_toc_chapter = (
+            logical_chapter_key is not None
+            and logical_group_started_from_toc
+            and not starts_toc_chapter
+            and not _looks_like_independent_chapter(chapter_title)
+        )
+        if continues_toc_chapter:
+            logical_part_order += 1
+        else:
+            logical_chapter_key = stable_chapter_key(href)
+            logical_part_order = 0
+            logical_group_started_from_toc = starts_toc_chapter
         content_hash = _source_content_hash(soup)
         sentence_texts = _sentence_texts(soup)
 
@@ -352,9 +379,11 @@ async def ingest_epub(book_id: int, db: AsyncSession) -> None:
                 chapter_number=chapter_num,
                 content_file_name=href,
                 stable_chapter_key=key,
+                logical_chapter_key=logical_chapter_key,
+                logical_part_order=logical_part_order,
                 source_href=href,
                 source_content_hash=content_hash,
-                title=_chapter_title(item, soup, chapter_num, toc_titles),
+                title=chapter_title,
                 spine_order=chapter_num - 1,
                 generation_state="pending",
                 needs_reassembly=True,
@@ -406,9 +435,11 @@ async def ingest_epub(book_id: int, db: AsyncSession) -> None:
         chapter.chapter_number = chapter_num
         chapter.content_file_name = href
         chapter.stable_chapter_key = key
+        chapter.logical_chapter_key = logical_chapter_key
+        chapter.logical_part_order = logical_part_order
         chapter.source_href = href
         chapter.source_content_hash = content_hash
-        chapter.title = _chapter_title(item, soup, chapter_num, toc_titles)
+        chapter.title = chapter_title
         chapter.spine_order = chapter_num - 1
 
         if not unchanged:

--- a/backend/app/services/processing_queue.py
+++ b/backend/app/services/processing_queue.py
@@ -27,7 +27,12 @@ from ..models import Book, ImportedAudiobook, ImportedAudiobookTrack, Processing
 from ..logging_config import redact_text
 from ..observability_context import correlation_context
 from .audiobook_alignment import process_alignment
-from .audiobook_import import process_import, rematch_imported_audiobook, upgrade_imported_audiobook
+from .audiobook_import import (
+    process_import,
+    rebuild_imported_audiobook,
+    rematch_imported_audiobook,
+    upgrade_imported_audiobook,
+)
 from .audiobook_queue import get_audiobook_queue
 from .audiobook_tts import generate_audio_for_sentence
 from .audiobook_assembly import assemble_chapter_preview
@@ -59,6 +64,7 @@ JOB_POLICIES: dict[str, tuple[str, int]] = {
     "generate_chapter_preview": ("tts", 3),
     "import_audiobook": ("cpu", 3),
     "upgrade_imported_audiobook": ("cpu", 3),
+    "rebuild_imported_audiobook": ("cpu", 3),
     "rematch_imported_audiobook": ("cpu", 3),
     "align_imported_audiobook": ("transcription", 3),
     "create_backup": ("maintenance", 1),
@@ -399,6 +405,35 @@ class ProcessingQueue:
                 lambda: self._imported_audio_progress(target_id),
             )
             return f"Human audiobook chapter assets upgraded to revision {revision}"
+        if job.job_type == "rebuild_imported_audiobook":
+            target_id = _required_target(job)
+
+            async def rebuild_audio():
+                async with SessionLocal() as db:
+                    return await rebuild_imported_audiobook(target_id, db)
+
+            result = await self._run_with_progress_mirror(
+                job.id,
+                rebuild_audio,
+                lambda: self._imported_audio_progress(target_id),
+            )
+            if result.realign:
+                child = await queue_processing_job(
+                    job_type="align_imported_audiobook",
+                    book_id=job.book_id,
+                    target_type="imported_audiobook",
+                    target_id=target_id,
+                    target_content_version=job.target_content_version,
+                    parent_job_id=job.id,
+                    dedupe_key=f"align_imported_audiobook:imported_audiobook:{target_id}",
+                    progress_detail="Queued after human-audiobook rebuild",
+                )
+                await self.enqueue(child.id)
+                return (
+                    f"Human audiobook rebuilt ({result.matched_track_count} of {result.track_count} tracks); "
+                    "timestamp alignment queued"
+                )
+            return f"Human audiobook rebuilt ({result.matched_track_count} of {result.track_count} tracks)"
         if job.job_type == "rematch_imported_audiobook":
             target_id = _required_target(job)
 

--- a/backend/app/services/transcription_providers.py
+++ b/backend/app/services/transcription_providers.py
@@ -52,16 +52,38 @@ def _headers(settings: AudiobookSettings) -> dict[str, str]:
     return headers
 
 
+def _raise_for_status(response: httpx.Response, action: str) -> None:
+    """Preserve the service's actionable error instead of only exposing an HTTP status."""
+    try:
+        response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        try:
+            payload = response.json()
+        except ValueError:
+            payload = None
+        detail = payload.get("detail") if isinstance(payload, dict) else None
+        if detail:
+            raise RuntimeError(f"Transcription service {action} failed: {detail}") from exc
+        raise
+
+
 async def _transcription_service_health_endpoint(settings: AudiobookSettings) -> dict:
     if transcription_provider_name(settings) == "none":
         raise RuntimeError("Configure a transcription provider first.")
     timeout = httpx.Timeout(30.0, connect=10.0)
     async with httpx.AsyncClient(timeout=timeout) as client:
         response = await client.get(f"{_service_root(settings)}/health", headers=_headers(settings))
-        response.raise_for_status()
+        _raise_for_status(response, "health check")
         payload = response.json()
     if payload.get("status") != "ready":
         raise RuntimeError(f"Transcription service is not ready: {payload.get('status', 'unknown')}.")
+    configured_model = settings.transcription_model
+    loaded_model = payload.get("model")
+    if configured_model and loaded_model and configured_model != loaded_model:
+        raise RuntimeError(
+            f"Transcription model mismatch: the service has {loaded_model!r} loaded, "
+            f"but Audio Settings request {configured_model!r}."
+        )
     return payload
 
 
@@ -98,7 +120,7 @@ async def _transcribe_file_endpoint(settings: AudiobookSettings, audio_path: Pat
                 files={"file": (audio_path.name, audio, "audio/flac")},
                 headers=_headers(settings),
             )
-            response.raise_for_status()
+            _raise_for_status(response, "request")
             payload = response.json()
 
     raw_words = payload.get("words")

--- a/backend/tests/test_audiobook_alignment.py
+++ b/backend/tests/test_audiobook_alignment.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import httpx
 import pytest
 from sqlalchemy import select
 
 from backend.app import models
-from backend.app.services import audiobook_alignment, transcription_providers
+from backend.app.services import audiobook_alignment, endpoint_pool, transcription_providers
 from backend.app.services.transcription_providers import TranscriptWord
 
 
@@ -96,6 +97,29 @@ def test_unmatched_sentence_is_interpolated_between_transcribed_anchors():
     assert result.cues[1].clip_end_ms == result.cues[2].clip_begin_ms
 
 
+def test_alignment_detects_and_explains_a_large_unused_transcript_tail():
+    transcript_text = ["1", "The", "body", "continues", "through", "the", "next", "physical", "spine", "file"]
+    transcript_text += ["with", "many", "more", "spoken", "words", "that", "belong", "to", "this", "chapter"]
+    words = _words(transcript_text, first_start=0)
+    duration_ms = words[-1].end_ms
+
+    heading_only = audiobook_alignment.align_transcript_to_sentences(
+        [(1, "1")],
+        words,
+        duration_ms=duration_ms,
+    )
+    expanded = audiobook_alignment.align_transcript_to_sentences(
+        [(1, "1"), (2, " ".join(transcript_text[1:]))],
+        words,
+        duration_ms=duration_ms,
+    )
+
+    assert heading_only.matched_transcript_token_count == 1
+    assert heading_only.transcript_token_count == len(transcript_text)
+    assert expanded.matched_transcript_token_count == len(transcript_text)
+    assert audiobook_alignment._continuation_improves_alignment(heading_only, expanded, duration_ms)
+
+
 class _Response:
     def raise_for_status(self):
         return None
@@ -153,6 +177,126 @@ async def test_whisperx_provider_sends_chapter_clip_and_parses_word_timestamps(t
     assert request["data"] == {"model": "large-v3", "language": "en"}
     assert request["headers"]["Authorization"] == "Bearer local-key"
     assert request["files"]["file"][0] == "chapter.flac"
+
+
+@pytest.mark.asyncio
+async def test_whisperx_provider_surfaces_service_error_detail(tmp_path, monkeypatch):
+    endpoint_pool.reset_cooldowns("transcription")
+
+    class ConflictClient(_Client):
+        async def post(self, url, **kwargs):
+            request = httpx.Request("POST", url)
+            response = httpx.Response(
+                409,
+                request=request,
+                json={"detail": "Service has 'large-v3' loaded, not requested model 'tiny.en'."},
+            )
+            return response
+
+    monkeypatch.setattr(transcription_providers.httpx, "AsyncClient", ConflictClient)
+    clip = tmp_path / "chapter.flac"
+    clip.write_bytes(b"flac-data")
+    settings = models.AudiobookSettings(
+        transcription_provider="whisperx",
+        transcription_base_url="http://whisper:8002",
+        transcription_model="tiny.en",
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Service has 'large-v3' loaded, not requested model 'tiny.en'",
+    ):
+        await transcription_providers.transcribe_file(settings, clip)
+
+
+@pytest.mark.asyncio
+async def test_whisperx_health_rejects_configured_model_mismatch(monkeypatch):
+    endpoint_pool.reset_cooldowns("transcription")
+
+    class HealthResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"status": "ready", "model": "large-v3"}
+
+    class HealthClient(_Client):
+        async def get(self, _url, **_kwargs):
+            return HealthResponse()
+
+    monkeypatch.setattr(transcription_providers.httpx, "AsyncClient", HealthClient)
+    settings = models.AudiobookSettings(
+        transcription_provider="whisperx",
+        transcription_base_url="http://whisper:8002",
+        transcription_model="tiny.en",
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="service has 'large-v3' loaded.*Audio Settings request 'tiny.en'",
+    ):
+        await transcription_providers.transcription_service_health(settings)
+
+
+@pytest.mark.asyncio
+async def test_alignment_selects_sentences_from_logical_chapter_continuations(db):
+    book = models.Book(title="Split Book")
+    db.add(book)
+    await db.flush()
+    heading = models.AudiobookChapter(
+        book_id=book.id,
+        chapter_number=1,
+        title="Chapter 1",
+        logical_chapter_key="logical-1",
+        logical_part_order=0,
+        spine_order=0,
+    )
+    body = models.AudiobookChapter(
+        book_id=book.id,
+        chapter_number=2,
+        title="Phase One",
+        logical_chapter_key="logical-1",
+        logical_part_order=1,
+        spine_order=1,
+    )
+    db.add_all([heading, body])
+    await db.flush()
+    db.add_all(
+        [
+            models.AudiobookSentence(
+                chapter_id=heading.id,
+                html_element_id="heading",
+                sequence_order=0,
+                original_text="1",
+            ),
+            models.AudiobookSentence(
+                chapter_id=body.id,
+                html_element_id="body",
+                sequence_order=0,
+                original_text="The body follows the split heading.",
+            ),
+        ]
+    )
+    edition = models.ImportedAudiobook(book_id=book.id, name="Human", status="ready")
+    db.add(edition)
+    await db.flush()
+    track = models.ImportedAudiobookTrack(
+        imported_audiobook_id=edition.id,
+        matched_chapter_id=heading.id,
+        sequence_order=1,
+        title="Chapter 1",
+        audio_file_path="library/chapter.m4a",
+        media_type="audio/mp4",
+        source_start_ms=0,
+        source_end_ms=10_000,
+        duration_ms=10_000,
+    )
+    db.add(track)
+    await db.commit()
+
+    sentences = await audiobook_alignment._sentences_for_track(track, db)
+
+    assert [sentence.original_text for sentence in sentences] == ["1", "The body follows the split heading."]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_audiobook_import.py
+++ b/backend/tests/test_audiobook_import.py
@@ -41,6 +41,8 @@ async def _seed_book_text(db) -> tuple[Book, AudiobookChapter]:
         title="1",
         content_file_name="text/chapter1.xhtml",
         stable_chapter_key="src-import-test",
+        logical_chapter_key="src-import-test",
+        logical_part_order=0,
         spine_order=0,
     )
     db.add(chapter)
@@ -335,8 +337,139 @@ async def test_manual_track_rematch_rebuilds_cues(db):
         .all()
     )
     assert cue_count == 2
+    assert track.match_method == "manual"
     assert cues[0].clip_begin_ms == 1_000
     assert cues[-1].clip_end_ms == 11_000
+
+
+@pytest.mark.asyncio
+async def test_human_audiobook_rebuild_preserves_valid_match_and_marks_pipeline_current(db):
+    book, chapter = await _seed_book_text(db)
+    edition = ImportedAudiobook(
+        book_id=book.id,
+        name="Existing human edition",
+        status="ready",
+        alignment_method="transcribed",
+        source_manifest_sha256="a" * 64,
+        derived_revision=3,
+        derived_format_version=audiobook_import.CURRENT_DERIVED_FORMAT_VERSION,
+        pipeline_version=0,
+    )
+    db.add(edition)
+    await db.flush()
+    track = ImportedAudiobookTrack(
+        imported_audiobook_id=edition.id,
+        matched_chapter_id=chapter.id,
+        sequence_order=1,
+        title="A manually corrected title",
+        audio_file_path="library/audio.mp3",
+        media_type="audio/mpeg",
+        source_start_ms=0,
+        source_end_ms=10_000,
+        duration_ms=10_000,
+        alignment_score=0.9,
+    )
+    db.add(track)
+    await db.commit()
+
+    result = await audiobook_import.rebuild_imported_audiobook(edition.id, db)
+    cues = list(
+        (
+            await db.execute(
+                select(ImportedAudiobookCue)
+                .where(ImportedAudiobookCue.track_id == track.id)
+                .order_by(ImportedAudiobookCue.sequence_order)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    assert result.matched_track_count == 1
+    assert result.track_count == 1
+    assert result.realign is True
+    assert result.derived_revision == 3
+    assert track.matched_chapter_id == chapter.id
+    assert track.match_method is None
+    assert track.alignment_score is None
+    assert len(cues) == 2
+    assert edition.pipeline_version == audiobook_import.CURRENT_HUMAN_AUDIOBOOK_PIPELINE_VERSION
+    assert edition.alignment_method == "estimated"
+
+
+@pytest.mark.asyncio
+async def test_logical_chapter_cues_span_multiple_epub_files(db):
+    book = Book(title="Split Book", author="Author", content_version=1)
+    db.add(book)
+    await db.flush()
+    heading = AudiobookChapter(
+        book_id=book.id,
+        chapter_number=1,
+        title="Chapter 1",
+        content_file_name="text/chapter-1-heading.xhtml",
+        stable_chapter_key="heading",
+        logical_chapter_key="logical-chapter-1",
+        logical_part_order=0,
+        spine_order=0,
+    )
+    continuation = AudiobookChapter(
+        book_id=book.id,
+        chapter_number=2,
+        title="Phase One",
+        content_file_name="text/chapter-1-body.xhtml",
+        stable_chapter_key="body",
+        logical_chapter_key="logical-chapter-1",
+        logical_part_order=1,
+        spine_order=1,
+    )
+    db.add_all([heading, continuation])
+    await db.flush()
+    sentences = [
+        AudiobookSentence(
+            chapter_id=heading.id,
+            html_element_id="heading-1",
+            sequence_order=0,
+            original_text="1",
+        ),
+        AudiobookSentence(
+            chapter_id=continuation.id,
+            html_element_id="body-1",
+            sequence_order=0,
+            original_text="The body starts here.",
+        ),
+        AudiobookSentence(
+            chapter_id=continuation.id,
+            html_element_id="body-2",
+            sequence_order=1,
+            original_text="It continues in the same audio track.",
+        ),
+    ]
+    edition = ImportedAudiobook(book_id=book.id, name="Human", status="ready")
+    db.add_all([*sentences, edition])
+    await db.flush()
+    track = ImportedAudiobookTrack(
+        imported_audiobook_id=edition.id,
+        matched_chapter_id=heading.id,
+        sequence_order=1,
+        title="Chapter 1",
+        audio_file_path="library/audio.m4a",
+        media_type="audio/mp4",
+        source_start_ms=0,
+        source_end_ms=60_000,
+        duration_ms=60_000,
+    )
+    db.add(track)
+    await db.commit()
+
+    cue_count = await audiobook_import.rebuild_estimated_cues(track, db)
+    cues = await audiobook_router.get_imported_track_cues(edition.id, track.id, db)
+    smil = await audiobook_router.get_imported_track_smil(edition.id, track.id, db)
+
+    assert cue_count == 3
+    assert [cue.text for cue in cues] == ["1", "The body starts here.", "It continues in the same audio track."]
+    assert b'src="chapter-1-heading.xhtml#heading-1"' in smil.body
+    assert b'src="chapter-1-body.xhtml#body-1"' in smil.body
+    assert b'src="chapter-1-body.xhtml#body-2"' in smil.body
 
 
 def test_prepare_sources_reuses_extracted_files_on_retry(tmp_path, monkeypatch):
@@ -693,6 +826,85 @@ async def test_upgrade_endpoints_queue_legacy_editions_and_skip_current_or_activ
         assert len(jobs) == 1
         assert jobs[0].target_id == legacy_id
         assert jobs[0].payload == {"format_version": audiobook_import.CURRENT_DERIVED_FORMAT_VERSION}
+
+
+@pytest.mark.asyncio
+async def test_rebuild_preview_and_bulk_queue_only_outdated_ready_editions(
+    app_client,
+    sqlite_sessionmaker,
+):
+    async with sqlite_sessionmaker() as db:
+        book, chapter = await _seed_book_text(db)
+        shared = {
+            "book_id": book.id,
+            "status": "ready",
+            "source_manifest_sha256": "a" * 64,
+            "derived_format_version": audiobook_import.CURRENT_DERIVED_FORMAT_VERSION,
+        }
+        outdated = ImportedAudiobook(
+            **shared,
+            name="Outdated",
+            alignment_method="transcribed",
+            pipeline_version=0,
+        )
+        current = ImportedAudiobook(
+            **shared,
+            name="Current",
+            alignment_method="estimated",
+            pipeline_version=audiobook_import.CURRENT_HUMAN_AUDIOBOOK_PIPELINE_VERSION,
+        )
+        active = ImportedAudiobook(
+            book_id=book.id,
+            name="Active",
+            status="aligning",
+            pipeline_version=0,
+        )
+        db.add_all([outdated, current, active])
+        await db.flush()
+        for edition in (outdated, current, active):
+            db.add(
+                ImportedAudiobookTrack(
+                    imported_audiobook_id=edition.id,
+                    matched_chapter_id=chapter.id,
+                    sequence_order=1,
+                    title="Chapter 1",
+                    audio_file_path=f"library/{edition.id}.m4b",
+                    media_type="audio/mp4",
+                    source_start_ms=0,
+                    source_end_ms=10_000,
+                    duration_ms=10_000,
+                )
+            )
+        await db.commit()
+        outdated_id = outdated.id
+
+    preview = app_client.get("/api/audiobook/imports/rebuild-preview")
+    assert preview.status_code == 200
+    assert preview.json() == {
+        "current_pipeline_version": audiobook_import.CURRENT_HUMAN_AUDIOBOOK_PIPELINE_VERSION,
+        "total_count": 3,
+        "rebuild_count": 1,
+        "realign_count": 1,
+        "up_to_date_count": 1,
+        "unavailable_count": 1,
+    }
+
+    response = app_client.post("/api/audiobook/imports/rebuild-all")
+    assert response.status_code == 200
+    assert response.json() == {
+        "queued_count": 1,
+        "skipped_count": 2,
+        "pipeline_version": audiobook_import.CURRENT_HUMAN_AUDIOBOOK_PIPELINE_VERSION,
+    }
+    async with sqlite_sessionmaker() as db:
+        job = (
+            await db.execute(select(ProcessingJob).where(ProcessingJob.job_type == "rebuild_imported_audiobook"))
+        ).scalar_one()
+        assert job.target_id == outdated_id
+        assert job.payload == {
+            "pipeline_version": audiobook_import.CURRENT_HUMAN_AUDIOBOOK_PIPELINE_VERSION,
+            "force": False,
+        }
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_audiobook_pipeline.py
+++ b/backend/tests/test_audiobook_pipeline.py
@@ -2112,6 +2112,30 @@ def _write_nested_epub(path: Path) -> None:
     epub.write_epub(path, book, {})
 
 
+def _write_split_spine_epub(path: Path) -> None:
+    book = epub.EpubBook()
+    book.set_identifier("split-spine-test")
+    book.set_title("Split Spine")
+    book.set_language("en")
+    book.add_author("Author")
+    heading = epub.EpubHtml(title="Chapter 1", file_name="Text/chapter-1-heading.xhtml", lang="en")
+    heading.content = "<html><body><h1>1</h1></body></html>"
+    continuation = epub.EpubHtml(title="Phase One", file_name="Text/chapter-1-body.xhtml", lang="en")
+    continuation.content = "<html><body><h2>Phase One</h2><p>The chapter body continues here.</p></body></html>"
+    chapter_two = epub.EpubHtml(title="Chapter 2", file_name="Text/chapter-2.xhtml", lang="en")
+    chapter_two.content = "<html><body><h1>2</h1><p>The next chapter starts here.</p></body></html>"
+    for item in (heading, continuation, chapter_two):
+        book.add_item(item)
+    book.add_item(epub.EpubNcx())
+    book.add_item(epub.EpubNav())
+    book.spine = ["nav", heading, continuation, chapter_two]
+    book.toc = (
+        epub.Link(heading.file_name, "Chapter 1", "chapter-1"),
+        epub.Link(chapter_two.file_name, "Chapter 2", "chapter-2"),
+    )
+    epub.write_epub(path, book, {})
+
+
 def _write_incremental_epub(path: Path, chapters: list[tuple[str, str, str]]) -> None:
     book = epub.EpubBook()
     book.set_identifier("incremental-test")
@@ -2202,6 +2226,31 @@ async def test_ingestion_preserves_nested_markup_and_records_spine_file(db, tmp_
     assert len(sentences) >= 2
     assert all(sentence.html_element_id.startswith(f"{chapters[0].stable_chapter_key}-") for sentence in sentences)
     assert all(soup.find("span", id=sentence.html_element_id) is not None for sentence in sentences)
+
+
+@pytest.mark.asyncio
+async def test_ingestion_groups_non_toc_spine_continuation_with_prior_chapter(db, tmp_path, monkeypatch):
+    library_path = tmp_path / "library"
+    library_path.mkdir()
+    epub_path = library_path / "split-spine.epub"
+    _write_split_spine_epub(epub_path)
+    book = await _make_book(
+        db,
+        immutable_path=str(epub_path.relative_to(library_path.parent)),
+        current_path=str(epub_path.relative_to(library_path.parent)),
+    )
+    monkeypatch.setattr(audiobook_ingestion, "LIBRARY_PATH", library_path)
+    monkeypatch.setattr(audiobook_publication, "LIBRARY_PATH", library_path)
+    monkeypatch.setattr(audiobook_ingestion, "_tokenize_text", _simple_sentence_split)
+
+    await audiobook_ingestion.ingest_epub(book.id, db)
+
+    chapters = await crud.audiobook.get_chapters_for_book(db, book.id)
+    assert [chapter.title for chapter in chapters] == ["Chapter 1", "Phase One", "Chapter 2"]
+    assert chapters[0].logical_chapter_key == chapters[1].logical_chapter_key
+    assert [chapters[0].logical_part_order, chapters[1].logical_part_order] == [0, 1]
+    assert chapters[2].logical_chapter_key != chapters[0].logical_chapter_key
+    assert chapters[2].logical_part_order == 0
 
 
 @pytest.mark.asyncio

--- a/frontend/src/api/audiobook.js
+++ b/frontend/src/api/audiobook.js
@@ -217,6 +217,23 @@ export function upgradeAllImportedAudiobooks() {
   });
 }
 
+export function previewHumanAudiobookRebuilds() {
+  return getJson(
+    "/api/audiobook/imports/rebuild-preview",
+    "Failed to inspect human audiobooks",
+  );
+}
+
+export function rebuildAllHumanAudiobooks({ force = false } = {}) {
+  return sendWithoutBody(
+    `/api/audiobook/imports/rebuild-all?force=${force}`,
+    {
+      method: "POST",
+      fallbackMessage: "Failed to queue human audiobook rebuilds",
+    },
+  );
+}
+
 export function alignImportedAudiobook(editionId) {
   return sendWithoutBody(`/api/imported-audiobooks/${editionId}/align`, {
     method: "POST",

--- a/frontend/src/components/ProcessingJobs.jsx
+++ b/frontend/src/components/ProcessingJobs.jsx
@@ -3,7 +3,6 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { getBookCatalog } from "../api/books";
 import useDebouncedValue from "../hooks/useDebouncedValue";
 import useLifecycleDefinitions from "../hooks/useLifecycleDefinitions";
-import { upgradeAllImportedAudiobooks } from "../api/audiobook";
 import {
   cancelProcessingJob,
   getProcessingJobs,
@@ -19,6 +18,7 @@ const JOB_LABELS = {
   audiobook_pipeline: "Generate AI audiobook",
   import_audiobook: "Import human audiobook",
   upgrade_imported_audiobook: "Upgrade human audiobook files",
+  rebuild_imported_audiobook: "Rebuild human audiobook",
   rematch_imported_audiobook: "Rematch human audiobook",
   align_imported_audiobook: "Align human audiobook",
   metadata_sync: "Sync metadata",
@@ -162,15 +162,6 @@ function ProcessingJobs() {
       refresh();
     },
   });
-  const upgradeAllMutation = useMutation({
-    mutationFn: upgradeAllImportedAudiobooks,
-    onSuccess: (data) => {
-      setQueueNotice(
-        `${data.queued_count} human audiobook upgrade${data.queued_count === 1 ? "" : "s"} queued; ${data.skipped_count} skipped.`,
-      );
-      refresh();
-    },
-  });
   const retryMutation = useMutation({
     mutationFn: retryProcessingJob,
     onSuccess: refresh,
@@ -256,14 +247,6 @@ function ProcessingJobs() {
             disabled={queueMutation.isPending}
           >
             Refresh all web books
-          </button>
-          <button
-            onClick={() => upgradeAllMutation.mutate()}
-            disabled={upgradeAllMutation.isPending}
-          >
-            {upgradeAllMutation.isPending
-              ? "Queueing audiobook upgrades…"
-              : "Upgrade stored human audiobooks"}
           </button>
         </div>
         <div className="processing-book-picker">

--- a/frontend/src/components/Utilities.jsx
+++ b/frontend/src/components/Utilities.jsx
@@ -17,6 +17,10 @@ import {
 } from "../api/books";
 import { createBackup, deleteBackup, getBackups, verifyBackup } from "../api/backups";
 import { getProcessingJobs } from "../api/processing";
+import {
+  previewHumanAudiobookRebuilds,
+  rebuildAllHumanAudiobooks,
+} from "../api/audiobook";
 
 const utilityTabs = [
   { key: "audit", label: "Audit" },
@@ -119,6 +123,9 @@ function Utilities({ onBack }) {
   const [selectedMatchIds, setSelectedMatchIds] = useState({});
   const [permanentDeleteTarget, setPermanentDeleteTarget] = useState(null);
   const [backupDeleteTarget, setBackupDeleteTarget] = useState(null);
+  const [audiobookRebuildOpen, setAudiobookRebuildOpen] = useState(false);
+  const [audiobookRebuildForce, setAudiobookRebuildForce] = useState(false);
+  const [audiobookRebuildNotice, setAudiobookRebuildNotice] = useState("");
 
   useEffect(() => {
     const onPopState = () => setActiveTab(getRequestedUtilityTab());
@@ -270,6 +277,34 @@ function Utilities({ onBack }) {
       queryClient.invalidateQueries({ queryKey: ["backups"] });
     },
   });
+
+  const {
+    data: audiobookRebuildPreview,
+    isLoading: audiobookRebuildPreviewLoading,
+    error: audiobookRebuildPreviewError,
+  } = useQuery({
+    queryKey: ["human-audiobook-rebuild-preview"],
+    queryFn: previewHumanAudiobookRebuilds,
+    enabled: activeTab === "audiobooks",
+  });
+
+  const audiobookRebuildMutation = useMutation({
+    mutationFn: () => rebuildAllHumanAudiobooks({ force: audiobookRebuildForce }),
+    onSuccess: (data) => {
+      setAudiobookRebuildOpen(false);
+      setAudiobookRebuildForce(false);
+      setAudiobookRebuildNotice(
+        `${data.queued_count} human audiobook rebuild${data.queued_count === 1 ? "" : "s"} queued; ${data.skipped_count} skipped.`,
+      );
+      queryClient.invalidateQueries({ queryKey: ["human-audiobook-rebuild-preview"] });
+      queryClient.invalidateQueries({ queryKey: ["processing-jobs"] });
+      queryClient.invalidateQueries({ queryKey: ["active-processing-jobs"] });
+    },
+  });
+  const audiobookRebuildTargetCount = audiobookRebuildForce
+    ? (audiobookRebuildPreview?.rebuild_count || 0) +
+      (audiobookRebuildPreview?.up_to_date_count || 0)
+    : audiobookRebuildPreview?.rebuild_count || 0;
 
   const handleDetectSeries = async () => {
     setDetectState("pending");
@@ -588,16 +623,81 @@ function Utilities({ onBack }) {
         )}
 
         {activeTab === "audiobooks" && (
-          <section className="settings-section">
-            <h3>Libation Backup Import</h3>
-            <p className="hint">
-              Preview book matches, resolve ambiguous titles, and queue the
-              selected backup through the guided import workflow.
-            </p>
-            <a className="btn btn-primary" href="/import?type=libation">
-              Open guided Libation import
-            </a>
-          </section>
+          <>
+            <section className="settings-section">
+              <h3>Rebuild Human Audiobooks</h3>
+              <p className="hint">
+                Bring imported human audiobooks forward using the latest source processing,
+                chapter matching, text cue, and timestamp-alignment pipeline. Existing audio,
+                valid chapter corrections, and compatible Whisper transcripts are reused.
+              </p>
+              {audiobookRebuildPreviewLoading ? (
+                <p className="hint">Inspecting imported audiobooks…</p>
+              ) : audiobookRebuildPreviewError ? (
+                <p className="error">{audiobookRebuildPreviewError.message}</p>
+              ) : audiobookRebuildPreview ? (
+                <p className="hint">
+                  {audiobookRebuildPreview.rebuild_count} of {audiobookRebuildPreview.total_count} edition
+                  {audiobookRebuildPreview.total_count === 1 ? "" : "s"} need pipeline v
+                  {audiobookRebuildPreview.current_pipeline_version}
+                  {audiobookRebuildPreview.realign_count > 0
+                    ? ` · ${audiobookRebuildPreview.realign_count} will be timestamp-aligned again`
+                    : ""}
+                  {audiobookRebuildPreview.unavailable_count > 0
+                    ? ` · ${audiobookRebuildPreview.unavailable_count} currently unavailable`
+                    : ""}
+                </p>
+              ) : null}
+              <div className="settings-actions">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setAudiobookRebuildForce(false);
+                    setAudiobookRebuildOpen(true);
+                  }}
+                  disabled={
+                    audiobookRebuildPreviewLoading ||
+                    !audiobookRebuildPreview?.rebuild_count ||
+                    audiobookRebuildMutation.isPending
+                  }
+                >
+                  Rebuild outdated human audiobooks
+                </button>
+                <button
+                  type="button"
+                  className="btn-text"
+                  onClick={() => {
+                    setAudiobookRebuildForce(true);
+                    setAudiobookRebuildOpen(true);
+                  }}
+                  disabled={
+                    audiobookRebuildPreviewLoading ||
+                    !(
+                      (audiobookRebuildPreview?.rebuild_count || 0) +
+                      (audiobookRebuildPreview?.up_to_date_count || 0)
+                    ) ||
+                    audiobookRebuildMutation.isPending
+                  }
+                >
+                  Force rebuild all ready editions
+                </button>
+              </div>
+              {audiobookRebuildNotice && <p className="success">{audiobookRebuildNotice}</p>}
+              {audiobookRebuildMutation.isError && (
+                <p className="error">{audiobookRebuildMutation.error.message}</p>
+              )}
+            </section>
+            <section className="settings-section">
+              <h3>Libation Backup Import</h3>
+              <p className="hint">
+                Preview book matches, resolve ambiguous titles, and queue the
+                selected backup through the guided import workflow.
+              </p>
+              <a className="btn btn-primary" href="/import?type=libation">
+                Open guided Libation import
+              </a>
+            </section>
+          </>
         )}
 
         {activeTab === "recycle-bin" && (
@@ -900,6 +1000,31 @@ function Utilities({ onBack }) {
         {activeTab === "reader-access" && <ReaderKeys />}
       </div>
 
+      <ConfirmActionDialog
+        open={audiobookRebuildOpen}
+        title={audiobookRebuildForce ? "Force rebuild all ready human audiobooks?" : "Rebuild outdated human audiobooks?"}
+        confirmLabel="Queue rebuilds"
+        busyLabel="Queueing…"
+        isPending={audiobookRebuildMutation.isPending}
+        onCancel={() => {
+          setAudiobookRebuildOpen(false);
+          setAudiobookRebuildForce(false);
+        }}
+        onConfirm={() => audiobookRebuildMutation.mutate()}
+      >
+        <p>
+          This will queue {audiobookRebuildTargetCount} imported edition
+          {audiobookRebuildTargetCount === 1 ? "" : "s"} for the latest pipeline.
+        </p>
+        {audiobookRebuildForce && (
+          <p><strong>This also rebuilds editions already marked current.</strong></p>
+        )}
+        <p>
+          Original audio and manual chapter corrections are preserved. Compatible cached transcripts
+          are reused; if a required transcript is missing or incompatible, the configured transcription
+          service will be called again.
+        </p>
+      </ConfirmActionDialog>
       <ConfirmActionDialog
         open={Boolean(permanentDeleteTarget)}
         title={`Permanently delete “${permanentDeleteTarget?.title || "this book"}”?`}

--- a/frontend/src/components/Utilities.test.jsx
+++ b/frontend/src/components/Utilities.test.jsx
@@ -58,6 +58,53 @@ describe("Utilities", () => {
     });
   });
 
+  it("previews and queues versioned human audiobook rebuilds", async () => {
+    window.history.replaceState(null, "", "/settings/library-tools?section=audiobooks");
+    globalThis.fetch = vi.fn((url, options) => {
+      if (url === "/api/metadata/jobs/latest") {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(null) });
+      }
+      if (url === "/api/metadata/inbox") {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+      }
+      if (url === "/api/audiobook/imports/rebuild-preview") {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              current_pipeline_version: 1,
+              total_count: 4,
+              rebuild_count: 2,
+              realign_count: 1,
+              up_to_date_count: 1,
+              unavailable_count: 1,
+            }),
+        });
+      }
+      if (url === "/api/audiobook/imports/rebuild-all?force=false" && options?.method === "POST") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ queued_count: 2, skipped_count: 2, pipeline_version: 1 }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+    });
+
+    renderWithClient(<Utilities onBack={() => {}} />);
+
+    expect(await screen.findByRole("heading", { name: "Rebuild Human Audiobooks" })).toBeInTheDocument();
+    expect(await screen.findByText(/2 of 4 editions need pipeline v1/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Rebuild outdated human audiobooks" }));
+    const dialog = screen.getByRole("dialog");
+    expect(within(dialog).getByText(/Original audio and manual chapter corrections are preserved/)).toBeInTheDocument();
+    fireEvent.click(within(dialog).getByRole("button", { name: "Queue rebuilds" }));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith("/api/audiobook/imports/rebuild-all?force=false", { method: "POST" });
+    });
+    expect(await screen.findByText("2 human audiobook rebuilds queued; 2 skipped.")).toBeInTheDocument();
+  });
+
   it("creates, downloads, verifies, and deliberately deletes backups", async () => {
     const filename = "story-manager-20260809T120000Z-abcd1234.story-manager.zip";
     const backup = {


### PR DESCRIPTION
## Summary
- group split EPUB spine items into logical audiobook chapters without rewriting source EPUBs
- improve transcript alignment coverage and transcription service error reporting
- add versioned human-audiobook rebuild jobs with automatic/manual match provenance
- add Library Tools preview, outdated rebuild, and force-rebuild controls

## Validation
- `make test` (455 backend tests, 77 frontend tests)
- `make pr-check`
- PostgreSQL migrations 0039 and 0040 tested through populated upgrade and downgrade paths
- live book 517 rematch verified chapters 1, 10, 17, and 23 contain full synchronized text