### PR TITLE
Show per-endpoint AI pool test results

### DIFF
--- a/backend/app/routers/audiobook.py
+++ b/backend/app/routers/audiobook.py
@@ -52,13 +52,13 @@ from ..services.audiobook_tts import (
 from ..services.processing_queue import queue_processing_job
 from ..services import audiobook_llm
 from ..services.transcription_providers import (
+    _transcription_service_health_endpoint,
     transcription_provider_name,
-    transcription_service_health,
 )
 from ..services.endpoint_pool import (
     configured_endpoints,
     configured_providers,
-    primary_provider,
+    probe_endpoints,
     reset_cooldowns,
     settings_for_provider,
 )
@@ -66,9 +66,9 @@ from ..services.endpoint_metrics import endpoint_summaries
 from ..services.metadata.scoring import normalize_text, title_similarity
 from ..services.tts_providers import (
     TTSRequest,
+    _synthesize_speech_endpoint,
     design_omnivoice_voice,
     get_omnivoice_voice_sample,
-    synthesize_speech_routed,
     tts_provider_name,
 )
 
@@ -2364,29 +2364,69 @@ async def get_endpoint_stats(db: AsyncSession = Depends(get_db)) -> AllEndpointS
     )
 
 
+def _endpoint_test_results(probes, value_details=None) -> list[dict[str, Any]]:
+    results = []
+    for priority, probe in enumerate(probes, start=1):
+        endpoint = probe.endpoint
+        result = {
+            "endpoint_id": endpoint.get("id"),
+            "endpoint": endpoint.get("name") or endpoint.get("base_url") or endpoint.get("id"),
+            "priority": priority,
+            "provider": endpoint.get("provider"),
+            "model": endpoint.get("model"),
+            "status": "ready" if probe.success else "error",
+            "duration_ms": round(probe.duration_ms, 1),
+            "error": probe.error,
+        }
+        if probe.success and isinstance(probe.value, dict):
+            result["response"] = probe.value
+        if probe.success and value_details is not None:
+            result.update(value_details(probe.value))
+        results.append(result)
+    return results
+
+
+def _pool_test_status(results: list[dict[str, Any]]) -> str:
+    ready_count = sum(result["status"] == "ready" for result in results)
+    if ready_count == len(results) and results:
+        return "ready"
+    return "partial" if ready_count else "failed"
+
+
 @router.post("/api/audiobook/settings/test-llm")
 async def test_llm_settings(db: AsyncSession = Depends(get_db)) -> dict[str, Any]:
     settings = await crud.audiobook.get_audiobook_settings(db)
-    if settings is None or primary_provider(settings, "llm", "stub") == "stub":
+    if settings is None:
         return {"status": "ready", "provider": "stub", "model": None, "response": "local harness"}
     schema = {
         "type": "object",
         "properties": {"status": {"type": "string"}},
         "required": ["status"],
     }
-    routed = await audiobook_llm._call_llm_routed(
-        settings,
-        [{"role": "user", "content": "Return JSON with status set to ready."}],
-        response_schema=schema,
-    )
-    raw = routed.value
-    parsed = audiobook_llm._extract_json(raw)
+
+    async def attempt(endpoint_settings):
+        if endpoint_settings.llm_provider == "stub":
+            return {"status": "ready", "response": "local harness"}
+        raw = await audiobook_llm._call_llm_endpoint(
+            endpoint_settings,
+            [{"role": "user", "content": "Return JSON with status set to ready."}],
+            response_schema=schema,
+        )
+        parsed = audiobook_llm._extract_json(raw)
+        if not isinstance(parsed, dict):
+            raise RuntimeError("The LLM test did not return a JSON object.")
+        return parsed
+
+    probes = await probe_endpoints(settings, "llm", attempt)
+    results = _endpoint_test_results(probes)
+    first_ready = next((result for result in results if result["status"] == "ready"), None)
     return {
-        "status": parsed.get("status", "unknown") if isinstance(parsed, dict) else "unknown",
-        "endpoint": routed.endpoint.get("name"),
-        "provider": routed.endpoint.get("provider"),
-        "model": routed.endpoint.get("model"),
-        "response": parsed,
+        "status": _pool_test_status(results),
+        "endpoint": first_ready.get("endpoint") if first_ready else None,
+        "provider": first_ready.get("provider") if first_ready else None,
+        "model": first_ready.get("model") if first_ready else None,
+        "response": first_ready.get("response") if first_ready else None,
+        "results": results,
     }
 
 
@@ -2395,21 +2435,26 @@ async def test_tts_settings(db: AsyncSession = Depends(get_db)) -> dict[str, Any
     settings = await crud.audiobook.get_audiobook_settings(db)
     if settings is None:
         return {"status": "ready", "provider": "stub", "model": None, "audio_bytes": 0}
-    routed = await synthesize_speech_routed(
-        settings,
-        TTSRequest(
-            text="Story Manager text to speech is ready.",
-        ),
-    )
-    audio = routed.value
-    if not audio:
-        raise HTTPException(status_code=502, detail="The TTS provider returned an empty response.")
+
+    async def attempt(endpoint_settings):
+        audio = await _synthesize_speech_endpoint(
+            endpoint_settings,
+            TTSRequest(text="Story Manager text to speech is ready."),
+        )
+        if not audio:
+            raise RuntimeError("The TTS provider returned an empty response.")
+        return audio
+
+    probes = await probe_endpoints(settings, "tts", attempt)
+    results = _endpoint_test_results(probes, value_details=lambda audio: {"audio_bytes": len(audio)})
+    first_ready = next((result for result in results if result["status"] == "ready"), None)
     return {
-        "status": "ready",
-        "endpoint": routed.endpoint.get("name"),
-        "provider": routed.endpoint.get("provider"),
-        "model": routed.endpoint.get("model"),
-        "audio_bytes": len(audio),
+        "status": _pool_test_status(results),
+        "endpoint": first_ready.get("endpoint") if first_ready else None,
+        "provider": first_ready.get("provider") if first_ready else None,
+        "model": first_ready.get("model") if first_ready else None,
+        "audio_bytes": first_ready.get("audio_bytes", 0) if first_ready else 0,
+        "results": results,
     }
 
 
@@ -2418,14 +2463,21 @@ async def test_transcription_settings(db: AsyncSession = Depends(get_db)) -> dic
     settings = await crud.audiobook.get_audiobook_settings(db)
     if settings is None:
         raise HTTPException(status_code=409, detail="Configure a transcription provider first.")
-    try:
-        payload = await transcription_service_health(settings)
-    except RuntimeError as exc:
-        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    probes = await probe_endpoints(settings, "transcription", _transcription_service_health_endpoint)
+    results = _endpoint_test_results(
+        probes,
+        value_details=lambda payload: {
+            "service_status": payload.get("status"),
+            "device": payload.get("device"),
+            "loaded_model": payload.get("model"),
+        },
+    )
+    first_ready = next((result for result in results if result["status"] == "ready"), None)
     return {
-        "status": payload.get("status"),
-        "endpoint": payload.get("endpoint", {}).get("name"),
-        "provider": payload.get("endpoint", {}).get("provider"),
-        "model": payload.get("model"),
-        "device": payload.get("device"),
+        "status": _pool_test_status(results),
+        "endpoint": first_ready.get("endpoint") if first_ready else None,
+        "provider": first_ready.get("provider") if first_ready else None,
+        "model": first_ready.get("loaded_model") if first_ready else None,
+        "device": first_ready.get("device") if first_ready else None,
+        "results": results,
     }

--- a/backend/app/services/endpoint_pool.py
+++ b/backend/app/services/endpoint_pool.py
@@ -23,6 +23,17 @@ class RoutedResult(Generic[T]):
     endpoint: dict[str, Any]
 
 
+@dataclass(frozen=True)
+class EndpointProbeResult(Generic[T]):
+    """The outcome of directly testing one configured endpoint."""
+
+    endpoint: dict[str, Any]
+    success: bool
+    duration_ms: float
+    value: T | None = None
+    error: str | None = None
+
+
 _cooldowns: dict[tuple[str, str], float] = {}
 
 
@@ -131,6 +142,84 @@ def _endpoint_settings(
 def cooldown_remaining(capability: str, endpoint: dict[str, Any]) -> float:
     remaining = _cooldowns.get(_endpoint_key(capability, endpoint), 0.0) - time.monotonic()
     return max(0.0, remaining)
+
+
+def _error_detail(exc: Exception) -> str:
+    """Include a provider response detail without dumping a large response body."""
+    message = str(exc).strip() or type(exc).__name__
+    response = getattr(exc, "response", None)
+    detail: Any = None
+    if response is not None:
+        try:
+            payload = response.json()
+        except (ValueError, TypeError):
+            payload = None
+        if isinstance(payload, dict):
+            detail = payload.get("detail") or payload.get("message") or payload.get("error")
+            if isinstance(detail, dict):
+                detail = detail.get("message") or str(detail)
+        if not detail:
+            try:
+                detail = response.text
+            except Exception:
+                detail = None
+    if detail:
+        normalized = " ".join(str(detail).split())
+        if normalized and normalized not in message:
+            message = f"{message} — {normalized}"
+    return message[:1000]
+
+
+async def probe_endpoints(
+    settings: AudiobookSettings,
+    capability: str,
+    attempt: Callable[[Any], Awaitable[T]],
+) -> list[EndpointProbeResult[T]]:
+    """Test every endpoint, including endpoints currently in cooldown."""
+    results: list[EndpointProbeResult[T]] = []
+    for endpoint in configured_endpoints(settings, capability):
+        key = _endpoint_key(capability, endpoint)
+        started_at = time.perf_counter()
+        try:
+            value = await attempt(_endpoint_settings(settings, capability, endpoint))
+        except Exception as exc:
+            duration_ms = (time.perf_counter() - started_at) * 1000
+            await _record_endpoint_attempt(
+                settings,
+                capability,
+                endpoint,
+                success=False,
+                duration_ms=duration_ms,
+                error_type=type(exc).__name__,
+            )
+            _cooldowns[key] = time.monotonic() + COOLDOWN_SECONDS
+            results.append(
+                EndpointProbeResult(
+                    endpoint=endpoint,
+                    success=False,
+                    duration_ms=duration_ms,
+                    error=_error_detail(exc),
+                )
+            )
+            continue
+        duration_ms = (time.perf_counter() - started_at) * 1000
+        await _record_endpoint_attempt(
+            settings,
+            capability,
+            endpoint,
+            success=True,
+            duration_ms=duration_ms,
+        )
+        _cooldowns.pop(key, None)
+        results.append(
+            EndpointProbeResult(
+                endpoint=endpoint,
+                success=True,
+                duration_ms=duration_ms,
+                value=value,
+            )
+        )
+    return results
 
 
 async def route_request(

--- a/backend/tests/test_endpoint_pool.py
+++ b/backend/tests/test_endpoint_pool.py
@@ -84,6 +84,45 @@ async def test_all_cooling_endpoints_fail_fast(monkeypatch):
         await endpoint_pool.route_request(settings, "tts", fail)
 
 
+@pytest.mark.asyncio
+async def test_pool_probe_tests_every_endpoint_and_ignores_cooldown(monkeypatch):
+    now = 2000.0
+    monkeypatch.setattr(endpoint_pool.time, "monotonic", lambda: now)
+    settings = models.AudiobookSettings(
+        tts_endpoints=[
+            {"id": "qwen", "name": "Qwen", "provider": "qwen3", "base_url": "http://qwen"},
+            {"id": "omni", "name": "OmniVoice", "provider": "omnivoice", "base_url": "http://omni"},
+        ]
+    )
+    endpoint_pool._cooldowns[("tts", "qwen")] = now + 30
+    calls = []
+
+    async def attempt(endpoint_settings):
+        calls.append(endpoint_settings.tts_base_url)
+        if endpoint_settings.tts_provider == "qwen3":
+            request = httpx.Request("POST", "http://qwen/generate")
+            response = httpx.Response(
+                409,
+                json={"detail": "configured model is not loaded"},
+                request=request,
+            )
+            raise httpx.HTTPStatusError(
+                "Qwen request failed",
+                request=request,
+                response=response,
+            )
+        return b"audio"
+
+    results = await endpoint_pool.probe_endpoints(settings, "tts", attempt)
+
+    assert calls == ["http://qwen", "http://omni"]
+    assert [(result.endpoint["id"], result.success) for result in results] == [
+        ("qwen", False),
+        ("omni", True),
+    ]
+    assert results[0].error == "Qwen request failed — configured model is not loaded"
+
+
 def test_reset_cooldowns_can_target_one_capability(monkeypatch):
     monkeypatch.setattr(endpoint_pool.time, "monotonic", lambda: 1000.0)
     endpoint_pool._cooldowns.update(
@@ -270,3 +309,62 @@ async def test_all_endpoint_stats_api_includes_tts_and_transcription(app_client,
     assert payload["llm"][0]["answered"] == 0
     assert payload["tts"][0]["answered"] == 1
     assert payload["transcription"][0]["answered"] == 1
+
+
+@pytest.mark.asyncio
+async def test_tts_pool_test_api_returns_each_endpoint_result(
+    app_client,
+    sqlite_sessionmaker,
+    monkeypatch,
+):
+    async with sqlite_sessionmaker() as db:
+        db.add(
+            models.AudiobookSettings(
+                tts_endpoints=[
+                    {"id": "qwen", "name": "Qwen", "provider": "qwen3", "base_url": "http://qwen"},
+                    {"id": "omni", "name": "OmniVoice", "provider": "omnivoice", "base_url": "http://omni"},
+                ]
+            )
+        )
+        await db.commit()
+
+    calls = []
+
+    async def synthesize(endpoint_settings, _request):
+        calls.append(endpoint_settings.tts_base_url)
+        if endpoint_settings.tts_provider == "qwen3":
+            raise RuntimeError("Qwen model is not loaded")
+        return b"mp3"
+
+    monkeypatch.setattr("backend.app.routers.audiobook._synthesize_speech_endpoint", synthesize)
+
+    response = app_client.post("/api/audiobook/settings/test-tts")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "partial"
+    assert payload["endpoint"] == "OmniVoice"
+    assert calls == ["http://qwen", "http://omni"]
+    assert payload["results"] == [
+        {
+            "endpoint_id": "qwen",
+            "endpoint": "Qwen",
+            "priority": 1,
+            "provider": "qwen3",
+            "model": None,
+            "status": "error",
+            "duration_ms": payload["results"][0]["duration_ms"],
+            "error": "Qwen model is not loaded",
+        },
+        {
+            "endpoint_id": "omni",
+            "endpoint": "OmniVoice",
+            "priority": 2,
+            "provider": "omnivoice",
+            "model": None,
+            "status": "ready",
+            "duration_ms": payload["results"][1]["duration_ms"],
+            "error": None,
+            "audio_bytes": 3,
+        },
+    ]

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1851,6 +1851,64 @@
   margin: 0;
 }
 
+.endpoint-test-results {
+  flex: 1 1 100%;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.endpoint-test-partial {
+  color: var(--warning, #a45f00);
+}
+
+.endpoint-test-result-list {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.endpoint-test-result {
+  padding: 0.75rem;
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+}
+
+.endpoint-test-result-ready {
+  border-left: 3px solid var(--success);
+}
+
+.endpoint-test-result-error {
+  border-left: 3px solid var(--danger, #b42318);
+}
+
+.endpoint-test-result-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.endpoint-test-result-heading div,
+.endpoint-test-result-heading strong,
+.endpoint-test-result-heading small {
+  display: block;
+}
+
+.endpoint-test-result-heading div > span,
+.endpoint-test-result-heading small {
+  color: var(--text-muted);
+  font-size: 0.72rem;
+}
+
+.endpoint-test-result-heading > span {
+  white-space: nowrap;
+  font-size: 0.78rem;
+}
+
+.endpoint-test-result > p {
+  margin-top: 0.55rem;
+  overflow-wrap: anywhere;
+}
+
 .llm-metrics {
   margin-top: 1.25rem;
   padding-top: 1.25rem;
@@ -1947,6 +2005,7 @@
 @media (max-width: 700px) {
   .endpoint-pool-heading,
   .endpoint-card-header,
+  .endpoint-test-result-heading,
   .llm-metrics-heading {
     align-items: stretch;
     flex-direction: column;

--- a/frontend/src/components/AudiobookSettings.jsx
+++ b/frontend/src/components/AudiobookSettings.jsx
@@ -572,30 +572,86 @@ function AudiobookSettings() {
 
   if (isLoading || !initialised) return <p>Loading settings…</p>;
 
-  const testStatus = (mutation, label) => (
-    <div className="endpoint-test-status">
-      <button
-        type="button"
-        onClick={() => mutation.mutate()}
-        disabled={mutation.isPending}
-      >
-        {mutation.isPending ? "Testing pool…" : `Save & Test ${label}`}
-      </button>
-      {mutation.isSuccess && (
-        <p className="success">
-          Connected
-          {mutation.data.endpoint ? ` via ${mutation.data.endpoint}` : ""} to{" "}
-          {mutation.data.provider}
-          {mutation.data.model ? ` / ${mutation.data.model}` : ""}.
-        </p>
-      )}
-      {mutation.isError && (
-        <p className="error">
-          {mutation.error?.message || `${label} test failed`}
-        </p>
-      )}
-    </div>
-  );
+  const testStatus = (mutation, label) => {
+    const results = mutation.data?.results;
+    const readyCount = results?.filter(
+      (result) => result.status === "ready",
+    ).length;
+    return (
+      <div className="endpoint-test-status">
+        <button
+          type="button"
+          onClick={() => mutation.mutate()}
+          disabled={mutation.isPending}
+        >
+          {mutation.isPending ? "Testing pool…" : `Save & Test ${label}`}
+        </button>
+        {mutation.isSuccess && !results && (
+          <p className="success">
+            Connected
+            {mutation.data.endpoint
+              ? ` via ${mutation.data.endpoint}`
+              : ""} to {mutation.data.provider}
+            {mutation.data.model ? ` / ${mutation.data.model}` : ""}.
+          </p>
+        )}
+        {mutation.isSuccess && results && (
+          <div
+            className="endpoint-test-results"
+            aria-label={`${label} endpoint test results`}
+          >
+            <p
+              className={
+                readyCount === results.length && results.length > 0
+                  ? "success"
+                  : readyCount > 0
+                    ? "endpoint-test-partial"
+                    : "error"
+              }
+            >
+              {readyCount} of {results.length} endpoints connected.
+            </p>
+            <div className="endpoint-test-result-list">
+              {results.map((result) => (
+                <article
+                  className={`endpoint-test-result endpoint-test-result-${result.status}`}
+                  key={result.endpoint_id || result.priority}
+                >
+                  <div className="endpoint-test-result-heading">
+                    <div>
+                      <span>Priority {result.priority}</span>
+                      <strong>{result.endpoint || "Unnamed endpoint"}</strong>
+                      <small>
+                        {result.provider}
+                        {result.model ? ` · ${result.model}` : ""}
+                      </small>
+                    </div>
+                    <span
+                      className={
+                        result.status === "ready" ? "success" : "error"
+                      }
+                    >
+                      {result.status === "ready" ? "Connected" : "Failed"}
+                      {result.duration_ms !== null &&
+                      result.duration_ms !== undefined
+                        ? ` · ${formatDuration(result.duration_ms)}`
+                        : ""}
+                    </span>
+                  </div>
+                  {result.error && <p className="error">{result.error}</p>}
+                </article>
+              ))}
+            </div>
+          </div>
+        )}
+        {mutation.isError && (
+          <p className="error">
+            {mutation.error?.message || `${label} test failed`}
+          </p>
+        )}
+      </div>
+    );
+  };
 
   return (
     <div className="settings-page">

--- a/frontend/src/components/AudiobookSettings.test.jsx
+++ b/frontend/src/components/AudiobookSettings.test.jsx
@@ -26,10 +26,7 @@ describe("AudiobookSettings", () => {
             }),
         });
       }
-      if (
-        url === "/api/audiobook/settings" &&
-        options?.method === "PUT"
-      ) {
+      if (url === "/api/audiobook/settings" && options?.method === "PUT") {
         const body = JSON.parse(options.body);
         updates.push(body);
         return Promise.resolve({
@@ -75,6 +72,86 @@ describe("AudiobookSettings", () => {
     expect(updates[0].tts_endpoints[0].api_key).toBeNull();
   });
 
+  it("shows the result of every endpoint tested in a fallback pool", async () => {
+    globalThis.fetch = vi.fn((url, options) => {
+      if (url === "/api/audiobook/settings" && !options) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              llm_provider: "stub",
+              tts_endpoints: [
+                {
+                  id: "qwen-host",
+                  name: "Qwen TTS",
+                  provider: "qwen3",
+                  base_url: "http://qwen:8001",
+                },
+                {
+                  id: "omni-host",
+                  name: "OmniVoice fallback",
+                  provider: "omnivoice",
+                  base_url: "http://omni:8001",
+                },
+              ],
+              transcription_provider: "none",
+            }),
+        });
+      }
+      if (url === "/api/audiobook/settings/test-tts") {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              status: "partial",
+              provider: "omnivoice",
+              endpoint: "OmniVoice fallback",
+              results: [
+                {
+                  endpoint_id: "qwen-host",
+                  endpoint: "Qwen TTS",
+                  priority: 1,
+                  provider: "qwen3",
+                  model: null,
+                  status: "error",
+                  duration_ms: 1250,
+                  error: "The worker has a different model loaded.",
+                },
+                {
+                  endpoint_id: "omni-host",
+                  endpoint: "OmniVoice fallback",
+                  priority: 2,
+                  provider: "omnivoice",
+                  model: null,
+                  status: "ready",
+                  duration_ms: 800,
+                  error: null,
+                },
+              ],
+            }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+
+    renderWithClient(<AudiobookSettings />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Save & Test TTS" }),
+    );
+
+    const results = await screen.findByLabelText("TTS endpoint test results");
+    expect(results).toHaveTextContent("1 of 2 endpoints connected");
+    expect(results).toHaveTextContent("Priority 1");
+    expect(results).toHaveTextContent("Qwen TTS");
+    expect(results).toHaveTextContent("Failed · 1.3 s");
+    expect(results).toHaveTextContent(
+      "The worker has a different model loaded.",
+    );
+    expect(results).toHaveTextContent("Priority 2");
+    expect(results).toHaveTextContent("OmniVoice fallback");
+    expect(results).toHaveTextContent("Connected · 800 ms");
+  });
+
   it("reorders endpoint priority before saving", async () => {
     const updates = [];
     globalThis.fetch = vi.fn((url, options) => {
@@ -113,9 +190,7 @@ describe("AudiobookSettings", () => {
     renderWithClient(<AudiobookSettings />);
 
     await screen.findByDisplayValue("Gaming PC");
-    fireEvent.click(
-      screen.getByRole("button", { name: "Move Gaming PC up" }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: "Move Gaming PC up" }));
     fireEvent.click(screen.getByRole("button", { name: "Save Settings" }));
 
     await waitFor(() => expect(updates).toHaveLength(1));
@@ -222,10 +297,14 @@ describe("AudiobookSettings", () => {
 
     renderWithClient(<AudiobookSettings />);
 
-    expect(await screen.findAllByText("Connection performance")).toHaveLength(3);
+    expect(await screen.findAllByText("Connection performance")).toHaveLength(
+      3,
+    );
     expect(screen.getByText("90% answered")).toBeInTheDocument();
     expect(screen.getByText("2.4 s")).toBeInTheDocument();
-    expect(screen.getByLabelText("Gaming PC speed breakdown")).toHaveTextContent("<5s 8");
+    expect(
+      screen.getByLabelText("Gaming PC speed breakdown"),
+    ).toHaveTextContent("<5s 8");
     expect(screen.getByText("TTS Host")).toBeInTheDocument();
     expect(screen.getByText("800 ms")).toBeInTheDocument();
     expect(screen.getByText("Speech Host")).toBeInTheDocument();


### PR DESCRIPTION
## Summary

- probe every configured LLM, TTS, and transcription endpoint during Save & Test
- show ordered per-endpoint success, failure, latency, provider, model, and detailed service errors
- bypass cooldowns for explicit pool tests while preserving normal request fallback behavior
- add backend and frontend coverage for partial-success pools and provider error details

## Validation

- make pr-check
- make test (457 backend tests, 78 frontend tests)