### PR TITLE
Order processing jobs by execution state

### DIFF
--- a/backend/app/crud/processing.py
+++ b/backend/app/crud/processing.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Iterable
 from uuid import uuid4
 
-from sqlalchemy import and_, desc, or_, select, update
+from sqlalchemy import and_, case, desc, or_, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -101,10 +101,28 @@ async def get_processing_jobs(
     book_id: int | None = None,
     limit: int = 100,
 ) -> list[tuple[ProcessingJob, str | None]]:
+    status_order = case(
+        (ProcessingJob.status == ProcessingJobStatus.RUNNING.value, 0),
+        (ProcessingJob.status == ProcessingJobStatus.QUEUED.value, 1),
+        else_=2,
+    )
+    running_started_at = case((ProcessingJob.status == ProcessingJobStatus.RUNNING.value, ProcessingJob.started_at))
+    queued_available_at = case((ProcessingJob.status == ProcessingJobStatus.QUEUED.value, ProcessingJob.available_at))
+    queued_created_at = case((ProcessingJob.status == ProcessingJobStatus.QUEUED.value, ProcessingJob.created_at))
+    active_id = case((ProcessingJob.status.in_(ACTIVE_PROCESSING_STATUSES), ProcessingJob.id))
+    terminal_created_at = case((~ProcessingJob.status.in_(ACTIVE_PROCESSING_STATUSES), ProcessingJob.created_at))
     query = (
         select(ProcessingJob, Book.title)
         .outerjoin(Book, ProcessingJob.book_id == Book.id)
-        .order_by(desc(ProcessingJob.created_at), desc(ProcessingJob.id))
+        .order_by(
+            status_order,
+            running_started_at,
+            queued_available_at,
+            queued_created_at,
+            active_id,
+            desc(terminal_created_at),
+            desc(ProcessingJob.id),
+        )
         .limit(limit)
     )
     if statuses:

--- a/backend/tests/test_processing_jobs.py
+++ b/backend/tests/test_processing_jobs.py
@@ -217,6 +217,68 @@ async def test_active_processing_job_deduplication_includes_running(sqlite_sessi
 
 
 @pytest.mark.asyncio
+async def test_processing_jobs_are_listed_in_execution_order(sqlite_sessionmaker):
+    now = datetime.now(timezone.utc)
+    async with sqlite_sessionmaker() as db:
+        running_first = ProcessingJob(
+            job_type="clean_book",
+            status="running",
+            started_at=now - timedelta(minutes=10),
+            created_at=now - timedelta(minutes=20),
+        )
+        queued_delayed = ProcessingJob(
+            job_type="refresh_book",
+            status="queued",
+            available_at=now + timedelta(minutes=5),
+            created_at=now - timedelta(minutes=15),
+        )
+        terminal_older = ProcessingJob(
+            job_type="metadata_sync",
+            status="completed",
+            created_at=now - timedelta(minutes=8),
+        )
+        queued_next = ProcessingJob(
+            job_type="audiobook_pipeline",
+            status="queued",
+            available_at=now,
+            created_at=now - timedelta(minutes=5),
+        )
+        running_second = ProcessingJob(
+            job_type="clean_all",
+            status="running",
+            started_at=now - timedelta(minutes=2),
+            created_at=now - timedelta(minutes=3),
+        )
+        terminal_newer = ProcessingJob(
+            job_type="refresh_all",
+            status="error",
+            created_at=now - timedelta(minutes=1),
+        )
+        db.add_all(
+            [
+                running_first,
+                queued_delayed,
+                terminal_older,
+                queued_next,
+                running_second,
+                terminal_newer,
+            ]
+        )
+        await db.commit()
+
+        rows = await crud.get_processing_jobs(db)
+
+    assert [job.id for job, _book_title in rows] == [
+        running_first.id,
+        running_second.id,
+        queued_next.id,
+        queued_delayed.id,
+        terminal_newer.id,
+        terminal_older.id,
+    ]
+
+
+@pytest.mark.asyncio
 async def test_canceled_abandoned_job_is_not_reclaimed(sqlite_sessionmaker):
     async with sqlite_sessionmaker() as db:
         job, _created = await crud.create_processing_job(


### PR DESCRIPTION
## Summary

- place running processing jobs first, ordered by their start time
- order queued jobs using the same availability and FIFO fields workers use to claim work
- keep terminal job history newest-first
- cover status precedence and queue ordering when job IDs conflict

## Testing

- `make pr-check`
- `PYTHONPATH=. .venv/bin/python3 -m pytest -m "not integration" backend/tests -q` (458 passed, 1 deselected)